### PR TITLE
Update bitcoin_hashes to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 
 [dependencies]
 bech32 = "0.7.2"
-bitcoin_hashes = "0.7.3"
+bitcoin_hashes = "0.9.0"
 secp256k1 = "0.17.1"
 
 bitcoinconsensus = { version = "0.19.0-1", optional = true }


### PR DESCRIPTION
The older version of `bitcoin_hashes` doesn't have `impl FromStr for ...` in the newtype macro, which is quite annoying, so I propose updating the version.