### PR TITLE
add is_coin_base

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -291,6 +291,9 @@ impl Script {
     /// Convert the script into a byte vector
     pub fn into_vec(self) -> Vec<u8> { self.0.into_vec() }
 
+    /// returns a copy of the script data
+    pub fn data (&self) -> Vec<u8> { self.0.clone().into_vec() }
+
     /// Compute the P2SH output corresponding to this redeem script
     pub fn to_p2sh(&self) -> Script {
         Builder::new().push_opcode(opcodes::All::OP_HASH160)

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -272,6 +272,11 @@ impl Transaction {
             Err(script::Error::SerializationError)
         }
     }
+
+    /// is this a coin base transaction?
+    pub fn is_coin_base (&self) -> bool {
+        self.input.len() == 1 && self.input[0].prev_index == 0xFFFFFFFF && self.input [0].prev_hash == Sha256dHash::default()
+    }
 }
 
 impl BitcoinHash for Transaction {
@@ -451,6 +456,18 @@ mod tests {
     fn test_txin() {
         let txin: Result<TxIn, _> = deserialize(&hex_bytes("a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff").unwrap());
         assert!(txin.is_ok());
+    }
+
+    #[test]
+    fn test_is_coinbase () {
+        use network::constants::Network;
+        use blockdata::constants;
+
+        let genesis = constants::genesis_block(Network::Bitcoin);
+        assert! (genesis.txdata[0].is_coin_base());
+        let hex_tx = hex_bytes("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
+        let tx: Transaction = deserialize(&hex_tx).unwrap();
+        assert!(!tx.is_coin_base());
     }
 
     #[test]


### PR DESCRIPTION
is_coin base is a convenience function
direct data access to Script content is needed as eg. BIP158 implementation does not use serialization of Script but Script content directly.