### PR TITLE
Add OutPoint::new() for one-liner construction

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -48,6 +48,15 @@ pub struct OutPoint {
 serde_struct_impl!(OutPoint, txid, vout);
 
 impl OutPoint {
+    /// Create a new [OutPoint].
+    #[inline]
+    pub fn new(txid: sha256d::Hash, vout: u32) -> OutPoint {
+        OutPoint {
+            txid: txid,
+            vout: vout,
+        }
+    }
+
     /// Creates a "null" `OutPoint`.
     ///
     /// This value is used for coinbase transactions because they don't have


### PR DESCRIPTION
Avoids having to use the 4-line constructor when txid and vout are variable names already.