### PR TITLE
segwit v1 test

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -743,4 +743,24 @@ mod tests {
             hex_script!("001454d26dddb59c7073c6a197946ea1841951fa7a74")
         );
     }
+
+    #[test]
+    fn test_segwit_v1() {
+        let addr_str = "bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ss52r5n8";
+        let addr = Address::from_str(&addr_str).unwrap();
+        assert_eq!(addr_str, addr.to_string());
+        assert_eq!(
+            addr.script_pubkey().to_hex(),
+            "5120da4710964f7852695de2da025290e24af6d8c281de5a0b902b7135fd9fd74d21"
+        );
+        if let Payload::WitnessProgram {
+            version: v,
+            program: _p,
+        } = &addr.payload
+        {
+            assert_eq!(v, &bech32::u5::try_from_u8(1).unwrap());
+        } else {
+            assert!(false);
+        }
+    }
 }


### PR DESCRIPTION
Pieter Wuille posted a segwit v1 address here https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-October/018254.html and I added a parsing test.

~The attached test fails on the script which I am not sure but I would expect should start with 01 (version 1) but it starts with 51 (OP_PUSHNUM_1)~

here is a mainnet tx done with aqua wallet, which is based on rust-bitcoin
https://blockstream.info/tx/b48a59fa9e036e997ba733904f631b1a64f5274be646698e49fd542141ca9404?expand
