### PR TITLE
Ready for Review: Introduce util::key and deprecate util::privkey

### DIFF
--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -42,6 +42,7 @@ use hex::encode as hex_encode;
 
 use bitcoin_bech32;
 use bitcoin_hashes::{sha256d, Hash as HashTrait};
+use secp256k1;
 
 use util::base58;
 
@@ -56,6 +57,8 @@ pub enum Error {
     Bech32(bitcoin_bech32::Error),
     /// Error from the `byteorder` crate
     ByteOrder(io::Error),
+    /// secp-related error
+    Secp256k1(secp256k1::Error),
     /// Network magic was not expected
     UnexpectedNetworkMagic {
         /// The expected network magic
@@ -98,6 +101,7 @@ impl fmt::Display for Error {
             Error::Base58(ref e) => fmt::Display::fmt(e, f),
             Error::Bech32(ref e) => fmt::Display::fmt(e, f),
             Error::ByteOrder(ref e) => fmt::Display::fmt(e, f),
+            Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
             Error::UnexpectedNetworkMagic { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), e, a),
             Error::OversizedVectorAllocation { requested: ref r, max: ref m } => write!(f, "{}: requested {}, maximum {}", error::Error::description(self), r, m),
             Error::InvalidChecksum { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), hex_encode(e), hex_encode(a)),
@@ -118,6 +122,7 @@ impl error::Error for Error {
             Error::Base58(ref e) => Some(e),
             Error::Bech32(ref e) => Some(e),
             Error::ByteOrder(ref e) => Some(e),
+            Error::Secp256k1(ref e) => Some(e),
             Error::UnexpectedNetworkMagic { .. }
             | Error::OversizedVectorAllocation { .. }
             | Error::InvalidChecksum { .. }
@@ -136,6 +141,7 @@ impl error::Error for Error {
             Error::Base58(ref e) => e.description(),
             Error::Bech32(ref e) => e.description(),
             Error::ByteOrder(ref e) => e.description(),
+            Error::Secp256k1(ref e) => e.description(),
             Error::UnexpectedNetworkMagic { .. } => "unexpected network magic",
             Error::OversizedVectorAllocation { .. } => "allocation of oversized vector requested",
             Error::InvalidChecksum { .. } => "invalid checksum",
@@ -163,6 +169,12 @@ impl From<bitcoin_bech32::Error> for Error {
     }
 }
 
+#[doc(hidden)]
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Error {
+        Error::Secp256k1(e)
+    }
+}
 
 #[doc(hidden)]
 impl From<io::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,6 @@ pub use network::constants::Network;
 pub use util::Error;
 pub use util::address::Address;
 pub use util::hash::BitcoinHash;
-pub use util::privkey::Privkey;
+pub use util::privkey::PrivateKey;
 pub use util::decimal::Decimal;
 pub use util::decimal::UDecimal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub use network::constants::Network;
 pub use util::Error;
 pub use util::address::Address;
 pub use util::hash::BitcoinHash;
-pub use util::privkey::PrivateKey;
+pub use util::key::PrivateKey;
+pub use util::key::PublicKey;
 pub use util::decimal::Decimal;
 pub use util::decimal::UDecimal;

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -107,8 +107,8 @@ mod tests {
     use network::constants::Network;
     use util::misc::hex_bytes;
     use util::address::Address;
+    use util::key::PublicKey;
     use hex;
-    use secp256k1::PublicKey;
 
     use super::*;
 

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -11,18 +11,56 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-//! Private key
+//! Bitcoin Keys
 //!
-//! A private key represents the secret data associated with its proposed use
+//! Keys used in Bitcoin that can be roundtrip (de)serialized.
 //!
 
 use std::fmt::{self, Write};
+use std::io;
 use std::str::FromStr;
 use secp256k1::{self, Secp256k1};
-use secp256k1::key::{PublicKey, SecretKey};
 use consensus::encode;
 use network::constants::Network;
 use util::base58;
+
+/// A Bitcoin ECDSA public key
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PublicKey {
+    /// Whether this public key represents a compressed address
+    pub compressed: bool,
+    /// The actual ECDSA key
+    pub key: secp256k1::PublicKey,
+}
+
+impl PublicKey {
+    /// Write the public key into a writer
+    pub fn write_into<W: io::Write>(&self, writer: &mut W) {
+        let write_res: io::Result<()> = if self.compressed {
+            writer.write_all(&self.key.serialize())
+        } else {
+            writer.write_all(&self.key.serialize_uncompressed())
+        };
+        debug_assert!(write_res.is_ok());
+    }
+
+    /// Deserialize a public key from a slice
+    pub fn from_slice(data: &[u8]) -> Result<PublicKey, encode::Error> {
+        let key: secp256k1::PublicKey = secp256k1::PublicKey::from_slice(data)
+            .map_err(|_| base58::Error::Other("Public key out of range".to_owned()))?;
+
+        let compressed: bool = match data.len() {
+            33 => true,
+            65 => false,
+            _ =>  { return Err(base58::Error::InvalidLength(data.len()).into()); },
+        };
+
+        Ok(PublicKey {
+            compressed: compressed,
+            key: key,
+        })
+    }
+}
 
 #[derive(Clone, PartialEq, Eq)]
 /// A Bitcoin ECDSA private key
@@ -32,13 +70,13 @@ pub struct PrivateKey {
     /// The network on which this key should be used
     pub network: Network,
     /// The actual ECDSA key
-    pub key: SecretKey
+    pub key: secp256k1::SecretKey,
 }
 
 impl PrivateKey {
     /// Computes the public key as supposed to be used with this secret
-    pub fn public_key<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> PublicKey {
-        PublicKey::from_secret_key(secp, &self.key)
+    pub fn public_key<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> secp256k1::PublicKey {
+        secp256k1::PublicKey::from_secret_key(secp, &self.key)
     }
 
     /// Format the private key to WIF format.
@@ -82,7 +120,7 @@ impl PrivateKey {
             x   => { return Err(encode::Error::Base58(base58::Error::InvalidVersion(vec![x]))); }
         };
 
-        let key = SecretKey::from_slice(&data[1..33])
+        let key = secp256k1::SecretKey::from_slice(&data[1..33])
             .map_err(|_| base58::Error::Other("Secret key out of range".to_owned()))?;
 
         Ok(PrivateKey {

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -27,7 +27,7 @@ use util::base58;
 /// A Bitcoin ECDSA public key
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PublicKey {
-    /// Whether this public key represents a compressed address
+    /// Whether this public key should be serialized as compressed
     pub compressed: bool,
     /// The actual ECDSA key
     pub key: secp256k1::PublicKey,
@@ -70,7 +70,7 @@ impl PublicKey {
 #[derive(Clone, PartialEq, Eq)]
 /// A Bitcoin ECDSA private key
 pub struct PrivateKey {
-    /// Whether this private key represents a compressed address
+    /// Whether this private key should be serialized as compressed
     pub compressed: bool,
     /// The network on which this key should be used
     pub network: Network,
@@ -79,7 +79,7 @@ pub struct PrivateKey {
 }
 
 impl PrivateKey {
-    /// Computes the public key as supposed to be used with this secret
+    /// Creates a public key from this private key
     pub fn public_key<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> PublicKey {
         PublicKey {
             compressed: self.compressed,

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -46,18 +46,15 @@ impl PublicKey {
 
     /// Deserialize a public key from a slice
     pub fn from_slice(data: &[u8]) -> Result<PublicKey, encode::Error> {
-        let key: secp256k1::PublicKey = secp256k1::PublicKey::from_slice(data)
-            .map_err(|_| base58::Error::Other("Public key out of range".to_owned()))?;
-
         let compressed: bool = match data.len() {
             33 => true,
             65 => false,
-            _ =>  { return Err(base58::Error::InvalidLength(data.len()).into()); },
+            len =>  { return Err(base58::Error::InvalidLength(len).into()); },
         };
 
         Ok(PublicKey {
             compressed: compressed,
-            key: key,
+            key: secp256k1::PublicKey::from_slice(data)?,
         })
     }
 
@@ -128,13 +125,10 @@ impl PrivateKey {
             x   => { return Err(encode::Error::Base58(base58::Error::InvalidVersion(vec![x]))); }
         };
 
-        let key = secp256k1::SecretKey::from_slice(&data[1..33])
-            .map_err(|_| base58::Error::Other("Secret key out of range".to_owned()))?;
-
         Ok(PrivateKey {
             compressed: compressed,
             network: network,
-            key: key
+            key: secp256k1::SecretKey::from_slice(&data[1..33])?,
         })
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! Functions needed by all parts of the Bitcoin library
 
-pub mod privkey;
+pub mod key;
 pub mod address;
 pub mod base58;
 pub mod bip32;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -29,8 +29,6 @@ pub mod uint;
 
 use std::{error, fmt};
 
-use secp256k1;
-
 use network;
 use consensus::encode;
 
@@ -59,8 +57,6 @@ pub trait BitArray {
 /// if appropriate.
 #[derive(Debug)]
 pub enum Error {
-    /// secp-related error
-    Secp256k1(secp256k1::Error),
     /// Encoding error
     Encode(encode::Error),
     /// Network error
@@ -74,7 +70,6 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
             Error::Encode(ref e) => fmt::Display::fmt(e, f),
             Error::Network(ref e) => fmt::Display::fmt(e, f),
             Error::SpvBadProofOfWork | Error::SpvBadTarget => f.write_str(error::Error::description(self)),
@@ -85,7 +80,6 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
-            Error::Secp256k1(ref e) => Some(e),
             Error::Encode(ref e) => Some(e),
             Error::Network(ref e) => Some(e),
             Error::SpvBadProofOfWork | Error::SpvBadTarget => None
@@ -94,19 +88,11 @@ impl error::Error for Error {
 
     fn description(&self) -> &str {
         match *self {
-            Error::Secp256k1(ref e) => e.description(),
             Error::Encode(ref e) => e.description(),
             Error::Network(ref e) => e.description(),
             Error::SpvBadProofOfWork => "target correct but not attained",
             Error::SpvBadTarget => "target incorrect",
         }
-    }
-}
-
-#[doc(hidden)]
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error {
-        Error::Secp256k1(e)
     }
 }
 

--- a/src/util/privkey.rs
+++ b/src/util/privkey.rs
@@ -20,14 +20,13 @@ use std::fmt::{self, Write};
 use std::str::FromStr;
 use secp256k1::{self, Secp256k1};
 use secp256k1::key::{PublicKey, SecretKey};
-use util::address::Address;
 use consensus::encode;
 use network::constants::Network;
 use util::base58;
 
 #[derive(Clone, PartialEq, Eq)]
 /// A Bitcoin ECDSA private key
-pub struct Privkey {
+pub struct PrivateKey {
     /// Whether this private key represents a compressed address
     pub compressed: bool,
     /// The network on which this key should be used
@@ -36,61 +35,10 @@ pub struct Privkey {
     pub key: SecretKey
 }
 
-impl Privkey {
-    /// Creates a `Privkey` from a raw secp256k1 secret key
-    #[inline]
-    pub fn from_secret_key(key: SecretKey, compressed: bool, network: Network) -> Privkey {
-        Privkey {
-            compressed: compressed,
-            network: network,
-            key: key,
-        }
-    }
-
+impl PrivateKey {
     /// Computes the public key as supposed to be used with this secret
     pub fn public_key<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> PublicKey {
         PublicKey::from_secret_key(secp, &self.key)
-    }
-
-    /// Converts a private key to a segwit address
-    #[inline]
-    pub fn to_address<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> Address {
-        Address::p2wpkh(&self.public_key(secp), self.network)
-    }
-
-    /// Converts a private key to a legacy (non-segwit) address
-    #[inline]
-    pub fn to_legacy_address<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> Address {
-        if self.compressed {
-            Address::p2pkh(&self.public_key(secp), self.network)
-        }
-        else {
-            Address::p2upkh(&self.public_key(secp), self.network)
-        }
-    }
-
-    /// Accessor for the underlying secp key
-    #[inline]
-    pub fn secret_key(&self) -> &SecretKey {
-        &self.key
-    }
-
-    /// Accessor for the underlying secp key that consumes the privkey
-    #[inline]
-    pub fn into_secret_key(self) -> SecretKey {
-        self.key
-    }
-
-    /// Accessor for the network type
-    #[inline]
-    pub fn network(&self) -> Network {
-        self.network
-    }
-
-    /// Accessor for the compressed flag
-    #[inline]
-    pub fn is_compressed(&self) -> bool {
-        self.compressed
     }
 
     /// Format the private key to WIF format.
@@ -111,7 +59,6 @@ impl Privkey {
     }
 
     /// Get WIF encoding of this private key.
-    #[inline]
     pub fn to_wif(&self) -> String {
         let mut buf = String::new();
         buf.write_fmt(format_args!("{}", self)).unwrap();
@@ -120,7 +67,7 @@ impl Privkey {
     }
 
     /// Parse WIF encoded private key.
-    pub fn from_wif(wif: &str) -> Result<Privkey, encode::Error> {
+    pub fn from_wif(wif: &str) -> Result<PrivateKey, encode::Error> {
         let data = base58::from_check(wif)?;
 
         let compressed = match data.len() {
@@ -138,7 +85,7 @@ impl Privkey {
         let key = SecretKey::from_slice(&data[1..33])
             .map_err(|_| base58::Error::Other("Secret key out of range".to_owned()))?;
 
-        Ok(Privkey {
+        Ok(PrivateKey {
             compressed: compressed,
             network: network,
             key: key
@@ -146,59 +93,60 @@ impl Privkey {
     }
 }
 
-impl fmt::Display for Privkey {
+impl fmt::Display for PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt_wif(f)
     }
 }
 
-impl fmt::Debug for Privkey {
+impl fmt::Debug for PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[private key data]")
     }
 }
 
-impl FromStr for Privkey {
+impl FromStr for PrivateKey {
     type Err = encode::Error;
-    fn from_str(s: &str) -> Result<Privkey, encode::Error> {
-        Privkey::from_wif(s)
+    fn from_str(s: &str) -> Result<PrivateKey, encode::Error> {
+        PrivateKey::from_wif(s)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Privkey;
+    use super::PrivateKey;
     use secp256k1::Secp256k1;
     use std::str::FromStr;
     use network::constants::Network::Testnet;
     use network::constants::Network::Bitcoin;
+    use util::address::Address;
 
     #[test]
     fn test_key_derivation() {
         // testnet compressed
-        let sk = Privkey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
-        assert_eq!(sk.network(), Testnet);
-        assert_eq!(sk.is_compressed(), true);
+        let sk = PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+        assert_eq!(sk.network, Testnet);
+        assert_eq!(sk.compressed, true);
         assert_eq!(&sk.to_wif(), "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy");
 
         let secp = Secp256k1::new();
-        let pk = sk.to_legacy_address(&secp);
+        let pk = Address::p2pkh(&sk.public_key(&secp), sk.network);
         assert_eq!(&pk.to_string(), "mqwpxxvfv3QbM8PU8uBx2jaNt9btQqvQNx");
 
         // test string conversion
         assert_eq!(&sk.to_string(), "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy");
         let sk_str =
-            Privkey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+            PrivateKey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
         assert_eq!(&sk.to_wif(), &sk_str.to_wif());
 
         // mainnet uncompressed
-        let sk = Privkey::from_wif("5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3").unwrap();
-        assert_eq!(sk.network(), Bitcoin);
-        assert_eq!(sk.is_compressed(), false);
+        let sk = PrivateKey::from_wif("5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3").unwrap();
+        assert_eq!(sk.network, Bitcoin);
+        assert_eq!(sk.compressed, false);
         assert_eq!(&sk.to_wif(), "5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3");
 
         let secp = Secp256k1::new();
-        let pk = sk.to_legacy_address(&secp);
+        let pk = Address::p2upkh(&sk.public_key(&secp), sk.network);
         assert_eq!(&pk.to_string(), "1GhQvF6dL8xa6wBxLnWmHcQsurx9RxiMc8");
     }
 }


### PR DESCRIPTION
- Move util::privkey::PrivKey to util::key::PrivateKey.
- Clean up util::key::PrivateKey.
- Add new util::key::PublicKey struct.
- Modify util::address::Address to appropriately wrap new
  util::key::PublicKey.

@apoelstra @stevenroose I've introduced a few `.clone()'s` that I would like to remove, and am not entirely happy about the copying that happens in `util::key::PublicKey::serialize`. Would love your opinions on how to design this better.