### PR TITLE
Drop message decode max length to 4_000_000

### DIFF
--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -343,7 +343,7 @@ impl<R: Read> ReadExt for R {
 }
 
 /// Maximum size, in bytes, of a vector we are allowed to decode
-pub const MAX_VEC_SIZE: usize = 32 * 1024 * 1024;
+pub const MAX_VEC_SIZE: usize = 4_000_000;
 
 /// Data which can be encoded in a consensus-consistent way
 pub trait Encodable {


### PR DESCRIPTION
It has been a long time since Bitcoin's maximum network message
length was 32MB, so we should follow suit. This is also an important
DoS limit, so we should limit it as much as possible.