### PR TITLE
Improve the Instructions iterator for scripts

### DIFF
--- a/fuzz/fuzz_targets/deserialize_script.rs
+++ b/fuzz/fuzz_targets/deserialize_script.rs
@@ -8,13 +8,14 @@ use bitcoin::consensus::encode;
 fn do_test(data: &[u8]) {
     let s: Result<script::Script, _> = encode::deserialize(data);
     if let Ok(script) = s {
-        let _: Vec<script::Instruction> = script.iter(false).collect();
-        let enforce_min: Vec<script::Instruction> = script.iter(true).collect();
+        let _: Result<Vec<script::Instruction>, script::Error> = script.instructions().collect();
 
         let mut b = script::Builder::new();
-        for ins in enforce_min {
-            match ins {
-                script::Instruction::Error(_) => return,
+        for ins in script.instructions_minimal() {
+            if ins.is_err() {
+                return;
+            }
+            match ins.ok().unwrap() {
                 script::Instruction::Op(op) => { b = b.push_opcode(op); }
                 script::Instruction::PushBytes(bytes) => {
                     // Any one-byte pushes, except -0, which can be interpreted as numbers, should be

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -227,8 +227,11 @@ pub fn untemplate(script: &script::Script) -> Result<(Template, Vec<PublicKey>),
     }
 
     let mut mode = Mode::SeekingKeys;
-    for instruction in script.iter(false) {
-        match instruction {
+    for instruction in script.instructions() {
+        if let Err(e) = instruction {
+            return Err(Error::Script(e));
+        }
+        match instruction.unwrap() {
             script::Instruction::PushBytes(data) => {
                 let n = data.len();
                 ret = match PublicKey::from_slice(data) {
@@ -275,7 +278,6 @@ pub fn untemplate(script: &script::Script) -> Result<(Template, Vec<PublicKey>),
                 }
                 ret = ret.push_opcode(op);
             }
-            script::Instruction::Error(e) => { return Err(Error::Script(e)); }
         }
     }
     Ok((Template::from(&ret[..]), retkeys))


### PR DESCRIPTION
- Rename the `iter` method to `instructions`.
- Add `instructions_minimal` for minimal-enforced iteration.
- Iterator has `Result<Instruction, Error>` as items.

Fixes https://github.com/rust-bitcoin/rust-bitcoin/issues/396.