### PR TITLE
BlockFilter `Clone`, `Debug` etc. derives

### DIFF
--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -94,6 +94,7 @@ impl From<io::Error> for Error {
 
 
 /// a computed or read block filter
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockFilter {
     /// Golomb encoded filter
     pub content: Vec<u8>


### PR DESCRIPTION
In working on a bip157 implementation, I ran into the lack of `Clone` & `Debug` on `BlockFilter`. I can live with only `Debug` and `Clone`, but eventually someone will ask for `Eq`, so I added it :)