### PR TITLE
Drop hex and byteorder (non-test) deps (and disable useless lints)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/lib.rs"
 [features]
 fuzztarget = ["secp256k1/fuzztarget", "bitcoin_hashes/fuzztarget"]
 unstable = []
-use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 rand = ["secp256k1/rand"]
+use-serde = ["hex", "serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 
 [dependencies]
 bech32 = "0.7.1"
@@ -26,10 +26,11 @@ byteorder = "1.2"
 bitcoin_hashes = "0.7"
 bitcoinconsensus = { version = "0.17", optional = true }
 serde = { version = "1", optional = true }
+hex = { version = "=0.3.2", optional = true }
 secp256k1 = "0.15"
-hex = "=0.3.2"
 
 [dev-dependencies]
+hex = "=0.3.2"
 serde_derive = "<1.0.99"
 serde_json = "1"
 serde_test = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ use-serde = ["hex", "serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 
 [dependencies]
 bech32 = "0.7.1"
-byteorder = "1.2"
 bitcoin_hashes = "0.7"
 bitcoinconsensus = { version = "0.17", optional = true }
 serde = { version = "1", optional = true }

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -165,15 +165,13 @@ impl BlockHeader {
 
     /// Checks that the proof-of-work for the block is valid.
     pub fn validate_pow(&self, required_target: &Uint256) -> Result<(), util::Error> {
-        use byteorder::{ByteOrder, LittleEndian};
-
         let target = &self.target();
         if target != required_target {
             return Err(BlockBadTarget);
         }
         let data: [u8; 32] = self.bitcoin_hash().into_inner();
         let mut ret = [0u64; 4];
-        LittleEndian::read_u64_into(&data, &mut ret);
+        util::endian::bytes_to_u64_slice_le(&data, &mut ret);
         let hash = &Uint256(ret);
         if hash <= target { Ok(()) } else { Err(BlockBadProofOfWork) }
     }

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -23,13 +23,13 @@
 //! This module provides the structures and functions needed to support transactions.
 //!
 
-use byteorder::{LittleEndian, WriteBytesExt};
 use std::default::Default;
 use std::{fmt, io};
 
 use hashes::{self, sha256d, Hash};
 use hashes::hex::FromHex;
 
+use util::endian;
 use util::hash::BitcoinHash;
 #[cfg(feature="bitcoinconsensus")] use blockdata::script;
 use blockdata::script::Script;
@@ -358,7 +358,7 @@ impl Transaction {
         };
         // hash the result
         let mut raw_vec = serialize(&tx);
-        raw_vec.write_u32::<LittleEndian>(sighash_u32).unwrap();
+        raw_vec.extend_from_slice(&endian::u32_to_array_le(sighash_u32));
         sha256d::Hash::hash(&raw_vec)
     }
 

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -36,7 +36,7 @@ use std::fmt;
 use std::io;
 use std::io::{Cursor, Read, Write};
 use byteorder::{LittleEndian, WriteBytesExt, ReadBytesExt};
-use hex::encode as hex_encode;
+use hashes::hex::ToHex;
 
 use hashes::{sha256d, Hash as HashTrait};
 use secp256k1;
@@ -104,7 +104,7 @@ impl fmt::Display for Error {
             Error::Psbt(ref e) => fmt::Display::fmt(e, f),
             Error::UnexpectedNetworkMagic { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), e, a),
             Error::OversizedVectorAllocation { requested: ref r, max: ref m } => write!(f, "{}: requested {}, maximum {}", error::Error::description(self), r, m),
-            Error::InvalidChecksum { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), hex_encode(e), hex_encode(a)),
+            Error::InvalidChecksum { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), e[..].to_hex(), a[..].to_hex()),
             Error::UnknownNetworkMagic(ref m) => write!(f, "{}: {}", error::Error::description(self), m),
             Error::ParseFailed(ref e) => write!(f, "{}: {}", error::Error::description(self), e),
             Error::UnsupportedSegwitFlag(ref swflag) => write!(f, "{}: {}", error::Error::description(self), swflag),
@@ -189,7 +189,7 @@ pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
 
 /// Encode an object into a hex-encoded string
 pub fn serialize_hex<T: Encodable + ?Sized>(data: &T) -> String {
-    hex_encode(serialize(data))
+    serialize(data)[..].to_hex()
 }
 
 /// Deserialize an object from a vector, will error if said deserialization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,11 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+// In general, rust is absolutely horrid at supporting users doing things like,
+// for example, compiling Rust code for real environments. Disable useless lints
+// that don't do anything but annoy us and cant actually ever be resolved.
+#![allow(bare_trait_objects)]
+#![allow(ellipsis_inclusive_range_patterns)]
 
 // Re-exported dependencies.
 pub extern crate bitcoin_hashes as hashes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,8 @@ pub extern crate bitcoin_hashes as hashes;
 pub extern crate secp256k1;
 pub extern crate bech32;
 
+#[cfg(any(test, feature = "serde"))] extern crate hex;
 extern crate byteorder;
