### PR TITLE
Add special human-readable serde for OutPoint and most bip32 types

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -45,7 +45,7 @@ pub struct OutPoint {
     /// The index of the referenced output in its transaction's vout
     pub vout: u32,
 }
-serde_struct_impl!(OutPoint, txid, vout);
+serde_struct_human_string_impl!(OutPoint, "an OutPoint", txid, vout);
 
 impl OutPoint {
     /// Create a new [OutPoint].

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -357,8 +357,8 @@ macro_rules! serde_string_impl {
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
-                use std::fmt::{self, Formatter};
-                use std::str::FromStr;
+                use $crate::std::fmt::{self, Formatter};
+                use $crate::std::str::FromStr;
 
                 struct Visitor;
                 impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
@@ -418,8 +418,8 @@ macro_rules! serde_struct_human_string_impl {
                 D: $crate::serde::de::Deserializer<'de>,
             {
                 if deserializer.is_human_readable() {
-                    use std::fmt::{self, Formatter};
-                    use std::str::FromStr;
+                    use $crate::std::fmt::{self, Formatter};
+                    use $crate::std::str::FromStr;
 
                     struct Visitor;
                     impl<'de> $crate::serde::de::Visitor<'de> for Visitor {

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -400,6 +400,63 @@ macro_rules! serde_struct_impl {
     )
 }
 
+macro_rules! serde_string_impl {
+    ($name:ident, $expecting:expr) => {
+        #[cfg(feature = "serde")]
+        impl<'de> $crate::serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
+            where
+                D: $crate::serde::de::Deserializer<'de>,
+            {
+                use std::fmt::{self, Formatter};
+                use std::str::FromStr;
+
+                struct Visitor;
+                impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
+                    type Value = $name;
+
+                    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                        formatter.write_str($expecting)
+                    }
+
+                    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                    where
+                        E: $crate::serde::de::Error,
+                    {
+                        $name::from_str(v).map_err(E::custom)
+                    }
+
+                    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+                    where
+                        E: $crate::serde::de::Error,
+                    {
+                        self.visit_str(v)
+                    }
+
+                    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                    where
+                        E: $crate::serde::de::Error,
+                    {
+                        self.visit_str(&v)
+                    }
+                }
+
+                deserializer.deserialize_str(Visitor)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de> $crate::serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: $crate::serde::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+    };
+}
+
 macro_rules! user_enum {
     (
         $(#[$attr:meta])*

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -451,7 +451,7 @@ macro_rules! serde_string_impl {
             where
                 S: $crate::serde::Serializer,
             {
-                serializer.serialize_str(&self.to_string())
+                serializer.collect_str(&self)
             }
         }
     };
@@ -601,7 +601,7 @@ macro_rules! serde_struct_human_string_impl {
                 S: $crate::serde::Serializer,
             {
                 if serializer.is_human_readable() {
-                    serializer.serialize_str(&self.to_string())
+                    serializer.collect_str(&self)
                 } else {
                     use $crate::serde::ser::SerializeStruct;
 
@@ -719,7 +719,7 @@ macro_rules! user_enum {
             where
                 S: ::serde::Serializer,
             {
-                serializer.serialize_str(&self.to_string())
+                serializer.collect_str(&self)
             }
         }
     );

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -457,6 +457,170 @@ macro_rules! serde_string_impl {
     };
 }
 
+/// A combination of serde_struct_impl and serde_string_impl where string is
+/// used for human-readable serialization and struct is used for
+/// non-human-readable serialization.
+macro_rules! serde_struct_human_string_impl {
+    ($name:ident, $expecting:expr, $($fe:ident),*) => (
+        #[cfg(feature = "serde")]
+        impl<'de> $crate::serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
+            where
+                D: $crate::serde::de::Deserializer<'de>,
+            {
+                if deserializer.is_human_readable() {
+                    use std::fmt::{self, Formatter};
+                    use std::str::FromStr;
+
+                    struct Visitor;
+                    impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
+                        type Value = $name;
+
+                        fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                            formatter.write_str($expecting)
+                        }
+
+                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            $name::from_str(v).map_err(E::custom)
+                        }
+
+                        fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            self.visit_str(v)
+                        }
+
+                        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            self.visit_str(&v)
+                        }
+                    }
+
+                    deserializer.deserialize_str(Visitor)
+                } else {
+                    use $crate::std::fmt::{self, Formatter};
+                    use $crate::serde::de::IgnoredAny;
+
+                    #[allow(non_camel_case_types)]
+                    enum Enum { Unknown__Field, $($fe),* }
+
+                    struct EnumVisitor;
+                    impl<'de> $crate::serde::de::Visitor<'de> for EnumVisitor {
+                        type Value = Enum;
+
+                        fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                            formatter.write_str("a field name")
+                        }
+
+                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            match v {
+                                $(
+                                stringify!($fe) => Ok(Enum::$fe)
+                                ),*,
+                                _ => Ok(Enum::Unknown__Field)
+                            }
+                        }
+                    }
+
+                    impl<'de> $crate::serde::Deserialize<'de> for Enum {
+                        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                        where
+                            D: $crate::serde::de::Deserializer<'de>,
+                        {
+                            deserializer.deserialize_str(EnumVisitor)
+                        }
+                    }
+
+                    struct Visitor;
+
+                    impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
+                        type Value = $name;
+
+                        fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                            formatter.write_str("a struct")
+                        }
+
+                        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                        where
+                            A: $crate::serde::de::MapAccess<'de>,
+                        {
+                            use $crate::serde::de::Error;
+
+                            $(let mut $fe = None;)*
+
+                            loop {
+                                match map.next_key::<Enum>()? {
+                                    Some(Enum::Unknown__Field) => {
+                                        map.next_value::<IgnoredAny>()?;
+                                    }
+                                    $(
+                                        Some(Enum::$fe) => {
+                                            $fe = Some(map.next_value()?);
+                                        }
+                                    )*
+                                    None => { break; }
+                                }
+                            }
+
+                            $(
+                                let $fe = match $fe {
+                                    Some(x) => x,
+                                    None => return Err(A::Error::missing_field(stringify!($fe))),
+                                };
+                            )*
+
+                            let ret = $name {
+                                $($fe: $fe),*
+                            };
+
+                            Ok(ret)
+                        }
+                    }
+                    // end type defs
+
+                    static FIELDS: &'static [&'static str] = &[$(stringify!($fe)),*];
+
+                    deserializer.deserialize_struct(stringify!($name), FIELDS, Visitor)
+                }
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de> $crate::serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: $crate::serde::Serializer,
+            {
+                if serializer.is_human_readable() {
+                    serializer.serialize_str(&self.to_string())
+                } else {
+                    use $crate::serde::ser::SerializeStruct;
+
+                    // Only used to get the struct length.
+                    static FIELDS: &'static [&'static str] = &[$(stringify!($fe)),*];
+
+                    let mut st = serializer.serialize_struct(stringify!($name), FIELDS.len())?;
+
+                    $(
+                        st.serialize_field(stringify!($fe), &self.$fe)?;
+                    )*
+
+                    st.end()
+                }
+            }
+        }
+    )
+}
+
 macro_rules! user_enum {
     (
         $(#[$attr:meta])*

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -46,9 +46,6 @@ use std::str::FromStr;
 use bitcoin_bech32::{self, WitnessProgram, u5};
 use bitcoin_hashes::{hash160, Hash};
 
-#[cfg(feature = "serde")]
-use serde;
-
 use blockdata::opcodes;
 use blockdata::script;
 use network::constants::Network;
@@ -75,6 +72,7 @@ pub struct Address {
     /// The network on which this address is usable
     pub network: Network,
 }
+serde_string_impl!(Address, "a Bitcoin address");
 
 impl Address {
     /// Creates a pay to (compressed) public key hash address from a public key
@@ -296,59 +294,6 @@ impl FromStr for Address {
 impl ::std::fmt::Debug for Address {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "{}", self.to_string())
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Address {
-    #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use std::fmt::{self, Formatter};
-
-        struct Visitor;
-        impl<'de> serde::de::Visitor<'de> for Visitor {
-            type Value = Address;
-
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                formatter.write_str("a Bitcoin address")
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Address::from_str(v).map_err(E::custom)
-            }
-
-            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                self.visit_str(v)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                self.visit_str(&v)
-            }
-        }
-
-        deserializer.deserialize_str(Visitor)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for Address {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -62,6 +62,7 @@ pub struct ExtendedPrivKey {
     /// Chain code
     pub chain_code: ChainCode
 }
+serde_string_impl!(ExtendedPrivKey, "a BIP-32 extended private key");
 
 /// Extended public key
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -79,6 +80,7 @@ pub struct ExtendedPubKey {
     /// Chain code
     pub chain_code: ChainCode
 }
+serde_string_impl!(ExtendedPubKey, "a BIP-32 extended public key");
 
 /// A child number for a derived key
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -213,6 +215,7 @@ impl serde::Serialize for ChildNumber {
 #[derive(Clone, PartialEq, Eq)]
 pub struct DerivationPath(Vec<ChildNumber>);
 impl_index_newtype!(DerivationPath, ChildNumber);
+serde_string_impl!(DerivationPath, "a BIP-32 derivation path");
 
 impl From<Vec<ChildNumber>> for DerivationPath {
     fn from(numbers: Vec<ChildNumber>) -> Self {
@@ -346,44 +349,6 @@ impl fmt::Display for DerivationPath {
 impl fmt::Debug for DerivationPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self, f)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for DerivationPath {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use std::fmt;
-        use serde::de;
-
-        struct Visitor;
-        impl<'de> de::Visitor<'de> for Visitor {
-            type Value = DerivationPath;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a Bitcoin address")
-            }
-
-            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                DerivationPath::from_str(v).map_err(E::custom)
-            }
-
-            fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
-                self.visit_str(v)
-            }
-
-            fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
-                self.visit_str(&v)
-            }
-        }
-
-        deserializer.deserialize_str(Visitor)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for DerivationPath {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.to_string())
     }
 }
 


### PR DESCRIPTION
Serialized OutPoint as `"<txid>:<vout>"` instead of a struct when a human-readable (de)serializer is used, f.e. JSON.

It should be noted that this is a breaking change for people relying on the current JSON serialization of OutPoint as a struct.

This PR is on top of https://github.com/rust-bitcoin/rust-bitcoin/pull/269, but doesn't have to be.

Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/202.