### PR TITLE
Introducing `bip32::KeySource`: wrapper for `(Fingerprint, DerivationPath)`

### DIFF
--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -347,8 +347,7 @@ impl fmt::Debug for DerivationPath {
 
 /// Full information on the used extended public key: fingerprint of the
 /// master extended public key and a derivation path from it.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct KeySource(pub Fingerprint, pub DerivationPath);
+pub type KeySource = (Fingerprint, DerivationPath);
 
 /// A BIP32 error
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -345,6 +345,11 @@ impl fmt::Debug for DerivationPath {
     }
 }
 
+/// Full information on the used extended public key: fingerprint of the
+/// master extended public key and a derivation path from it.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct KeySource(pub Fingerprint, pub DerivationPath);
+
 /// A BIP32 error
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Error {

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 use blockdata::script::Script;
 use blockdata::transaction::{SigHashType, Transaction, TxOut};
 use consensus::encode;
-use util::bip32::{DerivationPath, Fingerprint};
+use util::bip32::KeySource;
 use util::key::PublicKey;
 use util::psbt;
 use util::psbt::map::Map;
@@ -48,7 +48,7 @@ pub struct Input {
     pub witness_script: Option<Script>,
     /// A map from public keys needed to sign this input to their corresponding
     /// master key fingerprints and derivation paths.
-    pub hd_keypaths: BTreeMap<PublicKey, (Fingerprint, DerivationPath)>,
+    pub hd_keypaths: BTreeMap<PublicKey, KeySource>,
     /// The finalized, fully-constructed scriptSig with signatures and any other
     /// scripts necessary for this input to pass validation.
     pub final_script_sig: Option<Script>,
@@ -109,7 +109,7 @@ impl Map for Input {
             }
             6u8 => {
                 impl_psbt_insert_pair! {
-                    self.hd_keypaths <= <raw_key: PublicKey>|<raw_value: (Fingerprint, DerivationPath)>
+                    self.hd_keypaths <= <raw_key: PublicKey>|<raw_value: KeySource>
                 }
             }
             _ => match self.unknown.entry(raw_key) {
@@ -149,7 +149,7 @@ impl Map for Input {
         }
 
         impl_psbt_get_pair! {
-            rv.push(self.hd_keypaths as <6u8, PublicKey>|<(Fingerprint, DerivationPath)>)
+            rv.push(self.hd_keypaths as <6u8, PublicKey>|<KeySource>)
         }
 
         impl_psbt_get_pair! {

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -17,7 +17,7 @@ use std::collections::btree_map::Entry;
 
 use blockdata::script::Script;
 use consensus::encode;
-use util::bip32::{DerivationPath, Fingerprint};
+use util::bip32::KeySource;
 use util::key::PublicKey;
 use util::psbt;
 use util::psbt::map::Map;
@@ -34,7 +34,7 @@ pub struct Output {
     pub witness_script: Option<Script>,
     /// A map from public keys needed to spend this output to their
     /// corresponding master key fingerprints and derivation paths.
-    pub hd_keypaths: BTreeMap<PublicKey, (Fingerprint, DerivationPath)>,
+    pub hd_keypaths: BTreeMap<PublicKey, KeySource>,
     /// Unknown key-value pairs for this output.
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 }
@@ -59,7 +59,7 @@ impl Map for Output {
             }
             2u8 => {
                 impl_psbt_insert_pair! {
-                    self.hd_keypaths <= <raw_key: PublicKey>|<raw_value: (Fingerprint, DerivationPath)>
+                    self.hd_keypaths <= <raw_key: PublicKey>|<raw_value: KeySource>
                 }
             }
             _ => match self.unknown.entry(raw_key) {
@@ -83,7 +83,7 @@ impl Map for Output {
         }
 
         impl_psbt_get_pair! {
-            rv.push(self.hd_keypaths as <2u8, PublicKey>|<(Fingerprint, DerivationPath)>)
+            rv.push(self.hd_keypaths as <2u8, PublicKey>|<KeySource>)
         }
 
         for (key, value) in self.unknown.iter() {

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -227,7 +227,7 @@ mod tests {
 
         let pk: ExtendedPubKey = ExtendedPubKey::from_private(&secp, &sk);
 
-        hd_keypaths.insert(pk.public_key, KeySource(fprint, dpath.into()));
+        hd_keypaths.insert(pk.public_key, (fprint, dpath.into()));
 
         let expected: Output = Output {
             redeem_script: Some(hex_script!(

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -173,7 +173,7 @@ mod tests {
     use blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint};
     use network::constants::Network::Bitcoin;
     use consensus::encode::{deserialize, serialize, serialize_hex};
-    use util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey, Fingerprint};
+    use util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource};
     use util::key::PublicKey;
     use util::psbt::map::{Global, Output};
     use util::psbt::raw;
@@ -206,7 +206,7 @@ mod tests {
         let secp = &Secp256k1::new();
         let seed = Vec::from_hex("000102030405060708090a0b0c0d0e0f").unwrap();
 
-        let mut hd_keypaths: BTreeMap<PublicKey, (Fingerprint, DerivationPath)> = Default::default();
+        let mut hd_keypaths: BTreeMap<PublicKey, KeySource> = Default::default();
 
         let mut sk: ExtendedPrivKey = ExtendedPrivKey::new_master(Bitcoin, &seed).unwrap();
 
@@ -227,7 +227,7 @@ mod tests {
 
         let pk: ExtendedPubKey = ExtendedPubKey::from_private(&secp, &sk);
 
-        hd_keypaths.insert(pk.public_key, (fprint, dpath.into()));
+        hd_keypaths.insert(pk.public_key, KeySource(fprint, dpath.into()));
 
         let expected: Output = Output {
             redeem_script: Some(hex_script!(

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -101,7 +101,7 @@ impl Deserialize for KeySource {
             }
         }
 
-        Ok(KeySource(fprint, dpath.into()))
+        Ok((fprint, dpath.into()))
     }
 }
 

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -22,7 +22,7 @@ use std::io;
 use blockdata::script::Script;
 use blockdata::transaction::{SigHashType, Transaction, TxOut};
 use consensus::encode::{self, serialize, Decodable};
-use util::bip32::{ChildNumber, DerivationPath, Fingerprint};
+use util::bip32::{ChildNumber, Fingerprint, KeySource};
 use util::key::PublicKey;
 use util::psbt;
 
@@ -70,7 +70,7 @@ impl Deserialize for PublicKey {
     }
 }
 
-impl Serialize for (Fingerprint, DerivationPath) {
+impl Serialize for KeySource {
     fn serialize(&self) -> Vec<u8> {
         let mut rv: Vec<u8> = Vec::with_capacity(4 + 4 * (self.1).as_ref().len());
 
@@ -84,7 +84,7 @@ impl Serialize for (Fingerprint, DerivationPath) {
     }
 }
 
-impl Deserialize for (Fingerprint, DerivationPath) {
+impl Deserialize for KeySource {
     fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
         if bytes.len() < 4 {
             return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())
@@ -101,7 +101,7 @@ impl Deserialize for (Fingerprint, DerivationPath) {
             }
         }
 
-        Ok((fprint, dpath.into()))
+        Ok(KeySource(fprint, dpath.into()))
     }
 }
 


### PR DESCRIPTION
Combinations of `(Fingerprint, DerivationPath)` are frequently used with PSBTs throughout this library and in many dependencies (like Lightning, Miniscript). It even had it's own serializer! So I think it is reasonable to introduce a type for representing this pair. After a brief discussion in https://github.com/rust-bitcoin/rust-miniscript/pull/131#discussion_r487444127 it was decided to name it `KeySource`, but we can change the name if needed.