### PR TITLE
Add `Clone` instance to `RawNetworkMessage`

### DIFF
--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -90,7 +90,7 @@ impl Decodable for CommandString {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// A Network message
 pub struct RawNetworkMessage {
     /// Magic bytes to identify the network these messages are meant for


### PR DESCRIPTION
Very small change, but I've run into this too many times now. `NetworkMessage` has `Clone`, but not `RawNetworkMessage`. It's useful to have when there are multiple "consumers" of incoming network messages.