### PR TITLE
Fix ruy rust 1.22 inccompatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ serde_derive = "<1.0.99"
 serde_json = "<1.0.45"
 serde_test = "1"
 secp256k1 = { version = "0.17.1", features = ["rand-std"] }
+# We need to pin ryu (transitive dep from serde_json) to stay compatible with Rust 1.22.0
+ryu = "<1.0.5"


### PR DESCRIPTION
Fixes  #430 by pinning `ryu` (transitive dependency of `serde_json`) to an older version.