### PR TITLE
Regtest bech32 address support

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -95,9 +95,11 @@ mod tests {
   fn string_test() {
       assert_eq!(Network::Bitcoin.to_string(), "bitcoin");
       assert_eq!(Network::Testnet.to_string(), "testnet");
+      assert_eq!(Network::Regtest.to_string(), "regtest");
 
       assert_eq!("bitcoin".parse::<Network>().unwrap(), Network::Bitcoin);
       assert_eq!("testnet".parse::<Network>().unwrap(), Network::Testnet);
+      assert_eq!("regtest".parse::<Network>().unwrap(), Network::Regtest);
       assert!("fakenet".parse::<Network>().is_err());
   }
 }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -166,7 +166,8 @@ impl Address {
     fn bech_network (network: Network) -> bitcoin_bech32::constants::Network {
         match network {
             Network::Bitcoin => bitcoin_bech32::constants::Network::Bitcoin,
-            Network::Testnet | Network::Regtest => bitcoin_bech32::constants::Network::Testnet,
+            Network::Testnet => bitcoin_bech32::constants::Network::Testnet,
+            Network::Regtest => bitcoin_bech32::constants::Network::Regtest,
         }
     }
 
@@ -246,12 +247,14 @@ impl FromStr for Address {
     fn from_str(s: &str) -> Result<Address, Error> {
         // bech32 (note that upper or lowercase is allowed but NOT mixed case)
         if s.len() >= 3 &&
-           (&s.as_bytes()[0..3] == b"bc1" || &s.as_bytes()[0..3] == b"tb1" ||
-            &s.as_bytes()[0..3] == b"BC1" || &s.as_bytes()[0..3] == b"TB1") {
+            (&s.as_bytes()[0..3] == b"bc1" || &s.as_bytes()[0..3] == b"BC1" ||
+             &s.as_bytes()[0..3] == b"tb1" || &s.as_bytes()[0..3] == b"TB1" ||
+             &s.as_bytes()[0..5] == b"bcrt1" || &s.as_bytes()[0..5] == b"BCRT1") {
             let witprog = try!(WitnessProgram::from_address(s));
             let network = match witprog.network() {
                 bitcoin_bech32::constants::Network::Bitcoin => Network::Bitcoin,
                 bitcoin_bech32::constants::Network::Testnet => Network::Testnet,
+                bitcoin_bech32::constants::Network::Regtest => Network::Regtest,
                 _ => panic!("unknown network")
             };
             if witprog.version().to_u8() != 0 {
@@ -318,7 +321,7 @@ mod tests {
     use serialize::hex::FromHex;
 
     use blockdata::script::Script;
-    use network::constants::Network::{Bitcoin, Testnet};
+    use network::constants::Network::{Bitcoin, Testnet, Regtest};
     use util::hash::Hash160;
     use super::*;
 
@@ -422,6 +425,12 @@ mod tests {
         let addr = Address::from_str(addrstr).unwrap();
         assert_eq!(addr.network, Testnet);
         assert_eq!(addr.script_pubkey(), hex_script!("0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"));
+        assert_eq!(addr.to_string(), addrstr);
+
+        let addrstr = "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl";
+        let addr = Address::from_str(addrstr).unwrap();
+        assert_eq!(addr.network, Regtest);
+        assert_eq!(addr.script_pubkey(), hex_script!("001454d26dddb59c7073c6a197946ea1841951fa7a74"));
         assert_eq!(addr.to_string(), addrstr);
 
         // bad vectors


### PR DESCRIPTION
In the spirit of #84, add support for regtest bech32 addresses that start with "bcrt1".

Also added a test that I had added locally when updating rust-bitcoin with my rust-bech32-bitcoin/regtest library.

Please consider this PR, thanks!