### PR TITLE
Implemented segwit address types. Moved PrivKey into its own module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ See Transaction::verify and Script::verify methods.
 
 * Add bech32 support
 
+* Support segwit address types
+

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -328,12 +328,28 @@ impl Script {
         self.0[24] == opcodes::All::OP_CHECKSIG as u8
     }
 
+    /// Checks whether a script pubkey is a p2pkh output
+    #[inline]
+    pub fn is_p2pk(&self) -> bool {
+        self.0.len() == 67 &&
+            self.0[0] == opcodes::All::OP_PUSHBYTES_65 as u8 &&
+            self.0[66] == opcodes::All::OP_CHECKSIG as u8
+    }
+
     /// Checks whether a script pubkey is a p2wsh output
     #[inline]
     pub fn is_v0_p2wsh(&self) -> bool {
         self.0.len() == 34 &&
         self.0[0] == opcodes::All::OP_PUSHBYTES_0 as u8 &&
         self.0[1] == opcodes::All::OP_PUSHBYTES_32 as u8
+    }
+
+    /// Checks whether a script pubkey is a p2wpkh output
+    #[inline]
+    pub fn is_v0_p2wpkh(&self) -> bool {
+        self.0.len() == 22 &&
+            self.0[0] == opcodes::All::OP_PUSHBYTES_0 as u8 &&
+            self.0[1] == opcodes::All::OP_PUSHBYTES_20 as u8
     }
 
     /// Whether a script can be proven to have no satisfying input

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -215,7 +215,7 @@ pub fn create_address(secp: &Secp256k1,
         network: network,
         payload: address::Payload::ScriptHash(
             hash::Hash160::from_data(&script[..])
-        ),
+        )
     })
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,6 +16,7 @@
 //!
 //! Functions needed by all parts of the Bitcoin library
 
+pub mod privkey;
 pub mod address;
 pub mod base58;
 pub mod bip32;
@@ -83,7 +84,9 @@ pub enum Error {
     /// The header hash is not below the target
     SpvBadProofOfWork,
     /// Error propagated from subsystem
-    Detail(String, Box<Error>)
+    Detail(String, Box<Error>),
+    /// Unsupported witness version
+    UnsupportedWitnessVersion(u8)
 }
 
 impl fmt::Display for Error {
@@ -130,7 +133,8 @@ impl error::Error for Error {
             Error::Secp256k1(ref e) => e.description(),
             Error::SpvBadTarget => "target incorrect",
             Error::SpvBadProofOfWork => "target correct but not attained",
-            Error::Detail(_, ref e) => e.description()
+            Error::Detail(_, ref e) => e.description(),
+            Error::UnsupportedWitnessVersion(_) => "unsupported witness version"
         }
     }
 }

