### PR TITLE
Streamline Error types

### DIFF
--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -180,6 +180,64 @@ impl From<psbt::Error> for Error {
     }
 }
 
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match *self {
+            Error::Io(_) => false,
+            Error::Base58(ref e) => match *other {
+                Error::Base58(ref o) => e == o,
+                _ => false,
+            }
+            Error::ByteOrder(..) => match *other {
+                Error::ByteOrder(..) => true,
+                _ => false,
+            },
+            Error::Secp256k1(ref e) => match *other {
+                Error::Secp256k1(ref o) => e == o,
+                _ => false,
+            }
+            Error::Psbt(ref e) => match *other {
+                Error::Psbt(ref o) => e == o,
+                _ => false,
+            }
+            Error::UnexpectedNetworkMagic{ expected: e1, actual: e2 } => match *other {
+                Error::UnexpectedNetworkMagic{ expected: o1, actual: o2 } => e1 == o1 && e2 == o2,
+                _ => false
+            }
+            Error::OversizedVectorAllocation{ requested: e1, max: e2 } => match *other {
+                Error::OversizedVectorAllocation{ requested: o1, max: o2 } => e1 == o1 && e2 == o2,
+                _ => false
+            }
+            Error::InvalidChecksum{ expected: e1, actual: e2 } => match *other {
+                Error::InvalidChecksum{ expected: o1, actual: o2 } => e1 == o1 && e2 == o2,
+                _ => false
+            }
+            Error::UnknownNetworkMagic(e) => match *other {
+                Error::UnknownNetworkMagic(o) => e == o,
+                _ => false,
+            }
+            Error::ParseFailed(e) => match *other {
+                Error::ParseFailed(o) => e == o,
+                _ => false,
+            }
+            Error::UnsupportedSegwitFlag(e) => match *other {
+                Error::UnsupportedSegwitFlag(o) => e == o,
+                _ => false,
+            }
+            Error::UnrecognizedNetworkCommand(ref e) => match *other {
+                Error::UnrecognizedNetworkCommand(ref o) => e == o,
+                _ => false,
+            }
+            Error::UnexpectedHexDigit(e) => match *other {
+                Error::UnexpectedHexDigit(o) => e == o,
+                _ => false,
+            }
+        }
+    }
+}
+
+impl Eq for Error {}
+
 /// Encode an object into a vector
 pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
     let mut encoder = Cursor::new(vec![]);

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -74,3 +74,21 @@ impl error::Error for Error {
         }
     }
 }
+
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match *self {
+            Error::Io(_) => false,
+            Error::SocketMutexPoisoned => match *other {
+                Error::SocketMutexPoisoned => true,
+                _ => false,
+            }
+            Error::SocketNotConnectedToPeer => match *other {
+                Error::SocketNotConnectedToPeer => true,
+                _ => false,
+            }
+        }
+    }
+}
+
+impl Eq for Error {}

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -53,7 +53,7 @@ use util::base58;
 use util::key;
 
 /// Address error.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Error {
     /// Base58 encoding error
     Base58(base58::Error),
@@ -117,6 +117,8 @@ impl From<bech32::Error> for Error {
         Error::Bech32(e)
     }
 }
+
+impl Eq for Error {}
 
 /// The different types of addresses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -97,6 +97,20 @@ impl From<io::Error> for Error {
     }
 }
 
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match *self {
+            Error::UtxoMissing(ref e) => match *other {
+                Error::UtxoMissing(ref o) => e == o,
+                _ => false,
+            }
+            Error::Io(_) => false,
+        }
+    }
+}
+
+impl Eq for Error {}
+
 
 /// a computed or read block filter
 pub struct BlockFilter {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -58,7 +58,7 @@ pub trait BitArray {
 
 /// A general error code, other errors should implement conversions to/from this
 /// if appropriate.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     /// Encoding error
     Encode(encode::Error),

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -19,7 +19,7 @@ use blockdata::transaction::Transaction;
 use util::psbt::raw;
 
 /// Ways that a Partially Signed Transaction might fail.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Magic bytes for a PSBT must be the ASCII for "psbt" serialized in most
     /// significant byte order.


### PR DESCRIPTION
- All error types have Debug.
- All error types have PartialEq and Eq.
- All error types that don't have an std::io::Error variant
  have Clone.

The `PartialEq` can't be derived because `std::io::Error` doesn't implement it. 

So to manually implement it, there are several options: 

1. consider all `io::Error` equal,
2. consider all `io::Error` unequal,
3. use `io::Error::kind()` to compare them, or
4. use `to_string()` to compare them...

I currently opted for option 2 because all others are never 100% guaranteed. The fact that `io::Error` doesn't implement `PartialEq` kinda means we're not supposed to compare them, so we won't consider them equal ever.