### PR TITLE
Yet another MSRV breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,6 @@ hex = { version = "=0.3.2", optional = true }
 [dev-dependencies]
 hex = "=0.3.2"
 serde_derive = "<1.0.99"
-serde_json = "1"
+serde_json = "<1.0.45"
 serde_test = "1"
 secp256k1 = { version = "0.17.1", features = ["rand-std"] }


### PR DESCRIPTION
Here we go again.
serde-json broke MSRV last night and raised it to 1.31.

diff: https://github.com/serde-rs/json/compare/v1.0.44...v1.0.45
also documented in the README as a badge: https://github.com/serde-rs/json#serde-json----