### PR TITLE
Ready for Review: Improve consistency for bip32::ChildNumber

### DIFF
--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -103,19 +103,41 @@ pub enum ChildNumber {
 }
 
 impl ChildNumber {
-    /// Create a [ChildNumber::Normal] from an index, panics if the index is not
-    /// within [0, 2^31 - 1]
+    /// Create a [`Normal`] from an index, panics if the index is not within
+    /// [0, 2^31 - 1].
+    ///
+    /// [`Normal`]: #variant.Normal
     pub fn from_normal_idx(index: u32) -> Self {
         assert_eq!(index & (1 << 31),  0, "ChildNumber indices have to be within [0, 2^31 - 1], is: {}", index);
         ChildNumber::Normal { index: index }
     }
 
-    /// Create a [ChildNumber::Hardened] from an index, panics if the index is
-    /// not within [0, 2^31 - 1]
+    /// Create a [`Hardened`] from an index, panics if the index is not within
+    /// [0, 2^31 - 1].
+    ///
+    /// [`Hardened`]: #variant.Hardened
     pub fn from_hardened_idx(index: u32) -> Self {
         assert_eq!(index & (1 << 31),  0, "ChildNumber indices have to be within [0, 2^31 - 1], is: {}", index);
         ChildNumber::Hardened { index: index }
     }
+
+    /// Returns `true` if the child number is a [`Normal`] value.
+    ///
+    /// [`Normal`]: #variant.Normal
+    pub fn is_normal(&self) -> bool {
+        !self.is_hardened()
+    }
+
+    /// Returns `true` if the child number is a [`Hardened`] value.
+    ///
+    /// [`Hardened`]: #variant.Hardened
+    pub fn is_hardened(&self) -> bool {
+        match *self {
+            ChildNumber::Hardened {..} => true,
+            ChildNumber::Normal {..} => false,
+        }
+    }
+
 }
 
 impl From<u32> for ChildNumber {


### PR DESCRIPTION
There seemed to be some confusion as to whether the internal
represenation of a ChildNumber is supposed to be the index (0..2^31-1
for _both_ Normal and Hardened) or the actual number (0..2^31-1 for
Normal and 2^31..2^32-1 for Hardened). This commits fixes this
confusion.

- Make clear that the internal representation is the index rather
  than the actual number
- Make the internal representation non-public
- Provide methods for creating valid ChildNumbers
- Change relevant callers and tests to conform to this new ChildNumber

My rationale for using index rather than the actual number as internal
representation is that the difference between the two enum variants
already encode wether a ChildNumber is a normal one or a hardened one,
so the only bit of extra information left to be encoded is its index.