### PR TITLE
Avoid heap usage when encoding to base58

### DIFF
--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -75,7 +75,6 @@ struct SmallVec<T> {
 
 impl<T: Default + Copy> SmallVec<T> {
     pub fn new() -> SmallVec<T> {
-        use std::default::Default;
         SmallVec {
             len: 0,
             stack: [T::default(); 100],
@@ -265,6 +264,14 @@ mod tests {
         // Leading zeroes
         assert_eq!(&encode_slice(&[0, 13, 36][..]), "1211");
         assert_eq!(&encode_slice(&[0, 0, 0, 0, 13, 36][..]), "1111211");
+
+        // Long input (>100 bytes => has to use heap)
+        let res = encode_slice(&"BitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBit\
+        coinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoin".as_bytes());
+        let exp = "ZqC5ZdfpZRi7fjA8hbhX5pEE96MdH9hEaC1YouxscPtbJF16qVWksHWR4wwvx7MotFcs2ChbJqK8KJ9X\
+        wZznwWn1JFDhhTmGo9v6GjAVikzCsBWZehu7bm22xL8b5zBR5AsBygYRwbFJsNwNkjpyFuDKwmsUTKvkULCvucPJrN5\
+        QUdxpGakhqkZFL7RU4yT";
+        assert_eq!(&res, exp);
 
         // Addresses
         let addr = hex_decode("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap();


### PR DESCRIPTION
Instead of always allocating a `Vec` this implementation will work on the stack only as long as the output stays below 100 characters.

- [x] Test behavior with large messages
- [x] Cleanup

Closes #145 