### PR TITLE
Deprecate Error::description

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -105,15 +105,7 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(error::Error::description(self))
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> { None }
-
-    fn description(&self) -> &'static str {
-        match *self {
+        let str = match *self {
             Error::NonMinimalPush => "non-minimal datapush",
             Error::EarlyEndOfScript => "unexpected end of script",
             Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
@@ -123,7 +115,15 @@ impl error::Error for Error {
             Error::UnknownSpentOutput(ref _point) => "unknown spent output Transaction::verify()",
             #[cfg(feature="bitcoinconsensus")]
             Error::SerializationError => "can not serialize the spending transaction in Transaction::verify()",
-        }
+        };
+        f.write_str(str)
+    }
+}
+
+#[allow(deprecated)]
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -128,15 +128,10 @@ impl fmt::Display for ParseOutPointError {
     }
 }
 
+#[allow(deprecated)]
 impl ::std::error::Error for ParseOutPointError {
     fn description(&self) -> &str {
-        match *self {
-            ParseOutPointError::Txid(_) => "TXID parse error",
-            ParseOutPointError::Vout(_) => "vout parse error",
-            ParseOutPointError::Format => "outpoint format error",
-            ParseOutPointError::TooLong => "size error",
-            ParseOutPointError::VoutNotCanonical => "vout canonical error",
-        }
+        "description() is deprecated; use Display"
     }
 
     fn cause(&self) -> Option<&::std::error::Error> {

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -109,6 +109,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[allow(deprecated)]
 impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
@@ -127,7 +128,7 @@ impl error::Error for Error {
     }
 
     fn description(&self) -> &str {
-        "Bitcoin encoding error"
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,7 +14,7 @@
 
 //! Network Support
 //!
-//! This module defines support for (de)serialization and network transport 
+//! This module defines support for (de)serialization and network transport
 //! of Bitcoin data and network messages.
 //!
 
@@ -47,7 +47,8 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
-            Error::SocketMutexPoisoned | Error::SocketNotConnectedToPeer => f.write_str(error::Error::description(self)),
+            Error::SocketMutexPoisoned => f.write_str("socket mutex was poisoned"),
+            Error::SocketNotConnectedToPeer => f.write_str("not connected to peer"),
         }
     }
 }
@@ -59,13 +60,10 @@ impl From<io::Error> for Error {
     }
 }
 
+#[allow(deprecated)]
 impl error::Error for Error {
     fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref e) => e.description(),
