### PR TITLE
Replace feature serde with use-serde

### DIFF
--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -20,7 +20,7 @@
 
 #![allow(non_camel_case_types)]
 
-#[cfg(feature = "serde")] use serde;
+#[cfg(feature = "use-serde")] use serde;
 
 use std::fmt;
 
@@ -712,7 +712,7 @@ impl From<u8> for All {
 
 display_from_debug!(All);
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl serde::Serialize for All {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -750,7 +750,7 @@ pub enum Class {
 
 display_from_debug!(Class);
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl serde::Serialize for Class {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -27,7 +27,7 @@
 use std::default::Default;
 use std::{error, fmt, io};
 
-#[cfg(feature = "serde")] use serde;
+#[cfg(feature = "use-serde")] use serde;
 
 use blockdata::opcodes;
 use consensus::{encode, Decodable, Encodable};
@@ -685,7 +685,7 @@ impl From<Vec<u8>> for Builder {
 
 impl_index_newtype!(Builder, u8);
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl<'de> serde::Deserialize<'de> for Script {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -728,7 +728,7 @@ impl<'de> serde::Deserialize<'de> for Script {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl serde::Serialize for Script {
     /// User-facing serialization for `Script`.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -931,7 +931,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     fn script_json_serialize() {
         use serde_json;
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -798,7 +798,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     fn test_txn_encode_decode() {
         let hex_tx = Vec::<u8>::from_hex("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
         let tx: Transaction = deserialize(&hex_tx).unwrap();
@@ -819,7 +819,7 @@ mod tests {
     // Test decoding transaction `4be105f158ea44aec57bf12c5817d073a712ab131df6f37786872cfc70734188`
     // from testnet, which is the first BIP144-encoded transaction I encountered.
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     fn test_segwit_tx_decode() {
         let hex_tx = Vec::<u8>::from_hex("010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3603da1b0e00045503bd5704c7dd8a0d0ced13bb5785010800000000000a636b706f6f6c122f4e696e6a61506f6f6c2f5345475749542fffffffff02b4e5a212000000001976a914876fbb82ec05caa6af7a3b5e5a983aae6c6cc6d688ac0000000000000000266a24aa21a9edf91c46b49eb8a29089980f02ee6b57e7d63d33b18b4fddac2bcd7db2a39837040120000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
         let tx: Transaction = deserialize(&hex_tx).unwrap();

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -231,7 +231,7 @@ macro_rules! hex_hash (($s:expr) => (::hashes::sha256d::Hash::from_slice(&::hex:
 
 macro_rules! serde_struct_impl {
     ($name:ident, $($fe:ident),*) => (
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "use-serde")]
         impl<'de> $crate::serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
             where
@@ -326,7 +326,7 @@ macro_rules! serde_struct_impl {
             }
         }
 
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "use-serde")]
         impl<'de> $crate::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -351,7 +351,7 @@ macro_rules! serde_struct_impl {
 
 macro_rules! serde_string_impl {
     ($name:ident, $expecting:expr) => {
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "use-serde")]
         impl<'de> $crate::serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
             where
@@ -394,7 +394,7 @@ macro_rules! serde_string_impl {
             }
         }
 
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "use-serde")]
         impl<'de> $crate::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -411,7 +411,7 @@ macro_rules! serde_string_impl {
 /// non-human-readable serialization.
 macro_rules! serde_struct_human_string_impl {
     ($name:ident, $expecting:expr, $($fe:ident),*) => (
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "use-serde")]
         impl<'de> $crate::serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
             where
@@ -543,7 +543,7 @@ macro_rules! serde_struct_human_string_impl {
             }
         }
 
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "use-serde")]
         impl<'de> $crate::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -619,7 +619,7 @@ macro_rules! impl_bytes_newtype {
             }
         }
 
-        #[cfg(feature="serde")]
+        #[cfg(feature = "use-serde")]
         impl ::serde::Serialize for $t {
             fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 if s.is_human_readable() {
@@ -630,7 +630,7 @@ macro_rules! impl_bytes_newtype {
             }
         }
 
-        #[cfg(feature="serde")]
+        #[cfg(feature = "use-serde")]
         impl<'de> ::serde::Deserialize<'de> for $t {
             fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<$t, D::Error> {
                 if d.is_human_readable() {
@@ -737,7 +737,7 @@ macro_rules! user_enum {
             }
         }
 
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "use-serde")]
         impl<'de> $crate::serde::Deserialize<'de> for $name {
             #[inline]
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -786,7 +786,7 @@ macro_rules! user_enum {
             }
         }
 
-        #[cfg(feature = "serde")]
+        #[cfg(feature = "use-serde")]
         impl ::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,11 @@ pub extern crate bitcoin_hashes as hashes;
 pub extern crate secp256k1;
 pub extern crate bech32;
 
-#[cfg(any(test, feature = "serde"))] extern crate hex;
-#[cfg(feature = "serde")] extern crate serde;
-#[cfg(all(test, feature = "serde"))] #[macro_use] extern crate serde_derive; // for 1.22.0 compat
-#[cfg(all(test, feature = "serde"))] extern crate serde_json;
-#[cfg(all(test, feature = "serde"))] extern crate serde_test;
+#[cfg(any(test, feature = "use-serde"))] extern crate hex;
+#[cfg(feature = "use-serde")] extern crate serde;
+#[cfg(all(test, feature = "use-serde"))] #[macro_use] extern crate serde_derive; // for 1.22.0 compat
+#[cfg(all(test, feature = "use-serde"))] extern crate serde_json;
+#[cfg(all(test, feature = "use-serde"))] extern crate serde_test;
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 #[cfg(feature="bitcoinconsensus")] extern crate bitcoinconsensus;
 

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -16,7 +16,7 @@
 //!
 //! Internal macros used for unit tests
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 macro_rules! serde_round_trip (
     ($var:expr) => ({
         use serde_json;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -684,7 +684,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     fn test_json_serialize() {
         use serde_json;
 

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -887,7 +887,7 @@ impl FromStr for SignedAmount {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 pub mod serde {
     // methods are implementation of a standardized serde-specific signature
     #![allow(missing_docs)]
@@ -1039,7 +1039,7 @@ mod tests {
     use std::panic;
     use std::str::FromStr;
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     use serde_test;
 
     #[test]
@@ -1244,7 +1244,7 @@ mod tests {
         assert_eq!(Amount::from_str(&denom(&amt, D::MilliSatoshi)), Ok(amt));
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     #[test]
     fn serde_as_sat() {
 
@@ -1275,7 +1275,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     #[test]
     fn serde_as_btc() {
         use serde_json;
@@ -1309,7 +1309,7 @@ mod tests {
         assert!(t.unwrap_err().to_string().contains(&ParseAmountError::Negative.to_string()));
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     #[test]
     fn serde_as_btc_opt() {
         use serde_json;

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -19,7 +19,7 @@
 use std::default::Default;
 use std::{error, fmt};
 use std::str::FromStr;
-#[cfg(feature = "serde")] use serde;
+#[cfg(feature = "use-serde")] use serde;
 
 use hashes::{hex, hash160, sha512, Hash, HashEngine, Hmac, HmacEngine};
 use secp256k1::{self, Secp256k1};
@@ -189,7 +189,7 @@ impl FromStr for ChildNumber {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl<'de> serde::Deserialize<'de> for ChildNumber {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -199,7 +199,7 @@ impl<'de> serde::Deserialize<'de> for ChildNumber {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl serde::Serialize for ChildNumber {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -942,7 +942,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     pub fn encode_decode_childnumber() {
         serde_round_trip!(ChildNumber::from_normal_idx(0).unwrap());
         serde_round_trip!(ChildNumber::from_normal_idx(1).unwrap());
@@ -953,7 +953,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     pub fn encode_fingerprint_chaincode() {
         use serde_json;
         let fp = Fingerprint::from(&[1u8,2,3,42][..]);

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -243,14 +243,14 @@ impl ops::Index<ops::RangeFull> for PrivateKey {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl ::serde::Serialize for PrivateKey {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.collect_str(self)
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl<'de> ::serde::Deserialize<'de> for PrivateKey {
     fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<PrivateKey, D::Error> {
         struct WifVisitor;
@@ -285,7 +285,7 @@ impl<'de> ::serde::Deserialize<'de> for PrivateKey {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl ::serde::Serialize for PublicKey {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         if s.is_human_readable() {
@@ -300,7 +300,7 @@ impl ::serde::Serialize for PublicKey {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "use-serde")]
 impl<'de> ::serde::Deserialize<'de> for PublicKey {
     fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<PublicKey, D::Error> {
         if d.is_human_readable() {
@@ -400,7 +400,7 @@ mod tests {
         assert_eq!(pk, PublicKey::from_str("032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af").unwrap());
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "use-serde")]
     #[test]
     fn test_key_serde() {
         use serde_test::{Configure, Token, assert_tokens};


### PR DESCRIPTION
This will fix problems like #372
Basically the problem is that cargo doesn't allow colliding package names with feature names, so we had to use the feature `use-serde` instead of `serde` (common practice)
But now some users can get confuse and pass `serde` by mistake which will make it miscompile.

I replaced all usages of `feature = "serde"` with `feature = "use-serde"`. we could also add to the CI to test the "features" serde and hex such that it will still compile.
another option is to add a build.rs file that will test if `serde` is set without `use-serde` and will produce a meaningful error for the user.

Introduced in: https://github.com/rust-bitcoin/rust-bitcoin/pull/215
