### PR TITLE
Small modernization after MSRV bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ description = "General purpose library for using and interoperating with Bitcoin
 keywords = [ "crypto", "bitcoin" ]
 readme = "README.md"
 
-[lib]
-name = "bitcoin"
-path = "src/lib.rs"
 
 [features]
 fuzztarget = ["secp256k1/fuzztarget", "bitcoin_hashes/fuzztarget"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ bitcoinconsensus = { version = "0.19.0-1", optional = true }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]
-hex = "=0.3.2"
 serde_derive = "<1.0.99"
 serde_json = "<1.0.45"
 serde_test = "1"

--- a/fuzz/fuzz_targets/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/deser_net_msg.rs
@@ -31,9 +31,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_address.rs
+++ b/fuzz/fuzz_targets/deserialize_address.rs
@@ -36,9 +36,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_amount.rs
+++ b/fuzz/fuzz_targets/deserialize_amount.rs
@@ -53,9 +53,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_block.rs
+++ b/fuzz/fuzz_targets/deserialize_block.rs
@@ -31,9 +31,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/deserialize_psbt.rs
@@ -40,9 +40,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_script.rs
+++ b/fuzz/fuzz_targets/deserialize_script.rs
@@ -70,9 +70,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/deserialize_transaction.rs
@@ -52,9 +52,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/outpoint_string.rs
+++ b/fuzz/fuzz_targets/outpoint_string.rs
@@ -67,9 +67,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/fuzz/fuzz_targets/uint128_fuzz.rs
+++ b/fuzz/fuzz_targets/uint128_fuzz.rs
@@ -88,9 +88,9 @@ mod tests {
         for (idx, c) in hex.as_bytes().iter().enumerate() {
             b <<= 4;
             match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
                 _ => panic!("Bad hex"),
             }
             if (idx & 1) == 1 {

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -120,12 +120,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[allow(deprecated)]
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
-}
+impl error::Error for Error {}
 
 #[cfg(feature="bitcoinconsensus")]
 #[doc(hidden)]

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -422,7 +422,7 @@ impl Script {
     }
 
     /// Write the assembly decoding of the script to the formatter.
-    pub fn fmt_asm(&self, f: &mut fmt::Write) -> fmt::Result {
+    pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
         let mut index = 0;
         while index < self.0.len() {
             let opcode = opcodes::All::from(self.0[index]);

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -142,7 +142,7 @@ impl error::Error for ParseOutPointError {
 /// It does not permit leading zeroes or non-digit characters.
 fn parse_vout(s: &str) -> Result<u32, ParseOutPointError> {
     if s.len() > 1 {
-        let first = s.chars().nth(0).unwrap();
+        let first = s.chars().next().unwrap();
         if first == '0' || first == '+' {
             return Err(ParseOutPointError::VoutNotCanonical);
         }

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -128,12 +128,7 @@ impl fmt::Display for ParseOutPointError {
     }
 }
 
-#[allow(deprecated)]
 impl error::Error for ParseOutPointError {
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ParseOutPointError::Txid(ref e) => Some(e),

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -24,7 +24,7 @@
 //!
 
 use std::default::Default;
-use std::{fmt, io};
+use std::{error, fmt, io};
 
 use hashes::{self, Hash, sha256d};
 use hashes::hex::FromHex;
@@ -129,12 +129,12 @@ impl fmt::Display for ParseOutPointError {
 }
 
 #[allow(deprecated)]
-impl ::std::error::Error for ParseOutPointError {
+impl error::Error for ParseOutPointError {
     fn description(&self) -> &str {
         "description() is deprecated; use Display"
     }
 
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ParseOutPointError::Txid(ref e) => Some(e),
             ParseOutPointError::Vout(ref e) => Some(e),

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -376,14 +376,14 @@ impl_int_encodable!(i64, read_i64, emit_i64);
 
 impl VarInt {
     /// Gets the length of this VarInt when encoded.
-    /// Returns 1 for 0...0xFC, 3 for 0xFD...(2^16-1), 5 for 0x10000...(2^32-1),
+    /// Returns 1 for 0..=0xFC, 3 for 0xFD..=(2^16-1), 5 for 0x10000..=(2^32-1),
     /// and 9 otherwise.
     #[inline]
     pub fn len(&self) -> usize {
         match self.0 {
-            0...0xFC             => { 1 }
-            0xFD...0xFFFF        => { 3 }
-            0x10000...0xFFFFFFFF => { 5 }
+            0..=0xFC             => { 1 }
+            0xFD..=0xFFFF        => { 3 }
+            0x10000..=0xFFFFFFFF => { 5 }
             _                    => { 9 }
         }
     }
@@ -393,16 +393,16 @@ impl Encodable for VarInt {
     #[inline]
     fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, Error> {
         match self.0 {
-            0...0xFC => {
+            0..=0xFC => {
                 (self.0 as u8).consensus_encode(s)?;
                 Ok(1)
             },
-            0xFD...0xFFFF => {
+            0xFD..=0xFFFF => {
                 s.emit_u8(0xFD)?;
                 (self.0 as u16).consensus_encode(s)?;
                 Ok(3)
             },
-            0x10000...0xFFFFFFFF => {
+            0x10000..=0xFFFFFFFF => {
                 s.emit_u8(0xFE)?;
                 (self.0 as u32).consensus_encode(s)?;
                 Ok(5)

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -111,7 +111,7 @@ impl fmt::Display for Error {
 
 #[allow(deprecated)]
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
             Error::Psbt(ref e) => Some(e),

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -109,7 +109,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[allow(deprecated)]
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
@@ -125,10 +124,6 @@ impl error::Error for Error {
             | Error::UnrecognizedNetworkCommand(..)
             | Error::UnknownInventoryType(..) => None,
         }
-    }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
     }
 }
 

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -16,10 +16,7 @@
 //! to avoid mixing data of the same hash format (like SHA256d) but of different meaning
 //! (transaction id, block hash etc).
 
-use consensus::encode::{Encodable, Decodable, Error};
-use hashes::{Hash, sha256, sha256d, ripemd160, hash160};
-use hashes::hex::{FromHex, ToHex};
-use util::key::PublicKey;
+use hashes::{Hash, sha256, sha256d, hash160};
 
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,16 +23,8 @@
 //! software.
 //!
 
-#![crate_name = "bitcoin"]
-#![crate_type = "dylib"]
-#![crate_type = "rlib"]
-
 // Experimental features we need
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
-
-// Clippy whitelist
-#![cfg_attr(feature = "clippy", allow(needless_range_loop))] // suggests making a big mess of array newtypes
-#![cfg_attr(feature = "clippy", allow(extend_from_slice))]   // `extend_from_slice` only available since 1.6
 
 // Coding conventions
 #![forbid(unsafe_code)]
@@ -44,23 +36,17 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 
-// In general, rust is absolutely horrid at supporting users doing things like,
-// for example, compiling Rust code for real environments. Disable useless lints
-// that don't do anything but annoy us and cant actually ever be resolved.
-#![allow(bare_trait_objects)]
-#![allow(ellipsis_inclusive_range_patterns)]
-
 // Re-exported dependencies.
 #[macro_use] pub extern crate bitcoin_hashes as hashes;
 pub extern crate secp256k1;
 pub extern crate bech32;
 
+#[cfg(feature="bitcoinconsensus")] extern crate bitcoinconsensus;
 #[cfg(feature = "serde")] extern crate serde;
 #[cfg(all(test, feature = "serde"))] #[macro_use] extern crate serde_derive; // for 1.22.0 compat
 #[cfg(all(test, feature = "serde"))] extern crate serde_json;
 #[cfg(all(test, feature = "serde"))] extern crate serde_test;
 #[cfg(all(test, feature = "unstable"))] extern crate test;
-#[cfg(feature="bitcoinconsensus")] extern crate bitcoinconsensus;
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("rust-bitcoin cannot be used on 16-bit architectures");
@@ -75,8 +61,6 @@ pub mod network;
 pub mod blockdata;
 pub mod util;
 pub mod consensus;
-// Do not remove: required in order to get hash types implementation macros to work correctly
-#[allow(unused_imports)]
 pub mod hash_types;
 
 pub use hash_types::*;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -66,7 +66,7 @@ impl error::Error for Error {
         "description() is deprecated; use Display"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
             Error::SocketMutexPoisoned | Error::SocketNotConnectedToPeer => None,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -60,11 +60,7 @@ impl From<io::Error> for Error {
     }
 }
 
-#[allow(deprecated)]
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
 
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -87,7 +87,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[allow(deprecated)]
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
@@ -95,10 +94,6 @@ impl error::Error for Error {
             Error::Bech32(ref e) => Some(e),
             _ => None,
         }
-    }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -38,6 +38,7 @@
 
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
+use std::error;
 
 use bech32;
 use hashes::Hash;
@@ -87,8 +88,8 @@ impl fmt::Display for Error {
 }
 
 #[allow(deprecated)]
-impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&::std::error::Error> {
+impl error::Error for Error {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Base58(ref e) => Some(e),
             Error::Bech32(ref e) => Some(e),

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -115,13 +115,7 @@ impl fmt::Display for ParseAmountError {
     }
 }
 
-#[allow(deprecated)]
-impl error::Error for ParseAmountError {
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
-}
-
+impl error::Error for ParseAmountError {}
 
 fn is_too_precise(s: &str, precision: usize) -> bool {
     s.contains('.') || precision >= s.len() || s.chars().rev().take(precision).any(|d| d != '0')

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -172,7 +172,7 @@ fn parse_signed_to_satoshi(
     let mut value: u64 = 0; // as satoshis
     for c in s.chars() {
         match c {
-            '0'...'9' => {
+            '0'..='9' => {
                 // Do `value = 10 * value + digit`, catching overflows.
                 match 10_u64.checked_mul(value) {
                     None => return Err(ParseAmountError::TooBig),

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -215,7 +215,7 @@ fn parse_signed_to_satoshi(
 fn fmt_satoshi_in(
     satoshi: u64,
     negative: bool,
-    f: &mut fmt::Write,
+    f: &mut dyn fmt::Write,
     denom: Denomination,
 ) -> fmt::Result {
     if negative {
@@ -365,7 +365,7 @@ impl Amount {
     /// Format the value of this [Amount] in the given denomination.
     ///
     /// Does not include the denomination.
-    pub fn fmt_value_in(self, f: &mut fmt::Write, denom: Denomination) -> fmt::Result {
+    pub fn fmt_value_in(self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.as_sat(), false, f, denom)
     }
 
@@ -643,7 +643,7 @@ impl SignedAmount {
     /// Format the value of this [SignedAmount] in the given denomination.
     ///
     /// Does not include the denomination.
-    pub fn fmt_value_in(self, f: &mut fmt::Write, denom: Denomination) -> fmt::Result {
+    pub fn fmt_value_in(self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         let sats = self.as_sat().checked_abs().map(|a: i64| a as u64).unwrap_or_else(|| {
             // We could also hard code this into `9223372036854775808`
             u64::max_value() - self.as_sat() as u64 +1

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -52,12 +52,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[allow(deprecated)]
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
-}
+impl error::Error for Error {}
 
 /// Vector-like object that holds the first 100 elements on the stack. If more space is needed it
 /// will be allocated on the heap.

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -528,7 +528,6 @@ mod test {
 
     use super::*;
 
-    extern crate hex;
     extern crate serde_json;
     use self::serde_json::{Value};
 
@@ -557,18 +556,18 @@ mod test {
         let testdata = serde_json::from_str::<Value>(data).unwrap().as_array().unwrap().clone();
         for t in testdata.iter().skip(1) {
             let block_hash = BlockHash::from_hex(&t.get(1).unwrap().as_str().unwrap()).unwrap();
-            let block: Block = deserialize(hex::decode(&t.get(2).unwrap().as_str().unwrap().as_bytes()).unwrap().as_slice()).unwrap();
+            let block: Block = deserialize(&Vec::from_hex(&t.get(2).unwrap().as_str().unwrap()).unwrap()).unwrap();
             assert_eq!(block.block_hash(), block_hash);
             let scripts = t.get(3).unwrap().as_array().unwrap();
             let previous_filter_id = FilterHash::from_hex(&t.get(4).unwrap().as_str().unwrap()).unwrap();
-            let filter_content = hex::decode(&t.get(5).unwrap().as_str().unwrap().as_bytes()).unwrap();
+            let filter_content = Vec::from_hex(&t.get(5).unwrap().as_str().unwrap()).unwrap();
             let filter_id = FilterHash::from_hex(&t.get(6).unwrap().as_str().unwrap()).unwrap();
 
             let mut txmap = HashMap::new();
             let mut si = scripts.iter();
             for tx in block.txdata.iter().skip(1) {
                 for input in tx.input.iter() {
-                    txmap.insert(input.previous_output.clone(), Script::from(hex::decode(si.next().unwrap().as_str().unwrap()).unwrap()));
+                    txmap.insert(input.previous_output.clone(), Script::from(Vec::from_hex(si.next().unwrap().as_str().unwrap()).unwrap()));
                 }
             }
 
@@ -603,22 +602,22 @@ mod test {
     fn test_filter () {
         let mut patterns = HashSet::new();
 
-        patterns.insert(hex::decode("000000").unwrap());
-        patterns.insert(hex::decode("111111").unwrap());
-        patterns.insert(hex::decode("222222").unwrap());
-        patterns.insert(hex::decode("333333").unwrap());
-        patterns.insert(hex::decode("444444").unwrap());
-        patterns.insert(hex::decode("555555").unwrap());
-        patterns.insert(hex::decode("666666").unwrap());
-        patterns.insert(hex::decode("777777").unwrap());
-        patterns.insert(hex::decode("888888").unwrap());
-        patterns.insert(hex::decode("999999").unwrap());
-        patterns.insert(hex::decode("aaaaaa").unwrap());
-        patterns.insert(hex::decode("bbbbbb").unwrap());
-        patterns.insert(hex::decode("cccccc").unwrap());
-        patterns.insert(hex::decode("dddddd").unwrap());
-        patterns.insert(hex::decode("eeeeee").unwrap());
-        patterns.insert(hex::decode("ffffff").unwrap());
+        patterns.insert(Vec::from_hex("000000").unwrap());
+        patterns.insert(Vec::from_hex("111111").unwrap());
+        patterns.insert(Vec::from_hex("222222").unwrap());
+        patterns.insert(Vec::from_hex("333333").unwrap());
+        patterns.insert(Vec::from_hex("444444").unwrap());
+        patterns.insert(Vec::from_hex("555555").unwrap());
+        patterns.insert(Vec::from_hex("666666").unwrap());
+        patterns.insert(Vec::from_hex("777777").unwrap());
+        patterns.insert(Vec::from_hex("888888").unwrap());
+        patterns.insert(Vec::from_hex("999999").unwrap());
+        patterns.insert(Vec::from_hex("aaaaaa").unwrap());
+        patterns.insert(Vec::from_hex("bbbbbb").unwrap());
+        patterns.insert(Vec::from_hex("cccccc").unwrap());
+        patterns.insert(Vec::from_hex("dddddd").unwrap());
+        patterns.insert(Vec::from_hex("eeeeee").unwrap());
+        patterns.insert(Vec::from_hex("ffffff").unwrap());
 
         let mut out = Cursor::new(Vec::new());
         {
@@ -633,8 +632,8 @@ mod test {
 
         {
             let mut query = Vec::new();
-            query.push(hex::decode("abcdef").unwrap());
-            query.push(hex::decode("eeeeee").unwrap());
+            query.push(Vec::from_hex("abcdef").unwrap());
+            query.push(Vec::from_hex("eeeeee").unwrap());
 
             let reader = GCSFilterReader::new(0, 0, M, P);
             let mut input = Cursor::new(bytes.clone());
@@ -642,8 +641,8 @@ mod test {
         }
         {
             let mut query = Vec::new();
-            query.push(hex::decode("abcdef").unwrap());
-            query.push(hex::decode("123456").unwrap());
+            query.push(Vec::from_hex("abcdef").unwrap());
+            query.push(Vec::from_hex("123456").unwrap());
 
             let reader = GCSFilterReader::new(0, 0, M, P);
             let mut input = Cursor::new(bytes.clone());
@@ -664,7 +663,7 @@ mod test {
             for p in &patterns {
                 query.push(p.clone());
             }
-            query.push(hex::decode("abcdef").unwrap());
+            query.push(Vec::from_hex("abcdef").unwrap());
             let mut input = Cursor::new(bytes.clone());
             assert!(!reader.match_all(&mut input, &mut query.iter().map(|v| v.as_slice())).unwrap());
         }

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -75,12 +75,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[allow(deprecated)]
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
-}
+impl error::Error for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -411,10 +411,6 @@ impl error::Error for Error {
            None
        }
     }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
 }
 
 impl From<secp256k1::Error> for Error {

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -404,7 +404,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
        if let Error::Ecdsa(ref e) = *self {
            Some(e)
        } else {

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -73,7 +73,7 @@ impl fmt::Display for Error {
 
 #[allow(deprecated)]
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Secp(ref e) => Some(e),
             Error::Script(ref e) => Some(e),

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -71,7 +71,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[allow(deprecated)]
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
@@ -79,10 +78,6 @@ impl error::Error for Error {
             Error::Script(ref e) => Some(e),
             _ => None
         }
-    }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -60,7 +60,7 @@ pub fn bitcoin_merkle_root<T, I>(mut iter: I) -> T
         return Default::default();
     }
     if iter.len() == 1 {
-        return T::from_inner(iter.nth(0).unwrap().into_inner());
+        return T::from_inner(iter.next().unwrap().into_inner());
     }
     // Recursion
     let half_len = iter.len() / 2 + iter.len() % 2;

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -52,10 +52,6 @@ impl error::Error for Error {
             Error::Secp256k1(ref e) => Some(e),
         }
     }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
 }
 
 #[doc(hidden)]

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -46,7 +46,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Base58(ref e) => Some(e),
             Error::Secp256k1(ref e) => Some(e),
@@ -193,7 +193,7 @@ impl PrivateKey {
     }
 
     /// Format the private key to WIF format.
-    pub fn fmt_wif(&self, fmt: &mut fmt::Write) -> fmt::Result {
+    pub fn fmt_wif(&self, fmt: &mut dyn fmt::Write) -> fmt::Result {
         let mut ret = [0; 34];
         ret[0] = match self.network {
             Network::Bitcoin => 128,

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -445,7 +445,7 @@ impl MerkleBlock {
         match_txids: &HashSet<Txid>,
     ) -> Self {
         let matches: Vec<bool> = block_txids
-            .into_iter()
+            .iter()
             .map(|txid| match_txids.contains(txid))
             .collect();
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -85,7 +85,7 @@ impl fmt::Display for Error {
 
 #[allow(deprecated)]
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Encode(ref e) => Some(e),
             Error::Network(ref e) => Some(e),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -83,7 +83,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[allow(deprecated)]
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
@@ -91,10 +90,6 @@ impl error::Error for Error {
             Error::Network(ref e) => Some(e),
             Error::BlockBadProofOfWork | Error::BlockBadTarget => None
         }
-    }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
     }
 }
 

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -69,9 +69,4 @@ impl fmt::Display for Error {
     }
 }
 
-#[allow(deprecated)]
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
-}
+impl error::Error for Error {}


### PR DESCRIPTION
This is akin to https://github.com/rust-bitcoin/rust-secp256k1/pull/232
but also finally really removed the `hex` dependency from the tests (I have no idea how did I miss it in #381 )