-extern crate hex;
 #[cfg(feature = "serde")] extern crate serde;
 #[cfg(all(test, feature = "serde"))] #[macro_use] extern crate serde_derive; // for 1.22.0 compat
 #[cfg(all(test, feature = "serde"))] extern crate serde_json;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ pub extern crate secp256k1;
 pub extern crate bech32;
 
 #[cfg(any(test, feature = "serde"))] extern crate hex;
-extern crate byteorder;
 #[cfg(feature = "serde")] extern crate serde;
 #[cfg(all(test, feature = "serde"))] #[macro_use] extern crate serde_derive; // for 1.22.0 compat
 #[cfg(all(test, feature = "serde"))] extern crate serde_json;

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -23,7 +23,6 @@ use network::constants;
 use consensus::{Encodable, Decodable, ReadExt};
 use consensus::encode;
 use std::io;
-use byteorder::WriteBytesExt;
 use network::message_network::RejectReason::{MALFORMED, INVALID, OBSOLETE, DUPLICATE, NONSTANDARD, DUST, CHECKPOINT, FEE};
 use hashes::sha256d;
 
@@ -107,7 +106,7 @@ pub enum RejectReason {
 
 impl Encodable for RejectReason {
     fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, encode::Error> {
-        e.write_u8(*self as u8)?;
+        e.write_all(&[*self as u8])?;
         Ok(1)
     }
 }

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -16,9 +16,9 @@
 
 use std::{error, fmt, str, slice, iter};
 
-use byteorder::{ByteOrder, LittleEndian};
-
 use hashes::{sha256d, Hash};
+
+use util::endian;
 
 /// An error that might occur during base58 decoding
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -162,8 +162,8 @@ pub fn from_check(data: &str) -> Result<Vec<u8>, Error> {
         return Err(Error::TooShort(ret.len()));
     }
     let ck_start = ret.len() - 4;
-    let expected = LittleEndian::read_u32(&sha256d::Hash::hash(&ret[..ck_start])[..4]);
-    let actual = LittleEndian::read_u32(&ret[ck_start..(ck_start + 4)]);
+    let expected = endian::slice_to_u32_le(&sha256d::Hash::hash(&ret[..ck_start])[..4]);
+    let actual = endian::slice_to_u32_le(&ret[ck_start..(ck_start + 4)]);
     if expected != actual {
         return Err(Error::BadChecksum(expected, actual));
     }

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -51,13 +51,13 @@ use std::fmt::{Display, Formatter};
 use std::io::Cursor;
 
 use hashes::{Hash, sha256d, siphash24};
-use byteorder::{ByteOrder, LittleEndian};
 
 use blockdata::block::Block;
 use blockdata::script::Script;
 use blockdata::transaction::OutPoint;
 use consensus::{Decodable, Encodable};
 use consensus::encode::VarInt;
+use util::endian;
 use util::hash::BitcoinHash;
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845
@@ -155,8 +155,8 @@ impl<'a> BlockFilterWriter<'a> {
     /// Create a block filter writer
     pub fn new(writer: &'a mut io::Write, block: &'a Block) -> BlockFilterWriter<'a> {
         let block_hash_as_int = block.bitcoin_hash().into_inner();
-        let k0 = LittleEndian::read_u64(&block_hash_as_int[0..8]);
-        let k1 = LittleEndian::read_u64(&block_hash_as_int[8..16]);
+        let k0 = endian::slice_to_u64_le(&block_hash_as_int[0..8]);
+        let k1 = endian::slice_to_u64_le(&block_hash_as_int[8..16]);
         let writer = GCSFilterWriter::new(writer, k0, k1, M, P);
         BlockFilterWriter { block, writer }
     }
@@ -208,8 +208,8 @@ impl BlockFilterReader {
     /// Create a block filter reader
     pub fn new(block_hash: &sha256d::Hash) -> BlockFilterReader {
         let block_hash_as_int = block_hash.into_inner();
-        let k0 = LittleEndian::read_u64(&block_hash_as_int[0..8]);
-        let k1 = LittleEndian::read_u64(&block_hash_as_int[8..16]);
+        let k0 = endian::slice_to_u64_le(&block_hash_as_int[0..8]);
+        let k1 = endian::slice_to_u64_le(&block_hash_as_int[8..16]);
         BlockFilterReader { reader: GCSFilterReader::new(k0, k1, M, P) }
     }
 

--- a/src/util/endian.rs
+++ b/src/util/endian.rs
@@ -1,0 +1,125 @@
+macro_rules! define_slice_to_be {
+    ($name: ident, $type: ty) => {
+        #[inline]
+        pub fn $name(slice: &[u8]) -> $type {
+            assert_eq!(slice.len(), ::std::mem::size_of::<$type>());
+            let mut res = 0;
+            for i in 0..::std::mem::size_of::<$type>() {
+                res |= (slice[i] as $type) << (::std::mem::size_of::<$type>() - i - 1)*8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_slice_to_le {
+    ($name: ident, $type: ty) => {
+        #[inline]
+        pub fn $name(slice: &[u8]) -> $type {
+            assert_eq!(slice.len(), ::std::mem::size_of::<$type>());
+            let mut res = 0;
+            for i in 0..::std::mem::size_of::<$type>() {
+                res |= (slice[i] as $type) << i*8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_be_to_array {
+    ($name: ident, $type: ty, $byte_len: expr) => {
+        #[inline]
+        pub fn $name(val: $type) -> [u8; $byte_len] {
+            assert_eq!(::std::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            let mut res = [0; $byte_len];
+            for i in 0..$byte_len {
+                res[i] = ((val >> ($byte_len - i - 1)*8) & 0xff) as u8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_le_to_array {
+    ($name: ident, $type: ty, $byte_len: expr) => {
+        #[inline]
+        pub fn $name(val: $type) -> [u8; $byte_len] {
+            assert_eq!(::std::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            let mut res = [0; $byte_len];
+            for i in 0..$byte_len {
+                res[i] = ((val >> i*8) & 0xff) as u8;
+            }
+            res
+        }
+    }
+}
+
+define_slice_to_be!(slice_to_u32_be, u32);
+define_be_to_array!(u32_to_array_be, u32, 4);
+define_slice_to_le!(slice_to_u16_le, u16);
+define_slice_to_le!(slice_to_u32_le, u32);
+define_slice_to_le!(slice_to_u64_le, u64);
+define_le_to_array!(u16_to_array_le, u16, 2);
+define_le_to_array!(u32_to_array_le, u32, 4);
+define_le_to_array!(u64_to_array_le, u64, 8);
+
+#[inline]
+pub fn i16_to_array_le(val: i16) -> [u8; 2] {
+    u16_to_array_le(val as u16)
+}
+#[inline]
+pub fn slice_to_i16_le(slice: &[u8]) -> i16 {
+    slice_to_u16_le(slice) as i16
+}
+#[inline]
+pub fn slice_to_i32_le(slice: &[u8]) -> i32 {
+    slice_to_u32_le(slice) as i32
+}
+#[inline]
+pub fn i32_to_array_le(val: i32) -> [u8; 4] {
+    u32_to_array_le(val as u32)
+}
+#[inline]
+pub fn slice_to_i64_le(slice: &[u8]) -> i64 {
+    slice_to_u64_le(slice) as i64
+}
+#[inline]
+pub fn i64_to_array_le(val: i64) -> [u8; 8] {
+    u64_to_array_le(val as u64)
+}
+
+macro_rules! define_chunk_slice_to_int {
+    ($name: ident, $type: ty, $converter: ident) => {
+        #[inline]
+        pub fn $name(inp: &[u8], outp: &mut [$type]) {
+            assert_eq!(inp.len(), outp.len() * ::std::mem::size_of::<$type>());
+            for (outp_val, data_bytes) in outp.iter_mut().zip(inp.chunks(::std::mem::size_of::<$type>())) {
+                *outp_val = $converter(data_bytes);
+            }
+        }
+    }
+}
+define_chunk_slice_to_int!(bytes_to_u64_slice_le, u64, slice_to_u64_le);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endianness_test() {
+        assert_eq!(slice_to_u32_be(&[0xde, 0xad, 0xbe, 0xef]), 0xdeadbeef);
+        assert_eq!(u32_to_array_be(0xdeadbeef), [0xde, 0xad, 0xbe, 0xef]);
+
+        assert_eq!(slice_to_u16_le(&[0xad, 0xde]), 0xdead);
+        assert_eq!(slice_to_u32_le(&[0xef, 0xbe, 0xad, 0xde]), 0xdeadbeef);
+        assert_eq!(slice_to_u64_le(&[0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]), 0x1badcafedeadbeef);
+        assert_eq!(u16_to_array_le(0xdead), [0xad, 0xde]);
+        assert_eq!(u32_to_array_le(0xdeadbeef), [0xef, 0xbe, 0xad, 0xde]);
+        assert_eq!(u64_to_array_le(0x1badcafedeadbeef), [0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]);
+    }
+
+    #[test]
+    fn endian_chunk_test() {
+        let inp = [0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b, 0xfe, 0xca, 0xad, 0x1b, 0xce, 0xfa, 0x01, 0x02];
+        let mut out = [0; 2];
+        bytes_to_u64_slice_le(&inp, &mut out);
+        assert_eq!(out, [0x1badcafedeadbeef, 0x0201face1badcafe]);
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -30,6 +30,8 @@ pub mod psbt;
 pub mod uint;
 pub mod bip158;
 
+pub(crate) mod endian;
+
 use std::{error, fmt};
 
 use network;

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -20,6 +20,7 @@
 use std::{fmt, io};
 
 use consensus::encode::{self, Decodable, Encodable, VarInt, MAX_VEC_SIZE};
+use hashes::hex::ToHex;
 use util::psbt::Error;
 
 /// A PSBT key in its raw byte form.
@@ -46,7 +47,7 @@ impl fmt::Display for Key {
             f,
             "type: {:#x}, key: {}",
             self.type_value,
-            ::hex::encode(&self.key)
+            self.key[..].to_hex()
         )
     }
 }


### PR DESCRIPTION
Taking deps for such trivial things is.....really not useful, especially since bitcoin_hashes has its own hex impl.