### PR TITLE
Remove two old TODO comments [nit]

### DIFF
--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -116,7 +116,6 @@ pub enum NetworkMessage {
     Ping(u64),
     /// `pong`
     Pong(u64),
-    // TODO: reject,
     // TODO: bloom filtering
     /// BIP157 getcfilters
     GetCFilters(message_filter::GetCFilters),

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -54,8 +54,7 @@ pub struct VersionMessage {
 }
 
 impl VersionMessage {
-    // TODO: we have fixed services and relay to 0
-    /// Constructs a new `version` message
+    /// Constructs a new `version` message with `relay` set to false
     pub fn new(
         services: ServiceFlags,
         timestamp: i64,


### PR DESCRIPTION
The TODO comments are invalid thanks to contributions in recent months

* https://github.com/rust-bitcoin/rust-bitcoin/blame/master/src/network/message_network.rs#L57
* https://github.com/rust-bitcoin/rust-bitcoin/blame/master/src/network/message.rs#L119