### PR TITLE
Move witness inside of TxIn.

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -61,7 +61,6 @@ fn bitcoin_genesis_tx() -> Transaction {
         lock_time: 0,
         input: vec![],
         output: vec![],
-        witness: vec![]
     };
 
     // Inputs
@@ -73,7 +72,8 @@ fn bitcoin_genesis_tx() -> Transaction {
         prev_hash: Default::default(),
         prev_index: 0xFFFFFFFF,
         script_sig: in_script,
-        sequence: MAX_SEQUENCE
+        sequence: MAX_SEQUENCE,
+        witness: vec![],
     });
 
     // Outputs


### PR DESCRIPTION
This is a rather large breaking API change, but is significantly
more sensible. In the "do not allow internal representation to
represent an invalid state" category, this ensures that witness
cannot have an length other than the number of inputs. Further,
it reduces vec propagation, which may help performance in some
cases by reducing allocs. Fianlly, this just makes more sense (tm).
Witness are a per-input field like the scriptSig, placing them
outside of the TxIn is just where they are serialized, not where
they logically belong.