### PR TITLE
Expose features of secp256k1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ fuzztarget = ["secp256k1/fuzztarget", "bitcoin_hashes/fuzztarget"]
 unstable = []
 rand = ["secp256k1/rand-std"]
 use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]
+secp-recovery = ["secp256k1/recovery"]
+secp-endomorphism = ["secp256k1/endomorphism"]
+secp-lowmemory = ["secp256k1/lowmemory"]
 
 [dependencies]
 bech32 = "0.7.2"


### PR DESCRIPTION
I am particularly interested in the recovery feature since gdk is [using it](https://github.com/Blockstream/gdk/blob/master/subprojects/gdk_rust/gdk_electrum/Cargo.toml#L28) by adding explicit secp dependency, but I thought also endomorphism and lowmemory feature could be interesting