### PR TITLE
Make secp256k1/rand a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bech32 = "0.7.1"
 byteorder = "1.2"
 bitcoin_hashes = "0.7"
 bitcoinconsensus = { version = "0.16", optional = true }
+secp256k1 = "0.12"
 
 [dependencies.serde]
 version = "1"
@@ -33,11 +34,9 @@ optional = true
 [dependencies.hex]
 version = "=0.3.2"
 
-[dependencies.secp256k1]
-version = "0.12"
-features = [ "rand" ]
 
 [dev-dependencies]
 serde_derive = "1"
 serde_json = "1"
 serde_test = "1"
+secp256k1 = { version = "0.12", features = [ "rand" ] }


### PR DESCRIPTION
Right now we automatically compile rust-secp with the `rand` feature for no reason.
We need rand only in tests.