### PR TITLE
Export some dependencies

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -20,7 +20,7 @@
 //! these blocks and the blockchain.
 //!
 
-use bitcoin_hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash};
 
 use util;
 use util::Error::{BlockBadTarget, BlockBadProofOfWork};
@@ -30,7 +30,7 @@ use consensus::encode::Encodable;
 use network::constants::Network;
 use blockdata::transaction::Transaction;
 use blockdata::constants::max_target;
-use bitcoin_hashes::HashEngine;
+use hashes::HashEngine;
 
 /// A block header, which contains all the block's information except
 /// the actual transactions

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -31,10 +31,10 @@ use std::{error, fmt, io};
 
 use blockdata::opcodes;
 use consensus::{encode, Decodable, Encodable};
-use bitcoin_hashes::{hash160, sha256, Hash};
+use hashes::{hash160, sha256, Hash};
 #[cfg(feature="bitcoinconsensus")] use bitcoinconsensus;
 #[cfg(feature="bitcoinconsensus")] use std::convert;
-#[cfg(feature="bitcoinconsensus")] use bitcoin_hashes::sha256d;
+#[cfg(feature="bitcoinconsensus")] use hashes::sha256d;
 
 use util::key::PublicKey;
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -28,8 +28,8 @@ use std::default::Default;
 use std::{fmt, io};
 #[cfg(feature="bitcoinconsensus")] use std::collections::HashMap;
 
-use bitcoin_hashes::{self, sha256d, Hash};
-use bitcoin_hashes::hex::FromHex;
+use hashes::{self, sha256d, Hash};
+use hashes::hex::FromHex;
 
 use util::hash::BitcoinHash;
 #[cfg(feature="bitcoinconsensus")] use blockdata::script;
