### PR TITLE
BIP 32/SLIP 132 y,z...pub/priv types with generics

### DIFF
--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -213,7 +213,7 @@ pub enum KeyApplications {
 
 /// Extended private key
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct ExtendedPrivKey<R: VersionResolver> {
+pub struct ExtendedPrivKey<R: VersionResolver = DefaultResolver> {
     /// Version bytes specifying to which network the key belongs
     /// and for which types of scriptPubkey it may be used
     pub version: KeyVersion,
@@ -233,7 +233,7 @@ serde_string_impl!(ExtendedPrivKey<R: VersionResolver>, "a BIP-32 extended priva
 
 /// Extended public key
 #[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
-pub struct ExtendedPubKey<R: VersionResolver> {
+pub struct ExtendedPubKey<R: VersionResolver = DefaultResolver> {
     /// Version bytes specifying to which network the key belongs
     /// and for which types of scriptPubkey it may be used
     pub version: KeyVersion,

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -171,9 +171,8 @@ mod tests {
 
     use blockdata::script::Script;
     use blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint};
-    use network::constants::Network::Bitcoin;
     use consensus::encode::{deserialize, serialize, serialize_hex};
-    use util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource};
+    use util::bip32::{ChildNumber, KeySource, ExtendedPrivKey, ExtendedPubKey, Fingerprint, DefaultResolver, KeyVersion, VERSION_MAGIC_XPRV};
     use util::key::PublicKey;
     use util::psbt::map::{Global, Output};
     use util::psbt::raw;
@@ -208,9 +207,9 @@ mod tests {
 
         let mut hd_keypaths: BTreeMap<PublicKey, KeySource> = Default::default();
 
-        let mut sk: ExtendedPrivKey = ExtendedPrivKey::new_master(Bitcoin, &seed).unwrap();
+        let mut sk: ExtendedPrivKey<DefaultResolver> = ExtendedPrivKey::new_master(KeyVersion::from_bytes(VERSION_MAGIC_XPRV), &seed).unwrap();
 
-        let fprint: Fingerprint = sk.fingerprint(&secp);
+        let fprint: Fingerprint = sk.fingerprint(&secp).unwrap();
 
         let dpath: Vec<ChildNumber> = vec![
             ChildNumber::from_normal_idx(0).unwrap(),
@@ -225,7 +224,7 @@ mod tests {
 
         sk = sk.derive_priv(secp, &dpath).unwrap();
 
-        let pk: ExtendedPubKey = ExtendedPubKey::from_private(&secp, &sk);
+        let pk: ExtendedPubKey<DefaultResolver> = ExtendedPubKey::from_private(&secp, &sk).unwrap();
 
         hd_keypaths.insert(pk.public_key, (fprint, dpath.into()));
 


### PR DESCRIPTION
An alternative to https://github.com/rust-bitcoin/rust-bitcoin/pull/279 ypub and other extended pub/priv key support with generics. Will add more tests once this will get concept acks.

I have started working on this issue b/c of my other work on adding missed keys to PSBTs in #471, which required BIP 32 binary serialization of extended public key (#470). However it happened that this serialization is non-trivial b/c not of public key types are supported, so I ended up with this PR

Unlike the other alternative, this version allows to extend public key types by defining other concrete implementations of `VersionResolver` and using it with extended public and private keys.