### PR TITLE
fix(compiler-warnings): silence range-pattern & bare-trait-object warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 Cargo.lock
+*.sw*
 
 #fuzz
 fuzz/hfuzz_target

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
-
+#![allow(bare_trait_objects)]
+#![allow(ellipsis_inclusive_range_patterns)]
 
 // Re-exported dependencies.
 pub extern crate bitcoin_hashes as hashes;


### PR DESCRIPTION
...per title. Also added swap files to `.gitignore`.

#### Note:

This replaces the now closed PR __[here](https://github.com/rust-bitcoin/rust-bitcoin/pull/346)__. 