### PR TITLE
Add SegwitVersion type

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -38,6 +38,7 @@ use hashes::Hash;
 #[cfg(feature="bitcoinconsensus")] use OutPoint;
 
 use util::key::PublicKey;
+use util::address::SegwitVersion;
 
 #[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
 /// A Bitcoin script
@@ -241,21 +242,17 @@ impl Script {
 
     /// Generates P2WPKH-type of scriptPubkey
     pub fn new_v0_wpkh(pubkey_hash: &WPubkeyHash) -> Script {
-        Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &pubkey_hash.to_vec())
+        Script::new_witness_program(SegwitVersion::v0(), &pubkey_hash.to_vec())
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
     pub fn new_v0_wsh(script_hash: &WScriptHash) -> Script {
-        Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &script_hash.to_vec())
+        Script::new_witness_program(SegwitVersion::v0(), &script_hash.to_vec())
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
-    pub fn new_witness_program(ver: ::bech32::u5, program: &[u8]) -> Script {
-        let mut verop = ver.to_u8();
-        assert!(verop <= 16);
-        if verop > 0 {
-            verop = 0x50 + verop;
-        }
+    pub fn new_witness_program(ver: SegwitVersion, program: &[u8]) -> Script {
+        let verop = ver.to_op();
         Builder::new()
             .push_opcode(verop.into())
             .push_slice(&program)


### PR DESCRIPTION
At the moment if an address is built trough the struct with an invalid version it's possible to convert it to string and it will be an invalid address, we may want to panic in that case