@@ -105,7 +105,7 @@ impl fmt::Display for OutPoint {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ParseOutPointError {
     /// Error in TXID part.
-    Txid(bitcoin_hashes::hex::Error),
+    Txid(hashes::hex::Error),
     /// Error in vout part.
     Vout(::std::num::ParseIntError),
     /// Error in general format.
@@ -620,8 +620,8 @@ mod tests {
     use util::hash::BitcoinHash;
     use util::misc::hex_bytes;
 
-    use bitcoin_hashes::{sha256d, Hash};
-    use bitcoin_hashes::hex::FromHex;
+    use hashes::{sha256d, Hash};
+    use hashes::hex::FromHex;
 
     #[test]
     fn test_outpoint() {

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -38,7 +38,7 @@ use std::io::{Cursor, Read, Write};
 use byteorder::{LittleEndian, WriteBytesExt, ReadBytesExt};
 use hex::encode as hex_encode;
 
-use bitcoin_hashes::{sha256d, Hash as HashTrait};
+use hashes::{sha256d, Hash as HashTrait};
 use secp256k1;
 
 use util::base58;

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -227,7 +227,7 @@ macro_rules! display_from_debug {
 macro_rules! hex_script (($s:expr) => (::blockdata::script::Script::from(::hex::decode($s).unwrap())));
 
 #[cfg(test)]
-macro_rules! hex_hash (($s:expr) => (::bitcoin_hashes::sha256d::Hash::from_slice(&::hex::decode($s).unwrap()).unwrap()));
+macro_rules! hex_hash (($s:expr) => (::hashes::sha256d::Hash::from_slice(&::hex::decode($s).unwrap()).unwrap()));
 
 macro_rules! serde_struct_impl {
     ($name:ident, $($fe:ident),*) => (
@@ -572,10 +572,10 @@ macro_rules! serde_struct_human_string_impl {
 
 /// Implements several traits for byte-based newtypes.
 /// Implements:
-/// - std::fmt::LowerHex (implies bitcoin_hashes::hex::ToHex)
+/// - std::fmt::LowerHex (implies hashes::hex::ToHex)
 /// - std::fmt::Display
 /// - std::str::FromStr
-/// - bitcoin_hashes::hex::FromHex
+/// - hashes::hex::FromHex
 macro_rules! impl_bytes_newtype {
     ($t:ident, $len:expr) => (
 
@@ -594,9 +594,9 @@ macro_rules! impl_bytes_newtype {
             }
         }
 
-        impl ::bitcoin_hashes::hex::FromHex for $t {
-            fn from_byte_iter<I>(iter: I) -> Result<Self, bitcoin_hashes::hex::Error>
-                where I: Iterator<Item=Result<u8, bitcoin_hashes::hex::Error>> +
+        impl ::hashes::hex::FromHex for $t {
+            fn from_byte_iter<I>(iter: I) -> Result<Self, ::hashes::hex::Error>
+                where I: Iterator<Item=Result<u8, ::hashes::hex::Error>> +
                     ExactSizeIterator +
                     DoubleEndedIterator,
             {
@@ -607,13 +607,13 @@ macro_rules! impl_bytes_newtype {
                     }
                     Ok($t(ret))
                 } else {
-                    Err(::bitcoin_hashes::hex::Error::InvalidLength(2 * $len, 2 * iter.len()))
+                    Err(::hashes::hex::Error::InvalidLength(2 * $len, 2 * iter.len()))
                 }
             }
         }
 
         impl ::std::str::FromStr for $t {
-            type Err = bitcoin_hashes::hex::Error;
+            type Err = ::hashes::hex::Error;
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 hex::FromHex::from_hex(s)
             }
@@ -623,7 +623,7 @@ macro_rules! impl_bytes_newtype {
         impl ::serde::Serialize for $t {
             fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 if s.is_human_readable() {
-                    s.serialize_str(&::bitcoin_hashes::hex::ToHex::to_hex(self))
+                    s.serialize_str(&::hashes::hex::ToHex::to_hex(self))
                 } else {
                     s.serialize_bytes(&self[..])
                 }
@@ -648,7 +648,7 @@ macro_rules! impl_bytes_newtype {
                             E: ::serde::de::Error,
                         {
                             if let Ok(hex) = ::std::str::from_utf8(v) {
-                                ::bitcoin_hashes::hex::FromHex::from_hex(hex).map_err(E::custom)
+                                ::hashes::hex::FromHex::from_hex(hex).map_err(E::custom)
                             } else {
                                 return Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self));
                             }
@@ -658,7 +658,7 @@ macro_rules! impl_bytes_newtype {
                         where
                             E: ::serde::de::Error,
                         {
-                            ::bitcoin_hashes::hex::FromHex::from_hex(v).map_err(E::custom)
+                            ::hashes::hex::FromHex::from_hex(v).map_err(E::custom)
                         }
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,13 @@
 #![forbid(unsafe_code)]
 
 
+// Re-exported dependencies.
+pub extern crate bitcoin_hashes as hashes;
+pub extern crate secp256k1;
+
 extern crate bech32;
-extern crate bitcoin_hashes as hashes;
 extern crate byteorder;
 extern crate hex;
-extern crate secp256k1;
 #[cfg(feature = "serde")] extern crate serde;
 #[cfg(all(test, feature = "serde"))] #[macro_use] extern crate serde_derive; // for 1.22.0 compat
 #[cfg(all(test, feature = "serde"))] extern crate serde_json;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 
 
 extern crate bech32;
-extern crate bitcoin_hashes;
+extern crate bitcoin_hashes as hashes;
 extern crate byteorder;
 extern crate hex;
 extern crate secp256k1;

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -20,7 +20,7 @@
 
 use network::constants;
 use consensus::encode::{self, Decodable, Encodable};
-use bitcoin_hashes::sha256d;
+use hashes::sha256d;
 
 use std::io;
 

--- a/src/network/message_filter.rs
+++ b/src/network/message_filter.rs
@@ -1,7 +1,7 @@
 //!
 //! BIP157  Client Side Block Filtering network messages
 //!
-use bitcoin_hashes::sha256d;
+use hashes::sha256d;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 /// getcfilters message

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -44,7 +44,7 @@ use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
 use bech32;
-use bitcoin_hashes::{hash160, sha256, Hash};
+use hashes::{hash160, sha256, Hash};
 
 use blockdata::opcodes;
 use blockdata::script;
@@ -505,7 +505,7 @@ mod tests {
     use std::str::FromStr;
     use std::string::ToString;
 
-    use bitcoin_hashes::{hash160, Hash};
+    use hashes::{hash160, Hash};
     use hex::{decode as hex_decode, encode as hex_encode};
 
     use blockdata::script::Script;

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -18,7 +18,7 @@ use std::{error, fmt, str, slice, iter};
 
 use byteorder::{ByteOrder, LittleEndian};
 
-use bitcoin_hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash};
 
 /// An error that might occur during base58 decoding
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -19,7 +19,7 @@
 //! signatures, which are placed in the scriptSig.
 //!
 
-use bitcoin_hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash};
 
 use blockdata::script::Script;
 use blockdata::transaction::{Transaction, TxIn};

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -50,7 +50,7 @@ use std::error;
 use std::fmt::{Display, Formatter};
 use std::io::Cursor;
 
-use bitcoin_hashes::{Hash, sha256d, siphash24};
+use hashes::{Hash, sha256d, siphash24};
 use byteorder::{ByteOrder, LittleEndian};
 
 use blockdata::block::Block;
@@ -523,7 +523,7 @@ mod test {
     use std::collections::{HashSet, HashMap};
     use std::io::Cursor;
 
-    use bitcoin_hashes::hex::FromHex;
+    use hashes::hex::FromHex;
 
     use super::*;
 

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 #[cfg(feature = "serde")] use serde;
 
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
-use bitcoin_hashes::{self, hex, hash160, sha512, Hash, HashEngine, Hmac, HmacEngine};
+use hashes::{hex, hash160, sha512, Hash, HashEngine, Hmac, HmacEngine};
 use secp256k1::{self, Secp256k1};
 
 use network::constants::Network;

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -21,7 +21,7 @@
 use secp256k1::{self, Secp256k1};
 use PrivateKey;
 use PublicKey;
-use bitcoin_hashes::{hash160, sha256, Hash, HashEngine, Hmac, HmacEngine};
+use hashes::{hash160, sha256, Hash, HashEngine, Hmac, HmacEngine};
 use blockdata::{opcodes, script};
 
 use std::{error, fmt};

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -18,7 +18,7 @@
 use std::cmp::min;
 use std::default::Default;
 
-use bitcoin_hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash};
 
 use consensus::encode::Encodable;
 

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -59,7 +59,7 @@
 use std::collections::HashSet;
 use std::io;
 
-use bitcoin_hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash};
 
 use blockdata::constants::{MAX_BLOCK_WEIGHT, MIN_TRANSACTION_WEIGHT};
 use consensus::encode::{self, Decodable, Encodable};
@@ -498,8 +498,8 @@ impl Decodable for MerkleBlock {
 mod tests {
     use std::cmp::min;
 
-    use bitcoin_hashes::hex::{FromHex, ToHex};
-    use bitcoin_hashes::{sha256d, Hash};
+    use hashes::hex::{FromHex, ToHex};
+    use hashes::{sha256d, Hash};
     use secp256k1::rand::{weak_rng, Rng, XorShiftRng};
 
     use consensus::encode::{deserialize, serialize};

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -25,10 +25,9 @@
 //! # Examples
 //!
 //! ```rust
-//! extern crate bitcoin_hashes;
 //! extern crate bitcoin;
-//! use bitcoin_hashes::sha256d;
-//! use bitcoin_hashes::hex::FromHex;
+//! use bitcoin::hashes::sha256d;
+//! use bitcoin::hashes::hex::FromHex;
 //! use bitcoin::{Block, MerkleBlock};
 //!
 //! # fn main() {
@@ -133,10 +132,9 @@ impl PartialMerkleTree {
     /// # Examples
     ///
     /// ```rust
-    /// extern crate bitcoin_hashes;
     /// extern crate bitcoin;
-    /// use bitcoin_hashes::sha256d;
-    /// use bitcoin_hashes::hex::FromHex;
+    /// use bitcoin::hashes::sha256d;
+    /// use bitcoin::hashes::hex::FromHex;
     /// use bitcoin::util::merkleblock::PartialMerkleTree;
     ///
     /// # fn main() {
@@ -408,10 +406,9 @@ impl MerkleBlock {
     /// # Examples
     ///
     /// ```rust
-    /// extern crate bitcoin_hashes;
     /// extern crate bitcoin;
-    /// use bitcoin_hashes::sha256d;
-    /// use bitcoin_hashes::hex::FromHex;
+    /// use bitcoin::hashes::sha256d;
+    /// use bitcoin::hashes::hex::FromHex;
     /// use bitcoin::{Block, MerkleBlock};
     ///
     /// # fn main() {

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -16,7 +16,7 @@
 //!
 //! Various utility functions
 
-use bitcoin_hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash};
 use blockdata::opcodes;
 use consensus::encode;
 
@@ -173,7 +173,7 @@ mod benches {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_hashes::hex::ToHex;
+    use hashes::hex::ToHex;
     use super::script_find_and_remove;
     use super::hex_bytes;
     use super::signed_msg_hash;

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -162,8 +162,8 @@ impl Decodable for PartiallySignedTransaction {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_hashes::hex::FromHex;
-    use bitcoin_hashes::sha256d;
+    use hashes::hex::FromHex;
+    use hashes::sha256d;
 
     use std::collections::BTreeMap;
 
@@ -314,8 +314,8 @@ mod tests {
 
         use hex::decode as hex_decode;
 
-        use bitcoin_hashes::hex::FromHex;
-        use bitcoin_hashes::sha256d;
+        use hashes::hex::FromHex;
+        use hashes::sha256d;
 
         use blockdata::script::Script;
         use blockdata::transaction::{SigHashType, Transaction, TxIn, TxOut, OutPoint};


### PR DESCRIPTION
This export `bitcoin_hashes` as `bitcoin::hashes` and `secp256k1` as `bitcoin::secp256k1`.

This would mean that users of rust-bitcoin, (1) don't have to manually import those dependencies anymore and more importantly (2) can avoid certain dependency imcompatibility issues if some other module they use is using another version of `bitcoin_hashes` or `secp256k1`.

Solves https://github.com/rust-bitcoin/rust-bitcoin/issues/288.