### PR TITLE
Overloaded encode error

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -21,12 +21,13 @@
 
 use std::default::Default;
 
+use hashes::hex::FromHex;
+
 use blockdata::opcodes;
 use blockdata::script;
 use blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn};
 use blockdata::block::{Block, BlockHeader};
 use network::constants::Network;
-use util::misc::hex_bytes;
 use util::uint::Uint256;
 
 /// The maximum allowable sequence number
@@ -81,7 +82,7 @@ fn bitcoin_genesis_tx() -> Transaction {
 
     // Outputs
     let out_script = script::Builder::new()
-        .push_slice(&hex_bytes("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f").unwrap())
+        .push_slice(&Vec::<u8>::from_hex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f").unwrap())
         .push_opcode(opcodes::all::OP_CHECKSIG)
         .into_script();
     ret.output.push(TxOut {

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -626,7 +626,6 @@ mod tests {
     use consensus::encode::serialize;
     use consensus::encode::deserialize;
     use util::hash::BitcoinHash;
-    use util::misc::hex_bytes;
 
     use hashes::{sha256d, Hash};
     use hashes::hex::FromHex;
@@ -666,7 +665,7 @@ mod tests {
 
     #[test]
     fn test_txin() {
-        let txin: Result<TxIn, _> = deserialize(&hex_bytes("a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff").unwrap());
+        let txin: Result<TxIn, _> = deserialize(&Vec::<u8>::from_hex("a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff").unwrap());
         assert!(txin.is_ok());
     }
 
@@ -687,14 +686,14 @@ mod tests {
 
         let genesis = constants::genesis_block(Network::Bitcoin);
         assert! (genesis.txdata[0].is_coin_base());
-        let hex_tx = hex_bytes("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
+        let hex_tx = Vec::<u8>::from_hex("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
         let tx: Transaction = deserialize(&hex_tx).unwrap();
         assert!(!tx.is_coin_base());
     }
 
     #[test]
     fn test_transaction() {
-        let hex_tx = hex_bytes("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
+        let hex_tx = Vec::<u8>::from_hex("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
         let tx: Result<Transaction, _> = deserialize(&hex_tx);
         assert!(tx.is_ok());
         let realtx = tx.unwrap();
@@ -717,7 +716,7 @@ mod tests {
 
     #[test]
     fn tx_no_input_deserialization() {
-        let hex_tx = hex_bytes(
+        let hex_tx = Vec::<u8>::from_hex(
             "010000000001000100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000"
         ).unwrap();
         let tx: Transaction = deserialize(&hex_tx).expect("deserialize tx");
@@ -731,7 +730,7 @@ mod tests {
 
     #[test]
     fn test_ntxid() {
-        let hex_tx = hex_bytes("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
+        let hex_tx = Vec::<u8>::from_hex("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
         let mut tx: Transaction = deserialize(&hex_tx).unwrap();
 
         let old_ntxid = tx.ntxid();
@@ -747,7 +746,7 @@ mod tests {
     #[test]
     fn test_txid() {
         // segwit tx from Liquid integration tests, txid/hash from Core decoderawtransaction
-        let hex_tx = hex_bytes(
+        let hex_tx = Vec::<u8>::from_hex(
             "01000000000102ff34f95a672bb6a4f6ff4a7e90fa8c7b3be7e70ffc39bc99be3bda67942e836c00000000\
              23220020cde476664d3fa347b8d54ef3aee33dcb686a65ced2b5207cbf4ec5eda6b9b46e4f414d4c934ad8\
              1d330314e888888e3bd22c7dde8aac2ca9227b30d7c40093248af7812201000000232200200af6f6a071a6\
@@ -784,7 +783,7 @@ mod tests {
         assert_eq!(tx.get_weight(), 2718);
 
         // non-segwit tx from my mempool
-        let hex_tx = hex_bytes(
+        let hex_tx = Vec::<u8>::from_hex(
             "01000000010c7196428403d8b0c88fcb3ee8d64f56f55c8973c9ab7dd106bb4f3527f5888d000000006a47\
              30440220503a696f55f2c00eee2ac5e65b17767cd88ed04866b5637d3c1d5d996a70656d02202c9aff698f\
              343abb6d176704beda63fcdec503133ea4f6a5216b7f925fa9910c0121024d89b5a13d6521388969209df2\
@@ -801,15 +800,15 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_txn_encode_decode() {
-        let hex_tx = hex_bytes("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
+        let hex_tx = Vec::<u8>::from_hex("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
         let tx: Transaction = deserialize(&hex_tx).unwrap();
         serde_round_trip!(tx);
     }
 
     fn run_test_sighash(tx: &str, script: &str, input_index: usize, hash_type: i32, expected_result: &str) {
-        let tx: Transaction = deserialize(&hex_bytes(tx).unwrap()[..]).unwrap();
-        let script = Script::from(hex_bytes(script).unwrap());
-        let mut raw_expected = hex_bytes(expected_result).unwrap();
+        let tx: Transaction = deserialize(&Vec::<u8>::from_hex(tx).unwrap()[..]).unwrap();
+        let script = Script::from(Vec::<u8>::from_hex(script).unwrap());
+        let mut raw_expected = Vec::<u8>::from_hex(expected_result).unwrap();
         raw_expected.reverse();
         let expected_result = sha256d::Hash::from_slice(&raw_expected[..]).unwrap();
 
@@ -822,7 +821,7 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_segwit_tx_decode() {
-        let hex_tx = hex_bytes("010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3603da1b0e00045503bd5704c7dd8a0d0ced13bb5785010800000000000a636b706f6f6c122f4e696e6a61506f6f6c2f5345475749542fffffffff02b4e5a212000000001976a914876fbb82ec05caa6af7a3b5e5a983aae6c6cc6d688ac0000000000000000266a24aa21a9edf91c46b49eb8a29089980f02ee6b57e7d63d33b18b4fddac2bcd7db2a39837040120000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+        let hex_tx = Vec::<u8>::from_hex("010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3603da1b0e00045503bd5704c7dd8a0d0ced13bb5785010800000000000a636b706f6f6c122f4e696e6a61506f6f6c2f5345475749542fffffffff02b4e5a212000000001976a914876fbb82ec05caa6af7a3b5e5a983aae6c6cc6d688ac0000000000000000266a24aa21a9edf91c46b49eb8a29089980f02ee6b57e7d63d33b18b4fddac2bcd7db2a39837040120000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
         let tx: Transaction = deserialize(&hex_tx).unwrap();
         assert_eq!(tx.get_weight(), 780);
         serde_round_trip!(tx);

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -38,7 +38,6 @@ use std::io::{Cursor, Read, Write};
 use hashes::hex::ToHex;
 
 use hashes::{sha256d, Hash as HashTrait};
-use secp256k1;
 
 use util::endian;
 use util::psbt;
@@ -54,8 +53,6 @@ pub enum Error {
     Io(io::Error),
     /// Error from the `byteorder` crate
     ByteOrder(io::Error),
-    /// secp-related error
-    Secp256k1(secp256k1::Error),
     /// PSBT-related error
     Psbt(psbt::Error),
     /// Network magic was not expected
@@ -96,7 +93,6 @@ impl fmt::Display for Error {
         match *self {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
             Error::ByteOrder(ref e) => fmt::Display::fmt(e, f),
-            Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
             Error::Psbt(ref e) => fmt::Display::fmt(e, f),
             Error::UnexpectedNetworkMagic { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), e, a),
             Error::OversizedVectorAllocation { requested: ref r, max: ref m } => write!(f, "{}: requested {}, maximum {}", error::Error::description(self), r, m),
@@ -115,7 +111,6 @@ impl error::Error for Error {
         match *self {
             Error::Io(ref e) => Some(e),
             Error::ByteOrder(ref e) => Some(e),
-            Error::Secp256k1(ref e) => Some(e),
             Error::Psbt(ref e) => Some(e),
             Error::UnexpectedNetworkMagic { .. }
             | Error::OversizedVectorAllocation { .. }
@@ -132,7 +127,6 @@ impl error::Error for Error {
         match *self {
             Error::Io(ref e) => e.description(),
             Error::ByteOrder(ref e) => e.description(),
-            Error::Secp256k1(ref e) => e.description(),
             Error::Psbt(ref e) => e.description(),
             Error::UnexpectedNetworkMagic { .. } => "unexpected network magic",
             Error::OversizedVectorAllocation { .. } => "allocation of oversized vector requested",
@@ -147,13 +141,6 @@ impl error::Error for Error {
 }
 
 #[doc(hidden)]
-
-#[doc(hidden)]
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error {
-        Error::Secp256k1(e)
-    }
-}
 
 #[doc(hidden)]
 impl From<io::Error> for Error {

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -91,17 +91,22 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Io(ref e) => fmt::Display::fmt(e, f),
-            Error::ByteOrder(ref e) => fmt::Display::fmt(e, f),
-            Error::Psbt(ref e) => fmt::Display::fmt(e, f),
-            Error::UnexpectedNetworkMagic { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), e, a),
-            Error::OversizedVectorAllocation { requested: ref r, max: ref m } => write!(f, "{}: requested {}, maximum {}", error::Error::description(self), r, m),
-            Error::InvalidChecksum { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), e[..].to_hex(), a[..].to_hex()),
-            Error::UnknownNetworkMagic(ref m) => write!(f, "{}: {}", error::Error::description(self), m),
-            Error::ParseFailed(ref e) => write!(f, "{}: {}", error::Error::description(self), e),
-            Error::UnsupportedSegwitFlag(ref swflag) => write!(f, "{}: {}", error::Error::description(self), swflag),
-            Error::UnrecognizedNetworkCommand(ref nwcmd) => write!(f, "{}: {}", error::Error::description(self), nwcmd),
-            Error::UnexpectedHexDigit(ref d) => write!(f, "{}: {}", error::Error::description(self), d),
+            Error::Io(ref e) => write!(f, "I/O error: {}", e),
+            Error::ByteOrder(ref e) => write!(f, "byteorder error: {}", e),
+            Error::Psbt(ref e) => write!(f, "PSBT error: {}", e),
+            Error::UnexpectedNetworkMagic { expected: ref e, actual: ref a } => write!(f,
+                "unexpected network magic: expected {}, actual {}", e, a),
+            Error::OversizedVectorAllocation { requested: ref r, max: ref m } => write!(f,
+                "allocation of oversized vector: requested {}, maximum {}", r, m),
+            Error::InvalidChecksum { expected: ref e, actual: ref a } => write!(f,
+                "invalid checksum: expected {}, actual {}", e.to_hex(), a.to_hex()),
+            Error::UnknownNetworkMagic(ref m) => write!(f, "unknown network magic: {}", m),
+            Error::ParseFailed(ref e) => write!(f, "parse failed: {}", e),
+            Error::UnsupportedSegwitFlag(ref swflag) => write!(f,
+                "unsupported segwit version: {}", swflag),
+            Error::UnrecognizedNetworkCommand(ref nwcmd) => write!(f,
+                "unrecognized network command: {}", nwcmd),
+            Error::UnexpectedHexDigit(ref d) => write!(f, "unexpected hex digit: {}", d),
         }
     }
 }
@@ -124,19 +129,7 @@ impl error::Error for Error {
     }
 
     fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref e) => e.description(),
-            Error::ByteOrder(ref e) => e.description(),
-            Error::Psbt(ref e) => e.description(),
-            Error::UnexpectedNetworkMagic { .. } => "unexpected network magic",
-            Error::OversizedVectorAllocation { .. } => "allocation of oversized vector requested",
-            Error::InvalidChecksum { .. } => "invalid checksum",
-            Error::UnknownNetworkMagic(..) => "unknown network magic",
-            Error::ParseFailed(..) => "parse failed",
-            Error::UnsupportedSegwitFlag(..) => "unsupported segwit version",
-            Error::UnrecognizedNetworkCommand(..) => "unrecognized network command",
-            Error::UnexpectedHexDigit(..) => "unexpected hex digit",
-        }
+        "Bitcoin encoding error"
     }
 }
 

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -86,8 +86,6 @@ pub enum Error {
     UnsupportedSegwitFlag(u8),
     /// Unrecognized network command
     UnrecognizedNetworkCommand(String),
-    /// Unexpected hex digit
-    UnexpectedHexDigit(char),
 }
 
 impl fmt::Display for Error {
@@ -109,7 +107,6 @@ impl fmt::Display for Error {
                 "unsupported segwit version: {}", swflag),
             Error::UnrecognizedNetworkCommand(ref nwcmd) => write!(f,
                 "unrecognized network command: {}", nwcmd),
-            Error::UnexpectedHexDigit(ref d) => write!(f, "unexpected hex digit: {}", d),
         }
     }
 }
@@ -127,8 +124,7 @@ impl error::Error for Error {
             | Error::UnknownNetworkMagic(..)
             | Error::ParseFailed(..)
             | Error::UnsupportedSegwitFlag(..)
-            | Error::UnrecognizedNetworkCommand(..)
-            | Error::UnexpectedHexDigit(..) => None,
+            | Error::UnrecognizedNetworkCommand(..) => None,
         }
     }
 

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -41,7 +41,6 @@ use hashes::{sha256d, Hash as HashTrait};
 use secp256k1;
 
 use util::endian;
-use util::base58;
 use util::psbt;
 
 use blockdata::transaction::{TxOut, Transaction, TxIn};
@@ -53,8 +52,6 @@ use network::address::Address;
 pub enum Error {
     /// And I/O error
     Io(io::Error),
-    /// Base58 encoding error
-    Base58(base58::Error),
     /// Error from the `byteorder` crate
     ByteOrder(io::Error),
     /// secp-related error
@@ -98,7 +95,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
-            Error::Base58(ref e) => fmt::Display::fmt(e, f),
             Error::ByteOrder(ref e) => fmt::Display::fmt(e, f),
             Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
             Error::Psbt(ref e) => fmt::Display::fmt(e, f),
@@ -118,7 +114,6 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
-            Error::Base58(ref e) => Some(e),
             Error::ByteOrder(ref e) => Some(e),
             Error::Secp256k1(ref e) => Some(e),
             Error::Psbt(ref e) => Some(e),
@@ -136,7 +131,6 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Io(ref e) => e.description(),
-            Error::Base58(ref e) => e.description(),
             Error::ByteOrder(ref e) => e.description(),
             Error::Secp256k1(ref e) => e.description(),
             Error::Psbt(ref e) => e.description(),
@@ -153,11 +147,6 @@ impl error::Error for Error {
 }
 
 #[doc(hidden)]
-impl From<base58::Error> for Error {
-    fn from(e: base58::Error) -> Error {
-        Error::Base58(e)
-    }
-}
 
 #[doc(hidden)]
 impl From<secp256k1::Error> for Error {

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -51,8 +51,6 @@ use network::address::Address;
 pub enum Error {
     /// And I/O error
     Io(io::Error),
-    /// Error from the `byteorder` crate
-    ByteOrder(io::Error),
     /// PSBT-related error
     Psbt(psbt::Error),
     /// Network magic was not expected
@@ -92,7 +90,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref e) => write!(f, "I/O error: {}", e),
-            Error::ByteOrder(ref e) => write!(f, "byteorder error: {}", e),
             Error::Psbt(ref e) => write!(f, "PSBT error: {}", e),
             Error::UnexpectedNetworkMagic { expected: ref e, actual: ref a } => write!(f,
                 "unexpected network magic: expected {}, actual {}", e, a),
@@ -115,7 +112,6 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
-            Error::ByteOrder(ref e) => Some(e),
             Error::Psbt(ref e) => Some(e),
             Error::UnexpectedNetworkMagic { .. }
             | Error::OversizedVectorAllocation { .. }

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -105,9 +105,9 @@ mod tests {
     use blockdata::transaction::Transaction;
     use consensus::encode::deserialize;
     use network::constants::Network;
-    use util::misc::hex_bytes;
     use util::address::Address;
     use util::key::PublicKey;
+    use hashes::hex::FromHex;
     use hex;
 
     use super::*;
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn bip143_p2wpkh() {
         let tx = deserialize::<Transaction>(
-            &hex_bytes(
+            &Vec::<u8>::from_hex(
                 "0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f000000\
                 0000eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a01000000\
                 00ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093\
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn bip143_p2wpkh_nested_in_p2sh() {
         let tx = deserialize::<Transaction>(
-            &hex_bytes(
+            &Vec::<u8>::from_hex(
                 "0100000001db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477010000\
                 0000feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac00\
                 08af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac92040000",
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn bip143_p2wsh_nested_in_p2sh() {
         let tx = deserialize::<Transaction>(
-            &hex_bytes(
+            &Vec::<u8>::from_hex(
             "010000000136641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e0100000000\
              ffffffff0200e9a435000000001976a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688acc0832f\
              05000000001976a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac00000000").unwrap()[..],

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -53,7 +53,7 @@ pub struct PartiallySignedTransaction {
 impl PartiallySignedTransaction {
     /// Create a PartiallySignedTransaction from an unsigned transaction, error
     /// if not unsigned
-    pub fn from_unsigned_tx(tx: Transaction) -> Result<Self, encode::Error> {
+    pub fn from_unsigned_tx(tx: Transaction) -> Result<Self, self::Error> {
         Ok(PartiallySignedTransaction {
             inputs: vec![Default::default(); tx.input.len()],
             outputs: vec![Default::default(); tx.output.len()],


### PR DESCRIPTION
We're using the `encode::Error` in places where we probably shouldn't. I know it's a silly breaking change, so I'd be ok with having it stale here for a while until we're going to release a breaking version.

It's hard to get all encode errors out of the psbt module because of a circular dependency otherwise. (There is an `encode::Error::Psbt` variant.)