### PR TITLE
Pin serde and re-export bech32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ bitcoinconsensus = { version = "0.16", optional = true }
 secp256k1 = "0.12"
 
 [dependencies.serde]
-version = "1"
+version = "=1.0.98"
 features = ["derive"]
 optional = true
 
@@ -36,7 +36,7 @@ version = "=0.3.2"
 
 
 [dev-dependencies]
-serde_derive = "1"
+serde_derive = "=1.0.98"
 serde_json = "1"
 serde_test = "1"
 secp256k1 = { version = "0.12", features = [ "rand" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@
 // Re-exported dependencies.
 pub extern crate bitcoin_hashes as hashes;
 pub extern crate secp256k1;
+pub extern crate bech32;
 
-extern crate bech32;
 extern crate byteorder;
 extern crate hex;
 #[cfg(feature = "serde")] extern crate serde;


### PR DESCRIPTION
As per IRC discussion:
```
12:43 < andytoshi> oh, damn, i thought we re-exported bech32
12:45 < elichai2> no it was only hashes and secp iirc
12:47 < andytoshi> if someone is so inclined as to export bech32, that'd be cool..
12:47 < andytoshi> and bump to 0.19.1
12:49 < elichai2> We have a bigger problem
12:49 < elichai2> "Minimum supported rustc version is 1.31"
12:49 < andytoshi> where's that?
12:54 < elichai2> ok. apperantly it's serde-derive fault
12:54 < elichai2> he published a new minor version while bumping a major proc-macro2
12:54 < elichai2> https://github.com/serde-rs/serde/blob/v1.0.98/serde_derive/Cargo.toml
12:54 < elichai2> https://github.com/serde-rs/serde/blob/v1.0.99/serde_derive/Cargo.toml
13:01 < andytoshi> patch version even
13:02 < andytoshi> w/e we can just pi
13:02 < dongcarl> :man-facepalming:
13:02 < andytoshi> but 
13:04 < elichai2> yep
13:04 < elichai2> we'll see what dtolnay will say but I can probably guess.... https://github.com/serde-rs/serde/issues/1602
13:06 < elichai2> i'll open a PR pinning, exporting and bump to 0.19.1. wanna yank 0.19.0?
13:07 < andytoshi> all old versions are affected
```

cc https://github.com/serde-rs/serde/issues/1602