### PR TITLE
[WIP] Enums for scriptPubkey + better script templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bitcoinconsensus = { version = "0.17", optional = true }
 serde = { version = "1", optional = true }
 secp256k1 = "0.15"
 hex = "=0.3.2"
+enum-display-derive = "~0.1.0"
 
 [dev-dependencies]
 serde_derive = "<1.0.99"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub extern crate bech32;
 
 extern crate byteorder;
 extern crate hex;
+#[macro_use] extern crate enum_display_derive;
 #[cfg(feature = "serde")] extern crate serde;
 #[cfg(all(test, feature = "serde"))] #[macro_use] extern crate serde_derive; // for 1.22.0 compat
 #[cfg(all(test, feature = "serde"))] extern crate serde_json;

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -138,7 +138,7 @@ pub enum TemplateElement {
 
 /// A script template
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Template(Vec<TemplateElement>);
+pub struct Template(pub Vec<TemplateElement>);
 
 impl Template {
     /// Returns template for P2PKH output


### PR DESCRIPTION
This PR defines enum types for scriptPubkey variants (P2PKH etc) and adds support for template generation for standard txout script types. 

I'd like to hear your feedback on whether this is a needed feature for rust-bitcoin, and if you agree with the way I address the issue, I'll add testcases to prepare the PR for a merge.