### PR TITLE
Fix compilation warning when comparing usize and u64 on 32-bit arch

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -512,8 +512,8 @@ impl Builder {
     /// Adds instructions to push some arbitrary data onto the stack
     pub fn push_slice(mut self, data: &[u8]) -> Builder {
         // Start with a PUSH opcode
-        match data.len() {
-            n if n < opcodes::Ordinary::OP_PUSHDATA1 as usize => { self.0.push(n as u8); },
+        match data.len() as u64 {
+            n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => { self.0.push(n as u8); },
             n if n < 0x100 => {
                 self.0.push(opcodes::Ordinary::OP_PUSHDATA1 as u8);
                 self.0.push(n as u8);


### PR DESCRIPTION
Closes #117