### PR TITLE
Adding MSRV to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ please join us in
 [#rust-bitcoin](http://webchat.freenode.net/?channels=%23rust-bitcoin) on
 freenode.
 
+## Minimum Supported Rust Version (MSRV)
+This library should always compile with any combination of features on **Rust 1.22**.
+
 ## Installing Rust
 Rust can be installed using your package manager of choice or
 [rustup.rs](https://rustup.rs). The former way is considered more secure since


### PR DESCRIPTION
I hope this can prevent future PRs like 
https://github.com/rust-bitcoin/rust-bitcoin/pull/346 
https://github.com/rust-bitcoin/rust-secp256k1/pull/123
and others.

we could also add a `rust-toolchain` file, but then we also need to edit the CI to be explicit on the right toolchain that *isn't* what's in `rust-toolchain` https://github.com/rust-lang/rustup#override-precedence