--- a/src/util/privkey.rs
+++ b/src/util/privkey.rs
@@ -1,0 +1,167 @@
+// Rust Bitcoin Library
+// Written in 2014 by
+//     Andrew Poelstra <apoelstra@wpsoftware.net>
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # private key
+//!  A private key represents the secret data associated with its proposed use
+//!
+use std::str::FromStr;
+use util::Error;
+use secp256k1::Secp256k1;
+use secp256k1::key::{PublicKey, SecretKey};
+use util::address::Address;
+use network::constants::Network;
+use util::base58;
+
+#[derive(Clone, PartialEq, Eq)]
+/// A Bitcoin ECDSA private key
+pub struct Privkey {
+    /// Whether this private key represents a compressed address
+    pub compressed: bool,
+    /// The network on which this key should be used
+    pub network: Network,
+    /// The actual ECDSA key
+    pub key: SecretKey
+}
+
+impl Privkey {
+    /// Creates an address from a public key
+    #[inline]
+    pub fn from_secret_key(key: SecretKey, compressed: bool, network: Network) -> Privkey {
+        Privkey { compressed, network, key }
+    }
+
+    /// Computes the public key as supposed to be used with this secret
+    pub fn public_key(&self, secp: &Secp256k1) -> Result<PublicKey, Error> {
+        Ok(PublicKey::from_secret_key(secp, &self.key)?)
+    }
+
+    /// Converts a private key to a segwit address
+    #[inline]
+    pub fn to_address(&self, secp: &Secp256k1) -> Result<Address, Error> {
+        Ok(Address::p2wpkh(&self.public_key(secp)?, self.network))
+    }
+
+    /// Converts a private key to a legacy (non-segwit) address
+    #[inline]
+    pub fn to_legacy_address(&self, secp: &Secp256k1) -> Result<Address, Error> {
+        if self.compressed {
+            Ok(Address::p2pkh(&self.public_key(secp)?, self.network))
+        }
+        else {
+            Ok(Address::p2upkh(&self.public_key(secp)?, self.network))
+        }
+    }
+
+    /// Accessor for the underlying secp key
+    #[inline]
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.key
+    }
+
+    /// Accessor for the underlying secp key that consumes the privkey
+    #[inline]
+    pub fn into_secret_key(self) -> SecretKey {
+        self.key
+    }
+
+    /// Accessor for the network type
+    #[inline]
+    pub fn network(&self) -> Network {
+        self.network
+    }
+
+    /// Accessor for the compressed flag
+    #[inline]
+    pub fn is_compressed(&self) -> bool {
+        self.compressed
+    }
+}
+
+impl ToString for Privkey {
+    fn to_string(&self) -> String {
+        let mut ret = [0; 34];
+        ret[0] = match self.network {
+            Network::Bitcoin => 128,
+            Network::Testnet => 239
+        };
+        ret[1..33].copy_from_slice(&self.key[..]);
+        if self.compressed {
+            ret[33] = 1;
+            base58::check_encode_slice(&ret[..])
+        } else {
+            base58::check_encode_slice(&ret[..33])
+        }
+    }
+}
+
+impl FromStr for Privkey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Privkey, Error> {
+        let data = try!(base58::from_check(s));
+
+        let compressed = match data.len() {
+            33 => false,
+            34 => true,
+            _ => { return Err(Error::Base58(base58::Error::InvalidLength(data.len()))); }
+        };
+
+        let network = match data[0] {
+            128 => Network::Bitcoin,
+            239 => Network::Testnet,
+            x   => { return Err(Error::Base58(base58::Error::InvalidVersion(vec![x]))); }
+        };
+
+        let secp = Secp256k1::without_caps();
+        let key = try!(SecretKey::from_slice(&secp, &data[1..33])
+            .map_err(|_| base58::Error::Other("Secret key out of range".to_owned())));
+
+        Ok(Privkey {
+            compressed: compressed,
+            network: network,
+            key: key
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Privkey;
+    use secp256k1::Secp256k1;
+    use std::str::FromStr;
+    use network::constants::Network::Testnet;
+    use network::constants::Network::Bitcoin;
+
+    #[test]
+    fn test_key_derivation() {
+        // testnet compressed
+        let sk = Privkey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+        assert_eq!(sk.network(), Testnet);
+        assert_eq!(sk.is_compressed(), true);
+        assert_eq!(&sk.to_string(), "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy");
+
+        let secp = Secp256k1::new();
+        let pk = sk.to_legacy_address(&secp).unwrap();
+        assert_eq!(&pk.to_string(), "mqwpxxvfv3QbM8PU8uBx2jaNt9btQqvQNx");
+
+        // mainnet uncompressed
+        let sk = Privkey::from_str("5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3").unwrap();
+        assert_eq!(sk.network(), Bitcoin);
+        assert_eq!(sk.is_compressed(), false);
+        assert_eq!(&sk.to_string(), "5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3");
+
+        let secp = Secp256k1::new();
+        let pk = sk.to_legacy_address(&secp).unwrap();
+        assert_eq!(&pk.to_string(), "1GhQvF6dL8xa6wBxLnWmHcQsurx9RxiMc8");
+    }
+}


### PR DESCRIPTION
PrivKey was shadowing SecretKey only to implement a WIF, removed.
Implemented pay-to-pk address
unified parameter order as: key, compressed, network
