### PR TITLE
update rust-secp dependency to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ git = "https://github.com/KokaKiwi/rust-hex"
 rev = "19fd37137686c30058bd9d11d21590e726ffdf31"
 
 [dependencies.secp256k1]
-version = "0.10"
+version = "0.11"
 features = [ "rand" ]


### PR DESCRIPTION
This updates the version of rust-secp dependencies and other invisible-to-rust-bitcoin changes.