### PR TITLE
Change Amount Debug impl to BTC with 8 decimals

### DIFF
--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -463,7 +463,7 @@ impl Ord for Amount {
 
 impl fmt::Debug for Amount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Amount({} satoshi)", self.as_sat())
+        write!(f, "Amount({:.8} BTC)", self.as_btc())
     }
 }
 
@@ -807,7 +807,7 @@ impl Ord for SignedAmount {
 
 impl fmt::Debug for SignedAmount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SignedAmount({} satoshi)", self.as_sat())
+        write!(f, "SignedAmount({:.8} BTC)", self.as_btc())
     }
 }
 


### PR DESCRIPTION
I've been working a bit with Amounts and the satoshi notation is really confusing if you're dealing with 1 BTC+ amounts. The `Debug` trait is meant to as easily as possible give the developer an idea of the amount, so adding a decimal point gives strictly more information. Like this it always shows 8 digits.

This should not be considered a breaking change, IMO. The `Debug` trait is not intended to be parseable.