### PR TITLE
Draft: Reexporting macros from bitcoin_hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ use-serde = ["hex", "serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 
 [dependencies]
 bech32 = "0.7.2"
-bitcoin_hashes = "0.7.3"
+bitcoin_hashes = { git = "https://github.com/elichai/bitcoin_hashes", branch = "2020-01-hex" }
 secp256k1 = "0.17.1"
 
 bitcoinconsensus = { version = "0.19.0-1", optional = true }

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -53,7 +53,7 @@ hash_newtype!(WitnessMerkleNode, sha256d::Hash, 32, doc="A hash corresponding to
 hash_newtype!(WitnessCommitment, sha256d::Hash, 32, doc="A hash corresponding to the witness structure commitment in the coinbase transaction");
 hash_newtype!(XpubIdentifier, hash160::Hash, 20, doc="XpubIdentifier as defined in BIP-32.");
 
-hash_newtype!(FilterHash, sha256d::Hash, 32, doc="Bloom filter souble-SHA256 locator hash, as defined in BIP-168");
+hash_newtype!(FilterHash, sha256d::Hash, 32, doc="Bloom filter double-SHA256 locator hash, as defined in BIP-168");
 
 
 impl_hashencode!(Txid);
@@ -63,3 +63,16 @@ impl_hashencode!(BlockHash);
 impl_hashencode!(TxMerkleNode);
 impl_hashencode!(WitnessMerkleNode);
 impl_hashencode!(FilterHash);
+
+
+macro_rules! hash {
+    ($hash:ident, $($item:expr),+) => {
+        {
+            let mut engine = $hash::engine();
+            $(
+                $item.consensus_encode(&mut engine).expect("engines don't error");
+            )+
+            $hash::from_engine(engine)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,11 @@ pub mod consensus;
 #[allow(unused_imports)]
 pub mod hash_types;
 
+// Re-exporting macro
+pub use hashes::{hash_newtype, hex_fmt_impl, index_impl, borrow_slice_impl};
+#[cfg(feature = "serde")]
+pub use hashes::serde_impl;
+
 pub use hash_types::*;
 pub use blockdata::block::Block;
 pub use blockdata::block::BlockHeader;


### PR DESCRIPTION
`hash_newtype!` from bitcoin hashes was not available for the projects using rust-bitcoin. This PR fixes the issue by re-exporting the required set of macros, which allows to avoid direct dependency on bitcoin_hashes in downstream projects. The PR depends on https://github.com/rust-bitcoin/bitcoin_hashes/pull/71 and may be merged only after it (the dependency path should be updated in Cargo.toml)