### PR TITLE
[WIP] Expand on #183: Extract network and compressedness from key types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,6 @@ pub use network::constants::Network;
 pub use util::Error;
 pub use util::address::Address;
 pub use util::hash::BitcoinHash;
-pub use util::privkey::Privkey;
+pub use util::privkey::PrivateKey;
 pub use util::decimal::Decimal;
 pub use util::decimal::UDecimal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub use network::constants::Network;
 pub use util::Error;
 pub use util::address::Address;
 pub use util::hash::BitcoinHash;
-pub use util::privkey::PrivateKey;
+pub use util::key::PrivateKey;
+pub use util::key::PublicKey;
 pub use util::decimal::Decimal;
 pub use util::decimal::UDecimal;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -23,10 +23,9 @@
 //! extern crate bitcoin;
 //! 
 //! use bitcoin::network::constants::Network;
-//! use bitcoin::util::address::Payload;
-//! use bitcoin::util::address::Address;
+//! use bitcoin::util::address::{Address, Payload};
+//! use bitcoin::util::key;
 //! use secp256k1::Secp256k1;
-//! use secp256k1::key::PublicKey;
 //! use rand::thread_rng;
 //! 
 //! fn main() {
@@ -34,7 +33,13 @@
 //! 
 //!     // Generate random key pair
 //!     let s = Secp256k1::new();
-//!     let (secret_key, public_key) = s.generate_keypair(&mut thread_rng());
+//!     let (private_key, public_key) = {
+//!         let (sk, pk) = s.generate_keypair(&mut thread_rng());
+//!         (
+//!             key::PrivateKey { compressed: true, network: network, key: sk },
+//!             key::PublicKey { compressed: true, key: pk },
+//!         )
+//!     };
 //! 
 //!     // Generate pay-to-pubkey address
 //!     let address = Address::p2pk(&public_key, network);
@@ -43,7 +48,7 @@
 //!     assert_eq!(address.payload, Payload::Pubkey(public_key));
 //! 
 //!     // Check address can be unlocked by secret_key
-//!     assert_eq!(address.payload, Payload::Pubkey(PublicKey::from_secret_key(&s, &secret_key)));
+//!     assert_eq!(address.payload, Payload::Pubkey(key::PublicKey::from_private_key(&s, &private_key)));
 //! }
 //! ```
 
@@ -51,7 +56,6 @@ use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 use bitcoin_bech32::{self, WitnessProgram, u5};
-use secp256k1::key::PublicKey;
 
 #[cfg(feature = "serde")]
 use serde;
@@ -62,12 +66,13 @@ use network::constants::Network;
 use consensus::encode;
 use util::hash::Hash160;
 use util::base58;
