### PR TITLE
Various serialization fixes

### DIFF
--- a/fuzz/fuzz_targets/deserialize_script.rs
+++ b/fuzz/fuzz_targets/deserialize_script.rs
@@ -31,6 +31,7 @@ fn do_test(data: &[u8]) {
             }
         }
         assert_eq!(b.into_script(), script);
+        assert_eq!(data, &serialize::serialize(&script).unwrap()[..]);
     }
 }
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -408,12 +408,16 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for Transaction {
                     for txin in input.iter_mut() {
                         txin.witness = ConsensusDecodable::consensus_decode(d)?;
                     }
-                    Ok(Transaction {
-                        version: version,
-                        input: input,
-                        output: output,
-                        lock_time: ConsensusDecodable::consensus_decode(d)?,
-                    })
+                    if !input.is_empty() && input.iter().all(|input| input.witness.is_empty()) {
+                        Err(serialize::Error::ParseFailed("witness flag set but no witnesses present"))
+                    } else {
+                        Ok(Transaction {
+                            version: version,
+                            input: input,
+                            output: output,
+                            lock_time: ConsensusDecodable::consensus_decode(d)?,
+                        })
+                    }
                 }
                 // We don't support anything else
                 x => {


### PR DESCRIPTION
Rejects non-compact lengths and Segwit transactions which set the witness flag without providing witnesses (see https://github.com/bitcoin/bitcoin/pull/14039 ).

This is technically a breaking change, but it breaks behavior that should never have been valid, so I think it's OK to push into a point release.