### PR TITLE
Point users to `bip143::SighashComponents`

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -317,6 +317,8 @@ impl Transaction {
     /// ECDSA signer, the SigHashType appended to the resulting sig, and a
     /// script written around this, but this is the general (and hard) part.
     ///
+    /// For segwit v0 signatures, use `util::bip143::SighashComponents`.
+    ///
     /// *Warning* This does NOT attempt to support OP_CODESEPARATOR. In general
     /// this would require evaluating `script_pubkey` to determine which separators
     /// get evaluated and which don't, which we don't have the information to


### PR DESCRIPTION
An unaware user might try to use `signature_hash` for segwit signatures,
and not be aware of bip143.