-            Error::SocketMutexPoisoned => "socket mutex was poisoned",
-            Error::SocketNotConnectedToPeer => "not connected to peer",
-        }
+        "description() is deprecated; use Display"
     }
 
     fn cause(&self) -> Option<&error::Error> {

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -91,6 +91,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[allow(deprecated)]
 impl ::std::error::Error for Error {
     fn cause(&self) -> Option<&::std::error::Error> {
         match *self {
@@ -100,8 +101,8 @@ impl ::std::error::Error for Error {
         }
     }
 
-    fn description(&self) -> &'static str {
-        "std::error::Error::description is deprecated"
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -102,30 +102,22 @@ pub enum ParseAmountError {
 
 impl fmt::Display for ParseAmountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let desc = ::std::error::Error::description(self);
         match *self {
-            ParseAmountError::InvalidCharacter(c) => write!(f, "{}: {}", desc, c),
-            ParseAmountError::UnknownDenomination(ref d) => write!(f, "{}: {}", desc, d),
-            _ => f.write_str(desc),
+            ParseAmountError::Negative => f.write_str("amount is negative"),
+            ParseAmountError::TooBig => f.write_str("amount is too big"),
+            ParseAmountError::TooPrecise => f.write_str("amount has a too high precision"),
+            ParseAmountError::InvalidFormat => f.write_str("invalid number format"),
+            ParseAmountError::InputTooLarge => f.write_str("input string was too large"),
+            ParseAmountError::InvalidCharacter(c) => write!(f, "invalid character in input: {}", c),
+            ParseAmountError::UnknownDenomination(ref d) => write!(f, "unknown denomination: {}",d),
         }
     }
 }
 
+#[allow(deprecated)]
 impl error::Error for ParseAmountError {
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
-
-    fn description(&self) -> &'static str {
-        match *self {
-            ParseAmountError::Negative => "amount is negative",
-            ParseAmountError::TooBig => "amount is too big",
-            ParseAmountError::TooPrecise => "amount has a too high precision",
-            ParseAmountError::InvalidFormat => "invalid number format",
-            ParseAmountError::InputTooLarge => "input string was too large",
-            ParseAmountError::InvalidCharacter(_) => "invalid character in input",
-            ParseAmountError::UnknownDenomination(_) => "unknown denomination",
-        }
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -52,17 +52,10 @@ impl fmt::Display for Error {
     }
 }
 
+#[allow(deprecated)]
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> { None }
-    fn description(&self) -> &'static str {
-        match *self {
-            Error::BadByte(_) => "invalid b58 character",
-            Error::BadChecksum(_, _) => "invalid b58ck checksum",
-            Error::InvalidLength(_) => "invalid length for b58 type",
-            Error::InvalidVersion(_) => "invalid version for b58 type",
-            Error::TooShort(_) => "b58ck data less than 4 bytes",
-            Error::Other(_) => "unknown b58 error"
-        }
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -73,12 +73,10 @@ pub enum Error {
     Io(io::Error),
 }
 
+#[allow(deprecated)]
 impl error::Error for Error {
     fn description(&self) -> &str {
-        match *self {
-            Error::UtxoMissing(_) => "unresolved UTXO",
-            Error::Io(_) => "IO Error"
-        }
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -391,14 +391,7 @@ impl error::Error for Error {
     }
 
     fn description(&self) -> &str {
-        match *self {
-            Error::CannotDeriveFromHardenedKey => "cannot derive hardened key from public key",
-            Error::Ecdsa(ref e) => error::Error::description(e),
-            Error::InvalidChildNumber(_) => "child number is invalid",
-            Error::RngError(_) => "rng error",
-            Error::InvalidChildNumberFormat => "invalid child number format",
-            Error::InvalidDerivationPathFormat => "invalid derivation path format",
-        }
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -69,6 +69,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[allow(deprecated)]
 impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
@@ -78,16 +79,8 @@ impl error::Error for Error {
         }
     }
 
-    fn description(&self) -> &'static str {
-        match *self {
-            Error::Secp(_) => "libsecp256k1 error",
-            Error::Script(_) => "script error",
-            Error::UncompressedKey => "encountered uncompressed secp public key",
-            Error::ExpectedKey => "expected key when deserializing script",
-            Error::ExpectedChecksig => "expected OP_*CHECKSIG* when deserializing script",
-            Error::TooFewKeys(_) => "too few keys for template",
-            Error::TooManyKeys(_) => "too many keys for template"
-        }
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -52,7 +52,7 @@ impl error::Error for Error {
     }
 
     fn description(&self) -> &str {
-		"Bitcoin key error"
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -77,11 +77,13 @@ impl fmt::Display for Error {
         match *self {
             Error::Encode(ref e) => fmt::Display::fmt(e, f),
             Error::Network(ref e) => fmt::Display::fmt(e, f),
-            Error::BlockBadProofOfWork | Error::BlockBadTarget => f.write_str(error::Error::description(self)),
+            Error::BlockBadProofOfWork => f.write_str("block target correct but not attained"),
+            Error::BlockBadTarget => f.write_str("block target incorrect"),
         }
     }
 }
 
+#[allow(deprecated)]
 impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
@@ -92,12 +94,7 @@ impl error::Error for Error {
     }
 
     fn description(&self) -> &str {
-        match *self {
-            Error::Encode(ref e) => e.description(),
-            Error::Network(ref e) => e.description(),
-            Error::BlockBadProofOfWork => "block target correct but not attained",
-            Error::BlockBadTarget => "block target incorrect",
-        }
+        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -53,35 +53,25 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::InvalidKey(ref rkey) => write!(f, "{}: {}", error::Error::description(self), rkey),
-            Error::DuplicateKey(ref rkey) => write!(f, "{}: {}", error::Error::description(self), rkey),
-            Error::UnexpectedUnsignedTx { expected: ref e, actual: ref a } => write!(f, "{}: expected {}, actual {}", error::Error::description(self), e.txid(), a.txid()),
-            Error::NonStandardSigHashType(ref sht) => write!(f, "{}: {}", error::Error::description(self), sht),
-            Error::InvalidMagic
-            | Error::InvalidSeparator
-            | Error::UnsignedTxHasScriptSigs
-            | Error::UnsignedTxHasScriptWitnesses
-            | Error::MustHaveUnsignedTx
-            | Error::NoMorePairs => f.write_str(error::Error::description(self))
+            Error::InvalidKey(ref rkey) => write!(f, "invalid key: {}", rkey),
+            Error::DuplicateKey(ref rkey) => write!(f, "duplicate key: {}", rkey),
+            Error::UnexpectedUnsignedTx { expected: ref e, actual: ref a } => write!(f, "different unsigned transaction: expected {}, actual {}", e.txid(), a.txid()),
+            Error::NonStandardSigHashType(ref sht) => write!(f, "non-standard sighash type: {}", sht),
+            Error::InvalidMagic => f.write_str("invalid magic"),
+            Error::InvalidSeparator => f.write_str("invalid separator"),
+            Error::UnsignedTxHasScriptSigs => f.write_str("the unsigned transaction has script sigs"),
+            Error::UnsignedTxHasScriptWitnesses => f.write_str("the unsigned transaction has script witnesses"),
+            Error::MustHaveUnsignedTx => {
+                f.write_str("partially signed transactions must have an unsigned transaction")
+            }
+            Error::NoMorePairs => f.write_str("no more key-value pairs for this psbt map"),
         }
     }
 }
 
+#[allow(deprecated)]
 impl error::Error for Error {
     fn description(&self) -> &str {
-        match *self {
-            Error::InvalidMagic => "invalid magic",
-            Error::InvalidSeparator => "invalid separator",
-            Error::InvalidKey(..) => "invalid key",
-            Error::DuplicateKey(..) => "duplicate key",
-            Error::UnsignedTxHasScriptSigs => "the unsigned transaction has script sigs",
-            Error::UnsignedTxHasScriptWitnesses => "the unsigned transaction has script witnesses",
-            Error::MustHaveUnsignedTx => {
-                "partially signed transactions must have an unsigned transaction"
-            }
-            Error::NoMorePairs => "no more key-value pairs for this psbt map",
-            Error::UnexpectedUnsignedTx { .. } => "different unsigned transaction",
-            Error::NonStandardSigHashType(..) =>  "non-standard sighash type",
-        }
+        "description() is deprecated; use Display"
     }
 }


### PR DESCRIPTION
Now that 1.42.0 is out `std::error::Error::description` is officially deprecated. 
sadly we can't stop using it because of our MSRV, but at least we lay the ground and encourage our users to stop using it too.