### PR TITLE
Remove serde-derive as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 
 addons:
   apt:
@@ -17,11 +18,13 @@ addons:
 matrix:
   include:
     - rust: stable
-      env: DO_FUZZ=true DO_COV=true
+      env: DO_FUZZ=true DO_COV=true AS_DEPENDENCY=true
     - rust: beta
+      env: AS_DEPENDENCY=true
     - rust: nightly
-      env: DO_BENCH=true
+      env: DO_BENCH=true AS_DEPENDENCY=true
     - rust: 1.22.0
+      env: AS_DEPENDENCY=true
 
 script:
   - ./contrib/test.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,13 @@ byteorder = "1.2"
 bitcoin_hashes = "0.7"
 bitcoinconsensus = { version = "0.16", optional = true }
 secp256k1 = "0.12"
-
-[dependencies.serde]
-version = "=1.0.98"
-features = ["derive"]
-optional = true
+serde = { version = "1", optional = true }
 
 [dependencies.hex]
 version = "=0.3.2"
 
-
 [dev-dependencies]
-serde_derive = "=1.0.98"
+serde_derive = "<1.0.99"
 serde_json = "1"
 serde_test = "1"
 secp256k1 = { version = "0.12", features = [ "rand" ] }

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -38,3 +38,12 @@ if [ "$DO_BENCH" = true ]
 then
     cargo bench --features unstable
 fi
+
+# Use as dependency if told to
+if [ -n "$AS_DEPENDENCY" ]
+then
+    cargo new dep_test
+    cd dep_test
+    echo 'bitcoin = { path = "..", features = ["use-serde"] }' >> Cargo.toml
+    cargo test --verbose
+fi

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -696,7 +696,7 @@ impl<'de> serde::Deserialize<'de> for Script {
     where
         D: serde::Deserializer<'de>,
     {
-        use std::fmt::{self, Formatter};
+        use std::fmt::Formatter;
 
         struct Visitor;
         impl<'de> serde::de::Visitor<'de> for Visitor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
+#![deny(dead_code)]
+#![deny(unused_imports)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -956,7 +956,7 @@ pub mod serde {
         //! Serialize and deserialize [Amount] as real numbers denominated in satoshi.
         //! Use with `#[serde(with = "amount::serde::as_sat")]`.
 
-        use serde::{Deserialize, Deserializer, Serialize, Serializer};
+        use serde::{Deserializer, Serializer};
         use util::amount::serde::SerdeAmount;
 
         pub fn serialize<A: SerdeAmount, S: Serializer>(a: &A, s: S) -> Result<S::Ok, S::Error> {
@@ -971,7 +971,7 @@ pub mod serde {
             //! Serialize and deserialize [Optoin<Amount>] as real numbers denominated in satoshi.
             //! Use with `#[serde(default, with = "amount::serde::as_sat::opt")]`.
 
-            use serde::{Deserialize, Deserializer, Serializer};
+            use serde::{Deserializer, Serializer};
             use util::amount::serde::SerdeAmount;
 
             pub fn serialize<A: SerdeAmount, S: Serializer>(
@@ -996,7 +996,7 @@ pub mod serde {
         //! Serialize and deserialize [Amount] as JSON numbers denominated in BTC.
         //! Use with `#[serde(with = "amount::serde::as_btc")]`.
 
-        use serde::{Deserialize, Deserializer, Serialize, Serializer};
+        use serde::{Deserializer, Serializer};
         use util::amount::serde::SerdeAmount;
 
         pub fn serialize<A: SerdeAmount, S: Serializer>(a: &A, s: S) -> Result<S::Ok, S::Error> {
@@ -1011,7 +1011,7 @@ pub mod serde {
             //! Serialize and deserialize [Option<Amount>] as JSON numbers denominated in BTC.
             //! Use with `#[serde(default, with = "amount::serde::as_btc::opt")]`.
 
-            use serde::{Deserialize, Deserializer, Serializer};
+            use serde::{Deserializer, Serializer};
             use util::amount::serde::SerdeAmount;
 
             pub fn serialize<A: SerdeAmount, S: Serializer>(
@@ -1247,7 +1247,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn serde_as_sat() {
-        use serde::{Deserialize, Serialize};
 
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
         struct T {
@@ -1279,7 +1278,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn serde_as_btc() {
-        use serde::{Deserialize, Serialize};
         use serde_json;
 
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -1314,7 +1312,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn serde_as_btc_opt() {
-        use serde::{Deserialize, Serialize};
         use serde_json;
 
         #[derive(Serialize, Deserialize, PartialEq, Debug)]


### PR DESCRIPTION
Thanks for @dtolnay for bringing to our attention that we don't use `serde-derive` outside of testing (https://github.com/serde-rs/serde/issues/1602#issuecomment-522274093)

I removed that, and added a test that use `rust-bitcoin` as a dependency.
And added a deny unused imports to help see when we don't actually use something.

2 things I'm not sure about:
1. what's the best way to abstract the features used in that test in a way that will be easy for future features.
2. Is it bad that now in the tests the `serde` version and `serde-derive` version might not much (and the `serde-test` version too)