### PR TITLE
Export the util::amount::Denomination type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ pub use util::Error;
 pub use util::address::Address;
 pub use util::address::AddressType;
 pub use util::amount::Amount;
+pub use util::amount::Denomination;
 pub use util::amount::SignedAmount;
 pub use util::key::PrivateKey;
 pub use util::key::PublicKey;


### PR DESCRIPTION
Just thought this might be useful for some people. I don't think there will every be a conflicting type named Denomination anyway. If people think this clutters the API, just as good.