### PR TITLE
Refactor Address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ unstable = []
 use-serde = ["serde", "bitcoin_hashes/serde"]
 
 [dependencies]
-bitcoin-bech32 = "0.9.0"
+bech32 = "0.7.1"
 byteorder = "1.2"
 bitcoin_hashes = "0.7"
 bitcoinconsensus = { version = "0.16", optional = true }

--- a/fuzz/fuzz_targets/deserialize_script.rs
+++ b/fuzz/fuzz_targets/deserialize_script.rs
@@ -1,5 +1,7 @@
 extern crate bitcoin;
 
+use bitcoin::util::address::Address;
+use bitcoin::network::constants::Network;
 use bitcoin::blockdata::script;
 use bitcoin::consensus::encode;
 
@@ -32,6 +34,11 @@ fn do_test(data: &[u8]) {
         }
         assert_eq!(b.into_script(), script);
         assert_eq!(data, &encode::serialize(&script)[..]);
+
+        // Check if valid address and if that address roundtrips.
+        if let Some(addr) = Address::from_script(&script, Network::Bitcoin) {
+            assert_eq!(addr.script_pubkey(), script);
+        }
     }
 }
 

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -86,8 +86,6 @@ pub enum Error {
     UnknownNetworkMagic(u32),
     /// Parsing error
     ParseFailed(&'static str),
-    /// Unsupported witness version
-    UnsupportedWitnessVersion(u8),
     /// Unsupported Segwit flag
     UnsupportedSegwitFlag(u8),
     /// Unrecognized network command
@@ -109,7 +107,6 @@ impl fmt::Display for Error {
             Error::InvalidChecksum { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), hex_encode(e), hex_encode(a)),
             Error::UnknownNetworkMagic(ref m) => write!(f, "{}: {}", error::Error::description(self), m),
             Error::ParseFailed(ref e) => write!(f, "{}: {}", error::Error::description(self), e),
-            Error::UnsupportedWitnessVersion(ref wver) => write!(f, "{}: {}", error::Error::description(self), wver),
             Error::UnsupportedSegwitFlag(ref swflag) => write!(f, "{}: {}", error::Error::description(self), swflag),
             Error::UnrecognizedNetworkCommand(ref nwcmd) => write!(f, "{}: {}", error::Error::description(self), nwcmd),
             Error::UnexpectedHexDigit(ref d) => write!(f, "{}: {}", error::Error::description(self), d),
@@ -130,7 +127,6 @@ impl error::Error for Error {
             | Error::InvalidChecksum { .. }
             | Error::UnknownNetworkMagic(..)
             | Error::ParseFailed(..)
-            | Error::UnsupportedWitnessVersion(..)
             | Error::UnsupportedSegwitFlag(..)
             | Error::UnrecognizedNetworkCommand(..)
             | Error::UnexpectedHexDigit(..) => None,
@@ -149,7 +145,6 @@ impl error::Error for Error {
             Error::InvalidChecksum { .. } => "invalid checksum",
             Error::UnknownNetworkMagic(..) => "unknown network magic",
             Error::ParseFailed(..) => "parse failed",
-            Error::UnsupportedWitnessVersion(..) => "unsupported witness version",
             Error::UnsupportedSegwitFlag(..) => "unsupported segwit version",
             Error::UnrecognizedNetworkCommand(..) => "unrecognized network command",
             Error::UnexpectedHexDigit(..) => "unexpected hex digit",

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -38,7 +38,6 @@ use std::io::{Cursor, Read, Write};
 use byteorder::{LittleEndian, WriteBytesExt, ReadBytesExt};
 use hex::encode as hex_encode;
 
-use bitcoin_bech32;
 use bitcoin_hashes::{sha256d, Hash as HashTrait};
 use secp256k1;
 
@@ -56,8 +55,6 @@ pub enum Error {
     Io(io::Error),
     /// Base58 encoding error
     Base58(base58::Error),
-    /// Bech32 encoding error
-    Bech32(bitcoin_bech32::Error),
     /// Error from the `byteorder` crate
     ByteOrder(io::Error),
     /// secp-related error
@@ -104,7 +101,6 @@ impl fmt::Display for Error {
         match *self {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
             Error::Base58(ref e) => fmt::Display::fmt(e, f),
-            Error::Bech32(ref e) => fmt::Display::fmt(e, f),
             Error::ByteOrder(ref e) => fmt::Display::fmt(e, f),
             Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
             Error::Psbt(ref e) => fmt::Display::fmt(e, f),
@@ -126,7 +122,6 @@ impl error::Error for Error {
         match *self {
             Error::Io(ref e) => Some(e),
             Error::Base58(ref e) => Some(e),
-            Error::Bech32(ref e) => Some(e),
             Error::ByteOrder(ref e) => Some(e),
             Error::Secp256k1(ref e) => Some(e),
             Error::Psbt(ref e) => Some(e),
@@ -146,7 +141,6 @@ impl error::Error for Error {
         match *self {
             Error::Io(ref e) => e.description(),
             Error::Base58(ref e) => e.description(),
-            Error::Bech32(ref e) => e.description(),
             Error::ByteOrder(ref e) => e.description(),
             Error::Secp256k1(ref e) => e.description(),
             Error::Psbt(ref e) => e.description(),
@@ -167,13 +161,6 @@ impl error::Error for Error {
 impl From<base58::Error> for Error {
     fn from(e: base58::Error) -> Error {
         Error::Base58(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<bitcoin_bech32::Error> for Error {
-    fn from(e: bitcoin_bech32::Error) -> Error {
-        Error::Bech32(e)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 #![forbid(unsafe_code)]
 
 
-extern crate bitcoin_bech32;
+extern crate bech32;
 extern crate bitcoin_hashes;
 extern crate byteorder;
 extern crate hex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub use consensus::encode::VarInt;
 pub use network::constants::Network;
 pub use util::Error;
 pub use util::address::Address;
+pub use util::address::AddressType;
 pub use util::amount::Amount;
 pub use util::amount::SignedAmount;
 pub use util::hash::BitcoinHash;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -71,14 +71,21 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let desc = ::std::error::Error::description(self);
         match *self {
-            Error::Base58(ref e) => write!(f, "{}: {}", desc, e),
-            Error::Bech32(ref e) => write!(f, "{}: {}", desc, e),
-            Error::InvalidWitnessVersion(v) => write!(f, "{}: {}", desc, v),
-            Error::InvalidWitnessProgramLength(l) => write!(f, "{}: {}", desc, l),
-            Error::InvalidSegwitV0ProgramLength(l) => write!(f, "{}: {}", desc, l),
-            _ => f.write_str(desc),
+            Error::Base58(ref e) => write!(f, "base58: {}", e),
+            Error::Bech32(ref e) => write!(f, "bech32: {}", e),
+            Error::EmptyBech32Payload => write!(f, "the bech32 payload was empty"),
+            Error::InvalidWitnessVersion(v) => write!(f, "invalid witness script version: {}", v),
+            Error::InvalidWitnessProgramLength(l) => write!(
+                f,
+                "the witness program must be between 2 and 40 bytes in length: lengh={}",
+                l
+            ),
+            Error::InvalidSegwitV0ProgramLength(l) => write!(
+                f,
+                "a v0 witness program must be either of length 20 or 32 bytes: length={}",
+                l
+            ),
         }
     }
 }
@@ -92,19 +99,8 @@ impl ::std::error::Error for Error {
         }
     }
 
-    fn description(&self) -> &str {
-        match *self {
-            Error::Base58(..) => "base58 error",
-            Error::Bech32(..) => "bech32 error",
-            Error::EmptyBech32Payload => "the bech32 payload was empty",
-            Error::InvalidWitnessVersion(..) => "invalid witness script version",
-            Error::InvalidWitnessProgramLength(..) => {
-                "the witness program must be between 2 and 40 bytes in length"
-            },
-            Error::InvalidSegwitV0ProgramLength(..) => {
-                "a v0 witness program must be either of length 20 or 32"
-            },
-        }
+    fn description(&self) -> &'static str {
+        "std::error::Error::description is deprecated"
     }
 }
 

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -44,7 +44,7 @@ use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 use bech32::{self, u5, FromBase32, ToBase32};
-use bitcoin_hashes::{hash160, Hash, sha256};
+use bitcoin_hashes::{hash160, sha256, Hash};
 
 use blockdata::opcodes;
 use blockdata::script;
@@ -247,7 +247,7 @@ impl Address {
 
         Address {
             network: network,
-            payload: Payload::PubkeyHash(hash160::Hash::from_engine(hash_engine))
+            payload: Payload::PubkeyHash(hash160::Hash::from_engine(hash_engine)),
         }
     }
 
@@ -257,13 +257,13 @@ impl Address {
     pub fn p2sh(script: &script::Script, network: Network) -> Address {
         Address {
             network: network,
-            payload: Payload::ScriptHash(hash160::Hash::hash(&script[..]))
+            payload: Payload::ScriptHash(hash160::Hash::hash(&script[..])),
         }
     }
 
     /// Create a witness pay to public key address from a public key
     /// This is the native segwit address type for an output redeemable with a single signature
-    pub fn p2wpkh (pk: &key::PublicKey, network: Network) -> Address {
+    pub fn p2wpkh(pk: &key::PublicKey, network: Network) -> Address {
         let mut hash_engine = hash160::Hash::engine();
         pk.write_into(&mut hash_engine);
 
@@ -278,7 +278,7 @@ impl Address {
 
     /// Create a pay to script address that embeds a witness pay to public key
     /// This is a segwit address type that looks familiar (as p2sh) to legacy clients
-    pub fn p2shwpkh (pk: &key::PublicKey, network: Network) -> Address {
+    pub fn p2shwpkh(pk: &key::PublicKey, network: Network) -> Address {
         let mut hash_engine = hash160::Hash::engine();
         pk.write_into(&mut hash_engine);
 
@@ -288,14 +288,12 @@ impl Address {
 
         Address {
             network: network,
-            payload: Payload::ScriptHash(
-                hash160::Hash::hash(builder.into_script().as_bytes())
-            )
+            payload: Payload::ScriptHash(hash160::Hash::hash(builder.into_script().as_bytes())),
         }
     }
 
     /// Create a witness pay to script hash address
-    pub fn p2wsh (script: &script::Script, network: Network) -> Address {
+    pub fn p2wsh(script: &script::Script, network: Network) -> Address {
         Address {
             network: network,
             payload: Payload::WitnessProgram {
@@ -307,14 +305,15 @@ impl Address {
 
     /// Create a pay to script address that embeds a witness pay to script hash address
     /// This is a segwit address type that looks familiar (as p2sh) to legacy clients
-    pub fn p2shwsh (script: &script::Script, network: Network) -> Address {
-        let ws = script::Builder::new().push_int(0)
-                                       .push_slice(&sha256::Hash::hash(&script[..])[..])
-                                       .into_script();
+    pub fn p2shwsh(script: &script::Script, network: Network) -> Address {
+        let ws = script::Builder::new()
+            .push_int(0)
+            .push_slice(&sha256::Hash::hash(&script[..])[..])
+            .into_script();
 
         Address {
             network: network,
-            payload: Payload::ScriptHash(hash160::Hash::hash(&ws[..]))
+            payload: Payload::ScriptHash(hash160::Hash::hash(&ws[..])),
         }
     }
 
@@ -337,7 +336,7 @@ impl Address {
                     },
                     _ => None,
                 }
-            },
+            }
         }
     }
 
@@ -375,7 +374,7 @@ impl Display for Address {
                 };
                 prefixed[1..].copy_from_slice(&hash[..]);
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
-            },
+            }
             Payload::ScriptHash(ref hash) => {
                 let mut prefixed = [0; 21];
                 prefixed[0] = match self.network {
@@ -471,19 +470,19 @@ impl FromStr for Address {
         let (network, payload) = match data[0] {
             0 => (
                 Network::Bitcoin,
-                Payload::PubkeyHash(hash160::Hash::from_slice(&data[1..]).unwrap())
+                Payload::PubkeyHash(hash160::Hash::from_slice(&data[1..]).unwrap()),
             ),
             5 => (
                 Network::Bitcoin,
-                Payload::ScriptHash(hash160::Hash::from_slice(&data[1..]).unwrap())
+                Payload::ScriptHash(hash160::Hash::from_slice(&data[1..]).unwrap()),
             ),
             111 => (
                 Network::Testnet,
-                Payload::PubkeyHash(hash160::Hash::from_slice(&data[1..]).unwrap())
+                Payload::PubkeyHash(hash160::Hash::from_slice(&data[1..]).unwrap()),
             ),
             196 => (
                 Network::Testnet,
-                Payload::ScriptHash(hash160::Hash::from_slice(&data[1..]).unwrap())
+                Payload::ScriptHash(hash160::Hash::from_slice(&data[1..]).unwrap()),
             ),
             x => return Err(Error::Base58(base58::Error::InvalidVersion(vec![x]))),
         };
@@ -510,7 +509,7 @@ mod tests {
     use hex::{decode as hex_decode, encode as hex_encode};
 
     use blockdata::script::Script;
-    use network::constants::Network::{Bitcoin, Testnet, Regtest};
+    use network::constants::Network::{Bitcoin, Testnet};
     use util::key::PublicKey;
 
     use super::*;
@@ -522,12 +521,16 @@ mod tests {
 
     fn roundtrips(addr: &Address) {
         assert_eq!(
-            Address::from_str(&addr.to_string()).unwrap(), *addr,
-            "string round-trip failed for {}", addr,
+            Address::from_str(&addr.to_string()).unwrap(),
+            *addr,
+            "string round-trip failed for {}",
+            addr,
         );
         assert_eq!(
-            Address::from_script(&addr.script_pubkey(), addr.network).as_ref(), Some(addr),
-            "script round-trip failed for {}", addr,
+            Address::from_script(&addr.script_pubkey(), addr.network).as_ref(),
+            Some(addr),
+            "script round-trip failed for {}",
+            addr,
         );
         //TODO: add serde roundtrip after no-strason PR
     }
@@ -536,12 +539,13 @@ mod tests {
     fn test_p2pkh_address_58() {
         let addr = Address {
             network: Bitcoin,
-            payload: Payload::PubkeyHash(
-                hex_hash160!("162c5ea71c0b23f5b9022ef047c4a86470a5b070")
-            )
+            payload: Payload::PubkeyHash(hex_hash160!("162c5ea71c0b23f5b9022ef047c4a86470a5b070")),
         };
 
-        assert_eq!(addr.script_pubkey(), hex_script!("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac"));
+        assert_eq!(
+            addr.script_pubkey(),
+            hex_script!("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac")
+        );
         assert_eq!(&addr.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
         assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
         roundtrips(&addr);
@@ -564,12 +568,13 @@ mod tests {
     fn test_p2sh_address_58() {
         let addr = Address {
             network: Bitcoin,
-            payload: Payload::ScriptHash(
-                hex_hash160!("162c5ea71c0b23f5b9022ef047c4a86470a5b070")
-            )
+            payload: Payload::ScriptHash(hex_hash160!("162c5ea71c0b23f5b9022ef047c4a86470a5b070")),
         };
 
-        assert_eq!(addr.script_pubkey(), hex_script!("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087"));
+        assert_eq!(
+            addr.script_pubkey(),
+            hex_script!("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087")
+        );
         assert_eq!(&addr.to_string(), "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k");
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
         roundtrips(&addr);
@@ -586,7 +591,7 @@ mod tests {
     }
 
     #[test]
-    fn test_p2wpkh () {
+    fn test_p2wpkh() {
         // stolen from Bitcoin transaction: b3c8c2b6cfc335abbcb2c7823a8453f55d64b2b5125a9a61e8737230cdb8ce20
         let key = hex_key!("033bc8c83c52df5712229a2f72206d90192366c36428cb0c12b6af98324d97bfbc");
         let addr = Address::p2wpkh(&key, Bitcoin);
@@ -596,11 +601,14 @@ mod tests {
     }
 
     #[test]
-    fn test_p2wsh () {
+    fn test_p2wsh() {
         // stolen from Bitcoin transaction 5df912fda4becb1c29e928bec8d64d93e9ba8efa9b5b405bd683c86fd2c65667
         let script = hex_script!("52210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae");
         let addr = Address::p2wsh(&script, Bitcoin);
-        assert_eq!(&addr.to_string(), "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej");
+        assert_eq!(
+            &addr.to_string(),
+            "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej"
+        );
         assert_eq!(addr.address_type(), Some(AddressType::P2wsh));
         roundtrips(&addr);
     }
@@ -609,7 +617,9 @@ mod tests {
     fn test_non_existent_segwit_version() {
         let version = 13;
         // 40-byte program
-        let program = hex!("654f6ea368e0acdfd92976b7c2103a1b26313f430654f6ea368e0acdfd92976b7c2103a1b26313f4");
+        let program = hex!(
+            "654f6ea368e0acdfd92976b7c2103a1b26313f430654f6ea368e0acdfd92976b7c2103a1b26313f4"
+        );
         let addr = Address {
             payload: Payload::WitnessProgram {
                 version: u5::try_from_u8(version).expect("0<32"),
@@ -660,7 +670,10 @@ mod tests {
 
         let addr = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM").unwrap();
         let json = serde_json::to_value(&addr).unwrap();
-        assert_eq!(json, serde_json::Value::String("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".to_owned()));
+        assert_eq!(
+            json,
+            serde_json::Value::String("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".to_owned())
+        );
         let into: Address = serde_json::from_value(json).unwrap();
         assert_eq!(addr.to_string(), into.to_string());
         assert_eq!(
@@ -670,7 +683,10 @@ mod tests {
 
         let addr = Address::from_str("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k").unwrap();
         let json = serde_json::to_value(&addr).unwrap();
-        assert_eq!(json, serde_json::Value::String("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k".to_owned()));
+        assert_eq!(
+            json,
+            serde_json::Value::String("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k".to_owned())
+        );
         let into: Address = serde_json::from_value(json).unwrap();
         assert_eq!(addr.to_string(), into.to_string());
         assert_eq!(
@@ -678,9 +694,16 @@ mod tests {
             hex_script!("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087")
         );
 
-        let addr = Address::from_str("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7").unwrap();
+        let addr =
+            Address::from_str("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
+                .unwrap();
         let json = serde_json::to_value(&addr).unwrap();
-        assert_eq!(json, serde_json::Value::String("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7".to_owned()));
+        assert_eq!(
+            json,
+            serde_json::Value::String(
+                "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7".to_owned()
+            )
+        );
         let into: Address = serde_json::from_value(json).unwrap();
         assert_eq!(addr.to_string(), into.to_string());
         assert_eq!(
@@ -690,7 +713,10 @@ mod tests {
 
         let addr = Address::from_str("bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl").unwrap();
         let json = serde_json::to_value(&addr).unwrap();
-        assert_eq!(json, serde_json::Value::String("bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl".to_owned()));
+        assert_eq!(
+            json,
+            serde_json::Value::String("bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl".to_owned())
+        );
         let into: Address = serde_json::from_value(json).unwrap();
         assert_eq!(addr.to_string(), into.to_string());
         assert_eq!(

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -476,6 +476,14 @@ mod tests {
     macro_rules! hex_script (($hex:expr) => (Script::from(hex!($hex))));
     macro_rules! hex_hash160 (($hex:expr) => (hash160::Hash::from_slice(&hex!($hex)).unwrap()));
 
+    fn roundtrips(addr: &Address) {
+        assert_eq!(
+            Address::from_str(&addr.to_string()).unwrap(), *addr,
+            "string round-trip failed for {}", addr,
+        );
+        //TODO: add serde roundtrip after no-strason PR
+    }
+
     #[test]
     fn test_p2pkh_address_58() {
         let addr = Address {
@@ -487,8 +495,8 @@ mod tests {
 
         assert_eq!(addr.script_pubkey(), hex_script!("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac"));
         assert_eq!(&addr.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
-        assert_eq!(Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM").unwrap(), addr);
         assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
+        roundtrips(&addr);
     }
 
     #[test]
@@ -501,6 +509,7 @@ mod tests {
         let addr = Address::p2pkh(&key, Testnet);
         assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
         assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
+        roundtrips(&addr);
     }
 
     #[test]
@@ -514,8 +523,8 @@ mod tests {
 
         assert_eq!(addr.script_pubkey(), hex_script!("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087"));
         assert_eq!(&addr.to_string(), "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k");
-        assert_eq!(Address::from_str("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k").unwrap(), addr);
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr);
     }
 
     #[test]
@@ -524,8 +533,8 @@ mod tests {
         let addr = Address::p2sh(&script, Testnet);
 
         assert_eq!(&addr.to_string(), "2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr");
-        assert_eq!(Address::from_str("2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr").unwrap(), addr);
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr);
     }
 
     #[test]
@@ -535,6 +544,7 @@ mod tests {
         let addr = Address::p2wpkh(&key, Bitcoin);
         assert_eq!(&addr.to_string(), "bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw");
         assert_eq!(addr.address_type(), Some(AddressType::P2wpkh));
+        roundtrips(&addr);
     }
 
     #[test]
@@ -544,6 +554,7 @@ mod tests {
         let addr = Address::p2wsh(&script, Bitcoin);
         assert_eq!(&addr.to_string(), "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej");
         assert_eq!(addr.address_type(), Some(AddressType::P2wsh));
+        roundtrips(&addr);
     }
 
     #[test]
@@ -559,18 +570,21 @@ mod tests {
         assert_eq!(addr.network, Testnet);
         assert_eq!(addr.script_pubkey(), hex_script!("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"));
         assert_eq!(addr.to_string(), addrstr);
+        roundtrips(&addr);
 
         let addrstr = "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy";
         let addr = Address::from_str(addrstr).unwrap();
         assert_eq!(addr.network, Testnet);
         assert_eq!(addr.script_pubkey(), hex_script!("0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"));
         assert_eq!(addr.to_string(), addrstr);
+        roundtrips(&addr);
 
         let addrstr = "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl";
         let addr = Address::from_str(addrstr).unwrap();
         assert_eq!(addr.network, Regtest);
         assert_eq!(addr.script_pubkey(), hex_script!("001454d26dddb59c7073c6a197946ea1841951fa7a74"));
         assert_eq!(addr.to_string(), addrstr);
+        roundtrips(&addr);
 
         // bad vectors
         let addrstr = "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty"; // invalid hrp

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -614,6 +614,26 @@ mod tests {
     }
 
     #[test]
+    fn test_p2shwpkh() {
+        // stolen from Bitcoin transaction: ad3fd9c6b52e752ba21425435ff3dd361d6ac271531fc1d2144843a9f550ad01
+        let key = hex_key!("026c468be64d22761c30cd2f12cbc7de255d592d7904b1bab07236897cc4c2e766");
+        let addr = Address::p2shwpkh(&key, Bitcoin);
+        assert_eq!(&addr.to_string(), "3QBRmWNqqBGme9er7fMkGqtZtp4gjMFxhE");
+        assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr);
+    }
+
+    #[test]
+    fn test_p2shwsh() {
+        // stolen from Bitcoin transaction f9ee2be4df05041d0e0a35d7caa3157495ca4f93b233234c9967b6901dacf7a9
+        let script = hex_script!("522103e5529d8eaa3d559903adb2e881eb06c86ac2574ffa503c45f4e942e2a693b33e2102e5f10fcdcdbab211e0af6a481f5532536ec61a5fdbf7183770cf8680fe729d8152ae");
+        let addr = Address::p2shwsh(&script, Bitcoin);
+        assert_eq!(&addr.to_string(), "36EqgNnsWW94SreZgBWc1ANC6wpFZwirHr");
+        assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr);
+    }
+
+    #[test]
     fn test_non_existent_segwit_version() {
         let version = 13;
         // 40-byte program


### PR DESCRIPTION
Inspired by: https://github.com/ElementsProject/rust-elements/pull/16/.

- use `address::Error` instead of `encode::Error`
- replace using bech32-bitcoin with `Payload::WitnessProgram` variant
- add `Address::from_script`, `Payload::from_script` and `Payload::script_pubkey`

Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/253.
