### PR TITLE
Enforcing semver on dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bitcoin_hashes = "0.7"
 bitcoinconsensus = { version = "0.16", optional = true }
 
 [dependencies.serde]
-version = "1"
+version = "1.0.0"
 features = ["derive"]
 optional = true
 
@@ -38,7 +38,7 @@ version = "0.12"
 features = [ "rand" ]
 
 [dev-dependencies]
-serde_derive = "1"
-serde_json = "1"
-serde_test = "1"
-tempfile = "3"
+serde_derive = "1.0.0"
+serde_json = "1.0.0"
+serde_test = "1.0.0"
+tempfile = "3.0.0"


### PR DESCRIPTION
Hi,
After an IRC discussion I saw that some times it updates `tempfile` to `3.1.0` which is semantically correct according to the semver rules.
but this breaks support, the new tempfile doesn't support old compilers, specifically it requires rand 0.7 which uses latest getrandom that doesn't support older than 1.32

This will make cargo not bump any major versions.
if we want to be even pickier we can pin to exact versions but i'm not sure if it's necessary as this are just test dependencies (except the serde one)  