### PR TITLE
Bump bitcoin-bech32 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ unstable = []
 use-serde = ["serde", "bitcoin_hashes/serde"]
 
 [dependencies]
-bitcoin-bech32 = "0.8.0"
+bitcoin-bech32 = "0.9.0"
 byteorder = "1.2"
 rand = "0.3"
 bitcoin_hashes = "0.3"


### PR DESCRIPTION
This makes the `Address::Payload::WitnessProgram` inner type compatiblewith rust-lightning-invoice's `Fallback::SegWitProgram`'s inner type.
This allows specifying fallbacks from addresses.