### PR TITLE
Clarify to_v0_p2wsh docs a bit further

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -302,7 +302,8 @@ impl Script {
                       .into_script()
     }
 
-    /// Compute the P2WSH output corresponding to this witness script
+    /// Compute the P2WSH output corresponding to this witnessScript (aka the "witness redeem
+    /// script")
     pub fn to_v0_p2wsh(&self) -> Script {
         let mut tmp = [0; 32];
         let mut sha2 = Sha256::new();


### PR DESCRIPTION
"witness script" is usually styled witnessScript to ensure its less ambiguous, and also mention the other name of "witness redeem script". It seems we're stuck in the shitty situation of having multiple ambiguous names for this thing :(.