### PR TITLE
Implement BIP39 without other deps

### DIFF
--- a/src/util/bip39.rs
+++ b/src/util/bip39.rs
@@ -1,0 +1,503 @@
+//
+// Copyright 2018-2019 Tamas Blummer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//!
+//! # BIP39 mnemonic
+//!
+//! Mnemonic code for generating deterministic keys
+//! mnemonic in english
+//!
+use hashes::core::fmt::{Display, Formatter};
+use hashes::{sha256, sha512, Hash, HashEngine, Hmac, HmacEngine};
+use secp256k1::rand::{thread_rng, RngCore};
+use std::io::Cursor;
+use util::bip158::{BitStreamReader, BitStreamWriter};
+
+/// Represent the BIP39 mnemonic as a vector of values representing 11 bits each
+/// It is conveniently stored in usize to be used as index of the WORDS const vec
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Mnemonic(Vec<usize>);
+
+/// BIP39 possible errors
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Error {
+    /// Mnemonic must have a word count divisible with 6
+    MnemonicNotDivisibleBy6,
+
+    /// Mnemonic contains an unknown word
+    UnknownWord,
+
+    /// Checksum failed
+    ChecksumFailed,
+
+    /// Data for mnemonic should have a length divisible by 4
+    DataNotDivisibleBy4,
+
+    /// Can only extend mnemonic of 12 words to 24 words
+    CannotExtend,
+}
+
+impl Display for Mnemonic {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (i, e) in self.0.iter().enumerate() {
+            if i < self.0.len() - 1 {
+                write!(f, "{} ", WORDS[*e])?;
+            } else {
+                write!(f, "{}", WORDS[*e])?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Mnemonic {
+
+    /// create a seed from this mnemonic
+    /// with optional passphrase for plausible deniability
+    /// it is the pbkdf2 algorithm specific for BIP39
+    /// with a single block and using c = 2048 and Hmac with Sha512
+    pub fn to_seed(&self, pd_passphrase: Option<&str>) -> Seed {
+        let orig_engine: HmacEngine<sha512::Hash> = HmacEngine::new(self.to_string().as_bytes());
+        let passphrase = "mnemonic".to_owned() + pd_passphrase.unwrap_or("");
+        let salt = passphrase.as_bytes();
+
+        let mut engine = orig_engine.clone();
+        engine.input(salt);
+        engine.input(&[0u8, 0, 0, 1]); // idx = 1
+        let mut block = Hmac::from_engine(engine).into_inner();
+
+        let mut engine = orig_engine.clone();
+        engine.input(&block);
+        let mut temp = Hmac::from_engine(engine).into_inner();
+        for (output, &input) in block.iter_mut().zip(temp.iter()) {
+            *output ^= input;
+        }
+
+        for _ in 2..2048 {
+            let mut engine = orig_engine.clone();
+            engine.input(&temp);
+            temp = Hmac::from_engine(engine).into_inner();
+            for (output, &input) in block.iter_mut().zip(temp.iter()) {
+                *output ^= input;
+            }
+        }
+
+        Seed(block.to_vec())
+    }
+
+    /// Iterator over the words of this mnemonic
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().map(|s| WORDS[*s])
+    }
+
+    /// Parse a string into a mnemonic, if valid according to the rules
+    pub fn from_str(s: &str) -> Result<Mnemonic, Error> {
+        let words: Vec<_> = s.split(' ').collect();
+        if words.len() < 6 || words.len() % 6 != 0 {
+            return Err(Error::MnemonicNotDivisibleBy6);
+        }
+        let mut data = Vec::new();
+        let mut writer = BitStreamWriter::new(&mut data);
+        let mut mnemonic = Vec::new();
+        for word in &words {
+            if let Ok(idx) = WORDS.binary_search(word) {
+                mnemonic.push(idx);
+                writer.write(idx as u64, 11).unwrap();
+            } else {
+                return Err(Error::UnknownWord);
+            }
+        }
+        writer.flush().unwrap();
+        let l = data.len();
+        let (payload, checksum) = data.split_at(l - if l > 33 { 2 } else { 1 });
+        if Self::checksum(payload).as_slice() != checksum {
+            return Err(Error::ChecksumFailed);
+        }
+
+        Ok(Mnemonic(mnemonic))
+    }
+
+    /// Create a random mnemonic with the entropy bytes length given as parameter
+    pub fn new_random(entropy: MasterKeyEntropy) -> Result<Mnemonic, Error> {
+        let len = match entropy {
+            MasterKeyEntropy::Sufficient => 16,
+            MasterKeyEntropy::Double => 32,
+            MasterKeyEntropy::Paranoid => 64,
+        };
+        let mut random = vec![0u8; len];
+        thread_rng().fill_bytes(random.as_mut_slice());
+        Self::new(random.as_slice())
+    }
+
+    /// create a mnemonic for some data
+    pub fn new(data: &[u8]) -> Result<Mnemonic, Error> {
+        if data.len() % 4 != 0 {
+            return Err(Error::DataNotDivisibleBy4);
+        }
+        let mut with_checksum = data.to_vec();
+        with_checksum.extend_from_slice(Self::checksum(data).as_slice());
+        let mut cursor = Cursor::new(&with_checksum);
+        let mut reader = BitStreamReader::new(&mut cursor);
+        let mlen = data.len() * 3 / 4;
+        let mut mnemonic = Vec::new();
+        for _ in 0..mlen {
+            mnemonic.push(reader.read(11).unwrap() as usize);
+        }
+        Ok(Mnemonic(mnemonic))
+    }
+
+    /// Try to extend a 12 words mnemonic to a 24 words mnemonic
+    pub fn extend(&self) -> Result<Mnemonic, Error> {
+        if self.0.len() != 12 {
+            return Err(Error::CannotExtend);
+        }
+        let mut data = Vec::new();
+        let mut writer = BitStreamWriter::new(&mut data);
+        for idx in &self.0 {
+            writer.write(*idx as u64, 11).unwrap();
+        }
+        for _ in 0..11 {
+            writer.write(thread_rng().next_u64(), 11).unwrap();
+        }
+        writer.write(thread_rng().next_u64(), 3).unwrap();
+        writer.flush().unwrap();
+        data.extend_from_slice(Self::checksum(&data).as_slice());
+        let mut cursor = Cursor::new(&data[..]);
+        let mut reader = BitStreamReader::new(&mut cursor);
+        let mut mnemonic = Vec::new();
+        for _ in 0..24 {
+            mnemonic.push(reader.read(11).unwrap() as usize);
+        }
+        Ok(Mnemonic(mnemonic))
+    }
+
+    /// Compute the mnemonic checksum
+    fn checksum(data: &[u8]) -> Vec<u8> {
+        let mut checksum = Vec::new();
+        let mut writer = BitStreamWriter::new(&mut checksum);
+
+        let hash = sha256::Hash::hash(data).into_inner();
+        let mut check_cursor = Cursor::new(&hash);
+        let mut check_reader = BitStreamReader::new(&mut check_cursor);
+        for _ in 0..data.len() / 4 {
+            writer.write(check_reader.read(1).unwrap(), 1).unwrap();
+        }
+        writer.flush().unwrap();
+        checksum
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::io::Read;
+    use std::path::PathBuf;
+
+    use hashes::hex::FromHex;
+    use network::constants::Network;
+    extern crate serde_json;
+    use self::serde_json::Value;
+
+    use super::*;
+    use util::bip32::ExtendedPrivKey;
+
+    #[test]
+    fn test_mnemonic() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("test_data/BIP39.json");
+        let mut file = File::open(d).unwrap();
+        let mut data = String::new();
+        file.read_to_string(&mut data).unwrap();
+
+        let json: Value = serde_json::from_str(&data).unwrap();
+        let tests = json.as_array().unwrap();
+
+        let mut test_count = 0;
+
+        for t in 0..tests.len() {
+            let values = tests[t].as_array().unwrap();
+            let data = Vec::from_hex(values[0].as_str().unwrap()).unwrap();
+            let m = values[1].as_str().unwrap();
+            let mnemonic = Mnemonic::from_str(m).unwrap();
+            let seed = mnemonic.to_seed(Some("TREZOR"));
+            assert_eq!(
+                mnemonic.to_string(),
+                Mnemonic::new(data.as_slice()).unwrap().to_string()
+            );
+            assert_eq!(seed.0, Vec::from_hex(values[2].as_str().unwrap()).unwrap());
+
+            if values.len() == 4 {
+                let pk = values[3].as_str().unwrap();
+
+                let private_key = ExtendedPrivKey::new_master(Network::Bitcoin, &seed.0).unwrap();
+
+                let key = private_key.clone();
+
+                assert_eq!(key.to_string(), pk);
+                test_count += 1;
+            }
+        }
+        assert_eq!(test_count, 24); // 24 test cases with private key
+
+        assert!(Mnemonic::from_str(
+            "letter advice cage absurd amount doctor acoustic avoid letter advice cage above"
+        )
+            .is_ok());
+        assert!(Mnemonic::from_str(
+            "getter advice cage absurd amount doctor acoustic avoid letter advice cage above"
+        )
+            .is_err());
+    }
+
+    #[test]
+    fn test_extend() {
+        let short = Mnemonic::new_random(MasterKeyEntropy::Sufficient).unwrap();
+        let extended = short.extend().unwrap();
+        let check = Mnemonic::from_str(extended.to_string().as_str()).unwrap();
+        assert!(short
+            .iter()
+            .zip(check.iter())
+            .take(12)
+            .all(|(a, b)| *a == *b));
+    }
+}
+
+const WORDS: [&str; 2048] = [
+    "abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract", "absurd",
+    "abuse", "access", "accident", "account", "accuse", "achieve", "acid", "acoustic", "acquire",
+    "across", "act", "action", "actor", "actress", "actual", "adapt", "add", "addict", "address",
+    "adjust", "admit", "adult", "advance", "advice", "aerobic", "affair", "afford", "afraid",
+    "again", "age", "agent", "agree", "ahead", "aim", "air", "airport", "aisle", "alarm", "album",
+    "alcohol", "alert", "alien", "all", "alley", "allow", "almost", "alone", "alpha", "already",
+    "also", "alter", "always", "amateur", "amazing", "among", "amount", "amused", "analyst",
+    "anchor", "ancient", "anger", "angle", "angry", "animal", "ankle", "announce", "annual",
+    "another", "answer", "antenna", "antique", "anxiety", "any", "apart", "apology", "appear",
+    "apple", "approve", "april", "arch", "arctic", "area", "arena", "argue", "arm", "armed",
+    "armor", "army", "around", "arrange", "arrest", "arrive", "arrow", "art", "artefact", "artist",
+    "artwork", "ask", "aspect", "assault", "asset", "assist", "assume", "asthma", "athlete",
+    "atom", "attack", "attend", "attitude", "attract", "auction", "audit", "august", "aunt",
+    "author", "auto", "autumn", "average", "avocado", "avoid", "awake", "aware", "away", "awesome",
+    "awful", "awkward", "axis", "baby", "bachelor", "bacon", "badge", "bag", "balance", "balcony",
+    "ball", "bamboo", "banana", "banner", "bar", "barely", "bargain", "barrel", "base", "basic",
+    "basket", "battle", "beach", "bean", "beauty", "because", "become", "beef", "before", "begin",
+    "behave", "behind", "believe", "below", "belt", "bench", "benefit", "best", "betray", "better",
+    "between", "beyond", "bicycle", "bid", "bike", "bind", "biology", "bird", "birth", "bitter",
+    "black", "blade", "blame", "blanket", "blast", "bleak", "bless", "blind", "blood", "blossom",
+    "blouse", "blue", "blur", "blush", "board", "boat", "body", "boil", "bomb", "bone", "bonus",
+    "book", "boost", "border", "boring", "borrow", "boss", "bottom", "bounce", "box", "boy",
+    "bracket", "brain", "brand", "brass", "brave", "bread", "breeze", "brick", "bridge", "brief",
+    "bright", "bring", "brisk", "broccoli", "broken", "bronze", "broom", "brother", "brown",
+    "brush", "bubble", "buddy", "budget", "buffalo", "build", "bulb", "bulk", "bullet", "bundle",
+    "bunker", "burden", "burger", "burst", "bus", "business", "busy", "butter", "buyer", "buzz",
+    "cabbage", "cabin", "cable", "cactus", "cage", "cake", "call", "calm", "camera", "camp", "can",
+    "canal", "cancel", "candy", "cannon", "canoe", "canvas", "canyon", "capable", "capital",
+    "captain", "car", "carbon", "card", "cargo", "carpet", "carry", "cart", "case", "cash",
+    "casino", "castle", "casual", "cat", "catalog", "catch", "category", "cattle", "caught",
+    "cause", "caution", "cave", "ceiling", "celery", "cement", "census", "century", "cereal",
+    "certain", "chair", "chalk", "champion", "change", "chaos", "chapter", "charge", "chase",
+    "chat", "cheap", "check", "cheese", "chef", "cherry", "chest", "chicken", "chief", "child",
+    "chimney", "choice", "choose", "chronic", "chuckle", "chunk", "churn", "cigar", "cinnamon",
+    "circle", "citizen", "city", "civil", "claim", "clap", "clarify", "claw", "clay", "clean",
+    "clerk", "clever", "click", "client", "cliff", "climb", "clinic", "clip", "clock", "clog",
+    "close", "cloth", "cloud", "clown", "club", "clump", "cluster", "clutch", "coach", "coast",
+    "coconut", "code", "coffee", "coil", "coin", "collect", "color", "column", "combine", "come",
+    "comfort", "comic", "common", "company", "concert", "conduct", "confirm", "congress",
+    "connect", "consider", "control", "convince", "cook", "cool", "copper", "copy", "coral",
+    "core", "corn", "correct", "cost", "cotton", "couch", "country", "couple", "course", "cousin",
+    "cover", "coyote", "crack", "cradle", "craft", "cram", "crane", "crash", "crater", "crawl",
+    "crazy", "cream", "credit", "creek", "crew", "cricket", "crime", "crisp", "critic", "crop",
+    "cross", "crouch", "crowd", "crucial", "cruel", "cruise", "crumble", "crunch", "crush", "cry",
+    "crystal", "cube", "culture", "cup", "cupboard", "curious", "current", "curtain", "curve",
+    "cushion", "custom", "cute", "cycle", "dad", "damage", "damp", "dance", "danger", "daring",
+    "dash", "daughter", "dawn", "day", "deal", "debate", "debris", "decade", "december", "decide",
+    "decline", "decorate", "decrease", "deer", "defense", "define", "defy", "degree", "delay",
+    "deliver", "demand", "demise", "denial", "dentist", "deny", "depart", "depend", "deposit",
+    "depth", "deputy", "derive", "describe", "desert", "design", "desk", "despair", "destroy",
+    "detail", "detect", "develop", "device", "devote", "diagram", "dial", "diamond", "diary",
+    "dice", "diesel", "diet", "differ", "digital", "dignity", "dilemma", "dinner", "dinosaur",
+    "direct", "dirt", "disagree", "discover", "disease", "dish", "dismiss", "disorder", "display",
+    "distance", "divert", "divide", "divorce", "dizzy", "doctor", "document", "dog", "doll",
+    "dolphin", "domain", "donate", "donkey", "donor", "door", "dose", "double", "dove", "draft",
+    "dragon", "drama", "drastic", "draw", "dream", "dress", "drift", "drill", "drink", "drip",
+    "drive", "drop", "drum", "dry", "duck", "dumb", "dune", "during", "dust", "dutch", "duty",
+    "dwarf", "dynamic", "eager", "eagle", "early", "earn", "earth", "easily", "east", "easy",
+    "echo", "ecology", "economy", "edge", "edit", "educate", "effort", "egg", "eight", "either",
+    "elbow", "elder", "electric", "elegant", "element", "elephant", "elevator", "elite", "else",
+    "embark", "embody", "embrace", "emerge", "emotion", "employ", "empower", "empty", "enable",
+    "enact", "end", "endless", "endorse", "enemy", "energy", "enforce", "engage", "engine",
+    "enhance", "enjoy", "enlist", "enough", "enrich", "enroll", "ensure", "enter", "entire",
+    "entry", "envelope", "episode", "equal", "equip", "era", "erase", "erode", "erosion", "error",
+    "erupt", "escape", "essay", "essence", "estate", "eternal", "ethics", "evidence", "evil",
+    "evoke", "evolve", "exact", "example", "excess", "exchange", "excite", "exclude", "excuse",
+    "execute", "exercise", "exhaust", "exhibit", "exile", "exist", "exit", "exotic", "expand",
+    "expect", "expire", "explain", "expose", "express", "extend", "extra", "eye", "eyebrow",
+    "fabric", "face", "faculty", "fade", "faint", "faith", "fall", "false", "fame", "family",
+    "famous", "fan", "fancy", "fantasy", "farm", "fashion", "fat", "fatal", "father", "fatigue",
+    "fault", "favorite", "feature", "february", "federal", "fee", "feed", "feel", "female",
+    "fence", "festival", "fetch", "fever", "few", "fiber", "fiction", "field", "figure", "file",
+    "film", "filter", "final", "find", "fine", "finger", "finish", "fire", "firm", "first",
+    "fiscal", "fish", "fit", "fitness", "fix", "flag", "flame", "flash", "flat", "flavor", "flee",
+    "flight", "flip", "float", "flock", "floor", "flower", "fluid", "flush", "fly", "foam",
+    "focus", "fog", "foil", "fold", "follow", "food", "foot", "force", "forest", "forget", "fork",
+    "fortune", "forum", "forward", "fossil", "foster", "found", "fox", "fragile", "frame",
+    "frequent", "fresh", "friend", "fringe", "frog", "front", "frost", "frown", "frozen", "fruit",
+    "fuel", "fun", "funny", "furnace", "fury", "future", "gadget", "gain", "galaxy", "gallery",
+    "game", "gap", "garage", "garbage", "garden", "garlic", "garment", "gas", "gasp", "gate",
+    "gather", "gauge", "gaze", "general", "genius", "genre", "gentle", "genuine", "gesture",
+    "ghost", "giant", "gift", "giggle", "ginger", "giraffe", "girl", "give", "glad", "glance",
+    "glare", "glass", "glide", "glimpse", "globe", "gloom", "glory", "glove", "glow", "glue",
+    "goat", "goddess", "gold", "good", "goose", "gorilla", "gospel", "gossip", "govern", "gown",
+    "grab", "grace", "grain", "grant", "grape", "grass", "gravity", "great", "green", "grid",
+    "grief", "grit", "grocery", "group", "grow", "grunt", "guard", "guess", "guide", "guilt",
+    "guitar", "gun", "gym", "habit", "hair", "half", "hammer", "hamster", "hand", "happy",
+    "harbor", "hard", "harsh", "harvest", "hat", "have", "hawk", "hazard", "head", "health",
+    "heart", "heavy", "hedgehog", "height", "hello", "helmet", "help", "hen", "hero", "hidden",
+    "high", "hill", "hint", "hip", "hire", "history", "hobby", "hockey", "hold", "hole", "holiday",
+    "hollow", "home", "honey", "hood", "hope", "horn", "horror", "horse", "hospital", "host",
+    "hotel", "hour", "hover", "hub", "huge", "human", "humble", "humor", "hundred", "hungry",
+    "hunt", "hurdle", "hurry", "hurt", "husband", "hybrid", "ice", "icon", "idea", "identify",
+    "idle", "ignore", "ill", "illegal", "illness", "image", "imitate", "immense", "immune",
+    "impact", "impose", "improve", "impulse", "inch", "include", "income", "increase", "index",
+    "indicate", "indoor", "industry", "infant", "inflict", "inform", "inhale", "inherit",
+    "initial", "inject", "injury", "inmate", "inner", "innocent", "input", "inquiry", "insane",
+    "insect", "inside", "inspire", "install", "intact", "interest", "into", "invest", "invite",
+    "involve", "iron", "island", "isolate", "issue", "item", "ivory", "jacket", "jaguar", "jar",
+    "jazz", "jealous", "jeans", "jelly", "jewel", "job", "join", "joke", "journey", "joy", "judge",
+    "juice", "jump", "jungle", "junior", "junk", "just", "kangaroo", "keen", "keep", "ketchup",
+    "key", "kick", "kid", "kidney", "kind", "kingdom", "kiss", "kit", "kitchen", "kite", "kitten",
+    "kiwi", "knee", "knife", "knock", "know", "lab", "label", "labor", "ladder", "lady", "lake",
+    "lamp", "language", "laptop", "large", "later", "latin", "laugh", "laundry", "lava", "law",
+    "lawn", "lawsuit", "layer", "lazy", "leader", "leaf", "learn", "leave", "lecture", "left",
+    "leg", "legal", "legend", "leisure", "lemon", "lend", "length", "lens", "leopard", "lesson",
+    "letter", "level", "liar", "liberty", "library", "license", "life", "lift", "light", "like",
+    "limb", "limit", "link", "lion", "liquid", "list", "little", "live", "lizard", "load", "loan",
+    "lobster", "local", "lock", "logic", "lonely", "long", "loop", "lottery", "loud", "lounge",
+    "love", "loyal", "lucky", "luggage", "lumber", "lunar", "lunch", "luxury", "lyrics", "machine",
+    "mad", "magic", "magnet", "maid", "mail", "main", "major", "make", "mammal", "man", "manage",
+    "mandate", "mango", "mansion", "manual", "maple", "marble", "march", "margin", "marine",
+    "market", "marriage", "mask", "mass", "master", "match", "material", "math", "matrix",
+    "matter", "maximum", "maze", "meadow", "mean", "measure", "meat", "mechanic", "medal", "media",
+    "melody", "melt", "member", "memory", "mention", "menu", "mercy", "merge", "merit", "merry",
+    "mesh", "message", "metal", "method", "middle", "midnight", "milk", "million", "mimic", "mind",
+    "minimum", "minor", "minute", "miracle", "mirror", "misery", "miss", "mistake", "mix", "mixed",
+    "mixture", "mobile", "model", "modify", "mom", "moment", "monitor", "monkey", "monster",
+    "month", "moon", "moral", "more", "morning", "mosquito", "mother", "motion", "motor",
+    "mountain", "mouse", "move", "movie", "much", "muffin", "mule", "multiply", "muscle", "museum",
+    "mushroom", "music", "must", "mutual", "myself", "mystery", "myth", "naive", "name", "napkin",
+    "narrow", "nasty", "nation", "nature", "near", "neck", "need", "negative", "neglect",
+    "neither", "nephew", "nerve", "nest", "net", "network", "neutral", "never", "news", "next",
+    "nice", "night", "noble", "noise", "nominee", "noodle", "normal", "north", "nose", "notable",
+    "note", "nothing", "notice", "novel", "now", "nuclear", "number", "nurse", "nut", "oak",
+    "obey", "object", "oblige", "obscure", "observe", "obtain", "obvious", "occur", "ocean",
+    "october", "odor", "off", "offer", "office", "often", "oil", "okay", "old", "olive", "olympic",
+    "omit", "once", "one", "onion", "online", "only", "open", "opera", "opinion", "oppose",
+    "option", "orange", "orbit", "orchard", "order", "ordinary", "organ", "orient", "original",
+    "orphan", "ostrich", "other", "outdoor", "outer", "output", "outside", "oval", "oven", "over",
+    "own", "owner", "oxygen", "oyster", "ozone", "pact", "paddle", "page", "pair", "palace",
+    "palm", "panda", "panel", "panic", "panther", "paper", "parade", "parent", "park", "parrot",
+    "party", "pass", "patch", "path", "patient", "patrol", "pattern", "pause", "pave", "payment",
+    "peace", "peanut", "pear", "peasant", "pelican", "pen", "penalty", "pencil", "people",
+    "pepper", "perfect", "permit", "person", "pet", "phone", "photo", "phrase", "physical",
+    "piano", "picnic", "picture", "piece", "pig", "pigeon", "pill", "pilot", "pink", "pioneer",
+    "pipe", "pistol", "pitch", "pizza", "place", "planet", "plastic", "plate", "play", "please",
+    "pledge", "pluck", "plug", "plunge", "poem", "poet", "point", "polar", "pole", "police",
+    "pond", "pony", "pool", "popular", "portion", "position", "possible", "post", "potato",
+    "pottery", "poverty", "powder", "power", "practice", "praise", "predict", "prefer", "prepare",
+    "present", "pretty", "prevent", "price", "pride", "primary", "print", "priority", "prison",
+    "private", "prize", "problem", "process", "produce", "profit", "program", "project", "promote",
+    "proof", "property", "prosper", "protect", "proud", "provide", "public", "pudding", "pull",
+    "pulp", "pulse", "pumpkin", "punch", "pupil", "puppy", "purchase", "purity", "purpose",
+    "purse", "push", "put", "puzzle", "pyramid", "quality", "quantum", "quarter", "question",
+    "quick", "quit", "quiz", "quote", "rabbit", "raccoon", "race", "rack", "radar", "radio",
+    "rail", "rain", "raise", "rally", "ramp", "ranch", "random", "range", "rapid", "rare", "rate",
+    "rather", "raven", "raw", "razor", "ready", "real", "reason", "rebel", "rebuild", "recall",
+    "receive", "recipe", "record", "recycle", "reduce", "reflect", "reform", "refuse", "region",
+    "regret", "regular", "reject", "relax", "release", "relief", "rely", "remain", "remember",
+    "remind", "remove", "render", "renew", "rent", "reopen", "repair", "repeat", "replace",
+    "report", "require", "rescue", "resemble", "resist", "resource", "response", "result",
+    "retire", "retreat", "return", "reunion", "reveal", "review", "reward", "rhythm", "rib",
+    "ribbon", "rice", "rich", "ride", "ridge", "rifle", "right", "rigid", "ring", "riot", "ripple",
+    "risk", "ritual", "rival", "river", "road", "roast", "robot", "robust", "rocket", "romance",
+    "roof", "rookie", "room", "rose", "rotate", "rough", "round", "route", "royal", "rubber",
+    "rude", "rug", "rule", "run", "runway", "rural", "sad", "saddle", "sadness", "safe", "sail",
+    "salad", "salmon", "salon", "salt", "salute", "same", "sample", "sand", "satisfy", "satoshi",
+    "sauce", "sausage", "save", "say", "scale", "scan", "scare", "scatter", "scene", "scheme",
+    "school", "science", "scissors", "scorpion", "scout", "scrap", "screen", "script", "scrub",
+    "sea", "search", "season", "seat", "second", "secret", "section", "security", "seed", "seek",
+    "segment", "select", "sell", "seminar", "senior", "sense", "sentence", "series", "service",
+    "session", "settle", "setup", "seven", "shadow", "shaft", "shallow", "share", "shed", "shell",
+    "sheriff", "shield", "shift", "shine", "ship", "shiver", "shock", "shoe", "shoot", "shop",
+    "short", "shoulder", "shove", "shrimp", "shrug", "shuffle", "shy", "sibling", "sick", "side",
+    "siege", "sight", "sign", "silent", "silk", "silly", "silver", "similar", "simple", "since",
+    "sing", "siren", "sister", "situate", "six", "size", "skate", "sketch", "ski", "skill", "skin",
+    "skirt", "skull", "slab", "slam", "sleep", "slender", "slice", "slide", "slight", "slim",
+    "slogan", "slot", "slow", "slush", "small", "smart", "smile", "smoke", "smooth", "snack",
+    "snake", "snap", "sniff", "snow", "soap", "soccer", "social", "sock", "soda", "soft", "solar",
+    "soldier", "solid", "solution", "solve", "someone", "song", "soon", "sorry", "sort", "soul",
+    "sound", "soup", "source", "south", "space", "spare", "spatial", "spawn", "speak", "special",
+    "speed", "spell", "spend", "sphere", "spice", "spider", "spike", "spin", "spirit", "split",
+    "spoil", "sponsor", "spoon", "sport", "spot", "spray", "spread", "spring", "spy", "square",
+    "squeeze", "squirrel", "stable", "stadium", "staff", "stage", "stairs", "stamp", "stand",
+    "start", "state", "stay", "steak", "steel", "stem", "step", "stereo", "stick", "still",
+    "sting", "stock", "stomach", "stone", "stool", "story", "stove", "strategy", "street",
+    "strike", "strong", "struggle", "student", "stuff", "stumble", "style", "subject", "submit",
+    "subway", "success", "such", "sudden", "suffer", "sugar", "suggest", "suit", "summer", "sun",
+    "sunny", "sunset", "super", "supply", "supreme", "sure", "surface", "surge", "surprise",
+    "surround", "survey", "suspect", "sustain", "swallow", "swamp", "swap", "swarm", "swear",
+    "sweet", "swift", "swim", "swing", "switch", "sword", "symbol", "symptom", "syrup", "system",
+    "table", "tackle", "tag", "tail", "talent", "talk", "tank", "tape", "target", "task", "taste",
+    "tattoo", "taxi", "teach", "team", "tell", "ten", "tenant", "tennis", "tent", "term", "test",
+    "text", "thank", "that", "theme", "then", "theory", "there", "they", "thing", "this",
+    "thought", "three", "thrive", "throw", "thumb", "thunder", "ticket", "tide", "tiger", "tilt",
+    "timber", "time", "tiny", "tip", "tired", "tissue", "title", "toast", "tobacco", "today",
+    "toddler", "toe", "together", "toilet", "token", "tomato", "tomorrow", "tone", "tongue",
+    "tonight", "tool", "tooth", "top", "topic", "topple", "torch", "tornado", "tortoise", "toss",
+    "total", "tourist", "toward", "tower", "town", "toy", "track", "trade", "traffic", "tragic",
+    "train", "transfer", "trap", "trash", "travel", "tray", "treat", "tree", "trend", "trial",
+    "tribe", "trick", "trigger", "trim", "trip", "trophy", "trouble", "truck", "true", "truly",
+    "trumpet", "trust", "truth", "try", "tube", "tuition", "tumble", "tuna", "tunnel", "turkey",
+    "turn", "turtle", "twelve", "twenty", "twice", "twin", "twist", "two", "type", "typical",
+    "ugly", "umbrella", "unable", "unaware", "uncle", "uncover", "under", "undo", "unfair",
+    "unfold", "unhappy", "uniform", "unique", "unit", "universe", "unknown", "unlock", "until",
+    "unusual", "unveil", "update", "upgrade", "uphold", "upon", "upper", "upset", "urban", "urge",
+    "usage", "use", "used", "useful", "useless", "usual", "utility", "vacant", "vacuum", "vague",
+    "valid", "valley", "valve", "van", "vanish", "vapor", "various", "vast", "vault", "vehicle",
+    "velvet", "vendor", "venture", "venue", "verb", "verify", "version", "very", "vessel",
+    "veteran", "viable", "vibrant", "vicious", "victory", "video", "view", "village", "vintage",
+    "violin", "virtual", "virus", "visa", "visit", "visual", "vital", "vivid", "vocal", "voice",
+    "void", "volcano", "volume", "vote", "voyage", "wage", "wagon", "wait", "walk", "wall",
+    "walnut", "want", "warfare", "warm", "warrior", "wash", "wasp", "waste", "water", "wave",
+    "way", "wealth", "weapon", "wear", "weasel", "weather", "web", "wedding", "weekend", "weird",
+    "welcome", "west", "wet", "whale", "what", "wheat", "wheel", "when", "where", "whip",
+    "whisper", "wide", "width", "wife", "wild", "will", "win", "window", "wine", "wing", "wink",
+    "winner", "winter", "wire", "wisdom", "wise", "wish", "witness", "wolf", "woman", "wonder",
+    "wood", "wool", "word", "work", "world", "worry", "worth", "wrap", "wreck", "wrestle", "wrist",
+    "write", "wrong", "yard", "year", "yellow", "you", "young", "youth", "zebra", "zero", "zone",
+    "zoo",
+];
+
+/// chose your security level
+#[derive(Copy, Clone)]
+pub enum MasterKeyEntropy {
+    /// 16 Bytes of entropy
+    Sufficient = 16,
+    /// 32 Bytes of entropy
+    Double = 32,
+    /// 64 Bytes of entropy
+    Paranoid = 64,
+}
+
+/// seed of the master key
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Seed(pub Vec<u8>);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -21,6 +21,7 @@ pub mod address;
 pub mod amount;
 pub mod base58;
 pub mod bip32;
+pub mod bip39;
 pub mod bip143;
 pub mod contracthash;
 pub mod hash;

--- a/test_data/BIP39.json
+++ b/test_data/BIP39.json
@@ -1,0 +1,208 @@
+[
+  [
+    "00000000000000000000000000000000",
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+    "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF"
+  ],
+  [
+    "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+    "legal winner thank year wave sausage worth useful legal winner thank yellow",
+    "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
+    "xprv9s21ZrQH143K2gA81bYFHqU68xz1cX2APaSq5tt6MFSLeXnCKV1RVUJt9FWNTbrrryem4ZckN8k4Ls1H6nwdvDTvnV7zEXs2HgPezuVccsq"
+  ],
+  [
+    "80808080808080808080808080808080",
+    "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+    "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
+    "xprv9s21ZrQH143K2shfP28KM3nr5Ap1SXjz8gc2rAqqMEynmjt6o1qboCDpxckqXavCwdnYds6yBHZGKHv7ef2eTXy461PXUjBFQg6PrwY4Gzq"
+  ],
+  [
+    "ffffffffffffffffffffffffffffffff",
+    "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+    "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
+    "xprv9s21ZrQH143K2V4oox4M8Zmhi2Fjx5XK4Lf7GKRvPSgydU3mjZuKGCTg7UPiBUD7ydVPvSLtg9hjp7MQTYsW67rZHAXeccqYqrsx8LcXnyd"
+  ],
+  [
+    "000000000000000000000000000000000000000000000000",
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+    "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
+    "xprv9s21ZrQH143K3mEDrypcZ2usWqFgzKB6jBBx9B6GfC7fu26X6hPRzVjzkqkPvDqp6g5eypdk6cyhGnBngbjeHTe4LsuLG1cCmKJka5SMkmU"
+  ],
+  [
+    "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+    "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+    "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
+    "xprv9s21ZrQH143K3Lv9MZLj16np5GzLe7tDKQfVusBni7toqJGcnKRtHSxUwbKUyUWiwpK55g1DUSsw76TF1T93VT4gz4wt5RM23pkaQLnvBh7"
+  ],
+  [
+    "808080808080808080808080808080808080808080808080",
+    "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+    "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65",
+    "xprv9s21ZrQH143K3VPCbxbUtpkh9pRG371UCLDz3BjceqP1jz7XZsQ5EnNkYAEkfeZp62cDNj13ZTEVG1TEro9sZ9grfRmcYWLBhCocViKEJae"
+  ],
+  [
+    "ffffffffffffffffffffffffffffffffffffffffffffffff",
+    "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+    "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528",
+    "xprv9s21ZrQH143K36Ao5jHRVhFGDbLP6FCx8BEEmpru77ef3bmA928BxsqvVM27WnvvyfWywiFN8K6yToqMaGYfzS6Db1EHAXT5TuyCLBXUfdm"
+  ],
+  [
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+    "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
+    "xprv9s21ZrQH143K32qBagUJAMU2LsHg3ka7jqMcV98Y7gVeVyNStwYS3U7yVVoDZ4btbRNf4h6ibWpY22iRmXq35qgLs79f312g2kj5539ebPM"
+  ],
+  [
+    "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+    "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+    "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
+    "xprv9s21ZrQH143K3Y1sd2XVu9wtqxJRvybCfAetjUrMMco6r3v9qZTBeXiBZkS8JxWbcGJZyio8TrZtm6pkbzG8SYt1sxwNLh3Wx7to5pgiVFU"
+  ],
+  [
+    "8080808080808080808080808080808080808080808080808080808080808080",
+    "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+    "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
+    "xprv9s21ZrQH143K3CSnQNYC3MqAAqHwxeTLhDbhF43A4ss4ciWNmCY9zQGvAKUSqVUf2vPHBTSE1rB2pg4avopqSiLVzXEU8KziNnVPauTqLRo"
+  ],
+  [
+    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+    "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
+    "xprv9s21ZrQH143K2WFF16X85T2QCpndrGwx6GueB72Zf3AHwHJaknRXNF37ZmDrtHrrLSHvbuRejXcnYxoZKvRquTPyp2JiNG3XcjQyzSEgqCB"
+  ],
+  [
+    "9e885d952ad362caeb4efe34a8e91bd2",
+    "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+    "274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028",
+    "xprv9s21ZrQH143K2oZ9stBYpoaZ2ktHj7jLz7iMqpgg1En8kKFTXJHsjxry1JbKH19YrDTicVwKPehFKTbmaxgVEc5TpHdS1aYhB2s9aFJBeJH"
+  ],
+  [
+    "6610b25967cdcca9d59875f5cb50b0ea75433311869e930b",
+    "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+    "628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac",
+    "xprv9s21ZrQH143K3uT8eQowUjsxrmsA9YUuQQK1RLqFufzybxD6DH6gPY7NjJ5G3EPHjsWDrs9iivSbmvjc9DQJbJGatfa9pv4MZ3wjr8qWPAK"
+  ],
+  [
+    "68a79eaca2324873eacc50cb9c6eca8cc68ea5d936f98787c60c7ebc74e6ce7c",
+    "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+    "64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440",
+    "xprv9s21ZrQH143K2XTAhys3pMNcGn261Fi5Ta2Pw8PwaVPhg3D8DWkzWQwjTJfskj8ofb81i9NP2cUNKxwjueJHHMQAnxtivTA75uUFqPFeWzk"
+  ],
+  [
+    "c0ba5a8e914111210f2bd131f3d5e08d",
+    "scheme spot photo card baby mountain device kick cradle pact join borrow",
+    "ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612",
+    "xprv9s21ZrQH143K3FperxDp8vFsFycKCRcJGAFmcV7umQmcnMZaLtZRt13QJDsoS5F6oYT6BB4sS6zmTmyQAEkJKxJ7yByDNtRe5asP2jFGhT6"
+  ],
+  [
+    "6d9be1ee6ebd27a258115aad99b7317b9c8d28b6d76431c3",
+    "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+    "fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d",
+    "xprv9s21ZrQH143K3R1SfVZZLtVbXEB9ryVxmVtVMsMwmEyEvgXN6Q84LKkLRmf4ST6QrLeBm3jQsb9gx1uo23TS7vo3vAkZGZz71uuLCcywUkt"
+  ],
+  [
+    "9f6a2878b2520799a44ef18bc7df394e7061a224d2c33cd015b157d746869863",
+    "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+    "72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d",
+    "xprv9s21ZrQH143K2WNnKmssvZYM96VAr47iHUQUTUyUXH3sAGNjhJANddnhw3i3y3pBbRAVk5M5qUGFr4rHbEWwXgX4qrvrceifCYQJbbFDems"
+  ],
+  [
+    "23db8160a31d3e0dca3688ed941adbf3",
+    "cat swing flag economy stadium alone churn speed unique patch report train",
+    "deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5",
+    "xprv9s21ZrQH143K4G28omGMogEoYgDQuigBo8AFHAGDaJdqQ99QKMQ5J6fYTMfANTJy6xBmhvsNZ1CJzRZ64PWbnTFUn6CDV2FxoMDLXdk95DQ"
+  ],
+  [
+    "8197a4a47f0425faeaa69deebc05ca29c0a5b5cc76ceacc0",
+    "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+    "4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02",
+    "xprv9s21ZrQH143K3wtsvY8L2aZyxkiWULZH4vyQE5XkHTXkmx8gHo6RUEfH3Jyr6NwkJhvano7Xb2o6UqFKWHVo5scE31SGDCAUsgVhiUuUDyh"
+  ],
+  [
+    "066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad",
+    "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+    "26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d",
+    "xprv9s21ZrQH143K3rEfqSM4QZRVmiMuSWY9wugscmaCjYja3SbUD3KPEB1a7QXJoajyR2T1SiXU7rFVRXMV9XdYVSZe7JoUXdP4SRHTxsT1nzm"
+  ],
+  [
+    "f30f8c1da665478f49b001d94c5fc452",
+    "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+    "2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f",
+    "xprv9s21ZrQH143K2QWV9Wn8Vvs6jbqfF1YbTCdURQW9dLFKDovpKaKrqS3SEWsXCu6ZNky9PSAENg6c9AQYHcg4PjopRGGKmdD313ZHszymnps"
+  ],
+  [
+    "c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05",
+    "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+    "7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88",
+    "xprv9s21ZrQH143K4aERa2bq7559eMCCEs2QmmqVjUuzfy5eAeDX4mqZffkYwpzGQRE2YEEeLVRoH4CSHxianrFaVnMN2RYaPUZJhJx8S5j6puX"
+  ],
+  [
+    "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
+    "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+    "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
+    "xprv9s21ZrQH143K39rnQJknpH1WEPFJrzmAqqasiDcVrNuk926oizzJDDQkdiTvNPr2FYDYzWgiMiC63YmfPAa2oPyNB23r2g7d1yiK6WpqaQS"
+  ],
+
+  [
+    "77c2b00716cec7213839159e404db50d",
+    "jelly better achieve collect unaware mountain thought cargo oxygen act hood bridge",
+    "b5b6d0127db1a9d2226af0c3346031d77af31e918dba64287a1b44b8ebf63cdd52676f672a290aae502472cf2d602c051f3e6f18055e84e4c43897fc4e51a6ff"
+  ],
+  [
+    "b63a9c59a6e641f288ebc103017f1da9f8290b3da6bdef7b",
+    "renew stay biology evidence goat welcome casual join adapt armor shuffle fault little machine walk stumble urge swap",
+    "9248d83e06f4cd98debf5b6f010542760df925ce46cf38a1bdb4e4de7d21f5c39366941c69e1bdbf2966e0f6e6dbece898a0e2f0a4c2b3e640953dfe8b7bbdc5"
+  ],
+  [
+    "3e141609b97933b66a060dcddc71fad1d91677db872031e85f4c015c5e7e8982",
+    "dignity pass list indicate nasty swamp pool script soccer toe leaf photo multiply desk host tomato cradle drill spread actor shine dismiss champion exotic",
+    "ff7f3184df8696d8bef94b6c03114dbee0ef89ff938712301d27ed8336ca89ef9635da20af07d4175f2bf5f3de130f39c9d9e8dd0472489c19b1a020a940da67"
+  ],
+  [
+    "0460ef47585604c5660618db2e6a7e7f",
+    "afford alter spike radar gate glance object seek swamp infant panel yellow",
+    "65f93a9f36b6c85cbe634ffc1f99f2b82cbb10b31edc7f087b4f6cb9e976e9faf76ff41f8f27c99afdf38f7a303ba1136ee48a4c1e7fcd3dba7aa876113a36e4"
+  ],
+  [
+    "72f60ebac5dd8add8d2a25a797102c3ce21bc029c200076f",
+    "indicate race push merry suffer human cruise dwarf pole review arch keep canvas theme poem divorce alter left",
+    "3bbf9daa0dfad8229786ace5ddb4e00fa98a044ae4c4975ffd5e094dba9e0bb289349dbe2091761f30f382d4e35c4a670ee8ab50758d2c55881be69e327117ba"
+  ],
+  [
+    "2c85efc7f24ee4573d2b81a6ec66cee209b2dcbd09d8eddc51e0215b0b68e416",
+    "clutch control vehicle tonight unusual clog visa ice plunge glimpse recipe series open hour vintage deposit universe tip job dress radar refuse motion taste",
+    "fe908f96f46668b2d5b37d82f558c77ed0d69dd0e7e043a5b0511c48c2f1064694a956f86360c93dd04052a8899497ce9e985ebe0c8c52b955e6ae86d4ff4449"
+  ],
+  [
+    "eaebabb2383351fd31d703840b32e9e2",
+    "turtle front uncle idea crush write shrug there lottery flower risk shell",
+    "bdfb76a0759f301b0b899a1e3985227e53b3f51e67e3f2a65363caedf3e32fde42a66c404f18d7b05818c95ef3ca1e5146646856c461c073169467511680876c"
+  ],
+  [
+    "7ac45cfe7722ee6c7ba84fbc2d5bd61b45cb2fe5eb65aa78",
+    "kiss carry display unusual confirm curtain upgrade antique rotate hello void custom frequent obey nut hole price segment",
+    "ed56ff6c833c07982eb7119a8f48fd363c4a9b1601cd2de736b01045c5eb8ab4f57b079403485d1c4924f0790dc10a971763337cb9f9c62226f64fff26397c79"
+  ],
+  [
+    "4fa1a8bc3e6d80ee1316050e862c1812031493212b7ec3f3bb1b08f168cabeef",
+    "exile ask congress lamp submit jacket era scheme attend cousin alcohol catch course end lucky hurt sentence oven short ball bird grab wing top",
+    "095ee6f817b4c2cb30a5a797360a81a40ab0f9a4e25ecd672a3f58a0b5ba0687c096a6b14d2c0deb3bdefce4f61d01ae07417d502429352e27695163f7447a8c"
+  ],
+  [
+    "18ab19a9f54a9274f03e5209a2ac8a91",
+    "board flee heavy tunnel powder denial science ski answer betray cargo cat",
+    "6eff1bb21562918509c73cb990260db07c0ce34ff0e3cc4a8cb3276129fbcb300bddfe005831350efd633909f476c45c88253276d9fd0df6ef48609e8bb7dca8"
+  ],
+  [
+    "18a2e1d81b8ecfb2a333adcb0c17a5b9eb76cc5d05db91a4",
+    "board blade invite damage undo sun mimic interest slam gaze truly inherit resist great inject rocket museum chief",
+    "f84521c777a13b61564234bf8f8b62b3afce27fc4062b51bb5e62bdfecb23864ee6ecf07c1d5a97c0834307c5c852d8ceb88e7c97923c0a3b496bedd4e5f88a9"
+  ],
+  [
+    "15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419",
+    "beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut",
+    "b15509eaa2d09d3efd3e006ef42151b30367dc6e3aa5e44caba3fe4d3e352e65101fbdb86a96776b91946ff06f8eac594dc6ee1d3e82a42dfe1b40fef6bcc3fd"
+  ]
+
+]


### PR DESCRIPTION
Implement BIP39 without adding external dependencies, based on https://github.com/rust-bitcoin/rust-wallet/blob/master/src/mnemonic.rs with the following changes:
- implement the specific case of the pbkdf2 required by BIP39 removing the rust crypto dep, using the internal Hmac with sha512 implementation
- Use specific errors defined internally
- Impl Display trait instead of ToString (you get to_string for free)