### PR TITLE
Merkle root calculation and witness commitment check for Block

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -27,7 +27,6 @@ use blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn};
 use blockdata::block::{Block, BlockHeader};
 use network::constants::Network;
 use util::misc::hex_bytes;
-use util::hash::MerkleRoot;
 use util::uint::Uint256;
 
 /// The maximum allowable sequence number
@@ -98,7 +97,7 @@ pub fn genesis_block(network: Network) -> Block {
                 header: BlockHeader {
                     version: 1,
                     prev_blockhash: Default::default(),
-                    merkle_root: txdata.merkle_root(),
+                    merkle_root: txdata[0].txid(),
                     time: 1231006505,
                     bits: 0x1d00ffff,
                     nonce: 2083236893
@@ -112,7 +111,7 @@ pub fn genesis_block(network: Network) -> Block {
                 header: BlockHeader {
                     version: 1,
                     prev_blockhash: Default::default(),
-                    merkle_root: txdata.merkle_root(),
+                    merkle_root: txdata[0].txid(),
                     time: 1296688602,
                     bits: 0x1d00ffff,
                     nonce: 414098458
@@ -126,7 +125,7 @@ pub fn genesis_block(network: Network) -> Block {
                 header: BlockHeader {
                     version: 1,
                     prev_blockhash: Default::default(),
-                    merkle_root: txdata.merkle_root(),
+                    merkle_root: txdata[0].txid(),
                     time: 1296688602,
                     bits: 0x207fffff,
                     nonce: 2

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -51,18 +51,6 @@ pub fn bitcoin_merkle_root(data: Vec<sha256d::Hash>) -> sha256d::Hash {
     bitcoin_merkle_root(next)
 }
 
-impl<'a, T: BitcoinHash> MerkleRoot for &'a [T] {
-    fn merkle_root(&self) -> sha256d::Hash {
-        bitcoin_merkle_root(self.iter().map(|obj| obj.bitcoin_hash()).collect())
-    }
-}
-
-impl <T: BitcoinHash> MerkleRoot for Vec<T> {
-    fn merkle_root(&self) -> sha256d::Hash {
-        (&self[..]).merkle_root()
-    }
-}
-
 /// Objects which are referred to by hash
 pub trait BitcoinHash {
     /// Produces a Sha256dHash which can be used to refer to the object


### PR DESCRIPTION
Merkle root calculation for a block should use txid() of transactions. 
There was no specialized implementation of MerkleRoot for Block, but one for &[ ? :BitcoinHash] which matches the txdata vector in Block, thereby misleading to use it for merkle root calculation of blocks.