### PR TITLE
[Trivial] RawNetworkMessage::command should be public.

### DIFF
--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -123,7 +123,7 @@ pub enum NetworkMessage {
 }
 
 impl RawNetworkMessage {
-    fn command(&self) -> String {
+    pub fn command(&self) -> String {
         match self.payload {
             NetworkMessage::Version(_) => "version",
             NetworkMessage::Verack     => "verack",

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -123,6 +123,7 @@ pub enum NetworkMessage {
 }
 
 impl RawNetworkMessage {
+    /// Return the message command. This is useful for debug outputs.
     pub fn command(&self) -> String {
         match self.payload {
             NetworkMessage::Version(_) => "version",


### PR DESCRIPTION
RawNetworkMessage::command should be public. It is useful for debug messages and does no harm.