### PR TITLE
Immutable block header

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -25,15 +25,17 @@ use util::Error::{SpvBadTarget, SpvBadProofOfWork};
 use util::hash::Sha256dHash;
 use util::uint::Uint256;
 use network::encodable::VarInt;
-use network::serialize::BitcoinHash;
 use network::constants::Network;
+use network::encodable::{ConsensusDecodable, ConsensusEncodable};
+use network::serialize::{serialize, BitcoinHash, SimpleDecoder, SimpleEncoder};
 use blockdata::transaction::Transaction;
 use blockdata::constants::max_target;
 
-/// A block header, which contains all the block's information except
+
+/// Block header content, which contains all the block's information except
 /// the actual transactions
 #[derive(Copy, PartialEq, Eq, Clone, Debug)]
-pub struct BlockHeader {
+pub struct BlockHeaderContent {
     /// The protocol version. Should always be 1.
     pub version: u32,
     /// Reference to the previous block in the chain
@@ -47,6 +49,16 @@ pub struct BlockHeader {
     pub bits: u32,
     /// The nonce, selected to obtain a low enough blockhash
     pub nonce: u32,
+}
+
+/// A block header, which contains all the block's information except
+/// the actual transactions
+#[derive(Copy, PartialEq, Eq, Clone, Debug)]
+pub struct BlockHeader {
+    /// the actual content of the block header
+    content: BlockHeaderContent,
+    /// precomputed hash of the content, that also identifies the header
+    hash: Sha256dHash
 }
 
 /// A Bitcoin block, which is a collection of transactions with an attached
@@ -71,6 +83,42 @@ pub struct LoneBlockHeader {
 }
 
 impl BlockHeader {
+    /// Create a new block header from enumerated content
+    pub fn new (version: u32,
+                prev_blockhash: Sha256dHash,
+                merkle_root: Sha256dHash,
+                time: u32, bits: u32, nonce: u32) -> BlockHeader {
+        let content = BlockHeaderContent {
+            version, prev_blockhash, merkle_root, time, bits, nonce };
+        let hash = Sha256dHash::from_data(&serialize(&content).unwrap());
+        BlockHeader { content, hash }
+    }
+
+    /// The protocol version. Used to be 1, now a nonce for ASICBOOST
+    #[inline]
+    pub fn version(&self) -> u32 { self.content.version }
+
+    /// Reference to the previous block in the chain
+    #[inline]
+    pub fn prev_blockhash(&self) -> Sha256dHash { self.content.prev_blockhash }
+
+    /// The root hash of the merkle tree of transactions in the block
+    #[inline]
+    pub fn merkle_root(&self) -> Sha256dHash { self.content.merkle_root }
+
+    /// The timestamp of the block, as claimed by the mainer
+    #[inline]
+    pub fn time(&self) -> u32 { self.content.time }
+
+    /// The target value below which the blockhash must lie, encoded as a
+    /// a float (with well-defined rounding, of course)
+    #[inline]
+    pub fn bits(&self) -> u32 { self.content.bits }
+
+    /// The nonce, selected to obtain a low enough blockhash
+    #[inline]
+    pub fn nonce(&self) -> u32 { self.content.nonce }
+
     /// Computes the target [0, T] that a blockhash must land in to be valid
     pub fn target(&self) -> Uint256 {
         // This is a floating-point "compact" encoding originally used by
@@ -78,11 +126,11 @@ impl BlockHeader {
         // with it. The exponent needs to have 3 subtracted from it, hence
         // this goofy decoding code:
         let (mant, expt) = {
-            let unshifted_expt = self.bits >> 24;
+            let unshifted_expt = self.bits() >> 24;
             if unshifted_expt <= 3 {
-                ((self.bits & 0xFFFFFF) >> (8 * (3 - unshifted_expt as usize)), 0)
+                ((self.bits() & 0xFFFFFF) >> (8 * (3 - unshifted_expt as usize)), 0)
             } else {
-                (self.bits & 0xFFFFFF, 8 * ((self.bits >> 24) - 3))
+                (self.bits() & 0xFFFFFF, 8 * ((self.bits() >> 24) - 3))
             }
         };
 
@@ -124,19 +172,39 @@ impl BlockHeader {
 }
 
 impl BitcoinHash for BlockHeader {
+    #[inline]
     fn bitcoin_hash(&self) -> Sha256dHash {
-        use network::serialize::serialize;
-        Sha256dHash::from_data(&serialize(self).unwrap())
+        self.hash
     }
 }
 
 impl BitcoinHash for Block {
+    #[inline]
     fn bitcoin_hash(&self) -> Sha256dHash {
         self.header.bitcoin_hash()
     }
 }
 
-impl_consensus_encoding!(BlockHeader, version, prev_blockhash, merkle_root, time, bits, nonce);
+
+impl<S: SimpleEncoder> ConsensusEncodable<S> for BlockHeader {
+    #[inline]
+    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+        try!(self.content.consensus_encode(s));
+        // Don't serialize the cached hash
+        Ok(())
+    }
+}
+
+impl<D: SimpleDecoder> ConsensusDecodable<D> for BlockHeader {
+    #[inline]
+    fn consensus_decode(d: &mut D) -> Result<BlockHeader, D::Error> {
+        let content: BlockHeaderContent = try!(ConsensusDecodable::consensus_decode(d));
+        let hash = Sha256dHash::from_data(&serialize(&content).unwrap());
+        Ok(BlockHeader { content, hash })
+    }
+}
+
+impl_consensus_encoding!(BlockHeaderContent, version, prev_blockhash, merkle_root, time, bits, nonce);
 impl_consensus_encoding!(Block, header, txdata);
 impl_consensus_encoding!(LoneBlockHeader, header, tx_count);
 

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -229,13 +229,13 @@ mod tests {
         assert!(decode.is_ok());
         assert!(bad_decode.is_err());
         let real_decode = decode.unwrap();
-        assert_eq!(real_decode.header.version, 1);
-        assert_eq!(serialize(&real_decode.header.prev_blockhash).ok(), Some(prevhash));
+        assert_eq!(real_decode.header.version(), 1);
+        assert_eq!(serialize(&real_decode.header.prev_blockhash()).ok(), Some(prevhash));
         // [test] TODO: actually compute the merkle root
-        assert_eq!(serialize(&real_decode.header.merkle_root).ok(), Some(merkle));
-        assert_eq!(real_decode.header.time, 1231965655);
-        assert_eq!(real_decode.header.bits, 486604799);
-        assert_eq!(real_decode.header.nonce, 2067413810);
+        assert_eq!(serialize(&real_decode.header.merkle_root()).ok(), Some(merkle));
+        assert_eq!(real_decode.header.time(), 1231965655);
+        assert_eq!(real_decode.header.bits(), 486604799);
+        assert_eq!(real_decode.header.nonce(), 2067413810);
         // [test] TODO: check the transaction data
     
         assert_eq!(serialize(&real_decode).ok(), Some(some_block));
@@ -253,12 +253,12 @@ mod tests {
 
         assert!(decode.is_ok());
         let real_decode = decode.unwrap();
-        assert_eq!(real_decode.header.version, 0x20000000);  // VERSIONBITS but no bits set
-        assert_eq!(serialize(&real_decode.header.prev_blockhash).ok(), Some(prevhash));
-        assert_eq!(serialize(&real_decode.header.merkle_root).ok(), Some(merkle));
-        assert_eq!(real_decode.header.time, 1472004949);
-        assert_eq!(real_decode.header.bits, 0x1a06d450);
-        assert_eq!(real_decode.header.nonce, 1879759182);
+        assert_eq!(real_decode.header.version(), 0x20000000);  // VERSIONBITS but no bits set
+        assert_eq!(serialize(&real_decode.header.prev_blockhash()).ok(), Some(prevhash));
+        assert_eq!(serialize(&real_decode.header.merkle_root()).ok(), Some(merkle));
+        assert_eq!(real_decode.header.time(), 1472004949);
+        assert_eq!(real_decode.header.bits(), 0x1a06d450);
+        assert_eq!(real_decode.header.nonce(), 1879759182);
         // [test] TODO: check the transaction data
 
         assert_eq!(serialize(&real_decode).ok(), Some(segwit_block));

--- a/src/blockdata/blockchain.rs
+++ b/src/blockdata/blockchain.rs
@@ -151,7 +151,7 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for Blockchain {
         // Reconnect all prev pointers
         let raw_tree = &tree as *const BlockTree;
         for node in tree.mut_iter() {
-            let hash = node.block.header.prev_blockhash.into_le();
+            let hash = node.block.header.prev_blockhash().into_le();
             let prevptr =
                 match unsafe { (*raw_tree).lookup(&hash, 256) } {
                     Some(node) => &**node as NodePtr,
@@ -422,7 +422,7 @@ impl Blockchain {
             return Err(DuplicateHash);
         }
         // Construct node, if possible
-        let new_block = match get_prev(self, block.header.prev_blockhash) {
+        let new_block = match get_prev(self, block.header.prev_blockhash()) {
             Some(prev) => {
                 let difficulty =
                     // Compute required difficulty if this is a diffchange block
@@ -434,7 +434,7 @@ impl Blockchain {
                                 scan = (*scan).prev;
                             }
                             // Get clamped timespan between first and last blocks
-                            match (*prev).block.header.time - (*scan).block.header.time {
+                            match (*prev).block.header.time() - (*scan).block.header.time() {
                                 n if n < DIFFCHANGE_TIMESPAN / 4 => DIFFCHANGE_TIMESPAN / 4,
                                 n if n > DIFFCHANGE_TIMESPAN * 4 => DIFFCHANGE_TIMESPAN * 4,
                                 n => n
@@ -452,7 +452,7 @@ impl Blockchain {
                     // On non-diffchange blocks, Testnet has a rule that any 20-minute-long
                     // block intervals result the difficulty
                     } else if self.network == Network::Testnet &&
-                                        block.header.time > unsafe { (*prev).block.header.time } + 2*TARGET_BLOCK_SPACING {
+                                        block.header.time() > unsafe { (*prev).block.header.time() } + 2*TARGET_BLOCK_SPACING {
                         max_target(self.network)
                     // On the other hand, if we are in Testnet and the block interval is less
                     // than 20 minutes, we need to scan backward to find a block for which the

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -150,13 +150,13 @@ mod test {
     fn bitcoin_genesis_full_block() {
         let gen = genesis_block(Network::Bitcoin);
 
-        assert_eq!(gen.header.version, 1);
-        assert_eq!(gen.header.prev_blockhash, Default::default());
-        assert_eq!(gen.header.merkle_root.be_hex_string(),
+        assert_eq!(gen.header.version(), 1);
+        assert_eq!(gen.header.prev_blockhash(), Default::default());
+        assert_eq!(gen.header.merkle_root().be_hex_string(),
                    "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string());
-        assert_eq!(gen.header.time, 1231006505);
-        assert_eq!(gen.header.bits, 0x1d00ffff);
-        assert_eq!(gen.header.nonce, 2083236893);
+        assert_eq!(gen.header.time(), 1231006505);
+        assert_eq!(gen.header.bits(), 0x1d00ffff);
+        assert_eq!(gen.header.nonce(), 2083236893);
         assert_eq!(gen.header.bitcoin_hash().be_hex_string(),
                    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f".to_string());
     }
@@ -164,13 +164,13 @@ mod test {
     #[test]
     fn testnet_genesis_full_block() {
         let gen = genesis_block(Network::Testnet);
-        assert_eq!(gen.header.version, 1);
-        assert_eq!(gen.header.prev_blockhash, Default::default());
-        assert_eq!(gen.header.merkle_root.be_hex_string(),
+        assert_eq!(gen.header.version(), 1);
+        assert_eq!(gen.header.prev_blockhash(), Default::default());
+        assert_eq!(gen.header.merkle_root().be_hex_string(),
                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string());
-        assert_eq!(gen.header.time, 1296688602);
-        assert_eq!(gen.header.bits, 0x1d00ffff);
-        assert_eq!(gen.header.nonce, 414098458);
+        assert_eq!(gen.header.time(), 1296688602);
+        assert_eq!(gen.header.bits(), 0x1d00ffff);
+        assert_eq!(gen.header.nonce(), 414098458);
         assert_eq!(gen.header.bitcoin_hash().be_hex_string(),
                    "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943".to_string());
     }

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -95,31 +95,21 @@ pub fn genesis_block(network: Network) -> Block {
     match network {
         Network::Bitcoin => {
             let txdata = vec![bitcoin_genesis_tx()];
-            Block {
-                header: BlockHeader {
-                    version: 1,
-                    prev_blockhash: Default::default(),
-                    merkle_root: txdata.merkle_root(),
-                    time: 1231006505,
-                    bits: 0x1d00ffff,
-                    nonce: 2083236893
-                },
-                txdata: txdata
+            Block { header: BlockHeader::new(1, Default::default(),
+                                         txdata.merkle_root(),
+                                         1231006505,
+                                         0x1d00ffff,
+                                         2083236893),
+                        txdata}
             }
-        }
         Network::Testnet => {
             let txdata = vec![bitcoin_genesis_tx()];
-            Block {
-                header: BlockHeader {
-                    version: 1,
-                    prev_blockhash: Default::default(),
-                    merkle_root: txdata.merkle_root(),
-                    time: 1296688602,
-                    bits: 0x1d00ffff,
-                    nonce: 414098458
-                },
-                txdata: txdata
-            }
+            Block { header: BlockHeader::new(1, Default::default(),
+                                        txdata.merkle_root(),
+                                        1296688602,
+                                        0x1d00ffff,
+                                        414098458),
+                       txdata}
         }
     }
 }


### PR DESCRIPTION
This PR is motivated by the issue https://github.com/rust-bitcoin/rust-bitcoin/issues/52
Profiler showed that significant time was wasted recomputing bitcoin_hash for block headers.
After this change BlockHeader is immutable and its hash is pre-computed. The time inserting into in-memory blockchain is less than half of before.

2018-03-09 15:37:57 INFO  [bitcoin_spv::node] loading headers from database...
2018-03-09 15:37:57 INFO  [bitcoin_spv::node] reading headers ...
2018-03-09 15:38:37 INFO  [bitcoin_spv::node] building in-memory header chain ...
2018-03-09 15:39:16 INFO  [bitcoin_spv::node] loaded 512744 headers from database
