### PR TITLE
[Trivial] add get_best_tip_height to blokchain

### DIFF
--- a/src/blockdata/blockchain.rs
+++ b/src/blockdata/blockchain.rs
@@ -535,6 +535,11 @@ impl Blockchain {
         unsafe { &(*self.best_tip).block }
     }
 
+    /// Returns the best tip height
+    pub fn best_tip_height(&self) -> u32 {
+        unsafe { (*self.best_tip).height }
+    }
+
     /// Returns the best tip's blockhash
     pub fn best_tip_hash(&self) -> Sha256dHash {
         self.best_hash


### PR DESCRIPTION
tip height is a useful information readily computed by the tree. It is e.g. needed to set the height in a version message that a peer would send. Added a public method to retrieve it.