### PR TITLE
Speed up consensus::[d]encode significantly

### DIFF
--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -7,7 +7,7 @@ for TARGET in fuzz_targets/*; do
 	if [ -d hfuzz_input/$FILE ]; then
 	    HFUZZ_INPUT_ARGS="-f hfuzz_input/$FILE/input"
 	fi
-	HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz" HFUZZ_RUN_ARGS="-N1000000 --exit_upon_crash -v $HFUZZ_INPUT_ARGS" cargo hfuzz run $FILE
+	HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz" HFUZZ_RUN_ARGS="-N200000 --exit_upon_crash -v $HFUZZ_INPUT_ARGS" cargo hfuzz run $FILE
 
 	if [ -f hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT ]; then
 		cat hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -99,6 +99,8 @@ pub enum NetworkMessage {
     Block(block::Block),
     /// `headers`
     Headers(Vec<block::BlockHeader>),
+    /// `sendheaders`
+    SendHeaders,
     /// `getaddr`
     GetAddr,
     // TODO: checkorder,
@@ -142,6 +144,7 @@ impl RawNetworkMessage {
             NetworkMessage::Tx(_)      => "tx",
             NetworkMessage::Block(_)   => "block",
             NetworkMessage::Headers(_) => "headers",
+            NetworkMessage::SendHeaders => "sendheaders",
             NetworkMessage::GetAddr    => "getaddr",
             NetworkMessage::Ping(_)    => "ping",
             NetworkMessage::Pong(_)    => "pong",
@@ -194,6 +197,7 @@ impl<S: Encoder> Encodable<S> for RawNetworkMessage {
             NetworkMessage::CFCheckpt(ref dat) => serialize(dat),
             NetworkMessage::Alert(ref dat)    => serialize(dat),
             NetworkMessage::Verack
+            | NetworkMessage::SendHeaders
             | NetworkMessage::MemPool
             | NetworkMessage::GetAddr => vec![],
         }).consensus_encode(s)
@@ -243,6 +247,7 @@ impl<D: Decoder> Decodable<D> for RawNetworkMessage {
             "headers" =>
                 NetworkMessage::Headers(<HeaderDeserializationWrapper as Decodable<Cursor<Vec<u8>>>>
                                         ::consensus_decode(&mut mem_d)?.0),
+            "sendheaders" => NetworkMessage::SendHeaders,
             "getaddr" => NetworkMessage::GetAddr,
             "ping"    => NetworkMessage::Ping(Decodable::consensus_decode(&mut mem_d)?),
             "pong"    => NetworkMessage::Pong(Decodable::consensus_decode(&mut mem_d)?),

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -348,7 +348,10 @@ macro_rules! construct_uint {
         impl<D: ::consensus::encode::Decoder> ::consensus::encode::Decodable<D> for $name {
             fn consensus_decode(d: &mut D) -> Result<$name, encode::Error> {
                 use consensus::encode::Decodable;
-                let ret: [u64; $n_words] = Decodable::consensus_decode(d)?;
+                let mut ret: [u64; $n_words] = [0; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = Decodable::consensus_decode(d)?;
+                }
                 Ok($name(ret))
             }
         }


### PR DESCRIPTION
This makes the (obvious) improvement of swapping out repeated single-byte reads for a read_slice method. For my network crawler (https://github.com/TheBlueMatt/dnsseed-rust/) this took CPU usage down from pegging 4 ARM cores for not-that-many connections to something more manageable. There's tons of functions left to migrate, but this is a good start. Note that, long-term, I'd really, really like to limit the generics that support Encodable/Decodable. Notably, its really easy to accidentally call [T]'s Decode when you meant to call [T; 32]'s Decode (they do different things...).

Also slipped in adding SendHeaders support, cause I need it and don't feel like separating it into its own PR.