### PR TITLE
Remove some needless allocations

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -33,7 +33,7 @@ use util::endian;
 use blockdata::constants::WITNESS_SCALE_FACTOR;
 #[cfg(feature="bitcoinconsensus")] use blockdata::script;
 use blockdata::script::Script;
-use consensus::{encode, serialize, Decodable, Encodable};
+use consensus::{encode, Decodable, Encodable};
 use hash_types::*;
 use VarInt;
 
@@ -378,9 +378,12 @@ impl Transaction {
             _ => unreachable!()
         };
         // hash the result
-        let mut raw_vec = serialize(&tx);
-        raw_vec.extend_from_slice(&endian::u32_to_array_le(sighash_u32));
-        SigHash::hash(&raw_vec)
+        // TODO: Sanity assert that consensus_encode returned length matches the hashed length in the hasher.
+        let sighash_arr = endian::u32_to_array_le(sighash_u32);
+        let mut engine = SigHash::engine();
+        tx.consensus_encode(&mut engine).unwrap();
+        sighash_arr.consensus_encode(&mut engine).unwrap();
+        SigHash::from_engine(engine)
     }
 
     /// Gets the "weight" of this transaction, as defined by BIP141. For transactions with an empty
@@ -441,7 +444,7 @@ impl Transaction {
     /// The lambda spent should not return the same TxOut twice!
     pub fn verify<S>(&self, mut spent: S) -> Result<(), script::Error>
         where S: FnMut(&OutPoint) -> Option<TxOut> {
-        let tx = serialize(&*self);
+        let tx = encode::serialize(&*self);
         for (idx, input) in self.input.iter().enumerate() {
             if let Some(output) = spent(&input.previous_output) {
                 output.script_pubkey.verify(idx, output.value, tx.as_slice())?;

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -378,10 +378,9 @@ impl Transaction {
             _ => unreachable!()
         };
         // hash the result
-        // TODO: Sanity assert that consensus_encode returned length matches the hashed length in the hasher.
-        let sighash_arr = endian::u32_to_array_le(sighash_u32);
         let mut engine = SigHash::engine();
         tx.consensus_encode(&mut engine).unwrap();
+        let sighash_arr = endian::u32_to_array_le(sighash_u32);
         sighash_arr.consensus_encode(&mut engine).unwrap();
         SigHash::from_engine(engine)
     }

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -149,10 +149,10 @@ impl From<psbt::Error> for Error {
 
 /// Encode an object into a vector
 pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
-    let mut encoder = Cursor::new(vec![]);
+    let mut encoder = Vec::new();
     let len = data.consensus_encode(&mut encoder).unwrap();
-    assert_eq!(len, encoder.get_ref().len());
-    encoder.into_inner()
+    assert_eq!(len, encoder.len());
+    encoder
 }
 
 /// Encode an object into a hex-encoded string

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -59,11 +59,10 @@ pub fn script_find_and_remove(haystack: &mut Vec<u8>, needle: &[u8]) -> usize {
 
 /// Hash message for signature using Bitcoin's message signing format
 pub fn signed_msg_hash(msg: &str) -> sha256d::Hash {
-    let msg_len = encode::VarInt(msg.len() as u64);
 
-    // TODO: Sanity assert that consensus_encode returned length matches the hashed length in the hasher.
     let mut engine = sha256d::Hash::engine();
     engine.input(MSG_SIGN_PREFIX);
+    let msg_len = encode::VarInt(msg.len() as u64);
     msg_len.consensus_encode(&mut engine).unwrap();
     engine.input(msg.as_bytes());
 

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -16,9 +16,9 @@
 //!
 //! Various utility functions
 
-use hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash, HashEngine};
 use blockdata::opcodes;
-use consensus::encode;
+use consensus::{encode, Encodable};
 
 static MSG_SIGN_PREFIX: &[u8] = b"\x18Bitcoin Signed Message:\n";
 
@@ -59,14 +59,15 @@ pub fn script_find_and_remove(haystack: &mut Vec<u8>, needle: &[u8]) -> usize {
 
 /// Hash message for signature using Bitcoin's message signing format
 pub fn signed_msg_hash(msg: &str) -> sha256d::Hash {
-    sha256d::Hash::hash(
-        &[
-            MSG_SIGN_PREFIX,
-            &encode::serialize(&encode::VarInt(msg.len() as u64)),
-            msg.as_bytes(),
-        ]
-        .concat(),
-    )
+    let msg_len = encode::VarInt(msg.len() as u64);
+
+    // TODO: Sanity assert that consensus_encode returned length matches the hashed length in the hasher.
+    let mut engine = sha256d::Hash::engine();
+    engine.input(MSG_SIGN_PREFIX);
+    msg_len.consensus_encode(&mut engine).unwrap();
+    engine.input(msg.as_bytes());
+
+    sha256d::Hash::from_engine(engine)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hi,
I removed allocations in places that we serialized into a Vec just to then hash it. instead we can feed the hasher itself instead of a vector and serialize into that.