### PR TITLE
Convert numeric representation of ServiceFlags to bitwise OR of the f…

### DIFF
--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -109,6 +109,7 @@ impl fmt::Debug for Address {
 mod test {
     use std::str::FromStr;
     use super::Address;
+    use network::constants::ServiceFlags;
     use std::net::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr};
 
     use consensus::encode::{deserialize, serialize};
@@ -116,7 +117,7 @@ mod test {
     #[test]
     fn serialize_address_test() {
         assert_eq!(serialize(&Address {
-            services: 1.into(),
+            services: ServiceFlags::NETWORK,
             address: [0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001],
             port: 8333
         }),
@@ -136,7 +137,7 @@ mod test {
                     _ => false
                 }
             );
-        assert_eq!(full.services, 1.into());
+        assert_eq!(full.services, ServiceFlags::NETWORK);
         assert_eq!(full.address, [0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001]);
         assert_eq!(full.port, 8333);
 
@@ -148,11 +149,11 @@ mod test {
     #[test]
     fn test_socket_addr () {
         let s4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(111,222,123,4)), 5555);
-        let a4 = Address::new(&s4, 9.into());
+        let a4 = Address::new(&s4, ServiceFlags::NETWORK | ServiceFlags::WITNESS);
         assert_eq!(a4.socket_addr().unwrap(), s4);
         let s6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0x1111, 0x2222, 0x3333, 0x4444,
         0x5555, 0x6666, 0x7777, 0x8888)), 9999);
-        let a6 = Address::new(&s6, 9.into());
+        let a6 = Address::new(&s6, ServiceFlags::NETWORK | ServiceFlags::WITNESS);
         assert_eq!(a6.socket_addr().unwrap(), s6);
     }
 
@@ -161,7 +162,7 @@ mod test {
         let onionaddr = SocketAddr::new(
             IpAddr::V6(
             Ipv6Addr::from_str("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").unwrap()), 1111);
-        let addr = Address::new(&onionaddr, 0.into());
+        let addr = Address::new(&onionaddr, ServiceFlags::NONE);
         assert!(addr.socket_addr().is_err());
     }
 }

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -334,6 +334,7 @@ impl Decodable for RawNetworkMessage {
 mod test {
     use std::io;
     use super::{RawNetworkMessage, NetworkMessage, CommandString};
+    use network::constants::ServiceFlags;
     use consensus::encode::{Encodable, deserialize, deserialize_partial, serialize};
 
     #[test]
@@ -429,7 +430,7 @@ mod test {
         assert_eq!(msg.magic, 0xd9b4bef9);
         if let NetworkMessage::Version(version_msg) = msg.payload {
             assert_eq!(version_msg.version, 70015);
-            assert_eq!(version_msg.services, 1037.into());
+            assert_eq!(version_msg.services, ServiceFlags::NETWORK | ServiceFlags::BLOOM | ServiceFlags::WITNESS | ServiceFlags::NETWORK_LIMITED);
             assert_eq!(version_msg.timestamp, 1548554224);
             assert_eq!(version_msg.nonce, 13952548347456104954);
             assert_eq!(version_msg.user_agent, "/Satoshi:0.17.1/");
@@ -466,7 +467,7 @@ mod test {
         assert_eq!(msg.magic, 0xd9b4bef9);
         if let NetworkMessage::Version(version_msg) = msg.payload {
             assert_eq!(version_msg.version, 70015);
-            assert_eq!(version_msg.services, 1037.into());
+            assert_eq!(version_msg.services, ServiceFlags::NETWORK | ServiceFlags::BLOOM | ServiceFlags::WITNESS | ServiceFlags::NETWORK_LIMITED);
             assert_eq!(version_msg.timestamp, 1548554224);
             assert_eq!(version_msg.nonce, 13952548347456104954);
             assert_eq!(version_msg.user_agent, "/Satoshi:0.17.1/");

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -148,6 +148,7 @@ mod tests {
     use super::VersionMessage;
 
     use hex::decode as hex_decode;
+    use network::constants::ServiceFlags;
 
     use consensus::encode::{deserialize, serialize};
 
@@ -160,7 +161,7 @@ mod tests {
         assert!(decode.is_ok());
         let real_decode = decode.unwrap();
         assert_eq!(real_decode.version, 70002);
-        assert_eq!(real_decode.services, 1.into());
+        assert_eq!(real_decode.services, ServiceFlags::NETWORK);
         assert_eq!(real_decode.timestamp, 1401217254);
         // address decodes should be covered by Address tests
         assert_eq!(real_decode.nonce, 16735069437859780935);

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -86,6 +86,7 @@ mod test {
     use std::io::{self, BufReader, Write};
     use std::net::{TcpListener, TcpStream, Shutdown};
     use std::thread::JoinHandle;
+    use network::constants::ServiceFlags;
 
     use super::StreamReader;
     use network::message::{NetworkMessage, RawNetworkMessage};
@@ -156,7 +157,7 @@ mod test {
         assert_eq!(msg.magic, 0xd9b4bef9);
         if let NetworkMessage::Version(ref version_msg) = msg.payload {
             assert_eq!(version_msg.version, 70015);
-            assert_eq!(version_msg.services, 1037.into());
+            assert_eq!(version_msg.services, ServiceFlags::NETWORK | ServiceFlags::BLOOM | ServiceFlags::WITNESS | ServiceFlags::NETWORK_LIMITED);
             assert_eq!(version_msg.timestamp, 1548554224);
             assert_eq!(version_msg.nonce, 13952548347456104954);
             assert_eq!(version_msg.user_agent, "/Satoshi:0.17.1/");


### PR DESCRIPTION
…lag names

Integer numbers are harder to understand than flag names