### PR TITLE
Fix Error type for SimpleDecoder and SimpleEncoder

### DIFF
--- a/fuzz/fuzz_targets/deserialize_block.rs
+++ b/fuzz/fuzz_targets/deserialize_block.rs
@@ -1,7 +1,7 @@
 extern crate bitcoin;
-type BResult = Result<bitcoin::blockdata::block::Block, bitcoin::util::Error>;
+
 fn do_test(data: &[u8]) {
-    let _: BResult = bitcoin::network::serialize::deserialize(data);
+    let _: Result<bitcoin::blockdata::block::Block, _>= bitcoin::network::serialize::deserialize(data);
 }
 
 #[cfg(feature = "afl")]

--- a/fuzz/fuzz_targets/deserialize_script.rs
+++ b/fuzz/fuzz_targets/deserialize_script.rs
@@ -1,7 +1,7 @@
 extern crate bitcoin;
-type BResult = Result<bitcoin::blockdata::script::Script, bitcoin::util::Error>;
+
 fn do_test(data: &[u8]) {
-    let _: BResult = bitcoin::network::serialize::deserialize(data);
+    let _: Result<bitcoin::blockdata::script::Script, _> = bitcoin::network::serialize::deserialize(data);
 }
 
 #[cfg(feature = "afl")]

--- a/fuzz/fuzz_targets/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/deserialize_transaction.rs
@@ -1,7 +1,7 @@
 extern crate bitcoin;