+use util::key;
 
 /// The method used to produce an address
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Payload {
     /// pay-to-pubkey
-    Pubkey(PublicKey),
+    Pubkey(key::PublicKey),
     /// pay-to-pkhash address
     PubkeyHash(Hash160),
     /// P2SH address
@@ -82,28 +87,20 @@ pub struct Address {
     /// The type of the address
     pub payload: Payload,
     /// The network on which this address is usable
-    pub network: Network
+    pub network: Network,
 }
 
 impl Address {
     /// Creates a pay to (compressed) public key hash address from a public key
     /// This is the preferred non-witness type address
     #[inline]
-    pub fn p2pkh(pk: &PublicKey, network: Network) -> Address {
-        Address {
-            network: network,
-            payload: Payload::PubkeyHash(Hash160::from_data(&pk.serialize()[..]))
-        }
-    }
+    pub fn p2pkh(pk: &key::PublicKey, network: Network) -> Address {
+        let mut hash = Vec::new();
+        pk.write_into(&mut hash);
 
-    /// Creates a pay to uncompressed public key hash address from a public key
-    /// This address type is discouraged as it uses more space but otherwise equivalent to p2pkh
-    /// therefore only adds ambiguity
-    #[inline]
-    pub fn p2upkh(pk: &PublicKey, network: Network) -> Address {
         Address {
             network: network,
-            payload: Payload::PubkeyHash(Hash160::from_data(&pk.serialize_uncompressed()[..]))
+            payload: Payload::PubkeyHash(Hash160::from_data(&hash)),
         }
     }
 
@@ -111,10 +108,10 @@ impl Address {
     /// This address type was used in the early history of Bitcoin.
     /// Satoshi's coins are still on addresses of this type.
     #[inline]
-    pub fn p2pk(pk: &PublicKey, network: Network) -> Address {
+    pub fn p2pk(pk: &key::PublicKey, network: Network) -> Address {
         Address {
             network: network,
-            payload: Payload::Pubkey(*pk)
+            payload: Payload::Pubkey(*pk),
         }
     }
 
@@ -124,34 +121,40 @@ impl Address {
     pub fn p2sh(script: &script::Script, network: Network) -> Address {
         Address {
             network: network,
-            payload: Payload::ScriptHash(Hash160::from_data(&script[..]))
+            payload: Payload::ScriptHash(Hash160::from_data(&script[..])),
         }
     }
 
     /// Create a witness pay to public key address from a public key
     /// This is the native segwit address type for an output redemable with a single signature
-    pub fn p2wpkh (pk: &PublicKey, network: Network) -> Address {
+    pub fn p2wpkh (pk: &key::PublicKey, network: Network) -> Address {
+        let mut hash = Vec::new();
+        pk.write_into(&mut hash);
+
         Address {
             network: network,
             payload: Payload::WitnessProgram(
                 // unwrap is safe as witness program is known to be correct as above
                 WitnessProgram::new(u5::try_from_u8(0).expect("0<32"),
-                                    Hash160::from_data(&pk.serialize()[..])[..].to_vec(),
-                                    Address::bech_network(network)).unwrap())
+                                    Hash160::from_data(&hash)[..].to_vec(),
+                                    Address::bech_network(network)).unwrap()),
         }
     }
 
     /// Create a pay to script address that embeds a witness pay to public key
     /// This is a segwit address type that looks familiar (as p2sh) to legacy clients
-    pub fn p2shwpkh (pk: &PublicKey, network: Network) -> Address {
+    pub fn p2shwpkh (pk: &key::PublicKey, network: Network) -> Address {
+        let mut hash = Vec::new();
+        pk.write_into(&mut hash);
+
         let builder = script::Builder::new()
             .push_int(0)
-            .push_slice(&Hash160::from_data(&pk.serialize()[..])[..]);
+            .push_slice(&Hash160::from_data(&hash)[..]);
         Address {
             network: network,
             payload: Payload::ScriptHash(
                 Hash160::from_data(builder.into_script().as_bytes())
-            )
+            ),
         }
     }
 
@@ -174,7 +177,7 @@ impl Address {
                     d.to_vec(),
                     Address::bech_network(network)
                 ).unwrap()
-            )
+            ),
         }
     }
 
@@ -192,7 +195,7 @@ impl Address {
 
         Address {
             network: network,
-            payload: Payload::ScriptHash(Hash160::from_data(ws.as_bytes()))
+            payload: Payload::ScriptHash(Hash160::from_data(ws.as_bytes())),
         }
     }
 
@@ -210,8 +213,11 @@ impl Address {
     pub fn script_pubkey(&self) -> script::Script {
         match self.payload {
             Payload::Pubkey(ref pk) => {
+                let mut hash = Vec::new();
+                pk.write_into(&mut hash);
+
                 script::Builder::new()
-                    .push_slice(&pk.serialize_uncompressed()[..])
+                    .push_slice(&hash)
                     .push_opcode(opcodes::All::OP_CHECKSIG)
             },
             Payload::PubkeyHash(ref hash) => {
@@ -242,7 +248,10 @@ impl Display for Address {
         match self.payload {
             // note: serialization for pay-to-pk is defined, but is irreversible
             Payload::Pubkey(ref pk) => {
-                let hash = &Hash160::from_data(&pk.serialize_uncompressed()[..]);
+                let mut bytes = Vec::new();
+                pk.write_into(&mut bytes);
+
+                let hash = &Hash160::from_data(&bytes);
                 let mut prefixed = [0; 21];
                 prefixed[0] = match self.network {
                     Network::Bitcoin => 0,
@@ -297,7 +306,7 @@ impl FromStr for Address {
             }
             return Ok(Address {
                 network: network,
-                payload: Payload::WitnessProgram(witprog)
+                payload: Payload::WitnessProgram(witprog),
             });
         }
 
@@ -404,12 +413,12 @@ mod tests {
     use std::string::ToString;
 
     use secp256k1::Secp256k1;
-    use secp256k1::key::PublicKey;
     use hex::decode as hex_decode;
 
     use blockdata::script::Script;
     use network::constants::Network::{Bitcoin, Testnet, Regtest};
     use util::hash::Hash160;
+    use util::key::PublicKey;
     use super::*;
 
     macro_rules! hex (($hex:expr) => (hex_decode($hex).unwrap()));
@@ -422,7 +431,7 @@ mod tests {
             network: Bitcoin,
             payload: Payload::PubkeyHash(
                 Hash160::from(&hex_decode("162c5ea71c0b23f5b9022ef047c4a86470a5b070").unwrap()[..])
-            )
+            ),
         };
 
         assert_eq!(addr.script_pubkey(), hex_script!("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac"));
@@ -435,7 +444,7 @@ mod tests {
         let secp = Secp256k1::without_caps();
 
         let key = hex_key!(&secp, "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183");
-        let addr = Address::p2upkh(&key, Bitcoin);
+        let addr = Address::p2pkh(&key, Bitcoin);
         assert_eq!(&addr.to_string(), "1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY");
 
         let key = hex_key!(&secp, &"03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f");
@@ -458,7 +467,7 @@ mod tests {
             network: Bitcoin,
             payload: Payload::ScriptHash(
                 Hash160::from(&hex_decode("162c5ea71c0b23f5b9022ef047c4a86470a5b070").unwrap()[..])
-            )
+            ),
         };
 
         assert_eq!(addr.script_pubkey(), hex_script!("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087"));

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -41,7 +41,7 @@
 //!     };
 //! 
 //!     // Generate pay-to-pubkey address that can be used on Bitcoin mainnet.
-//!     let address = Address::p2pkh(&public_key, Network::Bitcoin, true);
+//!     let address = Address::p2pkh(&public_key, Network::Bitcoin);
 //! 
 //!     // Check address payload is the hash of the public key given
 //!     let pk_bytes = public_key.to_bytes();
@@ -90,19 +90,22 @@ pub struct Address {
 }
 
 impl Address {
-    /// Creates a pay to (compressed) public key hash address from a public key
-    /// This is the preferred non-witness type address
+    /// Creates a pay to a (compressed) public key hash address from a public key.
+    /// This is the preferred non-witness type address.
     #[inline]
-    pub fn p2pkh(pk: &key::PublicKey, network: Network, compressed: bool) -> Address {
-        let pk_bytes = if compressed {
-            pk.to_bytes()
-        } else {
-            pk.to_bytes_uncompressed()
-        };
-
+    pub fn p2pkh(pk: &key::PublicKey, network: Network) -> Address {
         Address {
             network: network,
-            payload: Payload::PubkeyHash(Hash160::from_data(&pk_bytes)),
+            payload: Payload::PubkeyHash(Hash160::from_data(&pk.to_bytes())),
+        }
+    }
+
+    /// Creates a pay to an uncompressed public key hash address from a public key.
+    #[inline]
+    pub fn p2pkh_uncompressed(pk: &key::PublicKey, network: Network) -> Address {
+        Address {
+            network: network,
+            payload: Payload::PubkeyHash(Hash160::from_data(&pk.to_bytes_uncompressed())),
         }
     }
 
@@ -116,37 +119,52 @@ impl Address {
         }
     }
 
-    /// Create a witness pay to public key address from a public key
-    /// This is the native segwit address type for an output redemable with a single signature
-    pub fn p2wpkh (pk: &key::PublicKey, network: Network, compressed: bool) -> Address {
-        let pk_bytes = if compressed {
-            pk.to_bytes()
-        } else {
-            pk.to_bytes_uncompressed()
-        };
-
+    /// Create a witness pay to public key address from a (compressed) public key.
+    /// This is the native segwit address type for an output redemable with a single signature.
+    pub fn p2wpkh(pk: &key::PublicKey, network: Network) -> Address {
         Address {
             network: network,
             payload: Payload::WitnessProgram(
                 // unwrap is safe as witness program is known to be correct as above
                 WitnessProgram::new(u5::try_from_u8(0).expect("0<32"),
-                                    Hash160::from_data(&pk_bytes)[..].to_vec(),
+                                    Hash160::from_data(&pk.to_bytes())[..].to_vec(),
                                     Address::bech_network(network)).unwrap()),
         }
     }
 
-    /// Create a pay to script address that embeds a witness pay to public key
-    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients
-    pub fn p2shwpkh (pk: &key::PublicKey, network: Network, compressed: bool) -> Address {
-        let pk_bytes = if compressed {
-            pk.to_bytes()
-        } else {
-            pk.to_bytes_uncompressed()
-        };
+    /// Create a witness pay to public key address from an uncompressed public key.
+    /// This is a native segwit address type for an output redemable with a single signature.
+    pub fn p2wpkh_uncompressed(pk: &key::PublicKey, network: Network) -> Address {
+        Address {
+            network: network,
+            payload: Payload::WitnessProgram(
+                // unwrap is safe as witness program is known to be correct as above
+                WitnessProgram::new(u5::try_from_u8(0).expect("0<32"),
+                                    Hash160::from_data(&pk.to_bytes_uncompressed())[..].to_vec(),
+                                    Address::bech_network(network)).unwrap()),
+        }
+    }
 
+    /// Create a pay to script address that embeds a witness pay to a (compressed) public key.
+    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
+    pub fn p2shwpkh(pk: &key::PublicKey, network: Network) -> Address {
         let builder = script::Builder::new()
             .push_int(0)
-            .push_slice(&Hash160::from_data(&pk_bytes)[..]);
+            .push_slice(&Hash160::from_data(&pk.to_bytes())[..]);
+        Address {
+            network: network,
+            payload: Payload::ScriptHash(
+                Hash160::from_data(builder.into_script().as_bytes())
+            ),
+        }
+    }
+
+    /// Create a pay to script address that embeds a witness pay to an uncompressed public key.
+    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
+    pub fn p2shwpkh_uncompressed(pk: &key::PublicKey, network: Network) -> Address {
+        let builder = script::Builder::new()
+            .push_int(0)
+            .push_slice(&Hash160::from_data(&pk.to_bytes_uncompressed())[..]);
         Address {
             network: network,
             payload: Payload::ScriptHash(
@@ -419,11 +437,13 @@ mod tests {
         let secp = Secp256k1::without_caps();
 
         let (key, compressed) = hex_key!(&secp, "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183");
-        let addr = Address::p2pkh(&key, Bitcoin, compressed);
+        assert_eq!(compressed, false);
+        let addr = Address::p2pkh_uncompressed(&key, Bitcoin);
         assert_eq!(&addr.to_string(), "1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY");
 
         let (key, compressed) = hex_key!(&secp, &"03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f");
-        let addr = Address::p2pkh(&key, Testnet, compressed);
+        assert_eq!(compressed, true);
+        let addr = Address::p2pkh(&key, Testnet);
         assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
     }
 
@@ -455,7 +475,8 @@ mod tests {
         // stolen from Bitcoin transaction: b3c8c2b6cfc335abbcb2c7823a8453f55d64b2b5125a9a61e8737230cdb8ce20
         let secp = Secp256k1::without_caps();
         let (key, compressed) = hex_key!(&secp, "033bc8c83c52df5712229a2f72206d90192366c36428cb0c12b6af98324d97bfbc");
-        let addr = Address::p2wpkh(&key, Bitcoin, compressed);
+        assert_eq!(compressed, true);
+        let addr = Address::p2wpkh(&key, Bitcoin);
         assert_eq!(&addr.to_string(), "bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw");
     }
 

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -24,34 +24,32 @@
 //! 
 //! use bitcoin::network::constants::Network;
 //! use bitcoin::util::address::{Address, Payload};
-//! use bitcoin::util::key;
+//! use bitcoin::util::key::{PublicKey, PrivateKey};
 //! use bitcoin::util::hash::Hash160;
 //! use secp256k1::Secp256k1;
 //! use rand::thread_rng;
 //! 
 //! fn main() {
-//!     let network = Network::Bitcoin;
-//! 
 //!     // Generate random key pair
 //!     let s = Secp256k1::new();
 //!     let (private_key, public_key) = {
 //!         let (sk, pk) = s.generate_keypair(&mut thread_rng());
 //!         (
-//!             key::PrivateKey { compressed: true, network: network, key: sk },
-//!             key::PublicKey { compressed: true, key: pk },
+//!             PrivateKey { key: sk },
+//!             PublicKey { key: pk },
 //!         )
 //!     };
 //! 
-//!     // Generate pay-to-pubkey address
-//!     let address = Address::p2pkh(&public_key, network);
+//!     // Generate pay-to-pubkey address that can be used on Bitcoin mainnet.
+//!     let address = Address::p2pkh(&public_key, Network::Bitcoin, true);
 //! 
 //!     // Check address payload is the hash of the public key given
-//!     let pk_bytes = &public_key.serialize()[..];
-//!     assert_eq!(address.payload, Payload::PubkeyHash(Hash160::from_data(pk_bytes)));
+//!     let pk_bytes = public_key.to_bytes();
+//!     assert_eq!(address.payload, Payload::PubkeyHash(Hash160::from_data(&pk_bytes)));
 //! 
 //!     // Check address can be unlocked by secret_key
 //!     assert_eq!(address.payload, Payload::PubkeyHash(
-//!             Hash160::from_data(&PublicKey::from_secret_key(&s, &secret_key).serialize()[..])));
+//!             Hash160::from_data(&PublicKey::from_private_key(&s, &private_key).to_bytes())));
 //! }
 //! ```
 
@@ -95,13 +93,16 @@ impl Address {
     /// Creates a pay to (compressed) public key hash address from a public key
     /// This is the preferred non-witness type address
     #[inline]
-    pub fn p2pkh(pk: &key::PublicKey, network: Network) -> Address {
-        let mut hash = Vec::new();
-        pk.write_into(&mut hash);
+    pub fn p2pkh(pk: &key::PublicKey, network: Network, compressed: bool) -> Address {
+        let pk_bytes = if compressed {
+            pk.to_bytes()
+        } else {
+            pk.to_bytes_uncompressed()
+        };
 
         Address {
             network: network,
-            payload: Payload::PubkeyHash(Hash160::from_data(&hash)),
+            payload: Payload::PubkeyHash(Hash160::from_data(&pk_bytes)),
         }
     }
 
@@ -117,29 +118,35 @@ impl Address {
 
     /// Create a witness pay to public key address from a public key
     /// This is the native segwit address type for an output redemable with a single signature
-    pub fn p2wpkh (pk: &key::PublicKey, network: Network) -> Address {
-        let mut hash = Vec::new();
-        pk.write_into(&mut hash);
+    pub fn p2wpkh (pk: &key::PublicKey, network: Network, compressed: bool) -> Address {
+        let pk_bytes = if compressed {
+            pk.to_bytes()
+        } else {
+            pk.to_bytes_uncompressed()
+        };
 
         Address {
             network: network,
             payload: Payload::WitnessProgram(
                 // unwrap is safe as witness program is known to be correct as above
                 WitnessProgram::new(u5::try_from_u8(0).expect("0<32"),
-                                    Hash160::from_data(&hash)[..].to_vec(),
+                                    Hash160::from_data(&pk_bytes)[..].to_vec(),
                                     Address::bech_network(network)).unwrap()),
         }
     }
 
     /// Create a pay to script address that embeds a witness pay to public key
     /// This is a segwit address type that looks familiar (as p2sh) to legacy clients
-    pub fn p2shwpkh (pk: &key::PublicKey, network: Network) -> Address {
-        let mut hash = Vec::new();
-        pk.write_into(&mut hash);
+    pub fn p2shwpkh (pk: &key::PublicKey, network: Network, compressed: bool) -> Address {
+        let pk_bytes = if compressed {
+            pk.to_bytes()
+        } else {
+            pk.to_bytes_uncompressed()
+        };
 
         let builder = script::Builder::new()
             .push_int(0)
-            .push_slice(&Hash160::from_data(&hash)[..]);
+            .push_slice(&Hash160::from_data(&pk_bytes)[..]);
         Address {
             network: network,
             payload: Payload::ScriptHash(
@@ -411,12 +418,12 @@ mod tests {
     fn test_p2pkh_from_key() {
         let secp = Secp256k1::without_caps();
 
-        let key = hex_key!(&secp, "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183");
-        let addr = Address::p2pkh(&key, Bitcoin);
+        let (key, compressed) = hex_key!(&secp, "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183");
+        let addr = Address::p2pkh(&key, Bitcoin, compressed);
         assert_eq!(&addr.to_string(), "1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY");
 
-        let key = hex_key!(&secp, &"03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f");
-        let addr = Address::p2pkh(&key, Testnet);
+        let (key, compressed) = hex_key!(&secp, &"03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f");
+        let addr = Address::p2pkh(&key, Testnet, compressed);
         assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
     }
 
@@ -447,8 +454,8 @@ mod tests {
     fn test_p2wpkh () {
         // stolen from Bitcoin transaction: b3c8c2b6cfc335abbcb2c7823a8453f55d64b2b5125a9a61e8737230cdb8ce20
         let secp = Secp256k1::without_caps();
-        let key = hex_key!(&secp, "033bc8c83c52df5712229a2f72206d90192366c36428cb0c12b6af98324d97bfbc");
-        let addr = Address::p2wpkh(&key, Bitcoin);
+        let (key, compressed) = hex_key!(&secp, "033bc8c83c52df5712229a2f72206d90192366c36428cb0c12b6af98324d97bfbc");
+        let addr = Address::p2wpkh(&key, Bitcoin, compressed);
         assert_eq!(&addr.to_string(), "bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw");
     }
 

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -115,8 +115,8 @@ mod tests {
     fn p2pkh_hex(pk: &str) -> Script {
         let ctx = Secp256k1::new();
         let pk = hex::decode(pk).unwrap();
-        let (pk, compressed) = PublicKey::from_slice(&ctx, pk.as_slice()).unwrap();
-        assert_eq!(compressed, true);
+        let pk = PublicKey::from_slice(&ctx, pk.as_slice()).unwrap();
+        assert_eq!(pk.compressed, true);
         let witness_script = Address::p2pkh(&pk, Network::Bitcoin).script_pubkey();
         witness_script
     }

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -116,7 +116,8 @@ mod tests {
         let ctx = Secp256k1::new();
         let pk = hex::decode(pk).unwrap();
         let (pk, compressed) = PublicKey::from_slice(&ctx, pk.as_slice()).unwrap();
-        let witness_script = Address::p2pkh(&pk, Network::Bitcoin, compressed).script_pubkey();
+        assert_eq!(compressed, true);
+        let witness_script = Address::p2pkh(&pk, Network::Bitcoin).script_pubkey();
         witness_script
     }
 

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -115,8 +115,8 @@ mod tests {
     fn p2pkh_hex(pk: &str) -> Script {
         let ctx = Secp256k1::new();
         let pk = hex::decode(pk).unwrap();
-        let pk = PublicKey::from_slice(&ctx, pk.as_slice()).unwrap();
-        let witness_script = Address::p2pkh(&pk, Network::Bitcoin).script_pubkey();
+        let (pk, compressed) = PublicKey::from_slice(&ctx, pk.as_slice()).unwrap();
+        let witness_script = Address::p2pkh(&pk, Network::Bitcoin, compressed).script_pubkey();
         witness_script
     }
 

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -106,8 +106,9 @@ mod tests {
     use network::constants::Network;
     use util::misc::hex_bytes;
     use util::address::Address;
+    use util::key::PublicKey;
     use hex;
-    use secp256k1::{Secp256k1, PublicKey};
+    use secp256k1::Secp256k1;
 
     use super::*;
 

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -26,7 +26,7 @@ use network::constants::Network;
 use util::base58;
 
 /// A Bitcoin ECDSA public key
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PublicKey {
     /// Whether this public key represents a compressed address
     pub compressed: bool,
@@ -61,6 +61,11 @@ impl PublicKey {
             key: key,
         })
     }
+
+    /// Computes the public key as supposed to be used with this secret
+    pub fn from_private_key<C: secp256k1::Signing>(secp: &Secp256k1<C>, sk: &PrivateKey) -> PublicKey {
+        sk.public_key(secp)
+    }
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -76,8 +81,11 @@ pub struct PrivateKey {
 
 impl PrivateKey {
     /// Computes the public key as supposed to be used with this secret
-    pub fn public_key<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> secp256k1::PublicKey {
-        secp256k1::PublicKey::from_secret_key(secp, &self.key)
+    pub fn public_key<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> PublicKey {
+        PublicKey {
+            compressed: self.compressed,
+            key: secp256k1::PublicKey::from_secret_key(secp, &self.key)
+        }
     }
 
     /// Format the private key to WIF format.

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -202,7 +202,7 @@ mod tests {
         );
 
         let secp = Secp256k1::new();
-        let pk = Address::p2pkh(&sk.public_key(&secp), network, compressed);
+        let pk = Address::p2pkh(&sk.public_key(&secp), network);
         assert_eq!(&pk.to_string(), "mqwpxxvfv3QbM8PU8uBx2jaNt9btQqvQNx");
 
         // mainnet uncompressed

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! Functions needed by all parts of the Bitcoin library
 
-pub mod privkey;
+pub mod key;
 pub mod address;
 pub mod base58;
 pub mod bip32;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -27,6 +27,7 @@ pub mod hash;
 pub mod iter;
 pub mod misc;
 pub mod uint;
+pub mod wif;
 
 #[cfg(feature = "fuzztarget")]
 pub mod sha2;

--- a/src/util/wif.rs
+++ b/src/util/wif.rs
@@ -1,0 +1,131 @@
+// Rust Bitcoin Library
+// Written in 2014 by
+//     Andrew Poelstra <apoelstra@wpsoftware.net>
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Bitcoin Keys
+//!
+//! Structures and methods representing the public/secret data associated with
+//! its proposed use
+//!
+
+use std::fmt;
+
+use secp256k1::{self, Secp256k1};
+
+use consensus::encode;
+use network::constants::Network;
+use util::base58;
+use util::key;
+
+/// Format the private key to WIF format.
+pub fn write(fmt: &mut fmt::Write, pk: &key::PrivateKey, network: Network) -> fmt::Result {
+    let mut ret = [0; 34];
+    ret[0] = match network {
+        Network::Bitcoin => 128,
+        Network::Testnet | Network::Regtest => 239,
+    };
+    ret[1..33].copy_from_slice(&pk.key[..]);
+    ret[33] = 1;
+    fmt.write_str(&base58::check_encode_slice(&ret[..]))
+}
+
+/// Format the private key to WIF format for use with uncompressed addresses.
+pub fn write_uncompressed(
+    fmt: &mut fmt::Write,
+    pk: &key::PrivateKey,
+    network: Network,
+) -> fmt::Result {
+    let mut ret = [0; 34];
+    ret[0] = match network {
+        Network::Bitcoin => 128,
+        Network::Testnet | Network::Regtest => 239,
+    };
+    ret[1..33].copy_from_slice(&pk.key[..]);
+    fmt.write_str(&base58::check_encode_slice(&ret[..33]))
+}
+
+/// Get WIF encoding of this private key.
+pub fn encode(pk: &key::PrivateKey, network: Network) -> String {
+    let mut buf = String::new();
+    write(&mut buf, &pk, network).unwrap();
+    buf.shrink_to_fit();
+    buf
+}
+
+/// Get WIF encoding of this private key for use with uncompressed addresses.
+pub fn encode_uncompressed(pk: &key::PrivateKey, network: Network) -> String {
+    let mut buf = String::new();
+    write_uncompressed(&mut buf, &pk, network).unwrap();
+    buf.shrink_to_fit();
+    buf
+}
+
+/// Parse WIF encoded private key.  Returns a tuple containing the private key,
+/// the network the key is intended to be used with and whether the public key should be
+/// compressed when creating an address with this key.
+pub fn decode(wif: &str) -> Result<(key::PrivateKey, Network, bool), encode::Error> {
+    let data = base58::from_check(wif)?;
+
+    let compressed = match data.len() {
+        33 => false,
+        34 => true,
+        _ => {
+            return Err(encode::Error::Base58(base58::Error::InvalidLength(data.len())));
+        }
+    };
+
+    let network = match data[0] {
+        128 => Network::Bitcoin,
+        239 => Network::Testnet,
+        x => {
+            return Err(encode::Error::Base58(base58::Error::InvalidVersion(vec![x])));
+        }
+    };
+
+    let secp = Secp256k1::without_caps();
+    let key = secp256k1::SecretKey::from_slice(&secp, &data[1..33])
+        .map_err(|_| base58::Error::Other("Secret key out of range".to_owned()))?;
+
+    let pk = key::PrivateKey {
+        key: key,
+    };
+    Ok((pk, network, compressed))
+}
+
+#[cfg(test)]
+mod tests {
+    use network::constants::Network::Bitcoin;
+    use network::constants::Network::Testnet;
+
+    #[test]
+    fn test_wif() {
+        // testnet compressed
+        let (sk, network, compressed) =
+            super::decode("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+        assert_eq!(network, Testnet);
+        assert_eq!(compressed, true);
+        assert_eq!(
+            super::encode(&sk, network),
+            "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy"
+        );
+
+        // mainnet uncompressed
+        let (sk, network, compressed) =
+            super::decode("5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3").unwrap();
+        assert_eq!(network, Bitcoin);
+        assert_eq!(compressed, false);
+        assert_eq!(
+            super::encode_uncompressed(&sk, network),
+            "5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3"
+        );
+    }
+}


### PR DESCRIPTION
This is an attempt to alter https://github.com/rust-bitcoin/rust-bitcoin/pull/183 to take the network and compressedness properties out of the key types. This effectively creates Bitcoin-util wrappers around the secp256k1 types, which I think is fine.

It defers the network/compressedness decision all the way until an address is actually created and where it has any influence.