### PR TITLE
[TRIVIAL] enable serde serialization for block and blockheader

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -205,6 +205,8 @@ impl BitcoinHash for Block {
 
 impl_consensus_encoding!(BlockHeader, version, prev_blockhash, merkle_root, time, bits, nonce);
 impl_consensus_encoding!(Block, header, txdata);
+serde_struct_impl!(BlockHeader, version, prev_blockhash, merkle_root, time, bits, nonce);
+serde_struct_impl!(Block, header, txdata);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Transaction is already also serde serializable. The same is desirable for block and blockheader since extensions to consensus encoding are no longer possible outside this crate. serde encoded objects might contain block and blockheader not only transactions.