-type BResult = Result<bitcoin::blockdata::transaction::Transaction, bitcoin::util::Error>;
+
 fn do_test(data: &[u8]) {
-    let tx_result: BResult = bitcoin::network::serialize::deserialize(data);
+    let tx_result: Result<bitcoin::blockdata::transaction::Transaction, _> = bitcoin::network::serialize::deserialize(data);
     match tx_result {
         Err(_) => {},
         Ok(mut tx) => {

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -25,7 +25,7 @@ use util::Error::{SpvBadTarget, SpvBadProofOfWork};
 use util::hash::Sha256dHash;
 use util::uint::Uint256;
 use network::encodable::VarInt;
-use network::serialize::BitcoinHash;
+use network::serialize::{self, BitcoinHash};
 use network::constants::Network;
 use blockdata::transaction::Transaction;
 use blockdata::constants::max_target;

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -25,7 +25,7 @@ use util::Error::{SpvBadTarget, SpvBadProofOfWork};
 use util::hash::Sha256dHash;
 use util::uint::Uint256;
 use network::encodable::VarInt;
-use network::serialize::{self, BitcoinHash};
+use network::serialize::BitcoinHash;
 use network::constants::Network;
 use blockdata::transaction::Transaction;
 use blockdata::constants::max_target;

--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -25,7 +25,7 @@
 // Heavy stick to translate between opcode types
 use std::mem::transmute;
 
-use network::serialize::{SimpleDecoder, SimpleEncoder};
+use network::serialize::{self, SimpleDecoder, SimpleEncoder};
 use network::encodable::{ConsensusDecodable, ConsensusEncodable};
 
 // Note: I am deliberately not implementing PartialOrd or Ord on the
@@ -608,14 +608,14 @@ display_from_debug!(All);
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for All {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<All, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<All, serialize::Error> {
       Ok(All::from(d.read_u8()?))
     }
 }
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for All {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
       s.emit_u8(*self as u8)
     }
 }

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -32,7 +32,7 @@ use crypto::digest::Digest;
 
 use blockdata::opcodes;
 use network::encodable::{ConsensusDecodable, ConsensusEncodable};
-use network::serialize::{SimpleDecoder, SimpleEncoder};
+use network::serialize::{self, SimpleDecoder, SimpleEncoder};
 use util::hash::Hash160;
 #[cfg(feature="bitcoinconsensus")] use bitcoinconsensus;
 #[cfg(feature="bitcoinconsensus")] use std::convert;
@@ -621,14 +621,14 @@ impl serde::Serialize for Script {
 // Network serialization
 impl<S: SimpleEncoder> ConsensusEncodable<S> for Script {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         self.0.consensus_encode(s)
     }
 }
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for Script {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<Script, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Script, serialize::Error> {
         Ok(Script(ConsensusDecodable::consensus_decode(d)?))
     }
 }

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -31,7 +31,7 @@ use std::fmt;
 use util::hash::Sha256dHash;
 #[cfg(feature="bitcoinconsensus")] use blockdata::script;
 use blockdata::script::Script;
-use network::serialize::{serialize, BitcoinHash, SimpleEncoder, SimpleDecoder};
+use network::serialize::{self, serialize, BitcoinHash, SimpleEncoder, SimpleDecoder};
 use network::encodable::{ConsensusEncodable, ConsensusDecodable, VarInt};
 
 /// A reference to a transaction output
@@ -326,13 +326,13 @@ impl BitcoinHash for Transaction {
 impl_consensus_encoding!(TxOut, value, script_pubkey);
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for OutPoint {
-    fn consensus_encode(&self, s: &mut S) -> Result <(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result <(), serialize::Error> {
         self.txid.consensus_encode(s)?;
         self.vout.consensus_encode(s)
     }
 }
 impl<D: SimpleDecoder> ConsensusDecodable<D> for OutPoint {
-    fn consensus_decode(d: &mut D) -> Result<OutPoint, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<OutPoint, serialize::Error> {
         Ok(OutPoint {
             txid: ConsensusDecodable::consensus_decode(d)?,
             vout: ConsensusDecodable::consensus_decode(d)?,
@@ -341,14 +341,14 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for OutPoint {
 }
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for TxIn {
-    fn consensus_encode(&self, s: &mut S) -> Result <(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result <(), serialize::Error> {
         self.previous_output.consensus_encode(s)?;
         self.script_sig.consensus_encode(s)?;
         self.sequence.consensus_encode(s)
     }
 }
 impl<D: SimpleDecoder> ConsensusDecodable<D> for TxIn {
-    fn consensus_decode(d: &mut D) -> Result<TxIn, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<TxIn, serialize::Error> {
         Ok(TxIn {
             previous_output: ConsensusDecodable::consensus_decode(d)?,
             script_sig: ConsensusDecodable::consensus_decode(d)?,
@@ -359,7 +359,7 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for TxIn {
 }
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for Transaction {
-    fn consensus_encode(&self, s: &mut S) -> Result <(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result <(), serialize::Error> {
         self.version.consensus_encode(s)?;
         let mut have_witness = false;
         for input in &self.input {
@@ -385,7 +385,7 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for Transaction {
 }
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for Transaction {
-    fn consensus_decode(d: &mut D) -> Result<Transaction, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Transaction, serialize::Error> {
         let version: u32 = ConsensusDecodable::consensus_decode(d)?;
         let input: Vec<TxIn> = ConsensusDecodable::consensus_decode(d)?;
         // segwit

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -417,7 +417,7 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for Transaction {
                 }
                 // We don't support anything else
                 x => {
-                    Err(d.error(format!("segwit flag {:02x} not understood", x)))
+                    Err(serialize::Error::UnsupportedSegwitFlag(x))
                 }
             }
         // non-segwit

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -16,7 +16,7 @@ macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl<S: ::network::serialize::SimpleEncoder> ::network::encodable::ConsensusEncodable<S> for $thing {
             #[inline]
-            fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+            fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
                 $( self.$field.consensus_encode(s)?; )+
                 Ok(())
             }
@@ -24,7 +24,7 @@ macro_rules! impl_consensus_encoding {
 
         impl<D: ::network::serialize::SimpleDecoder> ::network::encodable::ConsensusDecodable<D> for $thing {
             #[inline]
-            fn consensus_decode(d: &mut D) -> Result<$thing, D::Error> {
+            fn consensus_decode(d: &mut D) -> Result<$thing, serialize::Error> {
                 use network::encodable::ConsensusDecodable;
                 Ok($thing {
                     $( $field: ConsensusDecodable::consensus_decode(d)?, )+
@@ -38,7 +38,7 @@ macro_rules! impl_newtype_consensus_encoding {
     ($thing:ident) => (
         impl<S: ::network::serialize::SimpleEncoder> ::network::encodable::ConsensusEncodable<S> for $thing {
             #[inline]
-            fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+            fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
                 let &$thing(ref data) = self;
                 data.consensus_encode(s)
             }
@@ -46,7 +46,7 @@ macro_rules! impl_newtype_consensus_encoding {
 
         impl<D: ::network::serialize::SimpleDecoder> ::network::encodable::ConsensusDecodable<D> for $thing {
             #[inline]
-            fn consensus_decode(d: &mut D) -> Result<$thing, D::Error> {
+            fn consensus_decode(d: &mut D) -> Result<$thing, serialize::Error> {
                 Ok($thing(ConsensusDecodable::consensus_decode(d)?))
             }
         }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -16,7 +16,7 @@ macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl<S: ::network::serialize::SimpleEncoder> ::network::encodable::ConsensusEncodable<S> for $thing {
             #[inline]
-            fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
+            fn consensus_encode(&self, s: &mut S) -> Result<(), ::network::serialize::Error> {
                 $( self.$field.consensus_encode(s)?; )+
                 Ok(())
             }
@@ -24,7 +24,7 @@ macro_rules! impl_consensus_encoding {
 
         impl<D: ::network::serialize::SimpleDecoder> ::network::encodable::ConsensusDecodable<D> for $thing {
             #[inline]
-            fn consensus_decode(d: &mut D) -> Result<$thing, serialize::Error> {
+            fn consensus_decode(d: &mut D) -> Result<$thing, ::network::serialize::Error> {
                 use network::encodable::ConsensusDecodable;
                 Ok($thing {
                     $( $field: ConsensusDecodable::consensus_decode(d)?, )+
@@ -38,7 +38,7 @@ macro_rules! impl_newtype_consensus_encoding {
     ($thing:ident) => (
         impl<S: ::network::serialize::SimpleEncoder> ::network::encodable::ConsensusEncodable<S> for $thing {
             #[inline]
-            fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
+            fn consensus_encode(&self, s: &mut S) -> Result<(), ::network::serialize::Error> {
                 let &$thing(ref data) = self;
                 data.consensus_encode(s)
             }
@@ -46,7 +46,7 @@ macro_rules! impl_newtype_consensus_encoding {
 
         impl<D: ::network::serialize::SimpleDecoder> ::network::encodable::ConsensusDecodable<D> for $thing {
             #[inline]
-            fn consensus_decode(d: &mut D) -> Result<$thing, serialize::Error> {
+            fn consensus_decode(d: &mut D) -> Result<$thing, ::network::serialize::Error> {
                 Ok($thing(ConsensusDecodable::consensus_decode(d)?))
             }
         }

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -22,7 +22,7 @@ use std::io;
 use std::fmt;
 use std::net::{SocketAddr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
-use network::serialize::{SimpleEncoder, SimpleDecoder};
+use network::serialize::{self, SimpleEncoder, SimpleDecoder};
 use network::encodable::{ConsensusDecodable, ConsensusEncodable};
 
 /// A message which can be sent on the Bitcoin network
@@ -74,7 +74,7 @@ fn addr_to_be(addr: [u16; 8]) -> [u16; 8] {
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for Address {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         self.services.consensus_encode(s)?;
         addr_to_be(self.address).consensus_encode(s)?;
         self.port.to_be().consensus_encode(s)
@@ -83,7 +83,7 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for Address {
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for Address {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<Address, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Address, serialize::Error> {
         Ok(Address {
             services: ConsensusDecodable::consensus_decode(d)?,
             address: addr_to_be(ConsensusDecodable::consensus_decode(d)?),

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -117,7 +117,7 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for Network {
         u32::consensus_decode(d)
             .and_then(|m| {
                 Network::from_magic(m)
-                    .ok_or(d.error(format!("Unknown network (magic {:x})", m)))
+                    .ok_or(serialize::Error::UnknownNetworkMagic(m))
             })
     }
 }

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -38,7 +38,7 @@
 //! ```
 
 use network::encodable::{ConsensusDecodable, ConsensusEncodable};
-use network::serialize::{SimpleEncoder, SimpleDecoder};
+use network::serialize::{self, SimpleEncoder, SimpleDecoder};
 
 /// Version of the protocol as appearing in network message headers
 pub const PROTOCOL_VERSION: u32 = 70001;
@@ -105,7 +105,7 @@ impl Network {
 impl<S: SimpleEncoder> ConsensusEncodable<S> for Network {
     /// Encodes the magic bytes of `Network`.
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         self.magic().consensus_encode(s)
     }
 }
@@ -113,7 +113,7 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for Network {
 impl<D: SimpleDecoder> ConsensusDecodable<D> for Network {
     /// Decodes the magic bytes of `Network`.
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<Network, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Network, serialize::Error> {
         u32::consensus_decode(d)
             .and_then(|m| {
                 Network::from_magic(m)

--- a/src/network/encodable.rs
+++ b/src/network/encodable.rs
@@ -34,7 +34,7 @@ use std::hash::Hash;
 use std::{mem, u32};
 
 use util::hash::Sha256dHash;
-use network::serialize::{SimpleDecoder, SimpleEncoder};
+use network::serialize::{self, SimpleDecoder, SimpleEncoder};
 
 /// Maximum size, in bytes, of a vector we are allowed to decode
 pub const MAX_VEC_SIZE: usize = 32 * 1024 * 1024;
@@ -42,13 +42,13 @@ pub const MAX_VEC_SIZE: usize = 32 * 1024 * 1024;
 /// Data which can be encoded in a consensus-consistent way
 pub trait ConsensusEncodable<S: SimpleEncoder> {
     /// Encode an object with a well-defined format
-    fn consensus_encode(&self, e: &mut S) -> Result<(), S::Error>;
+    fn consensus_encode(&self, e: &mut S) -> Result<(), serialize::Error>;
 }
 
 /// Data which can be encoded in a consensus-consistent way
 pub trait ConsensusDecodable<D: SimpleDecoder>: Sized {
     /// Decode an object with a well-defined format
-    fn consensus_decode(d: &mut D) -> Result<Self, D::Error>;
+    fn consensus_decode(d: &mut D) -> Result<Self, serialize::Error>;
 }
 
 /// A variable-length unsigned integer
@@ -64,12 +64,12 @@ macro_rules! impl_int_encodable{
     ($ty:ident, $meth_dec:ident, $meth_enc:ident) => (
         impl<D: SimpleDecoder> ConsensusDecodable<D> for $ty {
             #[inline]
-            fn consensus_decode(d: &mut D) -> Result<$ty, D::Error> { d.$meth_dec().map($ty::from_le) }
+            fn consensus_decode(d: &mut D) -> Result<$ty, serialize::Error> { d.$meth_dec().map($ty::from_le) }
         }
 
         impl<S: SimpleEncoder> ConsensusEncodable<S> for $ty {
             #[inline]
-            fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> { s.$meth_enc(self.to_le()) }
+            fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> { s.$meth_enc(self.to_le()) }
         }
     )
 }
@@ -100,7 +100,7 @@ impl VarInt {
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for VarInt {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         match self.0 {
             0...0xFC             => { (self.0 as u8).consensus_encode(s) }
             0xFD...0xFFFF        => { s.emit_u8(0xFD)?; (self.0 as u16).consensus_encode(s) }
@@ -112,7 +112,7 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for VarInt {
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for VarInt {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<VarInt, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<VarInt, serialize::Error> {
         let n = d.read_u8()?;
         match n {
             0xFF => d.read_u64().map(|n| VarInt(u64::from_le(n))),
@@ -126,25 +126,25 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for VarInt {
 // Booleans
 impl<S: SimpleEncoder> ConsensusEncodable<S> for bool {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> { s.emit_u8(if *self {1} else {0}) }
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> { s.emit_u8(if *self {1} else {0}) }
 }
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for bool {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<bool, D::Error> { d.read_u8().map(|n| n != 0) }
+    fn consensus_decode(d: &mut D) -> Result<bool, serialize::Error> { d.read_u8().map(|n| n != 0) }
 }
 
 // Strings
 impl<S: SimpleEncoder> ConsensusEncodable<S> for String {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         self.as_bytes().consensus_encode(s)
     }
 }
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for String {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<String, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<String, serialize::Error> {
         String::from_utf8(ConsensusDecodable::consensus_decode(d)?)
             .map_err(|_| d.error("String was not valid UTF8".to_owned()))
     }
@@ -156,7 +156,7 @@ macro_rules! impl_array {
     ( $size:expr ) => (
         impl<S: SimpleEncoder, T: ConsensusEncodable<S>> ConsensusEncodable<S> for [T; $size] {
             #[inline]
-            fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+            fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
                 for i in self.iter() { i.consensus_encode(s)?; }
                 Ok(())
             }
@@ -164,7 +164,7 @@ macro_rules! impl_array {
 
         impl<D: SimpleDecoder, T:ConsensusDecodable<D> + Copy> ConsensusDecodable<D> for [T; $size] {
             #[inline]
-            fn consensus_decode(d: &mut D) -> Result<[T; $size], D::Error> {
+            fn consensus_decode(d: &mut D) -> Result<[T; $size], serialize::Error> {
                 // Set everything to the first decode
                 let mut ret = [ConsensusDecodable::consensus_decode(d)?; $size];
                 // Set the rest
@@ -184,7 +184,7 @@ impl_array!(32);
 
 impl<S: SimpleEncoder, T: ConsensusEncodable<S>> ConsensusEncodable<S> for [T] {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         VarInt(self.len() as u64).consensus_encode(s)?;
         for c in self.iter() { c.consensus_encode(s)?; }
         Ok(())
@@ -196,12 +196,12 @@ impl<S: SimpleEncoder, T: ConsensusEncodable<S>> ConsensusEncodable<S> for [T] {
 // Vectors
 impl<S: SimpleEncoder, T: ConsensusEncodable<S>> ConsensusEncodable<S> for Vec<T> {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> { (&self[..]).consensus_encode(s) }
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> { (&self[..]).consensus_encode(s) }
 }
 
 impl<D: SimpleDecoder, T: ConsensusDecodable<D>> ConsensusDecodable<D> for Vec<T> {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<Vec<T>, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Vec<T>, serialize::Error> {
         let VarInt(len): VarInt = ConsensusDecodable::consensus_decode(d)?;
         let byte_size = (len as usize)
                             .checked_mul(mem::size_of::<T>())
@@ -217,12 +217,12 @@ impl<D: SimpleDecoder, T: ConsensusDecodable<D>> ConsensusDecodable<D> for Vec<T
 
 impl<S: SimpleEncoder, T: ConsensusEncodable<S>> ConsensusEncodable<S> for Box<[T]> {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> { (&self[..]).consensus_encode(s) }
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> { (&self[..]).consensus_encode(s) }
 }
 
 impl<D: SimpleDecoder, T: ConsensusDecodable<D>> ConsensusDecodable<D> for Box<[T]> {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<Box<[T]>, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Box<[T]>, serialize::Error> {
         let VarInt(len): VarInt = ConsensusDecodable::consensus_decode(d)?;
         let len = len as usize;
         if len > MAX_VEC_SIZE {
@@ -237,7 +237,7 @@ impl<D: SimpleDecoder, T: ConsensusDecodable<D>> ConsensusDecodable<D> for Box<[
 // Options (encoded as vectors of length 0 or 1)
 impl<S: SimpleEncoder, T: ConsensusEncodable<S>> ConsensusEncodable<S> for Option<T> {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         match *self {
             Some(ref data) => {
                 1u8.consensus_encode(s)?;
@@ -251,7 +251,7 @@ impl<S: SimpleEncoder, T: ConsensusEncodable<S>> ConsensusEncodable<S> for Optio
 
 impl<D: SimpleDecoder, T:ConsensusDecodable<D>> ConsensusDecodable<D> for Option<T> {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<Option<T>, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Option<T>, serialize::Error> {
         let bit: u8 = ConsensusDecodable::consensus_decode(d)?;
         Ok(if bit != 0 {
             Some(ConsensusDecodable::consensus_decode(d)?)
@@ -271,7 +271,7 @@ fn sha2_checksum(data: &[u8]) -> [u8; 4] {
 // Checked data
 impl<S: SimpleEncoder> ConsensusEncodable<S> for CheckedData {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         (self.0.len() as u32).consensus_encode(s)?;
         sha2_checksum(&self.0).consensus_encode(s)?;
         // We can't just pass to the slice encoder since it'll insert a length
@@ -284,7 +284,7 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for CheckedData {
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for CheckedData {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<CheckedData, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<CheckedData, serialize::Error> {
         let len: u32 = ConsensusDecodable::consensus_decode(d)?;
         let checksum: [u8; 4] = ConsensusDecodable::consensus_decode(d)?;
         let mut ret = Vec::with_capacity(len as usize);
@@ -304,7 +304,7 @@ macro_rules! tuple_encode {
         impl <S: SimpleEncoder, $($x: ConsensusEncodable<S>),*> ConsensusEncodable<S> for ($($x),*) {
             #[inline]
             #[allow(non_snake_case)]
-            fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+            fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
                 let &($(ref $x),*) = self;
                 $( $x.consensus_encode(s)?; )*
                 Ok(())
@@ -314,7 +314,7 @@ macro_rules! tuple_encode {
         impl<D: SimpleDecoder, $($x: ConsensusDecodable<D>),*> ConsensusDecodable<D> for ($($x),*) {
             #[inline]
             #[allow(non_snake_case)]
-            fn consensus_decode(d: &mut D) -> Result<($($x),*), D::Error> {
+            fn consensus_decode(d: &mut D) -> Result<($($x),*), serialize::Error> {
                 Ok(($({let $x = ConsensusDecodable::consensus_decode(d)?; $x }),*))
             }
         }
@@ -329,12 +329,12 @@ tuple_encode!(T0, T1, T2, T3, T4, T5, T6, T7);
 // References
 impl<S: SimpleEncoder, T: ConsensusEncodable<S>> ConsensusEncodable<S> for Box<T> {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> { (**self).consensus_encode(s) }
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> { (**self).consensus_encode(s) }
 }
 
 impl<D: SimpleDecoder, T: ConsensusDecodable<D>> ConsensusDecodable<D> for Box<T> {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<Box<T>, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Box<T>, serialize::Error> {
         ConsensusDecodable::consensus_decode(d).map(Box::new)
     }
 }
@@ -346,7 +346,7 @@ impl<S, K, V> ConsensusEncodable<S> for HashMap<K, V>
           V: ConsensusEncodable<S>
 {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         VarInt(self.len() as u64).consensus_encode(s)?;
         for (key, value) in self.iter() {
             key.consensus_encode(s)?;
@@ -362,7 +362,7 @@ impl<D, K, V> ConsensusDecodable<D> for HashMap<K, V>
           V: ConsensusDecodable<D>
 {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<HashMap<K, V>, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<HashMap<K, V>, serialize::Error> {
         let VarInt(len): VarInt = ConsensusDecodable::consensus_decode(d)?;
 
         let mut ret = HashMap::with_capacity(len as usize);

--- a/src/network/listener.rs
+++ b/src/network/listener.rs
@@ -22,7 +22,7 @@ use std::thread;
 use std::sync::mpsc::{channel, Receiver};
 
 use network::constants::Network;
-use network::{self, message};
+use network::message;
 use network::message::NetworkMessage::Verack;
 use network::socket::Socket;
 use util;
@@ -39,9 +39,7 @@ pub trait Listener {
     fn start(&self) -> Result<(Receiver<message::SocketResponse>, Socket), util::Error> {
         // Open socket
         let mut ret_sock = Socket::new(self.network());
-        if let Err(e) = ret_sock.connect(self.peer(), self.port()) {
-            return Err(util::Error::Network(network::Error::Detail("listener".to_owned(), Box::new(e))));
-        }
+        ret_sock.connect(self.peer(), self.port())?;
         let mut sock = ret_sock.clone();
 
         let (recv_tx, recv_rx) = channel();

--- a/src/network/listener.rs
+++ b/src/network/listener.rs
@@ -22,7 +22,7 @@ use std::thread;
 use std::sync::mpsc::{channel, Receiver};
 
 use network::constants::Network;
-use network::message;
+use network::{self, message};
 use network::message::NetworkMessage::Verack;
 use network::socket::Socket;
 use util;
@@ -40,7 +40,7 @@ pub trait Listener {
         // Open socket
         let mut ret_sock = Socket::new(self.network());
         if let Err(e) = ret_sock.connect(self.peer(), self.port()) {
-            return Err(util::Error::Detail("listener".to_owned(), Box::new(e)));
+            return Err(util::Error::Network(network::Error::Detail("listener".to_owned(), Box::new(e))));
         }
         let mut sock = ret_sock.clone();
 

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -196,7 +196,7 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for RawNetworkMessage {
             "pong"    => NetworkMessage::Pong(ConsensusDecodable::consensus_decode(&mut mem_d)?),
             "tx"      => NetworkMessage::Tx(ConsensusDecodable::consensus_decode(&mut mem_d)?),
             "alert"   => NetworkMessage::Alert(ConsensusDecodable::consensus_decode(&mut mem_d)?),
-            cmd => return Err(d.error(format!("unrecognized network command `{}`", cmd)))
+            _ => return Err(serialize::Error::UnrecognizedNetworkCommand(cmd)),
         };
         Ok(RawNetworkMessage {
             magic: magic,

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -30,8 +30,8 @@ use network::message_network;
 use network::message_blockdata;
 use network::encodable::{ConsensusDecodable, ConsensusEncodable};
 use network::encodable::CheckedData;
-use network::serialize::{serialize, RawDecoder, SimpleEncoder, SimpleDecoder};
-use util::{self, propagate_err};
+use network::serialize::{self, serialize, RawDecoder, SimpleEncoder, SimpleDecoder};
+use util;
 
 /// Serializer for command string
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -39,7 +39,7 @@ pub struct CommandString(pub String);
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for CommandString {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         let &CommandString(ref inner_str) = self;
         let mut rawbytes = [0u8; 12];
         let strbytes = inner_str.as_bytes();
@@ -55,7 +55,7 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for CommandString {
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for CommandString {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<CommandString, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<CommandString, serialize::Error> {
         let rawbytes: [u8; 12] = ConsensusDecodable::consensus_decode(d)?;
         let rv = iter::FromIterator::from_iter(rawbytes.iter().filter_map(|&u| if u > 0 { Some(u as char) } else { None }));
         Ok(CommandString(rv))
@@ -147,7 +147,7 @@ impl RawNetworkMessage {
 }
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for RawNetworkMessage {
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         self.magic.consensus_encode(s)?;
         CommandString(self.command()).consensus_encode(s)?;
         CheckedData(match self.payload {
@@ -172,32 +172,30 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for RawNetworkMessage {
     }
 }
 
-// TODO: restriction on D::Error is so that `propagate_err` will work;
-//       is there a more generic way to handle this?
-impl<D: SimpleDecoder<Error=util::Error>> ConsensusDecodable<D> for RawNetworkMessage {
-    fn consensus_decode(d: &mut D) -> Result<RawNetworkMessage, D::Error> {
+impl<D: SimpleDecoder> ConsensusDecodable<D> for RawNetworkMessage {
+    fn consensus_decode(d: &mut D) -> Result<RawNetworkMessage, serialize::Error> {
         let magic = ConsensusDecodable::consensus_decode(d)?;
         let CommandString(cmd): CommandString= ConsensusDecodable::consensus_decode(d)?;
         let CheckedData(raw_payload): CheckedData = ConsensusDecodable::consensus_decode(d)?;
 
         let mut mem_d = RawDecoder::new(Cursor::new(raw_payload));
         let payload = match &cmd[..] {
-            "version" => NetworkMessage::Version(propagate_err("version".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
+            "version" => NetworkMessage::Version(ConsensusDecodable::consensus_decode(&mut mem_d)?),
             "verack"  => NetworkMessage::Verack,
-            "addr"    => NetworkMessage::Addr(propagate_err("addr".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "inv"     => NetworkMessage::Inv(propagate_err("inv".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "getdata" => NetworkMessage::GetData(propagate_err("getdata".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "notfound" => NetworkMessage::NotFound(propagate_err("notfound".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "getblocks" => NetworkMessage::GetBlocks(propagate_err("getblocks".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "getheaders" => NetworkMessage::GetHeaders(propagate_err("getheaders".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
+            "addr"    => NetworkMessage::Addr(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "inv"     => NetworkMessage::Inv(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "getdata" => NetworkMessage::GetData(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "notfound" => NetworkMessage::NotFound(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "getblocks" => NetworkMessage::GetBlocks(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "getheaders" => NetworkMessage::GetHeaders(ConsensusDecodable::consensus_decode(&mut mem_d)?),
             "mempool" => NetworkMessage::MemPool,
-            "block"   => NetworkMessage::Block(propagate_err("block".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "headers" => NetworkMessage::Headers(propagate_err("headers".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
+            "block"   => NetworkMessage::Block(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "headers" => NetworkMessage::Headers(ConsensusDecodable::consensus_decode(&mut mem_d)?),
             "getaddr" => NetworkMessage::GetAddr,
-            "ping"    => NetworkMessage::Ping(propagate_err("ping".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "pong"    => NetworkMessage::Pong(propagate_err("pong".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "tx"      => NetworkMessage::Tx(propagate_err("tx".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
-            "alert"   => NetworkMessage::Alert(propagate_err("alert".to_owned(), ConsensusDecodable::consensus_decode(&mut mem_d))?),
+            "ping"    => NetworkMessage::Ping(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "pong"    => NetworkMessage::Pong(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "tx"      => NetworkMessage::Tx(ConsensusDecodable::consensus_decode(&mut mem_d)?),
+            "alert"   => NetworkMessage::Alert(ConsensusDecodable::consensus_decode(&mut mem_d)?),
             cmd => return Err(d.error(format!("unrecognized network command `{}`", cmd)))
         };
         Ok(RawNetworkMessage {

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -20,7 +20,7 @@
 
 use network::constants;
 use network::encodable::{ConsensusDecodable, ConsensusEncodable};
-use network::serialize::{SimpleDecoder, SimpleEncoder};
+use network::serialize::{self, SimpleDecoder, SimpleEncoder};
 use util::hash::Sha256dHash;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -103,7 +103,7 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 impl<S: SimpleEncoder> ConsensusEncodable<S> for Inventory {
     #[inline]
-    fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
         match self.inv_type {
             InvType::Error => 0u32, 
             InvType::Transaction => 1,
@@ -117,7 +117,7 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for Inventory {
 
 impl<D: SimpleDecoder> ConsensusDecodable<D> for Inventory {
     #[inline]
-    fn consensus_decode(d: &mut D) -> Result<Inventory, D::Error> {
+    fn consensus_decode(d: &mut D) -> Result<Inventory, serialize::Error> {
         let int_type: u32 = ConsensusDecodable::consensus_decode(d)?;
         Ok(Inventory {
             inv_type: match int_type {

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -20,7 +20,6 @@
 
 use network::constants;
 use network::address::Address;
-use network::serialize;
 use network::socket::Socket;
 use util;
 

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -20,6 +20,7 @@
 
 use network::constants;
 use network::address::Address;
+use network::serialize;
 use network::socket::Socket;
 use util;
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -49,7 +49,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
-            ref x => f.write_str(error::Error::description(x)),
+            Error::SocketMutexPoisoned | Error::SocketNotConnectedToPeer => f.write_str(error::Error::description(self)),
         }
     }
 }
@@ -58,7 +58,7 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
-            _ => None
+            Error::SocketMutexPoisoned | Error::SocketNotConnectedToPeer => None,
         }
     }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -43,15 +43,12 @@ pub enum Error {
     SocketMutexPoisoned,
     /// Not connected to peer
     SocketNotConnectedToPeer,
-    /// Error propagated from subsystem
-    Detail(String, Box<Error>),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
-            Error::Detail(ref s, ref e) => write!(f, "{}: {}", s, e),
             ref x => f.write_str(error::Error::description(x)),
         }
     }
@@ -61,7 +58,6 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
-            Error::Detail(_, ref e) => Some(e),
             _ => None
         }
     }
@@ -71,7 +67,6 @@ impl error::Error for Error {
             Error::Io(ref e) => e.description(),
             Error::SocketMutexPoisoned => "socket mutex was poisoned",
             Error::SocketNotConnectedToPeer => "not connected to peer",
-            Error::Detail(_, ref e) => e.description(),
         }
     }
 }

--- a/src/network/serialize.rs
+++ b/src/network/serialize.rs
@@ -105,7 +105,15 @@ impl error::Error for Error {
             Error::Base58(ref e) => Some(e),
             Error::Bech32(ref e) => Some(e),
             Error::ByteOrder(ref e) => Some(e),
-            _ => None
+            Error::UnexpectedNetworkMagic { .. }
+            | Error::OversizedVectorAllocation { .. }
+            | Error::InvalidChecksum { .. }
+            | Error::UnknownNetworkMagic(..)
+            | Error::ParseFailed(..)
+            | Error::UnsupportedWitnessVersion(..)
+            | Error::UnsupportedSegwitFlag(..)
+            | Error::UnrecognizedNetworkCommand(..)
+            | Error::UnexpectedHexDigit(..) => None,
         }
     }
 

--- a/src/network/serialize.rs
+++ b/src/network/serialize.rs
@@ -19,13 +19,100 @@
 //! It also defines (de)serialization routines for many primitives.
 //!
 
+use std::error;
+use std::fmt;
+use std::io;
 use std::io::{Cursor, Read, Write};
 use byteorder::{LittleEndian, WriteBytesExt, ReadBytesExt};
 use hex::encode as hex_encode;
 
+use bitcoin_bech32;
+
 use network::encodable::{ConsensusDecodable, ConsensusEncodable};
+use util::base58;
 use util::hash::Sha256dHash;
-use util;
+
+/// Serialization error
+#[derive(Debug)]
+pub enum Error {
+    /// And I/O error
+    Io(io::Error),
+    /// Base58 encoding error
+    Base58(base58::Error),
+    /// Bech32 encoding error
+    Bech32(bitcoin_bech32::Error),
+    /// Error from the `byteorder` crate
+    ByteOrder(io::Error),
+    /// Network magic was not what we expected
+    BadNetworkMagic(u32, u32),
+    /// Network message was unrecognized
+    BadNetworkMessage(String),
+    /// Parsing error
+    ParseFailed,
+    /// Error propagated from subsystem
+    Detail(String, Box<Error>),
+    /// Unsupported witness version
+    UnsupportedWitnessVersion(u8),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Io(ref e) => fmt::Display::fmt(e, f),
+            Error::Detail(ref s, ref e) => write!(f, "{}: {}", s, e),
+            ref x => f.write_str(error::Error::description(x)),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::Io(ref e) => Some(e),
+            Error::Base58(ref e) => Some(e),
+            Error::Bech32(ref e) => Some(e),
+            Error::ByteOrder(ref e) => Some(e),
+            Error::Detail(_, ref e) => Some(e),
+            _ => None
+        }
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            Error::Io(ref e) => e.description(),
+            Error::ParseFailed => "parsing error",
+            Error::Detail(_, ref e) => e.description(),
+            Error::Base58(ref e) => e.description(),
+            Error::Bech32(ref e) => e.description(),
+            Error::ByteOrder(ref e) => e.description(),
+            Error::BadNetworkMagic(_, _) => "incorrect network magic",
+            Error::BadNetworkMessage(_) => "incorrect/unexpected network message",
+            Error::UnsupportedWitnessVersion(_) => "unsupported witness version",
+        }
+    }
+}
+
+#[doc(hidden)]
+impl From<base58::Error> for Error {
+    fn from(e: base58::Error) -> Error {
+        Error::Base58(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<bitcoin_bech32::Error> for Error {
+    fn from(e: bitcoin_bech32::Error) -> Error {
+        Error::Bech32(e)
+    }
+}
+
+
+#[doc(hidden)]
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Error::Io(error)
+    }
+}
 
 /// Objects which are referred to by hash
 pub trait BitcoinHash {
@@ -41,7 +128,7 @@ impl BitcoinHash for Vec<u8> {
 }
 
 /// Encode an object into a vector
-pub fn serialize<T: ?Sized>(data: &T) -> Result<Vec<u8>, util::Error>
+pub fn serialize<T: ?Sized>(data: &T) -> Result<Vec<u8>, Error>
      where T: ConsensusEncodable<RawEncoder<Cursor<Vec<u8>>>>,
 {
     let mut encoder = RawEncoder::new(Cursor::new(vec![]));
@@ -50,7 +137,7 @@ pub fn serialize<T: ?Sized>(data: &T) -> Result<Vec<u8>, util::Error>
 }
 
 /// Encode an object into a hex-encoded string
-pub fn serialize_hex<T: ?Sized>(data: &T) -> Result<String, util::Error>
+pub fn serialize_hex<T: ?Sized>(data: &T) -> Result<String, Error>
      where T: ConsensusEncodable<RawEncoder<Cursor<Vec<u8>>>>
 {
     let serial = serialize(data)?;
@@ -59,7 +146,7 @@ pub fn serialize_hex<T: ?Sized>(data: &T) -> Result<String, util::Error>
 
 /// Deserialize an object from a vector, will error if said deserialization
 /// doesn't consume the entire vector.
-pub fn deserialize<'a, T>(data: &'a [u8]) -> Result<T, util::Error>
+pub fn deserialize<'a, T>(data: &'a [u8]) -> Result<T, Error>
      where T: ConsensusDecodable<RawDecoder<Cursor<&'a [u8]>>>
 {
     let mut decoder = RawDecoder::new(Cursor::new(data));
@@ -69,7 +156,7 @@ pub fn deserialize<'a, T>(data: &'a [u8]) -> Result<T, util::Error>
     if decoder.into_inner().position() == data.len() as u64 {
         Ok(rv)
     } else {
-        Err(util::Error::ParseFailed)
+        Err(Error::ParseFailed)
     }
 }
 
@@ -99,66 +186,60 @@ impl<R: Read> RawDecoder<R> {
 
 /// A simple Encoder trait
 pub trait SimpleEncoder {
-    /// An encoding error
-    type Error;
-
     /// Output a 64-bit uint
-    fn emit_u64(&mut self, v: u64) -> Result<(), Self::Error>;
+    fn emit_u64(&mut self, v: u64) -> Result<(), Error>;
     /// Output a 32-bit uint
-    fn emit_u32(&mut self, v: u32) -> Result<(), Self::Error>;
+    fn emit_u32(&mut self, v: u32) -> Result<(), Error>;
     /// Output a 16-bit uint
-    fn emit_u16(&mut self, v: u16) -> Result<(), Self::Error>;
+    fn emit_u16(&mut self, v: u16) -> Result<(), Error>;
     /// Output a 8-bit uint
-    fn emit_u8(&mut self, v: u8) -> Result<(), Self::Error>;
+    fn emit_u8(&mut self, v: u8) -> Result<(), Error>;
 
     /// Output a 64-bit int
-    fn emit_i64(&mut self, v: i64) -> Result<(), Self::Error>;
+    fn emit_i64(&mut self, v: i64) -> Result<(), Error>;
     /// Output a 32-bit int
-    fn emit_i32(&mut self, v: i32) -> Result<(), Self::Error>;
+    fn emit_i32(&mut self, v: i32) -> Result<(), Error>;
     /// Output a 16-bit int
-    fn emit_i16(&mut self, v: i16) -> Result<(), Self::Error>;
+    fn emit_i16(&mut self, v: i16) -> Result<(), Error>;
     /// Output a 8-bit int
-    fn emit_i8(&mut self, v: i8) -> Result<(), Self::Error>;
+    fn emit_i8(&mut self, v: i8) -> Result<(), Error>;
 
     /// Output a boolean
-    fn emit_bool(&mut self, v: bool) -> Result<(), Self::Error>;
+    fn emit_bool(&mut self, v: bool) -> Result<(), Error>;
 }
 
 /// A simple Decoder trait
 pub trait SimpleDecoder {
-    /// A decoding error
-    type Error;
-
     /// Read a 64-bit uint
-    fn read_u64(&mut self) -> Result<u64, Self::Error>;
+    fn read_u64(&mut self) -> Result<u64, Error>;
     /// Read a 32-bit uint
-    fn read_u32(&mut self) -> Result<u32, Self::Error>;
+    fn read_u32(&mut self) -> Result<u32, Error>;
     /// Read a 16-bit uint
-    fn read_u16(&mut self) -> Result<u16, Self::Error>;
+    fn read_u16(&mut self) -> Result<u16, Error>;
     /// Read a 8-bit uint
-    fn read_u8(&mut self) -> Result<u8, Self::Error>;
+    fn read_u8(&mut self) -> Result<u8, Error>;
 
     /// Read a 64-bit int
-    fn read_i64(&mut self) -> Result<i64, Self::Error>;
+    fn read_i64(&mut self) -> Result<i64, Error>;
     /// Read a 32-bit int
-    fn read_i32(&mut self) -> Result<i32, Self::Error>;
+    fn read_i32(&mut self) -> Result<i32, Error>;
     /// Read a 16-bit int
-    fn read_i16(&mut self) -> Result<i16, Self::Error>;
+    fn read_i16(&mut self) -> Result<i16, Error>;
     /// Read a 8-bit int
-    fn read_i8(&mut self) -> Result<i8, Self::Error>;
+    fn read_i8(&mut self) -> Result<i8, Error>;
 
     /// Read a boolean
-    fn read_bool(&mut self) -> Result<bool, Self::Error>;
+    fn read_bool(&mut self) -> Result<bool, Error>;
 
     /// Signal a decoding error
-    fn error(&mut self, err: String) -> Self::Error;
+    fn error(&mut self, err: String) -> Error;
 }
 
 macro_rules! encoder_fn {
     ($name:ident, $val_type:ty, $writefn:ident) => {
         #[inline]
-        fn $name(&mut self, v: $val_type) -> Result<(), util::Error> {
-            self.writer.$writefn::<LittleEndian>(v).map_err(util::Error::ByteOrder)
+        fn $name(&mut self, v: $val_type) -> Result<(), Error> {
+            self.writer.$writefn::<LittleEndian>(v).map_err(Error::Io)
         }
     }
 }
@@ -166,15 +247,13 @@ macro_rules! encoder_fn {
 macro_rules! decoder_fn {
     ($name:ident, $val_type:ty, $readfn:ident) => {
         #[inline]
-        fn $name(&mut self) -> Result<$val_type, util::Error> {
-            self.reader.$readfn::<LittleEndian>().map_err(util::Error::ByteOrder)
+        fn $name(&mut self) -> Result<$val_type, Error> {
+            self.reader.$readfn::<LittleEndian>().map_err(Error::Io)
         }
     }
 }
 
 impl<W: Write> SimpleEncoder for RawEncoder<W> {
-    type Error = util::Error;
-
     encoder_fn!(emit_u64, u64, write_u64);
     encoder_fn!(emit_u32, u32, write_u32);
     encoder_fn!(emit_u16, u16, write_u16);
@@ -183,22 +262,20 @@ impl<W: Write> SimpleEncoder for RawEncoder<W> {
     encoder_fn!(emit_i16, i16, write_i16);
 
     #[inline]
-    fn emit_i8(&mut self, v: i8) -> Result<(), util::Error> {
-        self.writer.write_i8(v).map_err(util::Error::ByteOrder)
+    fn emit_i8(&mut self, v: i8) -> Result<(), Error> {
+        self.writer.write_i8(v).map_err(Error::Io)
     }
     #[inline]
-    fn emit_u8(&mut self, v: u8) -> Result<(), util::Error> {
-        self.writer.write_u8(v).map_err(util::Error::ByteOrder)
+    fn emit_u8(&mut self, v: u8) -> Result<(), Error> {
+        self.writer.write_u8(v).map_err(Error::Io)
     }
     #[inline]
-    fn emit_bool(&mut self, v: bool) -> Result<(), util::Error> {
-        self.writer.write_i8(if v {1} else {0}).map_err(util::Error::ByteOrder)
+    fn emit_bool(&mut self, v: bool) -> Result<(), Error> {
+        self.writer.write_i8(if v {1} else {0}).map_err(Error::Io)
     }
 }
 
 impl<R: Read> SimpleDecoder for RawDecoder<R> {
-    type Error = util::Error;
-
     decoder_fn!(read_u64, u64, read_u64);
     decoder_fn!(read_u32, u32, read_u32);
     decoder_fn!(read_u16, u16, read_u16);
@@ -207,24 +284,24 @@ impl<R: Read> SimpleDecoder for RawDecoder<R> {
     decoder_fn!(read_i16, i16, read_i16);
 
     #[inline]
-    fn read_u8(&mut self) -> Result<u8, util::Error> {
-        self.reader.read_u8().map_err(util::Error::ByteOrder)
+    fn read_u8(&mut self) -> Result<u8, Error> {
+        self.reader.read_u8().map_err(Error::Io)
     }
     #[inline]
-    fn read_i8(&mut self) -> Result<i8, util::Error> {
-        self.reader.read_i8().map_err(util::Error::ByteOrder)
+    fn read_i8(&mut self) -> Result<i8, Error> {
+        self.reader.read_i8().map_err(Error::Io)
     }
     #[inline]
-    fn read_bool(&mut self) -> Result<bool, util::Error> {
+    fn read_bool(&mut self) -> Result<bool, Error> {
         match self.reader.read_i8() {
             Ok(bit) => Ok(bit != 0),
-            Err(e) => Err(util::Error::ByteOrder(e))
+            Err(e) => Err(Error::Io(e))
         }
     }
 
     #[inline]
-    fn error(&mut self, err: String) -> util::Error {
-        util::Error::Detail(err, Box::new(util::Error::ParseFailed))
+    fn error(&mut self, err: String) -> Error {
+        Error::Detail(err, Box::new(Error::ParseFailed))
     }
 }
 

--- a/src/network/socket.rs
+++ b/src/network/socket.rs
@@ -182,7 +182,10 @@ impl Socket {
             // Then for magic (this should come before parse error, but we can't
             // get to it if the deserialization failed). TODO restructure this
             if decoded.magic != self.magic {
-                Err(util::Error::Serialize(serialize::Error::BadNetworkMagic(self.magic, decoded.magic)))
+                Err(serialize::Error::UnexpectedNetworkMagic {
+                    expected: self.magic,
+                    actual: decoded.magic,
+                }.into())
             } else {
                 Ok(decoded.payload)
             }

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -29,7 +29,7 @@ use crypto::digest::Digest;
 use crypto::ripemd160::Ripemd160;
 
 use network::encodable::{ConsensusDecodable, ConsensusEncodable};
-use network::serialize::{SimpleEncoder, RawEncoder, BitcoinHash};
+use network::serialize::{self, SimpleEncoder, RawEncoder, BitcoinHash};
 use util::uint::Uint256;
 
 #[cfg(feature="fuzztarget")]      use util::sha2::Sha256;
@@ -108,61 +108,59 @@ impl Sha256dEncoder {
 }
 
 impl SimpleEncoder for Sha256dEncoder {
-    type Error = ();
-
-    fn emit_u64(&mut self, v: u64) -> Result<(), ()> {
+    fn emit_u64(&mut self, v: u64) -> Result<(), serialize::Error> {
         let mut data = [0; 8];
         (&mut data[..]).write_u64::<LittleEndian>(v).unwrap();
         self.0.input(&data);
         Ok(())
     }
 
-    fn emit_u32(&mut self, v: u32) -> Result<(), ()> {
+    fn emit_u32(&mut self, v: u32) -> Result<(), serialize::Error> {
         let mut data = [0; 4];
         (&mut data[..]).write_u32::<LittleEndian>(v).unwrap();
         self.0.input(&data);
         Ok(())
     }
 
-    fn emit_u16(&mut self, v: u16) -> Result<(), ()> {
+    fn emit_u16(&mut self, v: u16) -> Result<(), serialize::Error> {
         let mut data = [0; 2];
         (&mut data[..]).write_u16::<LittleEndian>(v).unwrap();
         self.0.input(&data);
         Ok(())
     }
 
-    fn emit_i64(&mut self, v: i64) -> Result<(), ()> {
+    fn emit_i64(&mut self, v: i64) -> Result<(), serialize::Error> {
         let mut data = [0; 8];
         (&mut data[..]).write_i64::<LittleEndian>(v).unwrap();
         self.0.input(&data);
         Ok(())
     }
 
-    fn emit_i32(&mut self, v: i32) -> Result<(), ()> {
+    fn emit_i32(&mut self, v: i32) -> Result<(), serialize::Error> {
         let mut data = [0; 4];
         (&mut data[..]).write_i32::<LittleEndian>(v).unwrap();
         self.0.input(&data);
         Ok(())
     }
 
-    fn emit_i16(&mut self, v: i16) -> Result<(), ()> {
+    fn emit_i16(&mut self, v: i16) -> Result<(), serialize::Error> {
         let mut data = [0; 2];
         (&mut data[..]).write_i16::<LittleEndian>(v).unwrap();
         self.0.input(&data);
         Ok(())
     }
 
-    fn emit_i8(&mut self, v: i8) -> Result<(), ()> {
+    fn emit_i8(&mut self, v: i8) -> Result<(), serialize::Error> {
         self.0.input(&[v as u8]);
         Ok(())
     }
 
-    fn emit_u8(&mut self, v: u8) -> Result<(), ()> {
+    fn emit_u8(&mut self, v: u8) -> Result<(), serialize::Error> {
         self.0.input(&[v]);
         Ok(())
     }
 
-    fn emit_bool(&mut self, v: bool) -> Result<(), ()> {
+    fn emit_bool(&mut self, v: bool) -> Result<(), serialize::Error> {
         self.0.input(&[if v {1} else {0}]);
         Ok(())
     }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -29,24 +29,15 @@ pub fn hex_bytes(s: &str) -> Result<Vec<u8>, serialize::Error> {
         if e.is_err() { e }
         else {
             match (f.to_digit(16), s.to_digit(16)) {
-                (None, _) => Err(serialize::Error::Detail(
-                    format!("expected hex, got {:}", f),
-                    Box::new(serialize::Error::ParseFailed)
-                )),
-                (_, None) => Err(serialize::Error::Detail(
-                    format!("expected hex, got {:}", s),
-                    Box::new(serialize::Error::ParseFailed)
-                )),
+                (None, _) => Err(serialize::Error::UnexpectedHexDigit(f)),
+                (_, None) => Err(serialize::Error::UnexpectedHexDigit(s)),
                 (Some(f), Some(s)) => { v.push((f * 0x10 + s) as u8); Ok(()) }
             }
         }
     )?;
     // Check that there was no remainder
     match iter.remainder() {
-        Some(_) => Err(serialize::Error::Detail(
-            "hexstring of odd length".to_owned(),
-            Box::new(serialize::Error::ParseFailed)
-        )),
+        Some(_) => Err(serialize::Error::ParseFailed("hexstring of odd length")),
         None => Ok(v)
     }
 }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -17,11 +17,11 @@
 //! Various utility functions
 
 use blockdata::opcodes;
-use util::Error;
 use util::iter::Pairable;
+use network::serialize;
 
 /// Convert a hexadecimal-encoded string to its corresponding bytes
-pub fn hex_bytes(s: &str) -> Result<Vec<u8>, Error> {
+pub fn hex_bytes(s: &str) -> Result<Vec<u8>, serialize::Error> {
     let mut v = vec![];
     let mut iter = s.chars().pair();
     // Do the parsing
@@ -29,13 +29,13 @@ pub fn hex_bytes(s: &str) -> Result<Vec<u8>, Error> {
         if e.is_err() { e }
         else {
             match (f.to_digit(16), s.to_digit(16)) {
-                (None, _) => Err(Error::Detail(
+                (None, _) => Err(serialize::Error::Detail(
                     format!("expected hex, got {:}", f),
-                    Box::new(Error::ParseFailed)
+                    Box::new(serialize::Error::ParseFailed)
                 )),
-                (_, None) => Err(Error::Detail(
+                (_, None) => Err(serialize::Error::Detail(
                     format!("expected hex, got {:}", s),
-                    Box::new(Error::ParseFailed)
+                    Box::new(serialize::Error::ParseFailed)
                 )),
                 (Some(f), Some(s)) => { v.push((f * 0x10 + s) as u8); Ok(()) }
             }
@@ -43,21 +43,12 @@ pub fn hex_bytes(s: &str) -> Result<Vec<u8>, Error> {
     )?;
     // Check that there was no remainder
     match iter.remainder() {
-        Some(_) => Err(Error::Detail(
+        Some(_) => Err(serialize::Error::Detail(
             "hexstring of odd length".to_owned(),
-            Box::new(Error::ParseFailed)
+            Box::new(serialize::Error::ParseFailed)
         )),
         None => Ok(v)
     }
-}
-
-/// Dump an error message to the screen
-/// TODO all uses of this should be replaced with some sort of logging infrastructure
-pub fn consume_err<T>(s: &str, res: Result<T, Error>) {
-    match res {
-        Ok(_) => {},
-        Err(e) => { println!("{}: {:?}", s, e); }
-    };
 }
 
 /// Search for `needle` in the vector `haystack` and remove every

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -59,19 +59,20 @@ pub trait BitArray {
     fn one() -> Self;
 }
 
-/// A general error code
+/// A general error code, other errors should implement conversions to/from this
+/// if appropriate.
 #[derive(Debug)]
 pub enum Error {
-    /// The `target` field of a block header did not match the expected difficulty
-    SpvBadTarget,
-    /// The header hash is not below the target
-    SpvBadProofOfWork,
     /// secp-related error
     Secp256k1(secp256k1::Error),
     /// Serialization error
     Serialize(serialize::Error),
     /// Network error
     Network(network::Error),
+    /// The header hash is not below the target
+    SpvBadProofOfWork,
+    /// The `target` field of a block header did not match the expected difficulty
+    SpvBadTarget,
 }
 
 impl fmt::Display for Error {
@@ -96,10 +97,10 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Secp256k1(ref e) => e.description(),
-            Error::SpvBadTarget => "target incorrect",
-            Error::SpvBadProofOfWork => "target correct but not attained",
             Error::Serialize(ref e) => e.description(),
             Error::Network(ref e) => e.description(),
+            Error::SpvBadProofOfWork => "target correct but not attained",
+            Error::SpvBadTarget => "target incorrect",
         }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -80,7 +80,8 @@ impl fmt::Display for Error {
         match *self {
             Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
             Error::Serialize(ref e) => fmt::Display::fmt(e, f),
-            ref x => f.write_str(error::Error::description(x))
+            Error::Network(ref e) => fmt::Display::fmt(e, f),
+            Error::SpvBadProofOfWork | Error::SpvBadTarget => f.write_str(error::Error::description(self)),
         }
     }
 }
@@ -90,7 +91,8 @@ impl error::Error for Error {
         match *self {
             Error::Secp256k1(ref e) => Some(e),
             Error::Serialize(ref e) => Some(e),
-            _ => None
+            Error::Network(ref e) => Some(e),
+            Error::SpvBadProofOfWork | Error::SpvBadTarget => None
         }
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -31,10 +31,12 @@ pub mod uint;
 #[cfg(feature = "fuzztarget")]
 pub mod sha2;
 
-use std::{error, fmt, io};
+use std::{error, fmt};
 
-use bitcoin_bech32;
 use secp256k1;
+
+use network;
+use network::serialize;
 
 /// A trait which allows numbers to act as fixed-size bit arrays
 pub trait BitArray {
@@ -60,49 +62,23 @@ pub trait BitArray {
 /// A general error code
 #[derive(Debug)]
 pub enum Error {
-    /// An I/O error
-    Io(io::Error),
-    /// Base58 encoding error
-    Base58(base58::Error),
-    /// Bech32 encoding error
-    Bech32(bitcoin_bech32::Error),
-    /// Error from the `byteorder` crate
-    ByteOrder(io::Error),
-    /// Network magic was not what we expected
-    BadNetworkMagic(u32, u32),
-    /// Network message was unrecognized
-    BadNetworkMessage(String),
-    /// An object was attempted to be added twice
-    DuplicateHash,
-    /// Some operation was attempted on a block (or blockheader) that doesn't exist
-    BlockNotFound,
-    /// Parsing error
-    ParseFailed,
-    /// An object was added but it does not link into existing history
-    PrevHashNotFound,
-    /// secp-related error
-    Secp256k1(secp256k1::Error),
     /// The `target` field of a block header did not match the expected difficulty
     SpvBadTarget,
     /// The header hash is not below the target
     SpvBadProofOfWork,
-    /// Error propagated from subsystem
-    Detail(String, Box<Error>),
-    /// Unsupported witness version
-    UnsupportedWitnessVersion(u8)
+    /// secp-related error
+    Secp256k1(secp256k1::Error),
+    /// Serialization error
+    Serialize(serialize::Error),
+    /// Network error
+    Network(network::Error),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Io(ref e) => fmt::Display::fmt(e, f),
-            Error::Base58(ref e) => fmt::Display::fmt(e, f),
-            Error::Bech32(ref e) => fmt::Display::fmt(e, f),
-            Error::ByteOrder(ref e) => fmt::Display::fmt(e, f),
-            Error::BadNetworkMagic(exp, got) => write!(f, "expected network magic 0x{:x}, got 0x{:x}", exp, got),
-            Error::BadNetworkMessage(ref got) => write!(f, "incorrect network message {}", got),
-            Error::Detail(ref s, ref e) => write!(f, "{}: {}", s, e),
             Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
+            Error::Serialize(ref e) => fmt::Display::fmt(e, f),
             ref x => f.write_str(error::Error::description(x))
         }
     }
@@ -111,53 +87,20 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
-            Error::Io(ref e) => Some(e),
-            Error::Base58(ref e) => Some(e),
-            Error::Bech32(ref e) => Some(e),
-            Error::ByteOrder(ref e) => Some(e),
-            Error::Detail(_, ref e) => Some(e),
             Error::Secp256k1(ref e) => Some(e),
+            Error::Serialize(ref e) => Some(e),
             _ => None
         }
     }
 
     fn description(&self) -> &str {
         match *self {
-            Error::Io(ref e) => e.description(),
-            Error::Base58(ref e) => e.description(),
-            Error::Bech32(ref e) => e.description(),
-            Error::ByteOrder(ref e) => e.description(),
-            Error::BadNetworkMagic(_, _) => "incorrect network magic",
-            Error::BadNetworkMessage(_) => "incorrect/unexpected network message",
-            Error::DuplicateHash => "duplicate hash",
-            Error::BlockNotFound => "no such block",
-            Error::ParseFailed => "parsing error",
-            Error::PrevHashNotFound => "prevhash not found",
             Error::Secp256k1(ref e) => e.description(),
             Error::SpvBadTarget => "target incorrect",
             Error::SpvBadProofOfWork => "target correct but not attained",
-            Error::Detail(_, ref e) => e.description(),
-            Error::UnsupportedWitnessVersion(_) => "unsupported witness version"
+            Error::Serialize(ref e) => e.description(),
+            Error::Network(ref e) => e.description(),
         }
-    }
-}
-
-/// Prepend the detail of an `IoResult`'s error with some text to get poor man's backtracing
-pub fn propagate_err<T>(s: String, res: Result<T, Error>) -> Result<T, Error> {
-    res.map_err(|err| Error::Detail(s, Box::new(err)))
-}
-
-#[doc(hidden)]
-impl From<base58::Error> for Error {
-    fn from(e: base58::Error) -> Error {
-        Error::Base58(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<bitcoin_bech32::Error> for Error {
-    fn from(e: bitcoin_bech32::Error) -> Error {
-        Error::Bech32(e)
     }
 }
 
@@ -168,3 +111,16 @@ impl From<secp256k1::Error> for Error {
     }
 }
 
+#[doc(hidden)]
+impl From<serialize::Error> for Error {
+    fn from(e: serialize::Error) -> Error {
+        Error::Serialize(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<network::Error> for Error {
+    fn from(e: network::Error) -> Error {
+        Error::Network(e)
+    }
+}

--- a/src/util/privkey.rs
+++ b/src/util/privkey.rs
@@ -16,10 +16,10 @@
 //! A private key represents the secret data associated with its proposed use
 //!
 use std::str::FromStr;
-use util::Error;
 use secp256k1::{self, Secp256k1};
 use secp256k1::key::{PublicKey, SecretKey};
 use util::address::Address;
+use network::serialize;
 use network::constants::Network;
 use util::base58;
 
@@ -110,21 +110,21 @@ impl ToString for Privkey {
 }
 
 impl FromStr for Privkey {
-    type Err = Error;
+    type Err = serialize::Error;
 
-    fn from_str(s: &str) -> Result<Privkey, Error> {
+    fn from_str(s: &str) -> Result<Privkey, serialize::Error> {
         let data = base58::from_check(s)?;
 
         let compressed = match data.len() {
             33 => false,
             34 => true,
-            _ => { return Err(Error::Base58(base58::Error::InvalidLength(data.len()))); }
+            _ => { return Err(serialize::Error::Base58(base58::Error::InvalidLength(data.len()))); }
         };
 
         let network = match data[0] {
             128 => Network::Bitcoin,
             239 => Network::Testnet,
-            x   => { return Err(Error::Base58(base58::Error::InvalidVersion(vec![x]))); }
+            x   => { return Err(serialize::Error::Base58(base58::Error::InvalidVersion(vec![x]))); }
         };
 
         let secp = Secp256k1::without_caps();

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -20,6 +20,7 @@
 
 use std::fmt;
 
+use network::serialize;
 use util::BitArray;
 
 macro_rules! construct_uint {
@@ -337,7 +338,7 @@ macro_rules! construct_uint {
 
         impl<S: ::network::serialize::SimpleEncoder> ::network::encodable::ConsensusEncodable<S> for $name {
             #[inline]
-            fn consensus_encode(&self, s: &mut S) -> Result<(), S::Error> {
+            fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
                 let &$name(ref data) = self;
                 for word in data.iter() { word.consensus_encode(s)?; }
                 Ok(())
@@ -345,7 +346,7 @@ macro_rules! construct_uint {
         }
 
         impl<D: ::network::serialize::SimpleDecoder> ::network::encodable::ConsensusDecodable<D> for $name {
-            fn consensus_decode(d: &mut D) -> Result<$name, D::Error> {
+            fn consensus_decode(d: &mut D) -> Result<$name, serialize::Error> {
                 use network::encodable::ConsensusDecodable;
                 let ret: [u64; $n_words] = ConsensusDecodable::consensus_decode(d)?;
                 Ok($name(ret))


### PR DESCRIPTION
- Separate serialize::Error and network::Error from util::Error
- Remove unneeded propagate_err and consume_err

Closes #131