### PR TITLE
Change Cargo.toml serde dev deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ bitcoinconsensus = { version = "0.19.0-1", optional = true }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]
-serde_derive = "<1.0.99"
-serde_json = "<1.0.45"
+serde_derive = "<1.0.99, >= 1.0.0"
+serde_json = "<1.0.45, >= 1.0.0"
 serde_test = "1"
 secp256k1 = { version = "0.19.0", features = ["rand-std"] }
 # We need to pin ryu (transitive dep from serde_json) to stay compatible with Rust 1.22.0


### PR DESCRIPTION
The serde dev dependency pinning breaks compilation on my machine with various build errors, setting the version to "1" fixes the incompatibilities.