### PR TITLE
Extract travis testing into locally-runnable script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
 language: rust
-rust:
-  - stable
-  - beta
-  - nightly
-  - 1.22.0
-
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y binutils-dev libunwind8-dev
 
+matrix:
+  include:
+    - rust: stable
+      env: DO_FUZZ=true
+    - rust: beta
+    - rust: nightly
+      env: DO_BENCH=true
+    - rust: 1.22.0
+
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo build --verbose --features=bitcoinconsensus
-  - cargo test --verbose --features=bitcoinconsensus
-  - cargo build --verbose --features=use-serde
-  - cargo test --verbose --features=use-serde
-  - cargo build --verbose --features=serde-decimal
-  - cargo test --verbose --features=serde-decimal
-  - if [ "$(rustup show | grep default | grep stable)" != "" ]; then cd fuzz && cargo test --verbose && ./travis-fuzz.sh; fi
-  - if [ "$(rustup show | grep default | grep nightly)" != "" ]; then cargo bench --features unstable; fi
+  - ./contrib/test.sh

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh -ex
+
+FEATURES="bitcoinconsensus use-serde serde-decimal"
+
+# Use toolchain if explicitly specified
+if [ -n "$TOOLCHAIN" ]
+then
+    alias cargo="cargo +$TOOLCHAIN"
+fi
+
+# Test without any features first
+cargo test --verbose
+
+# Test each feature
+for feature in ${FEATURES}
+do
+    cargo test --verbose --features="$feature"
+done
+
+# Fuzz if told to
+if [ "$DO_FUZZ" = true ]
+then
+    (
+        cd fuzz
+        cargo test --verbose
+        ./travis-fuzz.sh
+    )
+fi
+
+# Bench if told to
+if [ "$DO_BENCH" = true ]
+then
+    cargo bench --features unstable
+fi


### PR DESCRIPTION
This allows people to locally run `contrib/test.sh` on their fast hardware before Travis gets to it.