### PR TITLE
Bump Bech32 to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 
 * Add some trait impls to `PublicKey` for miniscript interoperability
 
-# 0.17.0 - 2019-02-28 - ``The PSBT Release''
+# 0.17.0 - 2019-02-28 - "The PSBT Release"
 
 * **Update minimum rustc version to 1.22**.
 * [Replace `rust-crypto` with `bitcoin_hashes`; refactor hash types](https://github.com/rust-bitcoin/rust-bitcoin/pull/215)
@@ -149,7 +149,7 @@ See `Transaction::verify` and `Script::verify` methods.
 * Add bech32 support
 * Support segwit address types
 
-### 0.11
+# 0.11
 
 * Remove `num` dependency at Matt's request; agree this is obnoxious to require all
 downstream users to also have a `num` dependency just so they can use `Uint256::from_u64`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.21.1"
+version = "0.21.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"
@@ -21,7 +21,7 @@ rand = ["secp256k1/rand"]
 use-serde = ["hex", "serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 
 [dependencies]
-bech32 = "0.7.1"
+bech32 = "0.7.2"
 bitcoin_hashes = "0.7"
 bitcoinconsensus = { version = "0.17", optional = true }
 serde = { version = "1", optional = true }


### PR DESCRIPTION
Quick dependency bump, after fixing a logic error in the Bech32 library.

See rust-bitcoin/rust-bech32#41.