### PR TITLE
update rand dependency to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde-decimal = ["serde", "strason"]
 [dependencies]
 bitcoin-bech32 = "0.8.0"
 byteorder = "1.1"
-rand = "0.3"
+rand = "0.4"
 rust-crypto = "0.2"
 bitcoinconsensus = { version = "0.16", optional = true }
 


### PR DESCRIPTION
rand was bumped in `rust-secp256k1`, but not here, which apparently resulted in a conflict during building the tests
fixes  #161