### PR TITLE
Remove empty code block

### DIFF
--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -439,8 +439,6 @@ impl MerkleBlock {
     ///
     /// The `header` is the block header, `block_txids` is the full list of txids included in the block and
     /// `match_txids` is a set containing the transaction ids that should be included in the partial merkle tree.
-    /// ```
-
     pub fn from_header_txids(
         header: &BlockHeader,
         block_txids: &[Txid],


### PR DESCRIPTION
Otherwise, `cargo doc` fails with:
```
warning: Rust code block is empty
   --> src/util/merkleblock.rs:442:9
    |
442 |     /// ```
    |         ^^^
    |
help: mark blocks that do not contain Rust code as text
    |
442 |     /// ```text
    |         ^^^^^^^

warning: 1 warning emitted
```