### PR TITLE
Revert the sighash method signatures

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -397,10 +397,11 @@ impl Transaction {
         input_index: usize,
         script_pubkey: &Script,
         sighash_u32: u32
-    ) -> Result<SigHash, encode::Error> {
+    ) -> SigHash {
         let mut engine = SigHash::engine();
-        self.encode_signing_data_to(&mut engine, input_index, script_pubkey, sighash_u32)?;
-        Ok(SigHash::from_engine(engine))
+        self.encode_signing_data_to(&mut engine, input_index, script_pubkey, sighash_u32)
+            .expect("engines don't error");
+        SigHash::from_engine(engine)
     }
 
     /// Gets the "weight" of this transaction, as defined by BIP141. For transactions with an empty
@@ -897,7 +898,7 @@ mod tests {
         raw_expected.reverse();
         let expected_result = SigHash::from_slice(&raw_expected[..]).unwrap();
 
-        let actual_result = tx.signature_hash(input_index, &script, hash_type as u32).unwrap();
+        let actual_result = tx.signature_hash(input_index, &script, hash_type as u32);
         assert_eq!(actual_result, expected_result);
     }
 

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -231,10 +231,11 @@ impl<R: Deref<Target=Transaction>> SigHashCache<R> {
         script_code: &Script,
         value: u64,
         sighash_type: SigHashType
-    ) -> Result<SigHash, encode::Error> {
+    ) -> SigHash {
         let mut enc = SigHash::engine();
-        self.encode_signing_data_to(&mut enc, input_index, script_code, value, sighash_type)?;
-        Ok(SigHash::from_engine(enc))
+        self.encode_signing_data_to(&mut enc, input_index, script_code, value, sighash_type)
+            .expect("engines don't error");
+        SigHash::from_engine(enc)
     }
 }
 
@@ -292,7 +293,7 @@ mod tests {
         let expected_result = SigHash::from_slice(&raw_expected[..]).unwrap();
         let mut cache = SigHashCache::new(&tx);
         let sighash_type = SigHashType::from_u32(hash_type);
-        let actual_result = cache.signature_hash(input_index, &script, value, sighash_type).unwrap();
+        let actual_result = cache.signature_hash(input_index, &script, value, sighash_type);
         assert_eq!(actual_result, expected_result);
     }
 


### PR DESCRIPTION
Hash engines don't product I/O errors, so encoding into them
shouldn't produce errors either.

This change was introduced in https://github.com/rust-bitcoin/rust-bitcoin/commit/3618d7a41d8aadd1f3c1762969893012cefff899 but wasn't needed and accidentally broke the API. This repairs that.