### PR TITLE
fixed serde_struct_impl macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ version = "=0.3.2"
 [dependencies.secp256k1]
 version = "0.11"
 features = [ "rand" ]
+
+[dev-dependencies]
+bincode = "1.0.1"

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -433,3 +433,24 @@ macro_rules! serde_struct_impl {
         }
     )
 }
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod test {
+    extern crate bincode;
+
+    use util::hash::Sha256dHash;
+    use OutPoint;
+
+    #[test]
+    fn test_serde_struct_impl_visit_seq() {
+        let txid = [1u8; 32];
+        let txid: Sha256dHash = From::from(&txid[..]);
+        let op = OutPoint {
+            txid,
+            vout: 1,
+        };
+        let rez: Vec<u8> = bincode::serialize(&op).unwrap();
+        let _rez: OutPoint = bincode::deserialize(&rez[..]).unwrap();
+    }
+}

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -350,6 +350,23 @@ macro_rules! serde_struct_impl {
                         formatter.write_str("a struct")
                     }
 
+                    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: $crate::serde::de::SeqAccess<'de>,
+                    {
+                        use $crate::serde::de::Error;
+
+                        let size: usize = seq.size_hint().unwrap_or(0);
+
+                        let ret = $name {
+                            $(
+                                $fe: seq.next_element()?.ok_or_else(|| Error::invalid_length(size, &self))?,
+                            )*
+                        };
+
+                        Ok(ret)
+                    }
+
                     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
                     where
                         A: $crate::serde::de::MapAccess<'de>,


### PR DESCRIPTION
At this moment this trivial example fails with such error: `Custom("invalid type: sequence, expected a struct")'`
```rust
extern crate bitcoin;
extern crate bincode;

use bitcoin::util::hash::Sha256dHash;

fn main() {
    let txid = [1u8; 32];
    let txid: Sha256dHash = From::from(&txid[..]);
    let op = bitcoin::OutPoint {
        txid,
        vout: 1,
    };
    let rez: Vec<u8> = bincode::serialize(&op).unwrap();
    let rez: bitcoin::OutPoint = bincode::deserialize(&rez[..]).unwrap();
}
```

In this PR I propose easy fix for this issue.