### PR TITLE
Cargo clippy changes

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -78,7 +78,7 @@ impl Block {
         if self.txdata.iter().all(|t| t.input.iter().all(|i| i.witness.is_empty())) {
             return true;
         }
-        if self.txdata.len() > 0 {
+        if !self.txdata.is_empty() {
             let coinbase = &self.txdata[0];
             if coinbase.is_coin_base() {
                 // commitment is in the last output that starts with below magic

--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -658,29 +658,29 @@ impl fmt::Debug for All {
 impl All {
     /// Classifies an Opcode into a broad class
     #[inline]
-    pub fn classify(&self) -> Class {
+    pub fn classify(self) -> Class {
         // 17 opcodes
-        if *self == all::OP_VERIF || *self == all::OP_VERNOTIF ||
-           *self == all::OP_CAT || *self == all::OP_SUBSTR ||
-           *self == all::OP_LEFT || *self == all::OP_RIGHT ||
-           *self == all::OP_INVERT || *self == all::OP_AND ||
-           *self == all::OP_OR || *self == all::OP_XOR ||
-           *self == all::OP_2MUL || *self == all::OP_2DIV ||
-           *self == all::OP_MUL || *self == all::OP_DIV || *self == all::OP_MOD ||
-           *self == all::OP_LSHIFT || *self == all::OP_RSHIFT {
+        if self == all::OP_VERIF || self == all::OP_VERNOTIF ||
+           self == all::OP_CAT || self == all::OP_SUBSTR ||
+           self == all::OP_LEFT || self == all::OP_RIGHT ||
+           self == all::OP_INVERT || self == all::OP_AND ||
+           self == all::OP_OR || self == all::OP_XOR ||
+           self == all::OP_2MUL || self == all::OP_2DIV ||
+           self == all::OP_MUL || self == all::OP_DIV || self == all::OP_MOD ||
+           self == all::OP_LSHIFT || self == all::OP_RSHIFT {
             Class::IllegalOp
         // 11 opcodes
-        } else if *self == all::OP_NOP ||
+        } else if self == all::OP_NOP ||
                   (all::OP_NOP1.code <= self.code &&
                    self.code <= all::OP_NOP10.code) {
             Class::NoOp
         // 75 opcodes
-        } else if *self == all::OP_RESERVED || *self == all::OP_VER || *self == all::OP_RETURN ||
-                  *self == all::OP_RESERVED1 || *self == all::OP_RESERVED2 ||
+        } else if self == all::OP_RESERVED || self == all::OP_VER || self == all::OP_RETURN ||
+                  self == all::OP_RESERVED1 || self == all::OP_RESERVED2 ||
                   self.code >= all::OP_RETURN_186.code {
             Class::ReturnOp
         // 1 opcode
-        } else if *self == all::OP_PUSHNUM_NEG1 {
+        } else if self == all::OP_PUSHNUM_NEG1 {
             Class::PushNum(-1)
         // 16 opcodes
         } else if all::OP_PUSHNUM_1.code <= self.code &&
@@ -691,13 +691,13 @@ impl All {
             Class::PushBytes(self.code as u32)
         // 60 opcodes
         } else {
-            Class::Ordinary(Ordinary::try_from_all(*self).unwrap())
+            Class::Ordinary(Ordinary::try_from_all(self).unwrap())
         }
     }
 
     /// Encode as a byte
     #[inline]
-    pub fn into_u8(&self) -> u8 {
+    pub fn into_u8(self) -> u8 {
         self.code
     }
 }
@@ -809,8 +809,8 @@ ordinary_opcode! {
 impl Ordinary {
     /// Encode as a byte
     #[inline]
-    pub fn into_u8(&self) -> u8 {
-      *self as u8
+    pub fn into_u8(self) -> u8 {
+      self as u8
   }
 }
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -598,8 +598,8 @@ pub enum SigHashType {
 
 impl SigHashType {
      /// Break the sighash flag into the "real" sighash flag and the ANYONECANPAY boolean
-     pub(crate) fn split_anyonecanpay_flag(&self) -> (SigHashType, bool) {
-         match *self {
+     pub(crate) fn split_anyonecanpay_flag(self) -> (SigHashType, bool) {
+         match self {
              SigHashType::All		=> (SigHashType::All, false),
              SigHashType::None		=> (SigHashType::None, false),
              SigHashType::Single	=> (SigHashType::Single, false),
@@ -626,7 +626,7 @@ impl SigHashType {
      }
 
      /// Converts to a u32
-     pub fn as_u32(&self) -> u32 { *self as u32 }
+     pub fn as_u32(self) -> u32 { self as u32 }
 }
 
 

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -543,8 +543,8 @@ impl Decodable for [u16; 8] {
     #[inline]
     fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
         let mut res = [0; 8];
-        for i in 0..8 {
-            res[i] = Decodable::consensus_decode(&mut d)?;
+        for item in &mut res {
+            *item = Decodable::consensus_decode(&mut d)?;
         }
         Ok(res)
     }

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -162,7 +162,7 @@ pub fn serialize_hex<T: Encodable + ?Sized>(data: &T) -> String {
 
 /// Deserialize an object from a vector, will error if said deserialization
 /// doesn't consume the entire vector.
-pub fn deserialize<'a, T: Decodable>(data: &'a [u8]) -> Result<T, Error> {
+pub fn deserialize<T: Decodable>(data: &[u8]) -> Result<T, Error> {
     let (rv, consumed) = deserialize_partial(data)?;
 
     // Fail if data are not consumed entirely.
@@ -175,8 +175,8 @@ pub fn deserialize<'a, T: Decodable>(data: &'a [u8]) -> Result<T, Error> {
 
 /// Deserialize an object from a vector, but will not report an error if said deserialization
 /// doesn't consume the entire vector.
-pub fn deserialize_partial<'a, T: Decodable>(
-    data: &'a [u8],
+pub fn deserialize_partial<T: Decodable>(
+    data: &[u8],
 ) -> Result<(T, usize), Error> {
     let mut decoder = Cursor::new(data);
     let rv = Decodable::consensus_decode(&mut decoder)?;

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -41,9 +41,9 @@ const ONION : [u16; 3] = [0xFD87, 0xD87E, 0xEB43];
 impl Address {
     /// Create an address message for a socket
     pub fn new (socket :&SocketAddr, services: ServiceFlags) -> Address {
-        let (address, port) = match socket {
-            &SocketAddr::V4(ref addr) => (addr.ip().to_ipv6_mapped().segments(), addr.port()),
-            &SocketAddr::V6(ref addr) => (addr.ip().segments(), addr.port())
+        let (address, port) = match *socket {
+            SocketAddr::V4(addr) => (addr.ip().to_ipv6_mapped().segments(), addr.port()),
+            SocketAddr::V6(addr) => (addr.ip().segments(), addr.port())
         };
         Address { address: address, port: port, services: services }
     }

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -89,9 +89,9 @@ impl Network {
     /// let network = Network::Bitcoin;
     /// assert_eq!(network.magic(), 0xD9B4BEF9);
     /// ```
-    pub fn magic(&self) -> u32 {
+    pub fn magic(self) -> u32 {
         // Note: any new entries here must be added to `from_magic` above
-        match *self {
+        match self {
             Network::Bitcoin => 0xD9B4BEF9,
             Network::Testnet => 0x0709110B,
             Network::Regtest => 0xDAB5BFFA,
@@ -154,12 +154,12 @@ impl ServiceFlags {
     }
 
     /// Check whether [ServiceFlags] are included in this one.
-    pub fn has(&self, flags: ServiceFlags) -> bool {
+    pub fn has(self, flags: ServiceFlags) -> bool {
         (self.0 | flags.0) == self.0
     }
 
     /// Get the integer representation of this [ServiceFlags].
-    pub fn as_u64(&self) -> u64 {
+    pub fn as_u64(self) -> u64 {
         self.0
     }
 }
@@ -178,11 +178,10 @@ impl fmt::UpperHex for ServiceFlags {
 
 impl fmt::Display for ServiceFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if *self == ServiceFlags::NONE {
+        let mut flags = *self;
+        if flags == ServiceFlags::NONE {
             return write!(f, "ServiceFlags(NONE)");
         }
-
-        let mut flags = self.clone();
         let mut first = true;
         macro_rules! write_flag {
             ($f:ident) => {

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -72,9 +72,7 @@ impl Encodable for CommandString {
         if strbytes.len() > 12 {
             return Err(encode::Error::UnrecognizedNetworkCommand(self.0.clone().into_owned()));
         }
-        for x in 0..strbytes.len() {
-            rawbytes[x] = strbytes[x];
-        }
+        rawbytes[..strbytes.len()].clone_from_slice(&strbytes[..]);
         rawbytes.consensus_encode(s)
     }
 }

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -111,7 +111,7 @@ impl GetBlocksMessage {
     pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetBlocksMessage {
         GetBlocksMessage {
             version: constants::PROTOCOL_VERSION,
-            locator_hashes: locator_hashes.clone(),
+            locator_hashes: locator_hashes,
             stop_hash: stop_hash
         }
     }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -18,26 +18,22 @@
 //! # Example: creating a new address from a randomly-generated key pair
 //!
 //! ```rust
-//! extern crate secp256k1;
-//! extern crate bitcoin;
 //!
 //! use bitcoin::network::constants::Network;
 //! use bitcoin::util::address::Address;
 //! use bitcoin::util::key;
-//! use secp256k1::Secp256k1;
-//! use secp256k1::rand::thread_rng;
+//! use bitcoin::secp256k1::Secp256k1;
+//! use bitcoin::secp256k1::rand::thread_rng;
 //!
-//! fn main() {
-//!     // Generate random key pair
-//!     let s = Secp256k1::new();
-//!     let public_key = key::PublicKey {
-//!         compressed: true,
-//!         key: s.generate_keypair(&mut thread_rng()).1,
-//!     };
+//! // Generate random key pair
+//! let s = Secp256k1::new();
+//! let public_key = key::PublicKey {
+//!     compressed: true,
+//!     key: s.generate_keypair(&mut thread_rng()).1,
+//! };
 //!
-//!     // Generate pay-to-pubkey-hash address
-//!     let address = Address::p2pkh(&public_key, Network::Bitcoin);
-//! }
+//! // Generate pay-to-pubkey-hash address
+//! let address = Address::p2pkh(&public_key, Network::Bitcoin);
 //! ```
 
 use std::fmt::{self, Display, Formatter};
@@ -219,7 +215,7 @@ impl Payload {
                 assert!(ver.to_u8() <= 16);
                 let mut verop = ver.to_u8();
                 if verop > 0 {
-                    verop = 0x50 + verop;
+                    verop += 0x50;
                 }
                 script::Builder::new().push_opcode(verop.into()).push_slice(&prog)
             }
@@ -406,7 +402,7 @@ impl Display for Address {
 /// Returns the same slice when no prefix is found.
 fn find_bech32_prefix(bech32: &str) -> &str {
     // Split at the last occurrence of the separator character '1'.
-    match bech32.rfind("1") {
+    match bech32.rfind('1') {
         None => bech32,
         Some(sep) => bech32.split_at(sep).0,
     }
@@ -427,7 +423,7 @@ impl FromStr for Address {
         if let Some(network) = bech32_network {
             // decode as bech32
             let (_, payload) = bech32::decode(s)?;
-            if payload.len() == 0 {
+            if payload.is_empty() {
                 return Err(Error::EmptyBech32Payload);
             }
 

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -340,7 +340,7 @@ impl Amount {
     /// Express this [Amount] as a floating-point value in the given denomination.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    pub fn to_float_in(&self, denom: Denomination) -> f64 {
+    pub fn to_float_in(self, denom: Denomination) -> f64 {
         f64::from_str(&self.to_string_in(denom)).unwrap()
     }
 
@@ -349,7 +349,7 @@ impl Amount {
     /// Equivalent to `to_float_in(Denomination::Bitcoin)`.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    pub fn as_btc(&self) -> f64 {
+    pub fn as_btc(self) -> f64 {
         self.to_float_in(Denomination::Bitcoin)
     }
 
@@ -370,14 +370,14 @@ impl Amount {
     /// Format the value of this [Amount] in the given denomination.
     ///
     /// Does not include the denomination.
-    pub fn fmt_value_in(&self, f: &mut fmt::Write, denom: Denomination) -> fmt::Result {
+    pub fn fmt_value_in(self, f: &mut fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.as_sat(), false, f, denom)
     }
 
     /// Get a string number of this [Amount] in the given denomination.
     ///
     /// Does not include the denomination.
-    pub fn to_string_in(&self, denom: Denomination) -> String {
+    pub fn to_string_in(self, denom: Denomination) -> String {
         let mut buf = String::new();
         self.fmt_value_in(&mut buf, denom).unwrap();
         buf
@@ -385,7 +385,7 @@ impl Amount {
 
     /// Get a formatted string of this [Amount] in the given denomination,
     /// suffixed with the abbreviation for the denomination.
-    pub fn to_string_with_denomination(&self, denom: Denomination) -> String {
+    pub fn to_string_with_denomination(self, denom: Denomination) -> String {
         let mut buf = String::new();
         self.fmt_value_in(&mut buf, denom).unwrap();
         write!(buf, " {}", denom).unwrap();
@@ -637,7 +637,7 @@ impl SignedAmount {
     /// Express this [SignedAmount] as a floating-point value in the given denomination.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    pub fn to_float_in(&self, denom: Denomination) -> f64 {
+    pub fn to_float_in(self, denom: Denomination) -> f64 {
         f64::from_str(&self.to_string_in(denom)).unwrap()
     }
 
@@ -646,7 +646,7 @@ impl SignedAmount {
     /// Equivalent to `to_float_in(Denomination::Bitcoin)`.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    pub fn as_btc(&self) -> f64 {
+    pub fn as_btc(self) -> f64 {
         self.to_float_in(Denomination::Bitcoin)
     }
 
@@ -667,7 +667,7 @@ impl SignedAmount {
     /// Format the value of this [SignedAmount] in the given denomination.
     ///
     /// Does not include the denomination.
-    pub fn fmt_value_in(&self, f: &mut fmt::Write, denom: Denomination) -> fmt::Result {
+    pub fn fmt_value_in(self, f: &mut fmt::Write, denom: Denomination) -> fmt::Result {
         let sats = self.as_sat().checked_abs().map(|a: i64| a as u64).unwrap_or_else(|| {
             // We could also hard code this into `9223372036854775808`
             u64::max_value() - self.as_sat() as u64 +1
@@ -678,7 +678,7 @@ impl SignedAmount {
     /// Get a string number of this [SignedAmount] in the given denomination.
     ///
     /// Does not include the denomination.
-    pub fn to_string_in(&self, denom: Denomination) -> String {
+    pub fn to_string_in(self, denom: Denomination) -> String {
         let mut buf = String::new();
         self.fmt_value_in(&mut buf, denom).unwrap();
         buf
@@ -686,7 +686,7 @@ impl SignedAmount {
 
     /// Get a formatted string of this [SignedAmount] in the given denomination,
     /// suffixed with the abbreviation for the denomination.
-    pub fn to_string_with_denomination(&self, denom: Denomination) -> String {
+    pub fn to_string_with_denomination(self, denom: Denomination) -> String {
         let mut buf = String::new();
         self.fmt_value_in(&mut buf, denom).unwrap();
         write!(buf, " {}", denom).unwrap();
@@ -1313,12 +1313,12 @@ mod tests {
         use super::Denomination as D;
         let amt = Amount::from_sat(42);
         let denom = Amount::to_string_with_denomination;
-        assert_eq!(Amount::from_str(&denom(&amt, D::Bitcoin)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(&amt, D::MilliBitcoin)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(&amt, D::MicroBitcoin)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(&amt, D::Bit)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(&amt, D::Satoshi)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(&amt, D::MilliSatoshi)), Ok(amt));
+        assert_eq!(Amount::from_str(&denom(amt, D::Bitcoin)), Ok(amt));
+        assert_eq!(Amount::from_str(&denom(amt, D::MilliBitcoin)), Ok(amt));
+        assert_eq!(Amount::from_str(&denom(amt, D::MicroBitcoin)), Ok(amt));
+        assert_eq!(Amount::from_str(&denom(amt, D::Bit)), Ok(amt));
+        assert_eq!(Amount::from_str(&denom(amt, D::Satoshi)), Ok(amt));
+        assert_eq!(Amount::from_str(&denom(amt, D::MilliSatoshi)), Ok(amt));
 
         assert_eq!(Amount::from_str("42 satoshi BTC"), Err(ParseAmountError::InvalidFormat));
         assert_eq!(SignedAmount::from_str("-42 satoshi BTC"), Err(ParseAmountError::InvalidFormat));

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -274,7 +274,7 @@ fn fmt_satoshi_in(
 /// zero is considered an underflow and will cause a panic if you're not using
 /// the checked arithmetic methods.
 ///
-#[derive(Copy, Clone, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Amount(u64);
 
 impl Amount {
@@ -445,25 +445,6 @@ impl default::Default for Amount {
     }
 }
 
-impl PartialEq for Amount {
-    fn eq(&self, other: &Amount) -> bool {
-        PartialEq::eq(&self.0, &other.0)
-    }
-}
-impl Eq for Amount {}
-
-impl PartialOrd for Amount {
-    fn partial_cmp(&self, other: &Amount) -> Option<::std::cmp::Ordering> {
-        PartialOrd::partial_cmp(&self.0, &other.0)
-    }
-}
-
-impl Ord for Amount {
-    fn cmp(&self, other: &Amount) -> ::std::cmp::Ordering {
-        Ord::cmp(&self.0, &other.0)
-    }
-}
-
 impl fmt::Debug for Amount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Amount({} satoshi)", self.as_sat())
@@ -571,7 +552,7 @@ impl FromStr for Amount {
 /// start with `checked_`.  The operations from [std::ops] that [Amount]
 /// implements will panic when overflow or underflow occurs.
 ///
-#[derive(Copy, Clone, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SignedAmount(i64);
 
 impl SignedAmount {
@@ -786,25 +767,6 @@ impl SignedAmount {
 impl default::Default for SignedAmount {
     fn default() -> Self {
         SignedAmount::ZERO
-    }
-}
-
-impl PartialEq for SignedAmount {
-    fn eq(&self, other: &SignedAmount) -> bool {
-        PartialEq::eq(&self.0, &other.0)
-    }
-}
-impl Eq for SignedAmount {}
-
-impl PartialOrd for SignedAmount {
-    fn partial_cmp(&self, other: &SignedAmount) -> Option<::std::cmp::Ordering> {
-        PartialOrd::partial_cmp(&self.0, &other.0)
-    }
-}
-
-impl Ord for SignedAmount {
-    fn cmp(&self, other: &SignedAmount) -> ::std::cmp::Ordering {
-        Ord::cmp(&self.0, &other.0)
     }
 }
 

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -103,7 +103,7 @@ impl<T: Default + Copy> SmallVec<T> {
     }
 }
 
-static BASE58_CHARS: &'static [u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+static BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 static BASE58_DIGITS: [Option<u8>; 128] = [
     None,     None,     None,     None,     None,     None,     None,     None,     // 0-7

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -241,7 +241,7 @@ impl GCSFilterReader {
     pub fn match_any(&self, reader: &mut io::Read, query: &mut Iterator<Item=&[u8]>) -> Result<bool, Error> {
         let mut decoder = reader;
         let n_elements: VarInt = Decodable::consensus_decode(&mut decoder).unwrap_or(VarInt(0));
-        let ref mut reader = decoder;
+        let reader = &mut decoder;
         // map hashes to [0, n_elements << grp]
         let nm = n_elements.0 * self.m;
         let mut mapped = query.map(|e| map_to_range(self.filter.hash(e), nm)).collect::<Vec<_>>();
@@ -281,7 +281,7 @@ impl GCSFilterReader {
     pub fn match_all(&self, reader: &mut io::Read, query: &mut Iterator<Item=&[u8]>) -> Result<bool, Error> {
         let mut decoder = reader;
         let n_elements: VarInt = Decodable::consensus_decode(&mut decoder).unwrap_or(VarInt(0));
-        let ref mut reader = decoder;
+        let reader = &mut decoder;
         // map hashes to [0, n_elements << grp]
         let nm = n_elements.0 * self.m;
         let mut mapped = query.map(|e| map_to_range(self.filter.hash(e), nm)).collect::<Vec<_>>();

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -124,15 +124,15 @@ impl ChildNumber {
     /// Returns `true` if the child number is a [`Normal`] value.
     ///
     /// [`Normal`]: #variant.Normal
-    pub fn is_normal(&self) -> bool {
+    pub fn is_normal(self) -> bool {
         !self.is_hardened()
     }
 
     /// Returns `true` if the child number is a [`Hardened`] value.
     ///
     /// [`Hardened`]: #variant.Hardened
-    pub fn is_hardened(&self) -> bool {
-        match *self {
+    pub fn is_hardened(self) -> bool {
+        match self {
             ChildNumber::Hardened {..} => true,
             ChildNumber::Normal {..} => false,
         }
@@ -548,7 +548,7 @@ impl ExtendedPubKey {
         i: ChildNumber,
     ) -> Result<ExtendedPubKey, Error> {
         let (sk, chain_code) = self.ckd_pub_tweak(i)?;
-        let mut pk = self.public_key.clone();
+        let mut pk = self.public_key;
         pk.key.add_exp_assign(secp, &sk[..]).map_err(Error::Ecdsa)?;
 
         Ok(ExtendedPubKey {
@@ -604,9 +604,9 @@ impl FromStr for ExtendedPrivKey {
         let cn_int: u32 = endian::slice_to_u32_be(&data[9..13]);
         let child_number: ChildNumber = ChildNumber::from(cn_int);
 
-        let network = if &data[0..4] == [0x04u8, 0x88, 0xAD, 0xE4] {
+        let network = if data[0..4] == [0x04u8, 0x88, 0xAD, 0xE4] {
             Network::Bitcoin
-        } else if &data[0..4] == [0x04u8, 0x35, 0x83, 0x94] {
+        } else if data[0..4] == [0x04u8, 0x35, 0x83, 0x94] {
             Network::Testnet
         } else {
             return Err(base58::Error::InvalidVersion((&data[0..4]).to_vec()));
@@ -661,9 +661,9 @@ impl FromStr for ExtendedPubKey {
         let child_number: ChildNumber = ChildNumber::from(cn_int);
 
         Ok(ExtendedPubKey {
-            network: if &data[0..4] == [0x04u8, 0x88, 0xB2, 0x1E] {
+            network: if data[0..4] == [0x04u8, 0x88, 0xB2, 0x1E] {
                 Network::Bitcoin
-            } else if &data[0..4] == [0x04u8, 0x35, 0x87, 0xCF] {
+            } else if data[0..4] == [0x04u8, 0x35, 0x87, 0xCF] {
                 Network::Testnet
             } else {
                 return Err(base58::Error::InvalidVersion((&data[0..4]).to_vec()));

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -30,7 +30,7 @@ pub fn bitcoin_merkle_root_inline<T>(data: &mut [T]) -> T
           <T as Hash>::Engine: io::Write,
 {
     // Base case
-    if data.len() < 1 {
+    if data.is_empty() {
         return Default::default();
     }
     if data.len() < 2 {

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -25,12 +25,10 @@
 //! # Examples
 //!
 //! ```rust
-//! extern crate bitcoin;
 //! use bitcoin::hash_types::Txid;
 //! use bitcoin::hashes::hex::FromHex;
 //! use bitcoin::{Block, MerkleBlock};
 //!
-//! # fn main() {
 //! // Get the proof from a bitcoind by running in the terminal:
 //! // $ TXID="5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2"
 //! // $ bitcoin-cli gettxoutproof [\"$TXID\"]
@@ -52,7 +50,6 @@
 //! );
 //! assert_eq!(1, index.len());
 //! assert_eq!(1, index[0]);
-//! # }
 //! ```
 
 use std::collections::HashSet;
@@ -133,12 +130,10 @@ impl PartialMerkleTree {
     /// # Examples
     ///
     /// ```rust
-    /// extern crate bitcoin;
     /// use bitcoin::hash_types::Txid;
     /// use bitcoin::hashes::hex::FromHex;
     /// use bitcoin::util::merkleblock::PartialMerkleTree;
     ///
-    /// # fn main() {
     /// // Block 80000
     /// let txids: Vec<Txid> = [
     ///     "c06fbab289f723c6261d3030ddb6be121f7d2508d77862bb1e484f5cd7f92b25",
@@ -152,7 +147,6 @@ impl PartialMerkleTree {
     /// let matches = vec![false, true];
     /// let tree = PartialMerkleTree::from_txids(&txids, &matches);
     /// assert!(tree.extract_matches(&mut vec![], &mut vec![]).is_ok());
-    /// # }
     /// ```
     pub fn from_txids(txids: &[Txid], matches: &[bool]) -> Self {
         // We can never have zero txs in a merkle block, we always need the coinbase tx
@@ -271,7 +265,7 @@ impl PartialMerkleTree {
         if height == 0 || !parent_of_match {
             // If at height 0, or nothing interesting below, store hash and stop
             let hash = self.calc_hash(height, pos, txids);
-            self.hashes.push(hash.into());
+            self.hashes.push(hash);
         } else {
             // Otherwise, don't store any hash, but descend into the subtrees
             self.traverse_and_build(height - 1, pos * 2, txids, matches);
@@ -407,12 +401,10 @@ impl MerkleBlock {
     /// # Examples
     ///
     /// ```rust
-    /// extern crate bitcoin;
     /// use bitcoin::hash_types::Txid;
     /// use bitcoin::hashes::hex::FromHex;
     /// use bitcoin::{Block, MerkleBlock};
     ///
-    /// # fn main() {
     /// // Block 80000
     /// let block_bytes = Vec::from_hex("01000000ba8b9cda965dd8e536670f9ddec10e53aab14b20bacad2\
     ///     7b9137190000000000190760b278fe7b8565fda3b968b918d5fd997f993b23674c0af3b6fde300b38f33\
@@ -437,7 +429,6 @@ impl MerkleBlock {
     /// let mut index: Vec<u32> = vec![];
     /// assert!(mb.extract_matches(&mut matches, &mut index).is_ok());
     /// assert_eq!(txid, matches[0]);
-    /// # }
     /// ```
     pub fn from_block(block: &Block, match_txids: &HashSet<Txid>) -> Self {
         let header = block.header;

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -20,14 +20,14 @@ use hashes::{sha256d, Hash};
 use blockdata::opcodes;
 use consensus::encode;
 
-static MSG_SIGN_PREFIX: &'static [u8] = b"\x18Bitcoin Signed Message:\n";
+static MSG_SIGN_PREFIX: &[u8] = b"\x18Bitcoin Signed Message:\n";
 
 /// Search for `needle` in the vector `haystack` and remove every
 /// instance of it, returning the number of instances removed.
 /// Loops through the vector opcode by opcode, skipping pushed data.
 pub fn script_find_and_remove(haystack: &mut Vec<u8>, needle: &[u8]) -> usize {
     if needle.len() > haystack.len() { return 0; }
-    if needle.len() == 0 { return 0; }
+    if needle.is_empty() { return 0; }
 
     let mut top = haystack.len() - needle.len();
     let mut n_deleted = 0;

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -119,12 +119,12 @@ macro_rules! impl_psbt_insert_pair {
         if !$raw_key.key.is_empty() {
             let key_val: $keyed_key_type = ::util::psbt::serialize::Deserialize::deserialize(&$raw_key.key)?;
 
-            if $slf.$keyed_name.contains_key(&key_val) {
-                return Err(::util::psbt::Error::DuplicateKey($raw_key).into());
-            } else {
-                let val: $keyed_value_type = ::util::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
-
-                $slf.$keyed_name.insert(key_val, val);
+            match $slf.$keyed_name.entry(key_val) {
+                ::std::collections::btree_map::Entry::Vacant(empty_key) => {
+                    let val: $keyed_value_type = ::util::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
+                    empty_key.insert(val);
+                }
+                ::std::collections::btree_map::Entry::Occupied(_) => return Err(::util::psbt::Error::DuplicateKey($raw_key).into()),
             }
         } else {
             return Err(::util::psbt::Error::InvalidKey($raw_key).into());

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -104,7 +104,7 @@ macro_rules! impl_psbtmap_consensus_enc_dec_oding {
 macro_rules! impl_psbt_insert_pair {
     ($slf:ident.$unkeyed_name:ident <= <$raw_key:ident: _>|<$raw_value:ident: $unkeyed_value_type:ty>) => {
         if $raw_key.key.is_empty() {
-            if let None = $slf.$unkeyed_name {
+            if $slf.$unkeyed_name.is_none() {
                 let val: $unkeyed_value_type = ::util::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
 
                 $slf.$unkeyed_name = Some(val)

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -112,12 +112,9 @@ impl Map for Input {
                     self.hd_keypaths <= <raw_key: PublicKey>|<raw_value: (Fingerprint, DerivationPath)>
                 }
             }
-            _ => {
-                if self.unknown.contains_key(&raw_key) {
-                    return Err(Error::DuplicateKey(raw_key).into());
-                } else {
-                    self.unknown.insert(raw_key, raw_value);
-                }
+            _ => match self.unknown.entry(raw_key) {
+                ::std::collections::btree_map::Entry::Vacant(empty_key) => {empty_key.insert(raw_value);},
+                ::std::collections::btree_map::Entry::Occupied(k) => return Err(Error::DuplicateKey(k.key().clone()).into()),
             }
         }
 

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -13,6 +13,7 @@
 //
 
 use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
 
 use blockdata::script::Script;
 use consensus::encode;
@@ -61,12 +62,9 @@ impl Map for Output {
                     self.hd_keypaths <= <raw_key: PublicKey>|<raw_value: (Fingerprint, DerivationPath)>
                 }
             }
-            _ => {
-                if self.unknown.contains_key(&raw_key) {
-                    return Err(Error::DuplicateKey(raw_key).into());
-                } else {
-                    self.unknown.insert(raw_key, raw_value);
-                }
+            _ => match self.unknown.entry(raw_key) {
+                    Entry::Vacant(empty_key) => {empty_key.insert(raw_value);},
+                    Entry::Occupied(k) => return Err(Error::DuplicateKey(k.key().clone()).into()),
             }
         }
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -67,8 +67,8 @@ impl PartiallySignedTransaction {
         let mut tx: Transaction = self.global.unsigned_tx;
 
         for (vin, psbtin) in tx.input.iter_mut().zip(self.inputs.into_iter()) {
-            vin.script_sig = psbtin.final_script_sig.unwrap_or_else(|| Script::new());
-            vin.witness = psbtin.final_script_witness.unwrap_or_else(|| Vec::new());
+            vin.script_sig = psbtin.final_script_sig.unwrap_or_else(Script::new);
+            vin.witness = psbtin.final_script_witness.unwrap_or_else(Vec::new);
         }
 
         tx


### PR DESCRIPTION
Hi,
This PR includes a bunch of stuff,
the first thing is to see how people feel about clippy suggestions, unlike rustfmt clippy's suggestions don't change that often and contain a lot of useful suggestions.

Commit e5ad634f3de824253501e812392900b14f8bd13b should increase performance by batching allocations. 
(https://rust-lang.github.io/rust-clippy/master/index.html#slow_vector_initialization, https://rust-lang.github.io/rust-clippy/master/index.html#map_entry)

Commit c9ba8ec9b9b07c89d183533238ccff43903f7f96 might reduce memory usage by removing needless references and pass by value small Copy objects.

Commit ae26c7d0daf73c55f2fcfceb534f4e26ef50fb9e is one that I think is important, `PartialEq` and `Hash` *must* agree (meaning that `a==a` means that `Hash(a)==Hash(a)`) so it is really discouraged to manually implement one but derive the other, 
and since we didn't do anything special there I preferred to derive them both. 
(https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq)

Commit bf82f63d3b911b883cf2400d20f1a01350afa11b contains idiomatic suggestions, some *might* improve performance (like using char instead of strings in `split()`), and some *might* improve reliability (using `b'a'` instead of `'a' as u8`) 
(https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern https://rust-lang.github.io/rust-clippy/master/index.html#char_lit_as_u8 )

~~The last commit 6e234f7d2031b443e666cbca63b476b112bcd840 I'm not sure how I feel about it I decided to add it, though it can be remove if wanted.~~ (dropped)