### PR TITLE
BIP339: Add wtxidrelay message and WTx inv type

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -42,6 +42,20 @@ use std::{fmt, io, ops};
 use consensus::encode::{self, Encodable, Decodable};
 
 /// Version of the protocol as appearing in network message headers
+/// This constant is used to signal to other peers which features you support.
+/// Increasing it implies that your software also supports every feature prior to this version.
+/// Doing so without support may lead to you incorrectly banning other peers or other peers banning you.
+/// These are the features required for each version:
+/// 70016 - Support receiving `wtxidrelay` message between `version` and `verack` message
+/// 70015 - Support receiving invalid compact blocks from a peer without banning them
+/// 70014 - Support compact block messages `sendcmpct`, `cmpctblock`, `getblocktxn` and `blocktxn`
+/// 70013 - Support `feefilter` message
+/// 70012 - Support `sendheaders` message and announce new blocks via headers rather than inv
+/// 70011 - Support NODE_BLOOM service flag and don't support bloom filter messages if it is not set
+/// 70002 - Support `reject` message
+/// 70001 - Support bloom filter messages `filterload`, `filterclear` `filteradd`, `merkleblock` and FILTERED_BLOCK inventory type
+/// 60002 - Support `mempool` message
+/// 60001 - Support `pong` message and nonce in `ping` message
 pub const PROTOCOL_VERSION: u32 = 70001;
 
 user_enum! {

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -157,6 +157,8 @@ pub enum NetworkMessage {
     Reject(message_network::Reject),
     /// `feefilter`
     FeeFilter(i64),
+    /// `wtxidrelay`
+    WtxidRelay,
 }
 
 impl NetworkMessage {
@@ -188,6 +190,7 @@ impl NetworkMessage {
             NetworkMessage::Alert(_)    => "alert",
             NetworkMessage::Reject(_)    => "reject",
             NetworkMessage::FeeFilter(_) => "feefilter",
+            NetworkMessage::WtxidRelay => "wtxidrelay",
         }
     }
 
@@ -260,7 +263,8 @@ impl Encodable for RawNetworkMessage {
             NetworkMessage::Verack
             | NetworkMessage::SendHeaders
             | NetworkMessage::MemPool
-            | NetworkMessage::GetAddr => vec![],
+            | NetworkMessage::GetAddr
+            | NetworkMessage::WtxidRelay => vec![],
         }).consensus_encode(&mut s)?;
         Ok(len)
     }
@@ -324,6 +328,7 @@ impl Decodable for RawNetworkMessage {
             "reject" => NetworkMessage::Reject(Decodable::consensus_decode(&mut mem_d)?),
             "alert"   => NetworkMessage::Alert(Decodable::consensus_decode(&mut mem_d)?),
             "feefilter" => NetworkMessage::FeeFilter(Decodable::consensus_decode(&mut mem_d)?),
+            "wtxidrelay" => NetworkMessage::WtxidRelay,
             _ => return Err(encode::Error::UnrecognizedNetworkCommand(cmd.into_owned())),
         };
         Ok(RawNetworkMessage {
@@ -387,6 +392,7 @@ mod test {
             NetworkMessage::Alert(vec![45,66,3,2,6,8,9,12,3,130]),
             NetworkMessage::Reject(Reject{message: "Test reject".into(), ccode: RejectReason::Duplicate, reason: "Cause".into(), hash: hash([255u8; 32])}),
             NetworkMessage::FeeFilter(1000),
+            NetworkMessage::WtxidRelay,
         ];
 
         for msg in msgs {

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -24,7 +24,7 @@ use hashes::sha256d;
 
 use network::constants;
 use consensus::encode::{self, Decodable, Encodable};
-use hash_types::{BlockHash, Txid};
+use hash_types::{BlockHash, Txid, Wtxid};
 
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash)]
@@ -35,6 +35,8 @@ pub enum Inventory {
     Transaction(Txid),
     /// Block
     Block(BlockHash),
+    /// Witness Transaction by Wtxid
+    WTx(Wtxid),
     /// Witness Transaction
     WitnessTransaction(Txid),
     /// Witness Block
@@ -57,6 +59,7 @@ impl Encodable for Inventory {
             Inventory::Error => encode_inv!(0, sha256d::Hash::default()),
             Inventory::Transaction(ref t) => encode_inv!(1, t),
             Inventory::Block(ref b) => encode_inv!(2, b),
+            Inventory::WTx(w) => encode_inv!(5, w),
             Inventory::WitnessTransaction(ref t) => encode_inv!(0x40000001, t),
             Inventory::WitnessBlock(ref b) => encode_inv!(0x40000002, b),
         })
@@ -71,6 +74,7 @@ impl Decodable for Inventory {
             0 => Inventory::Error,
             1 => Inventory::Transaction(Decodable::consensus_decode(&mut d)?),
             2 => Inventory::Block(Decodable::consensus_decode(&mut d)?),
+            5 => Inventory::WTx(Decodable::consensus_decode(&mut d)?),
             0x40000001 => Inventory::WitnessTransaction(Decodable::consensus_decode(&mut d)?),
             0x40000002 => Inventory::WitnessBlock(Decodable::consensus_decode(&mut d)?),
             tp => return Err(encode::Error::UnknownInventoryType(tp)),


### PR DESCRIPTION
BIP339 support was just merged into core: https://github.com/bitcoin/bitcoin/pull/18044

Not sure about changing the protocol version because I don't think every protocol is supported in rust-bitcoin yet
Not sure about the name for the new inv type, we already have WitnessTransaction