### PR TITLE
fix(compiler-warnings): switch range operators and add dyn to traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ fuzz/hfuzz_workspace
 #IntelliJ project files
 .idea
 *.iml
+*.sw*

--- a/fuzz/fuzz_targets/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/deser_net_msg.rs
@@ -31,9 +31,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_address.rs
+++ b/fuzz/fuzz_targets/deserialize_address.rs
@@ -36,9 +36,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_amount.rs
+++ b/fuzz/fuzz_targets/deserialize_amount.rs
@@ -53,9 +53,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_block.rs
+++ b/fuzz/fuzz_targets/deserialize_block.rs
@@ -31,9 +31,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/deserialize_psbt.rs
@@ -40,9 +40,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_script.rs
+++ b/fuzz/fuzz_targets/deserialize_script.rs
@@ -69,9 +69,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/deserialize_transaction.rs
@@ -52,9 +52,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/outpoint_string.rs
+++ b/fuzz/fuzz_targets/outpoint_string.rs
@@ -67,9 +67,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -109,7 +109,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> { None }
+    fn cause(&self) -> Option<&dyn error::Error> { None }
 
     fn description(&self) -> &'static str {
         match *self {
@@ -346,7 +346,7 @@ impl Script {
     }
 
     /// Write the assembly decoding of the script to the formatter.
-    pub fn fmt_asm(&self, f: &mut fmt::Write) -> fmt::Result {
+    pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
         let mut index = 0;
         while index < self.0.len() {
             let opcode = opcodes::All::from(self.0[index]);

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -138,7 +138,7 @@ impl ::std::error::Error for ParseOutPointError {
         }
     }
 
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             ParseOutPointError::Txid(ref e) => Some(e),
             ParseOutPointError::Vout(ref e) => Some(e),
@@ -640,7 +640,7 @@ mod tests {
                    Err(ParseOutPointError::Txid(sha256d::Hash::from_hex("5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X").unwrap_err())));
         assert_eq!(OutPoint::from_str("5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:lol"),
                    Err(ParseOutPointError::Vout(u32::from_str("lol").unwrap_err())));
- 
+
         assert_eq!(OutPoint::from_str("5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:42"),
                    Ok(OutPoint{
                        txid: sha256d::Hash::from_hex("5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456").unwrap(),

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -115,7 +115,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
             Error::Base58(ref e) => Some(e),
@@ -401,14 +401,14 @@ impl_int_encodable!(i64, read_i64, emit_i64);
 
 impl VarInt {
     /// Gets the length of this VarInt when encoded.
-    /// Returns 1 for 0...0xFC, 3 for 0xFD...(2^16-1), 5 for 0x10000...(2^32-1),
+    /// Returns 1 for 0..=0xFC, 3 for 0xFD..=(2^16-1), 5 for 0x10000..=(2^32-1),
     /// and 9 otherwise.
     #[inline]
     pub fn len(&self) -> usize {
         match self.0 {
-            0...0xFC             => { 1 }
-            0xFD...0xFFFF        => { 3 }
-            0x10000...0xFFFFFFFF => { 5 }
+            0..=0xFC             => { 1 }
+            0xFD..=0xFFFF        => { 3 }
+            0x10000..=0xFFFFFFFF => { 5 }
             _                    => { 9 }
         }
     }
@@ -418,16 +418,16 @@ impl Encodable for VarInt {
     #[inline]
     fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, Error> {
         match self.0 {
-            0...0xFC => {
+            0..=0xFC => {
                 (self.0 as u8).consensus_encode(s)?;
                 Ok(1)
             },
-            0xFD...0xFFFF => {
+            0xFD..=0xFFFF => {
                 s.emit_u8(0xFD)?;
                 (self.0 as u16).consensus_encode(s)?;
                 Ok(3)
             },
-            0x10000...0xFFFFFFFF => {
+            0x10000..=0xFFFFFFFF => {
                 s.emit_u8(0xFE)?;
                 (self.0 as u32).consensus_encode(s)?;
                 Ok(5)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
-
+#![allow(bare_trait_objects)]
+#![allow(ellipsis_inclusive_range_patterns)]
 
 // Re-exported dependencies.
 pub extern crate bitcoin_hashes as hashes;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,7 +14,7 @@
 
 //! Network Support
 //!
-//! This module defines support for (de)serialization and network transport 
+//! This module defines support for (de)serialization and network transport
 //! of Bitcoin data and network messages.
 //!
 
@@ -67,7 +67,7 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
             Error::SocketMutexPoisoned | Error::SocketNotConnectedToPeer => None,

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -91,7 +91,7 @@ impl fmt::Display for Error {
 }
 
 impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::Base58(ref e) => Some(e),
             Error::Bech32(ref e) => Some(e),

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -112,7 +112,7 @@ impl fmt::Display for ParseAmountError {
 }
 
 impl error::Error for ParseAmountError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 
@@ -179,7 +179,7 @@ fn parse_signed_to_satoshi(
     let mut value: u64 = 0; // as satoshis
     for c in s.chars() {
         match c {
-            '0'...'9' => {
+            '0'..='9' => {
                 // Do `value = 10 * value + digit`, catching overflows.
                 match 10_u64.checked_mul(value) {
                     None => return Err(ParseAmountError::TooBig),
@@ -222,7 +222,7 @@ fn parse_signed_to_satoshi(
 fn fmt_satoshi_in(
     satoshi: u64,
     negative: bool,
-    f: &mut fmt::Write,
+    f: &mut dyn fmt::Write,
     denom: Denomination,
 ) -> fmt::Result {
     if negative {
@@ -370,7 +370,7 @@ impl Amount {
     /// Format the value of this [Amount] in the given denomination.
     ///
     /// Does not include the denomination.
-    pub fn fmt_value_in(&self, f: &mut fmt::Write, denom: Denomination) -> fmt::Result {
+    pub fn fmt_value_in(&self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.as_sat(), false, f, denom)
     }
 
@@ -667,7 +667,7 @@ impl SignedAmount {
     /// Format the value of this [SignedAmount] in the given denomination.
     ///
     /// Does not include the denomination.
-    pub fn fmt_value_in(&self, f: &mut fmt::Write, denom: Denomination) -> fmt::Result {
+    pub fn fmt_value_in(&self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.as_sat().abs() as u64, self.is_negative(), f, denom)
     }
 

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -53,7 +53,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> { None }
+    fn cause(&self) -> Option<&dyn error::Error> { None }
     fn description(&self) -> &'static str {
         match *self {
             Error::BadByte(_) => "invalid b58 character",
@@ -181,7 +181,7 @@ where
 
     let mut leading_zero_count = 0;
     let mut leading_zeroes = true;
-    // Build string in little endian with 0-58 in place of characters...
+    // Build string in little endian with 0-58 in place of characters..=
     for d256 in data {
         let mut carry = d256 as usize;
         if leading_zeroes && carry == 0 {
@@ -201,7 +201,7 @@ where
         }
     }
 
-    // ... then reverse it and convert to chars
+    // ..= then reverse it and convert to chars
     for _ in 0..leading_zero_count {
         ret.push(0);
     }

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -133,13 +133,13 @@ impl BlockFilter {
     }
 
     /// match any query pattern
-    pub fn match_any(&self, block_hash: &sha256d::Hash, query: &mut Iterator<Item=&[u8]>) -> Result<bool, Error> {
+    pub fn match_any(&self, block_hash: &sha256d::Hash, query: &mut dyn Iterator<Item=&[u8]>) -> Result<bool, Error> {
         let filter_reader = BlockFilterReader::new(block_hash);
         filter_reader.match_any(&mut Cursor::new(self.content.as_slice()), query)
     }
 
     /// match all query pattern
-    pub fn match_all(&self, block_hash: &sha256d::Hash, query: &mut Iterator<Item=&[u8]>) -> Result<bool, Error> {
+    pub fn match_all(&self, block_hash: &sha256d::Hash, query: &mut dyn Iterator<Item=&[u8]>) -> Result<bool, Error> {
         let filter_reader = BlockFilterReader::new(block_hash);
         filter_reader.match_all(&mut Cursor::new(self.content.as_slice()), query)
     }
@@ -153,7 +153,7 @@ pub struct BlockFilterWriter<'a> {
 
 impl<'a> BlockFilterWriter<'a> {
     /// Create a block filter writer
-    pub fn new(writer: &'a mut io::Write, block: &'a Block) -> BlockFilterWriter<'a> {
+    pub fn new(writer: &'a mut dyn io::Write, block: &'a Block) -> BlockFilterWriter<'a> {
         let block_hash_as_int = block.bitcoin_hash().into_inner();
         let k0 = LittleEndian::read_u64(&block_hash_as_int[0..8]);
         let k1 = LittleEndian::read_u64(&block_hash_as_int[8..16]);
@@ -214,12 +214,12 @@ impl BlockFilterReader {
     }
 
     /// match any query pattern
-    pub fn match_any(&self, reader: &mut io::Read, query: &mut Iterator<Item=&[u8]>) -> Result<bool, Error> {
+    pub fn match_any(&self, reader: &mut dyn io::Read, query: &mut dyn Iterator<Item=&[u8]>) -> Result<bool, Error> {
         self.reader.match_any(reader, query)
     }
 
     /// match all query pattern
-    pub fn match_all(&self, reader: &mut io::Read, query: &mut Iterator<Item=&[u8]>) -> Result<bool, Error> {
+    pub fn match_all(&self, reader: &mut dyn io::Read, query: &mut dyn Iterator<Item=&[u8]>) -> Result<bool, Error> {
         self.reader.match_all(reader, query)
     }
 }
@@ -238,7 +238,7 @@ impl GCSFilterReader {
     }
 
     /// match any query pattern
-    pub fn match_any(&self, reader: &mut io::Read, query: &mut Iterator<Item=&[u8]>) -> Result<bool, Error> {
+    pub fn match_any(&self, reader: &mut dyn io::Read, query: &mut dyn Iterator<Item=&[u8]>) -> Result<bool, Error> {
         let mut decoder = reader;
         let n_elements: VarInt = Decodable::consensus_decode(&mut decoder).unwrap_or(VarInt(0));
         let ref mut reader = decoder;
@@ -278,7 +278,7 @@ impl GCSFilterReader {
     }
 
     /// match all query pattern
-    pub fn match_all(&self, reader: &mut io::Read, query: &mut Iterator<Item=&[u8]>) -> Result<bool, Error> {
+    pub fn match_all(&self, reader: &mut dyn io::Read, query: &mut dyn Iterator<Item=&[u8]>) -> Result<bool, Error> {
         let mut decoder = reader;
         let n_elements: VarInt = Decodable::consensus_decode(&mut decoder).unwrap_or(VarInt(0));
         let ref mut reader = decoder;
@@ -340,14 +340,14 @@ fn map_to_range(hash: u64, nm: u64) -> u64 {
 /// Colomb-Rice encoded filter writer
 pub struct GCSFilterWriter<'a> {
     filter: GCSFilter,
-    writer: &'a mut io::Write,
+    writer: &'a mut dyn io::Write,
     elements: HashSet<Vec<u8>>,
     m: u64
 }
 
 impl<'a> GCSFilterWriter<'a> {
     /// Create a new GCS writer wrapping a generic writer, with specific seed to siphash
-    pub fn new(writer: &'a mut io::Write, k0: u64, k1: u64, m: u64, p: u8) -> GCSFilterWriter<'a> {
+    pub fn new(writer: &'a mut dyn io::Write, k0: u64, k1: u64, m: u64, p: u8) -> GCSFilterWriter<'a> {
         GCSFilterWriter {
             filter: GCSFilter::new(k0, k1, p),
             writer,
@@ -436,12 +436,12 @@ impl GCSFilter {
 pub struct BitStreamReader<'a> {
     buffer: [u8; 1],
     offset: u8,
-    reader: &'a mut io::Read,
+    reader: &'a mut dyn io::Read,
 }
 
 impl<'a> BitStreamReader<'a> {
     /// Create a new BitStreamReader that reads bitwise from a given reader
-    pub fn new(reader: &'a mut io::Read) -> BitStreamReader {
+    pub fn new(reader: &'a mut dyn io::Read) -> BitStreamReader {
         BitStreamReader {
             buffer: [0u8],
             reader: reader,
@@ -474,12 +474,12 @@ impl<'a> BitStreamReader<'a> {
 pub struct BitStreamWriter<'a> {
     buffer: [u8; 1],
     offset: u8,
-    writer: &'a mut io::Write,
+    writer: &'a mut dyn io::Write,
 }
 
 impl<'a> BitStreamWriter<'a> {
     /// Create a new BitStreamWriter that writes bitwise to a given writer
-    pub fn new(writer: &'a mut io::Write) -> BitStreamWriter {
+    pub fn new(writer: &'a mut dyn io::Write) -> BitStreamWriter {
         BitStreamWriter {
             buffer: [0u8],
             writer: writer,

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -383,7 +383,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
        if let Error::Ecdsa(ref e) = *self {
            Some(e)
        } else {

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -69,7 +69,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Secp(ref e) => Some(e),
             Error::Script(ref e) => Some(e),

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -124,7 +124,7 @@ impl PrivateKey {
     }
 
     /// Format the private key to WIF format.
-    pub fn fmt_wif(&self, fmt: &mut fmt::Write) -> fmt::Result {
+    pub fn fmt_wif(&self, fmt: &mut dyn fmt::Write) -> fmt::Result {
         let mut ret = [0; 34];
         ret[0] = match self.network {
             Network::Bitcoin => 128,

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -524,7 +524,7 @@ mod tests {
                 height += 1;
             }
 
-            // Check with random subsets with inclusion chances 1, 1/2, 1/4, ..., 1/128
+            // Check with random subsets with inclusion chances 1, 1/2, 1/4, ..=, 1/128
             for att in 1..15 {
                 let mut matches = vec![false; num_tx];
                 let mut match_txid1 = vec![];

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -26,9 +26,9 @@ static MSG_SIGN_PREFIX: &'static [u8] = b"\x18Bitcoin Signed Message:\n";
 #[inline]
 fn hex_val(c: u8) -> Result<u8, encode::Error> {
     let res = match c {
-        b'0' ... b'9' => c - '0' as u8,
-        b'a' ... b'f' => c - 'a' as u8 + 10,
-        b'A' ... b'F' => c - 'A' as u8 + 10,
+        b'0' ..= b'9' => c - '0' as u8,
+        b'a' ..= b'f' => c - 'a' as u8 + 10,
+        b'A' ..= b'F' => c - 'A' as u8 + 10,
         _ => return Err(encode::Error::UnexpectedHexDigit(c as char)),
     };
     Ok(res)

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -81,7 +81,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Encode(ref e) => Some(e),
             Error::Network(ref e) => Some(e),

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -141,7 +141,7 @@ macro_rules! construct_uint {
                 let mut sub_copy = self;
                 let mut shift_copy = other;
                 let mut ret = [0u64; $n_words];
-        
+
                 let my_bits = self.bits();
                 let your_bits = other.bits();
 
@@ -332,7 +332,7 @@ macro_rules! construct_uint {
 
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                <fmt::Debug>::fmt(self, f)
+                <dyn fmt::Debug>::fmt(self, f)
             }
         }
 


### PR DESCRIPTION
...per title. Also added swap files to `.gitignore`. 

***

#### NOTE:

Force pushed due to noticing the global fix (`... => ..=`) I did on the deprecated range operators also caught a couple of ellipses in comments. Didn't notice until seeing the diff on here, and so restored those actual ellipses and forced the branch so the commits are clean.