### PR TITLE
Add Address::from_script constructor

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -375,6 +375,14 @@ mod tests {
     macro_rules! hex_script (($hex:expr) => (Script::from(hex!($hex))));
     macro_rules! hex_hash160 (($hex:expr) => (hash160::Hash::from_slice(&hex!($hex)).unwrap()));
 
+    fn roundtrips(addr: &Address) {
+        assert_eq!(
+            Address::from_str(&addr.to_string()).ok().as_ref(), Some(addr),
+            "string round-trip failed for {}", addr,
+        );
+        //TODO: add serde roundtrip after no-strason PR
+    }
+
     #[test]
     fn test_p2pkh_address_58() {
         let addr = Address {
@@ -386,7 +394,7 @@ mod tests {
 
         assert_eq!(addr.script_pubkey(), hex_script!("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac"));
         assert_eq!(&addr.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
-        assert_eq!(Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM").unwrap(), addr);
+        roundtrips(&addr);
     }
 
     #[test]
@@ -398,6 +406,7 @@ mod tests {
         let key = hex_key!(&"03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f");
         let addr = Address::p2pkh(&key, Testnet);
         assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
+        roundtrips(&addr);
     }
 
     #[test]
@@ -411,7 +420,7 @@ mod tests {
 
         assert_eq!(addr.script_pubkey(), hex_script!("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087"));
         assert_eq!(&addr.to_string(), "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k");
-        assert_eq!(Address::from_str("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k").unwrap(), addr);
+        roundtrips(&addr);
     }
 
     #[test]
@@ -420,7 +429,7 @@ mod tests {
         let addr = Address::p2sh(&script, Testnet);
 
         assert_eq!(&addr.to_string(), "2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr");
-        assert_eq!(Address::from_str("2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr").unwrap(), addr);
+        roundtrips(&addr);
     }
 
     #[test]
@@ -429,6 +438,7 @@ mod tests {
         let key = hex_key!("033bc8c83c52df5712229a2f72206d90192366c36428cb0c12b6af98324d97bfbc");
         let addr = Address::p2wpkh(&key, Bitcoin);
         assert_eq!(&addr.to_string(), "bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw");
+        roundtrips(&addr);
     }
 
 
@@ -438,6 +448,7 @@ mod tests {
         let script = hex_script!("52210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae");
         let addr = Address::p2wsh(&script, Bitcoin);
         assert_eq!(&addr.to_string(), "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej");
+        roundtrips(&addr);
     }
 
 
@@ -454,18 +465,21 @@ mod tests {
         assert_eq!(addr.network, Testnet);
         assert_eq!(addr.script_pubkey(), hex_script!("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"));
         assert_eq!(addr.to_string(), addrstr);
+        roundtrips(&addr);
 
         let addrstr = "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy";
         let addr = Address::from_str(addrstr).unwrap();
         assert_eq!(addr.network, Testnet);
         assert_eq!(addr.script_pubkey(), hex_script!("0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"));
         assert_eq!(addr.to_string(), addrstr);
+        roundtrips(&addr);
 
         let addrstr = "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl";
         let addr = Address::from_str(addrstr).unwrap();
         assert_eq!(addr.network, Regtest);
         assert_eq!(addr.script_pubkey(), hex_script!("001454d26dddb59c7073c6a197946ea1841951fa7a74"));
         assert_eq!(addr.to_string(), addrstr);
+        roundtrips(&addr);
 
         // bad vectors
         let addrstr = "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty"; // invalid hrp


### PR DESCRIPTION
There have been several occasions where such a method has been desired:
- https://github.com/stevenroose/hal/blob/master/src/address.rs#L28-L59
- https://github.com/blockstream/electrs/blob/new-index/src/util/script.rs#L8-L49 (@shesek)

I think it's useful, especially with the `is_xxx` inspectors on script, it goes well together.