### PR TITLE
readme: Add links to CHANGELOG.md and LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ support only a single blockchain.
 
 # Release Notes
 
-See CHANGELOG.md
+See [CHANGELOG.md](CHANGELOG.md).
 
 
 # Licensing
 
-The code in this project is licensed under the Creative Commons CC0 1.0
-Universal license.
+The code in this project is licensed under the [Creative Commons CC0 1.0
+Universal license](LICENSE).


### PR DESCRIPTION
For convenience, added links to the `CHANGELOG.md` and `LICENSE` that are referenced in `README.md`.