### PR TITLE
Hygiene/single code style for all existing macros

### DIFF
--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -20,7 +20,7 @@ macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl $crate::consensus::Encodable for $thing {
             #[inline]
-            fn consensus_encode<S: $crate::std::io::Write>(
+            fn consensus_encode<S: ::std::io::Write>(
                 &self,
                 mut s: S,
             ) -> Result<usize, $crate::consensus::encode::Error> {
@@ -32,7 +32,7 @@ macro_rules! impl_consensus_encoding {
 
         impl $crate::consensus::Decodable for $thing {
             #[inline]
-            fn consensus_decode<D: $crate::std::io::Read>(
+            fn consensus_decode<D: ::std::io::Read>(
                 mut d: D,
             ) -> Result<$thing, $crate::consensus::encode::Error> {
                 Ok($thing {
@@ -82,7 +82,7 @@ macro_rules! impl_array_newtype {
             pub fn into_bytes(self) -> [$ty; $len] { self.0 }
         }
 
-        impl<'a> $crate::std::convert::From<&'a [$ty]> for $thing {
+        impl<'a> ::std::convert::From<&'a [$ty]> for $thing {
             fn from(data: &'a [$ty]) -> $thing {
                 assert_eq!(data.len(), $len);
                 let mut ret = [0; $len];
@@ -91,7 +91,7 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl $crate::std::ops::Index<usize> for $thing {
+        impl ::std::ops::Index<usize> for $thing {
             type Output = $ty;
 
             #[inline]
@@ -103,57 +103,57 @@ macro_rules! impl_array_newtype {
 
         impl_index_newtype!($thing, $ty);
 
-        impl $crate::std::cmp::PartialEq for $thing {
+        impl ::std::cmp::PartialEq for $thing {
             #[inline]
             fn eq(&self, other: &$thing) -> bool {
                 &self[..] == &other[..]
             }
         }
 
-        impl $crate::std::cmp::Eq for $thing {}
+        impl ::std::cmp::Eq for $thing {}
 
-        impl $crate::std::cmp::PartialOrd for $thing {
+        impl ::std::cmp::PartialOrd for $thing {
             #[inline]
-            fn partial_cmp(&self, other: &$thing) -> Option<$crate::std::cmp::Ordering> {
+            fn partial_cmp(&self, other: &$thing) -> Option<::std::cmp::Ordering> {
                 Some(self.cmp(&other))
             }
         }
 
-        impl $crate::std::cmp::Ord for $thing {
+        impl ::std::cmp::Ord for $thing {
             #[inline]
-            fn cmp(&self, other: &$thing) -> $crate::std::cmp::Ordering {
+            fn cmp(&self, other: &$thing) -> ::std::cmp::Ordering {
                 // manually implement comparison to get little-endian ordering
                 // (we need this for our numeric types; non-numeric ones shouldn't
                 // be ordered anyway except to put them in BTrees or whatever, and
                 // they don't care how we order as long as we're consistent).
                 for i in 0..$len {
-                    if self[$len - 1 - i] < other[$len - 1 - i] { return $crate::std::cmp::Ordering::Less; }
-                    if self[$len - 1 - i] > other[$len - 1 - i] { return $crate::std::cmp::Ordering::Greater; }
+                    if self[$len - 1 - i] < other[$len - 1 - i] { return ::std::cmp::Ordering::Less; }
+                    if self[$len - 1 - i] > other[$len - 1 - i] { return ::std::cmp::Ordering::Greater; }
                 }
-                $crate::std::cmp::Ordering::Equal
+                ::std::cmp::Ordering::Equal
             }
         }
 
         #[cfg_attr(feature = "clippy", allow(expl_impl_clone_on_copy))] // we don't define the `struct`, we have to explicitly impl
-        impl $crate::std::clone::Clone for $thing {
+        impl ::std::clone::Clone for $thing {
             #[inline]
             fn clone(&self) -> $thing {
                 $thing::from(&self[..])
             }
         }
 
-        impl $crate::std::marker::Copy for $thing {}
+        impl ::std::marker::Copy for $thing {}
 
-        impl $crate::std::hash::Hash for $thing {
+        impl ::std::hash::Hash for $thing {
             #[inline]
             fn hash<H>(&self, state: &mut H)
-                where H: $crate::std::hash::Hasher
+                where H: ::std::hash::Hasher
             {
                 (&self[..]).hash(state);
             }
 
             fn hash_slice<H>(data: &[$thing], state: &mut H)
-                where H: $crate::std::hash::Hasher
+                where H: ::std::hash::Hasher
             {
                 for d in data.iter() {
                     (&d[..]).hash(state);
@@ -166,8 +166,8 @@ macro_rules! impl_array_newtype {
 /// Implements debug formatting for a given wrapper type
 macro_rules! impl_array_newtype_show {
     ($thing:ident) => {
-        impl $crate::std::fmt::Debug for $thing {
-            fn fmt(&self, f: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
+        impl ::std::fmt::Debug for $thing {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 write!(f, concat!(stringify!($thing), "({:?})"), &self[..])
             }
         }
@@ -177,38 +177,38 @@ macro_rules! impl_array_newtype_show {
 /// Implements standard indexing methods for a given wrapper type
 macro_rules! impl_index_newtype {
     ($thing:ident, $ty:ty) => {
-        impl $crate::std::ops::Index<$crate::std::ops::Range<usize>> for $thing {
+        impl ::std::ops::Index<::std::ops::Range<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: $crate::std::ops::Range<usize>) -> &[$ty] {
+            fn index(&self, index: ::std::ops::Range<usize>) -> &[$ty] {
                 &self.0[index]
             }
         }
 
-        impl $crate::std::ops::Index<$crate::std::ops::RangeTo<usize>> for $thing {
+        impl ::std::ops::Index<::std::ops::RangeTo<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: $crate::std::ops::RangeTo<usize>) -> &[$ty] {
+            fn index(&self, index: ::std::ops::RangeTo<usize>) -> &[$ty] {
                 &self.0[index]
             }
         }
 
-        impl $crate::std::ops::Index<$crate::std::ops::RangeFrom<usize>> for $thing {
+        impl ::std::ops::Index<::std::ops::RangeFrom<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: $crate::std::ops::RangeFrom<usize>) -> &[$ty] {
+            fn index(&self, index: ::std::ops::RangeFrom<usize>) -> &[$ty] {
                 &self.0[index]
             }
         }
 
-        impl $crate::std::ops::Index<$crate::std::ops::RangeFull> for $thing {
+        impl ::std::ops::Index<::std::ops::RangeFull> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, _: $crate::std::ops::RangeFull) -> &[$ty] {
+            fn index(&self, _: ::std::ops::RangeFull) -> &[$ty] {
                 &self.0[..]
             }
         }
@@ -218,9 +218,9 @@ macro_rules! impl_index_newtype {
 
 macro_rules! display_from_debug {
     ($thing:ident) => {
-        impl $crate::std::fmt::Display for $thing {
-            fn fmt(&self, f: &mut $crate::std::fmt::Formatter) -> Result<(), $crate::std::fmt::Error> {
-                $crate::std::fmt::Debug::fmt(self, f)
+        impl ::std::fmt::Display for $thing {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Debug::fmt(self, f)
             }
         }
     }
@@ -240,7 +240,7 @@ macro_rules! serde_struct_impl {
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
-                use $crate::std::fmt::{self, Formatter};
+                use ::std::fmt::{self, Formatter};
                 use $crate::serde::de::IgnoredAny;
 
                 #[allow(non_camel_case_types)]
@@ -382,8 +382,8 @@ macro_rules! serde_string_impl {
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
-                use $crate::std::fmt::{self, Formatter};
-                use $crate::std::str::FromStr;
+                use ::std::fmt::{self, Formatter};
+                use ::std::str::FromStr;
 
                 struct Visitor;
                 impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
@@ -443,8 +443,8 @@ macro_rules! serde_struct_human_string_impl {
                 D: $crate::serde::de::Deserializer<'de>,
             {
                 if deserializer.is_human_readable() {
-                    use $crate::std::fmt::{self, Formatter};
-                    use $crate::std::str::FromStr;
+                    use ::std::fmt::{self, Formatter};
+                    use ::std::str::FromStr;
 
                     struct Visitor;
                     impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
@@ -478,7 +478,7 @@ macro_rules! serde_struct_human_string_impl {
 
                     deserializer.deserialize_str(Visitor)
                 } else {
-                    use $crate::std::fmt::{self, Formatter};
+                    use ::std::fmt::{self, Formatter};
                     use $crate::serde::de::IgnoredAny;
 
                     #[allow(non_camel_case_types)]
@@ -626,8 +626,8 @@ macro_rules! serde_struct_human_string_impl {
 macro_rules! impl_bytes_newtype {
     ($t:ident, $len:expr) => (
 
-        impl $crate::std::fmt::LowerHex for $t {
-            fn fmt(&self, f: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
+        impl ::std::fmt::LowerHex for $t {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 for &ch in self.0.iter() {
                     write!(f, "{:02x}", ch)?;
                 }
@@ -635,17 +635,17 @@ macro_rules! impl_bytes_newtype {
             }
         }
 
-        impl $crate::std::fmt::Display for $t {
-            fn fmt(&self, f: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
+        impl ::std::fmt::Display for $t {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 fmt::LowerHex::fmt(self, f)
             }
         }
 
         impl $crate::hashes::hex::FromHex for $t {
             fn from_byte_iter<I>(iter: I) -> Result<Self, $crate::hashes::hex::Error>
-                where I: $crate::std::iter::Iterator<Item=Result<u8, $crate::hashes::hex::Error>> +
-                    $crate::std::iter::ExactSizeIterator +
-                    $crate::std::iter::DoubleEndedIterator,
+                where I: ::std::iter::Iterator<Item=Result<u8, $crate::hashes::hex::Error>> +
+                    ::std::iter::ExactSizeIterator +
+                    ::std::iter::DoubleEndedIterator,
             {
                 if iter.len() == $len {
                     let mut ret = [0; $len];
@@ -659,7 +659,7 @@ macro_rules! impl_bytes_newtype {
             }
         }
 
-        impl $crate::std::str::FromStr for $t {
+        impl ::std::str::FromStr for $t {
             type Err = $crate::hashes::hex::Error;
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 $crate::hashes::hex::FromHex::from_hex(s)
@@ -686,7 +686,7 @@ macro_rules! impl_bytes_newtype {
                     impl<'de> $crate::serde::de::Visitor<'de> for HexVisitor {
                         type Value = $t;
 
-                        fn expecting(&self, formatter: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
+                        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                             formatter.write_str("an ASCII hex string")
                         }
 
@@ -694,7 +694,7 @@ macro_rules! impl_bytes_newtype {
                         where
                             E: $crate::serde::de::Error,
                         {
-                            if let Ok(hex) = $crate::std::str::from_utf8(v) {
+                            if let Ok(hex) = ::std::str::from_utf8(v) {
                                 $crate::hashes::hex::FromHex::from_hex(hex).map_err(E::custom)
                             } else {
                                 return Err(E::invalid_value($crate::serde::de::Unexpected::Bytes(v), &self));
@@ -716,7 +716,7 @@ macro_rules! impl_bytes_newtype {
                     impl<'de> $crate::serde::de::Visitor<'de> for BytesVisitor {
                         type Value = $t;
 
-                        fn expecting(&self, formatter: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
+                        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                             formatter.write_str("a bytestring")
                         }
 
@@ -754,30 +754,30 @@ macro_rules! user_enum {
             $(#[$doc] $elem),*
         }
 
-        impl $crate::std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 f.pad(match *self {
                     $($name::$elem => $txt),*
                 })
             }
         }
 
-        impl $crate::std::fmt::Display for $name {
-            fn fmt(&self, f: &mut $crate::std::fmt::Formatter) -> $crate::std::fmt::Result {
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 f.pad(match *self {
                     $($name::$elem => $txt),*
                 })
             }
         }
 
-        impl $crate::std::str::FromStr for $name {
-            type Err = $crate::std::io::Error;
+        impl ::std::str::FromStr for $name {
+            type Err = ::std::io::Error;
             #[inline]
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {
                     $($txt => Ok($name::$elem)),*,
-                    _ => Err($crate::std::io::Error::new(
-                        $crate::std::io::ErrorKind::InvalidInput,
+                    _ => Err(::std::io::Error::new(
+                        ::std::io::ErrorKind::InvalidInput,
                         format!("Unknown network (type {})", s),
                     )),
                 }
@@ -791,7 +791,7 @@ macro_rules! user_enum {
             where
                 D: $crate::serde::Deserializer<'de>,
             {
-                use $crate::std::fmt::{self, Formatter};
+                use ::std::fmt::{self, Formatter};
 
                 struct Visitor;
                 impl<'de> $crate::serde::de::Visitor<'de> for Visitor {

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 #[cfg(feature = "serde")] use serde;
 
 use hash_types::XpubIdentifier;
-use hashes::{hex, sha512, Hash, HashEngine, Hmac, HmacEngine};
+use hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine};
 use secp256k1::{self, Secp256k1};
 
 use network::constants::Network;

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -55,7 +55,7 @@ macro_rules! impl_psbt_serialize {
 macro_rules! impl_psbtmap_consensus_encoding {
     ($thing:ty) => {
         impl $crate::consensus::Encodable for $thing {
-            fn consensus_encode<S: $crate::std::io::Write>(
+            fn consensus_encode<S: ::std::io::Write>(
                 &self,
                 mut s: S,
             ) -> Result<usize, $crate::consensus::encode::Error> {
@@ -76,10 +76,10 @@ macro_rules! impl_psbtmap_consensus_encoding {
 macro_rules! impl_psbtmap_consensus_decoding {
     ($thing:ty) => {
         impl $crate::consensus::Decodable for $thing {
-            fn consensus_decode<D: $crate::std::io::Read>(
+            fn consensus_decode<D: ::std::io::Read>(
                 mut d: D,
             ) -> Result<Self, $crate::consensus::encode::Error> {
-                let mut rv: Self = $crate::std::default::Default::default();
+                let mut rv: Self = ::std::default::Default::default();
 
                 loop {
                     match $crate::consensus::Decodable::consensus_decode(&mut d) {

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -14,7 +14,7 @@
 
 #[allow(unused_macros)]
 macro_rules! hex_psbt {
-    ($s:expr) => { ::consensus::deserialize(&<Vec<u8> as ::hashes::hex::FromHex>::from_hex($s).unwrap()) };
+    ($s:expr) => { $crate::consensus::deserialize(&<Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()) };
 }
 
 macro_rules! merge {
@@ -34,9 +34,9 @@ macro_rules! impl_psbt_de_serialize {
 
 macro_rules! impl_psbt_deserialize {
     ($thing:ty) => {
-        impl ::util::psbt::serialize::Deserialize for $thing {
-            fn deserialize(bytes: &[u8]) -> Result<Self, ::consensus::encode::Error> {
-                ::consensus::deserialize(&bytes[..])
+        impl $crate::util::psbt::serialize::Deserialize for $thing {
+            fn deserialize(bytes: &[u8]) -> Result<Self, $crate::consensus::encode::Error> {
+                $crate::consensus::deserialize(&bytes[..])
             }
         }
     };
@@ -44,9 +44,9 @@ macro_rules! impl_psbt_deserialize {
 
 macro_rules! impl_psbt_serialize {
     ($thing:ty) => {
-        impl ::util::psbt::serialize::Serialize for $thing {
+        impl $crate::util::psbt::serialize::Serialize for $thing {
             fn serialize(&self) -> Vec<u8> {
-                ::consensus::serialize(self)
+                $crate::consensus::serialize(self)
             }
         }
     };
@@ -54,20 +54,20 @@ macro_rules! impl_psbt_serialize {
 
 macro_rules! impl_psbtmap_consensus_encoding {
     ($thing:ty) => {
-        impl ::consensus::Encodable for $thing {
-            fn consensus_encode<S: ::std::io::Write>(
+        impl $crate::consensus::Encodable for $thing {
+            fn consensus_encode<S: $crate::std::io::Write>(
                 &self,
                 mut s: S,
-            ) -> Result<usize, ::consensus::encode::Error> {
+            ) -> Result<usize, $crate::consensus::encode::Error> {
                 let mut len = 0;
-                for pair in ::util::psbt::Map::get_pairs(self)? {
-                    len += ::consensus::Encodable::consensus_encode(
+                for pair in $crate::util::psbt::Map::get_pairs(self)? {
+                    len += $crate::consensus::Encodable::consensus_encode(
                         &pair,
                         &mut s,
                     )?;
                 }
 
-                Ok(len + ::consensus::Encodable::consensus_encode(&0x00_u8, s)?)
+                Ok(len + $crate::consensus::Encodable::consensus_encode(&0x00_u8, s)?)
             }
         }
     };
@@ -75,16 +75,16 @@ macro_rules! impl_psbtmap_consensus_encoding {
 
 macro_rules! impl_psbtmap_consensus_decoding {
     ($thing:ty) => {
-        impl ::consensus::Decodable for $thing {
-            fn consensus_decode<D: ::std::io::Read>(
+        impl $crate::consensus::Decodable for $thing {
+            fn consensus_decode<D: $crate::std::io::Read>(
                 mut d: D,
-            ) -> Result<Self, ::consensus::encode::Error> {
-                let mut rv: Self = ::std::default::Default::default();
+            ) -> Result<Self, $crate::consensus::encode::Error> {
+                let mut rv: Self = $crate::std::default::Default::default();
 
                 loop {
-                    match ::consensus::Decodable::consensus_decode(&mut d) {
-                        Ok(pair) => ::util::psbt::Map::insert_pair(&mut rv, pair)?,
-                        Err(::consensus::encode::Error::Psbt(::util::psbt::Error::NoMorePairs)) => return Ok(rv),
+                    match $crate::consensus::Decodable::consensus_decode(&mut d) {
+                        Ok(pair) => $crate::util::psbt::Map::insert_pair(&mut rv, pair)?,
+                        Err($crate::consensus::encode::Error::Psbt($crate::util::psbt::Error::NoMorePairs)) => return Ok(rv),
                         Err(e) => return Err(e),
                     }
                 }
@@ -105,29 +105,27 @@ macro_rules! impl_psbt_insert_pair {
     ($slf:ident.$unkeyed_name:ident <= <$raw_key:ident: _>|<$raw_value:ident: $unkeyed_value_type:ty>) => {
         if $raw_key.key.is_empty() {
             if $slf.$unkeyed_name.is_none() {
-                let val: $unkeyed_value_type = ::util::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
-
+                let val: $unkeyed_value_type = $crate::util::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
                 $slf.$unkeyed_name = Some(val)
             } else {
-                return Err(::util::psbt::Error::DuplicateKey($raw_key).into());
+                return Err($crate::util::psbt::Error::DuplicateKey($raw_key).into());
             }
         } else {
-            return Err(::util::psbt::Error::InvalidKey($raw_key).into());
+            return Err($crate::util::psbt::Error::InvalidKey($raw_key).into());
         }
     };
     ($slf:ident.$keyed_name:ident <= <$raw_key:ident: $keyed_key_type:ty>|<$raw_value:ident: $keyed_value_type:ty>) => {
         if !$raw_key.key.is_empty() {
-            let key_val: $keyed_key_type = ::util::psbt::serialize::Deserialize::deserialize(&$raw_key.key)?;
-
+            let key_val: $keyed_key_type = $crate::util::psbt::serialize::Deserialize::deserialize(&$raw_key.key)?;
             match $slf.$keyed_name.entry(key_val) {
                 ::std::collections::btree_map::Entry::Vacant(empty_key) => {
-                    let val: $keyed_value_type = ::util::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
+                    let val: $keyed_value_type = $crate::util::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
                     empty_key.insert(val);
                 }
-                ::std::collections::btree_map::Entry::Occupied(_) => return Err(::util::psbt::Error::DuplicateKey($raw_key).into()),
+                ::std::collections::btree_map::Entry::Occupied(_) => return Err($crate::util::psbt::Error::DuplicateKey($raw_key).into()),
             }
         } else {
-            return Err(::util::psbt::Error::InvalidKey($raw_key).into());
+            return Err($crate::util::psbt::Error::InvalidKey($raw_key).into());
         }
     };
 }
@@ -136,23 +134,23 @@ macro_rules! impl_psbt_insert_pair {
 macro_rules! impl_psbt_get_pair {
     ($rv:ident.push($slf:ident.$unkeyed_name:ident as <$unkeyed_typeval:expr, _>|<$unkeyed_value_type:ty>)) => {
         if let Some(ref $unkeyed_name) = $slf.$unkeyed_name {
-            $rv.push(::util::psbt::raw::Pair {
-                key: ::util::psbt::raw::Key {
+            $rv.push($crate::util::psbt::raw::Pair {
+                key: $crate::util::psbt::raw::Key {
                     type_value: $unkeyed_typeval,
                     key: vec![],
                 },
-                value: ::util::psbt::serialize::Serialize::serialize($unkeyed_name),
+                value: $crate::util::psbt::serialize::Serialize::serialize($unkeyed_name),
             });
         }
     };
     ($rv:ident.push($slf:ident.$keyed_name:ident as <$keyed_typeval:expr, $keyed_key_type:ty>|<$keyed_value_type:ty>)) => {
         for (key, val) in &$slf.$keyed_name {
-            $rv.push(::util::psbt::raw::Pair {
-                key: ::util::psbt::raw::Key {
+            $rv.push($crate::util::psbt::raw::Pair {
+                key: $crate::util::psbt::raw::Key {
                     type_value: $keyed_typeval,
-                    key: ::util::psbt::serialize::Serialize::serialize(key),
+                    key: $crate::util::psbt::serialize::Serialize::serialize(key),
                 },
-                value: ::util::psbt::serialize::Serialize::serialize(val),
+                value: $crate::util::psbt::serialize::Serialize::serialize(val),
             });
         }
     };


### PR DESCRIPTION
While being not really important, had to do hygiene of all internal macros (since many of which I re-use in other places) such they now follow the same standard/coding style for all namespace prefixes (i.e. starting with `::` followed by a fully-clarified name).

Also added doc strings to some of the macros