### PR TITLE
Add LowerHex and UpperHex impls for Hash160

### DIFF
--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -179,6 +179,30 @@ macro_rules! impl_array_newtype {
     }
 }
 
+macro_rules! impl_array_fmt_hex {
+    ($thing:ident) => {
+        impl ::std::fmt::LowerHex for $thing {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                for &ch in self.0.iter() {
+                    write!(f, "{:02x}", ch)?;
+                }
+                Ok(())
+            }
+        }
+
+        impl ::std::fmt::UpperHex for $thing {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                for &ch in self.0.iter() {
+                    write!(f, "{:02X}", ch)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 macro_rules! impl_array_newtype_encodable {
     ($thing:ident, $ty:ty, $len:expr) => {
         #[cfg(feature = "serde")]

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -72,10 +72,12 @@ pub struct Sha256dEncoder(Sha256);
 /// A RIPEMD-160 hash
 pub struct Ripemd160Hash([u8; 20]);
 impl_array_newtype!(Ripemd160Hash, u8, 20);
+impl_array_fmt_hex!(Ripemd160Hash);
 
 /// A Bitcoin hash160, 20-bytes, computed from x as RIPEMD160(SHA256(x))
 pub struct Hash160([u8; 20]);
 impl_array_newtype!(Hash160, u8, 20);
+impl_array_fmt_hex!(Hash160);
 
 /// A 32-bit hash obtained by truncating a real hash
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]


### PR DESCRIPTION
They can't go into the `_newtype` macro because `Sha256dHash` overwrites them with a reversed hex impl.