### PR TITLE
Simplifying macros

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -46,7 +46,7 @@ pub const PROTOCOL_VERSION: u32 = 70001;
 
 user_enum! {
     /// The cryptocurrency to act on
-    #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+    #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Debug)]
     pub enum Network {
         /// Classic Bitcoin
         Bitcoin <-> "bitcoin",

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -30,12 +30,14 @@ use util::{base58, endian};
 use util::key::{PublicKey, PrivateKey};
 
 /// A chain code
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainCode([u8; 32]);
 impl_array_newtype!(ChainCode, u8, 32);
 impl_array_newtype_show!(ChainCode);
 impl_bytes_newtype!(ChainCode, 32);
 
 /// A fingerprint
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Fingerprint([u8; 4]);
 impl_array_newtype!(Fingerprint, u8, 4);
 impl_array_newtype_show!(Fingerprint);


### PR DESCRIPTION
This is the first step in an attempt to simplify the macros we use in this crate.
I tried removing anything that can be derived. and removing the general functions implementation that might made sense on crates like `rust-secp256k1` for ffi reasons but less so here.

cc #352 
I'm trying to "Modernize" some of the great code @apoelstra wrote way before any of us ever heard of rust :)
The next stage is when these are simple enough I can write a custom derive crate for the rest of the things.

Sadly a thing that can greatly simplify the Index operations was is only stable from 1.28 https://github.com/rust-lang/rust/issues/35729


The breaking changes are:
1. removing a bunch of `as_pt` etc. implementations from `ChainCode` and `Fingerprint` (as I said before I don't think they make any sense here).
2. removing a `#[repr(C)]` from the Uints.

anything else here shouldn't be considered a breaking change (exact implementations of traits like `Hash` etc aren't supposed to be stable anyway)