### PR TITLE
Remove tempfile as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,3 @@ features = [ "rand" ]
 serde_derive = "1"
 serde_json = "1"
 serde_test = "1"
-tempfile = "3"


### PR DESCRIPTION
This removes `tempfile` as a dependency.
it wasn't really needed anyway, anything that was done via the fs can be done with in memory buffers.

this solves #306 and #305