### PR TITLE
Expose secp256k1 features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [features]
 fuzztarget = ["secp256k1/fuzztarget", "bitcoin_hashes/fuzztarget"]
 unstable = []
-use-serde = ["serde", "bitcoin_hashes/serde"]
+use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 rand = ["secp256k1/rand"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 fuzztarget = ["secp256k1/fuzztarget", "bitcoin_hashes/fuzztarget"]
 unstable = []
 use-serde = ["serde", "bitcoin_hashes/serde"]
+rand = ["secp256k1/rand"]
 
 [dependencies]
 bech32 = "0.7.1"

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-FEATURES="bitcoinconsensus use-serde"
+FEATURES="bitcoinconsensus use-serde rand"
 
 if [ "$DO_COV" = true ]
 then


### PR DESCRIPTION
This PR adds two patches that expose feature flags from the underlying `secp256k1` library.

The primary benefit here is that we can activate the `rand` feature from a crate that only depends on `rust-bitcoin` but would like to make use of the feature-gated `rand` functionality in `secp256k1`. The current workaround here is to add an additional dependency on `secp256k1` that includes the feature flag. This works because cargo accumulates feature flags across the dependency tree.

Unfortunately, this requires to activately keep those versions in sync. By giving access to the `rand` feature flag of `secp256k1` through a `rand` feature flag in `rust-bitcoin`, this situation can be avoided.

Additionally, I noticed that the `serde` feature in `secp256k1` is not included in the `use-serde` feature of `rust-bitcoin`. The 2nd patch fixes this.