### PR TITLE
Add fix for issue 15

### DIFF
--- a/src/network/listener.rs
+++ b/src/network/listener.rs
@@ -20,6 +20,7 @@
 
 use std::thread;
 use std::sync::mpsc::{channel, Receiver};
+use std::time::Duration;
 
 use network::constants::Network;
 use network::message;
@@ -55,8 +56,8 @@ pub trait Listener {
             let mut handshake_complete = false;
             let mut sock = sock;
             loop {
-                // yield just before receiving to give socket access to threads trying to send
-                thread::yield_now();
+                // sleep just before receiving to give socket access to threads trying to send
+                thread::sleep(Duration::from_millis(1));
                 
                 // Receive new message
                 match sock.receive_message() {

--- a/src/network/listener.rs
+++ b/src/network/listener.rs
@@ -20,6 +20,7 @@
 
 use std::thread;
 use std::sync::mpsc::{channel, Receiver};
+use std::time::Duration;
 
 use network::constants::Network;
 use network::message;
@@ -55,6 +56,9 @@ pub trait Listener {
             let mut handshake_complete = false;
             let mut sock = sock;
             loop {
+                // sleep just before receiving to give socket access to threads trying to send
+                thread::sleep(Duration::from_millis(1));
+                
                 // Receive new message
                 match sock.receive_message() {
                     Ok(payload) => {

--- a/src/network/listener.rs
+++ b/src/network/listener.rs
@@ -20,7 +20,6 @@
 
 use std::thread;
 use std::sync::mpsc::{channel, Receiver};
-use std::time::Duration;
 
 use network::constants::Network;
 use network::message;
@@ -56,8 +55,8 @@ pub trait Listener {
             let mut handshake_complete = false;
             let mut sock = sock;
             loop {
-                // sleep just before receiving to give socket access to threads trying to send
-                thread::sleep(Duration::from_millis(1));
+                // yield just before receiving to give socket access to threads trying to send
+                thread::yield_now();
                 
                 // Receive new message
                 match sock.receive_message() {


### PR DESCRIPTION
I've just added the little fix to listener.rs to allow pending outbound messages to be sent on the socket before it gets locked up again by the listener loop. It successfully built for me using cargo 0.12.0-nightly. Please let me know if I've done this correctly!
