### PR TITLE
Remove the BitcoinHash trait

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -151,7 +151,6 @@ mod test {
     use consensus::encode::serialize;
     use blockdata::constants::{genesis_block, bitcoin_genesis_tx};
     use blockdata::constants::{MAX_SEQUENCE, COIN_VALUE};
-    use util::hash::BitcoinHash;
 
     #[test]
     fn bitcoin_genesis_first_transaction() {
@@ -186,7 +185,7 @@ mod test {
         assert_eq!(gen.header.time, 1231006505);
         assert_eq!(gen.header.bits, 0x1d00ffff);
         assert_eq!(gen.header.nonce, 2083236893);
-        assert_eq!(format!("{:x}", gen.header.bitcoin_hash()),
+        assert_eq!(format!("{:x}", gen.header.block_hash()),
                    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f".to_string());
     }
 
@@ -200,7 +199,7 @@ mod test {
         assert_eq!(gen.header.time, 1296688602);
         assert_eq!(gen.header.bits, 0x1d00ffff);
         assert_eq!(gen.header.nonce, 414098458);
-        assert_eq!(format!("{:x}", gen.header.bitcoin_hash()),
+        assert_eq!(format!("{:x}", gen.header.block_hash()),
                    "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943".to_string());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@ pub use util::address::Address;
 pub use util::address::AddressType;
 pub use util::amount::Amount;
 pub use util::amount::SignedAmount;
-pub use util::hash::BitcoinHash;
 pub use util::key::PrivateKey;
 pub use util::key::PublicKey;
 pub use util::merkleblock::MerkleBlock;

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -59,7 +59,6 @@ use blockdata::transaction::OutPoint;
 use consensus::{Decodable, Encodable};
 use consensus::encode::VarInt;
 use util::endian;
-use util::hash::BitcoinHash;
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845
 const P: u8 = 19;
@@ -155,7 +154,7 @@ pub struct BlockFilterWriter<'a> {
 impl<'a> BlockFilterWriter<'a> {
     /// Create a block filter writer
     pub fn new(writer: &'a mut io::Write, block: &'a Block) -> BlockFilterWriter<'a> {
-        let block_hash_as_int = block.bitcoin_hash().into_inner();
+        let block_hash_as_int = block.block_hash().into_inner();
         let k0 = endian::slice_to_u64_le(&block_hash_as_int[0..8]);
         let k1 = endian::slice_to_u64_le(&block_hash_as_int[8..16]);
         let writer = GCSFilterWriter::new(writer, k0, k1, M, P);
@@ -559,7 +558,7 @@ mod test {
         for t in testdata.iter().skip(1) {
             let block_hash = BlockHash::from_hex(&t.get(1).unwrap().as_str().unwrap()).unwrap();
             let block: Block = deserialize(hex::decode(&t.get(2).unwrap().as_str().unwrap().as_bytes()).unwrap().as_slice()).unwrap();
-            assert_eq!(block.bitcoin_hash(), block_hash);
+            assert_eq!(block.block_hash(), block_hash);
             let scripts = t.get(3).unwrap().as_array().unwrap();
             let previous_filter_id = FilterHash::from_hex(&t.get(4).unwrap().as_str().unwrap()).unwrap();
             let filter_content = hex::decode(&t.get(5).unwrap().as_str().unwrap().as_bytes()).unwrap();
@@ -584,7 +583,7 @@ mod test {
 
             assert_eq!(test_filter.content, filter.content);
 
-            let block_hash = &block.header.bitcoin_hash();
+            let block_hash = &block.block_hash();
             assert!(filter.match_all(block_hash, &mut txmap.iter()
                 .filter_map(|(_, s)| if !s.is_empty() { Some(s.as_bytes()) } else { None })).unwrap());
 

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -75,9 +75,3 @@ pub fn bitcoin_merkle_root<T, I>(mut iter: I) -> T
     }
     bitcoin_merkle_root_inline(&mut alloc)
 }
-
-/// Objects which are referred to by hash
-pub trait BitcoinHash<T: Hash> {
-    /// Produces a Sha256dHash which can be used to refer to the object
-    fn bitcoin_hash(&self) -> T;
-}

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -502,7 +502,7 @@ mod tests {
     use secp256k1::rand::prelude::*;
 
     use consensus::encode::{deserialize, serialize};
-    use util::hash::{bitcoin_merkle_root, BitcoinHash};
+    use util::hash::bitcoin_merkle_root;
     use util::merkleblock::{MerkleBlock, PartialMerkleTree};
     use {hex, Block};
 
@@ -616,7 +616,7 @@ mod tests {
             af156d6fc30b55fad4112df2b95531e68114e9ad10011e72f7b7cfdb025700";
 
         let mb: MerkleBlock = deserialize(&hex::decode(mb_hex).unwrap()).unwrap();
-        assert_eq!(get_block_13b8a().bitcoin_hash(), mb.header.bitcoin_hash());
+        assert_eq!(get_block_13b8a().block_hash(), mb.header.block_hash());
         assert_eq!(
             mb.header.merkle_root,
             mb.txn.extract_matches(&mut vec![], &mut vec![]).unwrap()
@@ -645,7 +645,7 @@ mod tests {
 
         let merkle_block = MerkleBlock::from_block(&block, &txids);
 
-        assert_eq!(merkle_block.header.bitcoin_hash(), block.bitcoin_hash());
+        assert_eq!(merkle_block.header.block_hash(), block.block_hash());
 
         let mut matches: Vec<Txid> = vec![];
         let mut index: Vec<u32> = vec![];
@@ -678,7 +678,7 @@ mod tests {
 
         let merkle_block = MerkleBlock::from_block(&block, &txids);
 
-        assert_eq!(merkle_block.header.bitcoin_hash(), block.bitcoin_hash());
+        assert_eq!(merkle_block.header.block_hash(), block.block_hash());
 
         let mut matches: Vec<Txid> = vec![];
         let mut index: Vec<u32> = vec![];


### PR DESCRIPTION
Replaced by a `block_hash` method on both `Block` and `BlockHeader`.

Fixes https://github.com/rust-bitcoin/rust-bitcoin/issues/383.

This is a breaking change and is not very urgent. So either we can just stall it until we want another breaking change, or when we merge it we'd need a 0.23.x branch for minor releases.