### PR TITLE
Revert internal BIP-143 hashes to sha256d::Hash

### DIFF
--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -227,7 +227,7 @@ macro_rules! display_from_debug {
 macro_rules! hex_script (($s:expr) => (::blockdata::script::Script::from(::hex::decode($s).unwrap())));
 
 #[cfg(test)]
-macro_rules! hex_hash (($h:ident, $s:expr) => ($h::from_slice(&::hex::decode($s).unwrap()).unwrap()));
+macro_rules! from_hex (($s:expr) => (::hashes::hex::FromHex::from_hex($s).unwrap()));
 
 macro_rules! serde_struct_impl {
     ($name:ident, $($fe:ident),*) => (


### PR DESCRIPTION
They are not really SigHashes, just internal hashes.
Sadly this is a breaking change since the fields of this struct are
exposed. (I think they should be exposed, though.)

It also meant that the order of serialization is reverted.

Two things unrelated to this PR:
1. The `from_hex` macro for testing is actually quite useful. I think it can be used in a lot more tests. I can do a follow-up PR if there is interest.
2. I'm confused why the SigHash values had to be reversed. The `hash_newtype` macro preserves display order of the underlying hash. I think because they were not using the "display order" but the raw byte hex order for parsing.