### PR TITLE
Bump rustc version to 1.22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.14.0
+  - 1.22.0
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
It seems from IRC conversations and other discussions that `1.20.0` is an acceptable version to bump our rustc to.

- It is less than `1.24.0`, which is packaged by debian stable
- Associated constants is introduced in `1.20.0`

------------

This PR is now for bumping to 1.22.0