### PR TITLE
Cleanup opcode classification

### DIFF
--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -724,7 +724,7 @@ impl All {
             || self.code >= all::OP_RETURN_186.code
     }
 
-    /// Indicates whether this opcode fits in the PushNumm class
+    /// Indicates whether this opcode fits in the PushNum class
     fn is_push_num_positive(&self) -> bool {
         all::OP_PUSHNUM_1.code <= self.code && self.code <= all::OP_PUSHNUM_16.code
     }


### PR DESCRIPTION
This PR cleans up up the encapsulation of `classify()` in `opcode.rs`, and adds testing around the method for each classification.