### PR TITLE
Avoid a few assertions that shouldn't be necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# 0.25.1 - 2020-10-26
+
+- Remove an incorrect `debug_assert` that can cause a panic when running using
+  the dev profile.
+
 # 0.25.1 - 2020-10-07
 
 - [Expose methods on `Script`](https://github.com/rust-bitcoin/rust-bitcoin/pull/387) to generate various scriptpubkeys

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -252,7 +252,7 @@ impl Script {
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
     pub fn new_witness_program(ver: ::bech32::u5, program: &[u8]) -> Script {
         let mut verop = ver.to_u8();
-        assert!(verop <= 16);
+        assert!(verop <= 16, "incorrect witness version provided: {}", verop);
         if verop > 0 {
             verop = 0x50 + verop;
         }

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -249,7 +249,7 @@ macro_rules! decoder_fn {
     ($name:ident, $val_type:ty, $readfn:ident, $byte_len: expr) => {
         #[inline]
         fn $name(&mut self) -> Result<$val_type, Error> {
-            assert_eq!(::std::mem::size_of::<$val_type>(), $byte_len); // size_of isn't a constfn in 1.22
+            debug_assert_eq!(::std::mem::size_of::<$val_type>(), $byte_len); // size_of isn't a constfn in 1.22
             let mut val = [0; $byte_len];
             self.read_exact(&mut val[..]).map_err(Error::Io)?;
             Ok(endian::$readfn(&val))

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -147,7 +147,7 @@ impl From<psbt::Error> for Error {
 pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
     let mut encoder = Vec::new();
     let len = data.consensus_encode(&mut encoder).unwrap();
-    assert_eq!(len, encoder.len());
+    debug_assert_eq!(len, encoder.len());
     encoder
 }
 

--- a/src/util/endian.rs
+++ b/src/util/endian.rs
@@ -28,7 +28,7 @@ macro_rules! define_be_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
         pub fn $name(val: $type) -> [u8; $byte_len] {
-            assert_eq!(::std::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            debug_assert_eq!(::std::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
             let mut res = [0; $byte_len];
             for i in 0..$byte_len {
                 res[i] = ((val >> ($byte_len - i - 1)*8) & 0xff) as u8;
@@ -41,7 +41,7 @@ macro_rules! define_le_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
         pub fn $name(val: $type) -> [u8; $byte_len] {
-            assert_eq!(::std::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            debug_assert_eq!(::std::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
             let mut res = [0; $byte_len];
             for i in 0..$byte_len {
                 res[i] = ((val >> i*8) & 0xff) as u8;

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -102,12 +102,11 @@ impl PublicKey {
 
     /// Write the public key into a writer
     pub fn write_into<W: io::Write>(&self, mut writer: W) {
-        let write_res: io::Result<()> = if self.compressed {
+        let _: io::Result<()> = if self.compressed {
             writer.write_all(&self.key.serialize())
         } else {
             writer.write_all(&self.key.serialize_uncompressed())
         };
-        debug_assert!(write_res.is_ok());
     }
 
     /// Serialize the public key to bytes

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -83,8 +83,11 @@ macro_rules! construct_uint {
             /// Create an object from a given signed 64-bit integer
             #[inline]
             pub fn from_i64(init: i64) -> Option<$name> {
-                assert!(init >= 0);
-                $name::from_u64(init as u64)
+                if init >= 0 {
+                    $name::from_u64(init as u64)
+                } else {
+                    None
+                }
             }
 
             /// Creates big integer value from a byte slice array using


### PR DESCRIPTION
I went over all existing assertions, the ones I left are mostly wrong user input on methods that expect slices of a fixed size (like in decoding for endianness or so), I think those still make sense.

I just hit the `PublicKey::write_into` debug assertion running a long test involving programs sending messages over TCP connections (and not building with `--release`). So when one peer closes a TCP connection at the exact moment the other side is writing a public key, the assertion would cause the sender to panic.