### PR TITLE
PSBT: making input and output field names match spec type names

### DIFF
--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -49,7 +49,7 @@ pub struct Input {
     pub witness_script: Option<Script>,
     /// A map from public keys needed to sign this input to their corresponding
     /// master key fingerprints and derivation paths.
-    pub hd_keypaths: BTreeMap<PublicKey, KeySource>,
+    pub bip32_derivation: BTreeMap<PublicKey, KeySource>,
     /// The finalized, fully-constructed scriptSig with signatures and any other
     /// scripts necessary for this input to pass validation.
     pub final_script_sig: Option<Script>,
@@ -70,7 +70,7 @@ pub struct Input {
 }
 serde_struct_impl!(
     Input, non_witness_utxo, witness_utxo, partial_sigs,
-    sighash_type, redeem_script, witness_script, hd_keypaths,
+    sighash_type, redeem_script, witness_script, bip32_derivation,
     final_script_sig, final_script_witness,
     ripemd_preimages, sha256_preimages, hash160_preimages, hash256_preimages,
     unknown
@@ -126,7 +126,7 @@ impl Map for Input {
             }
             6u8 => {
                 impl_psbt_insert_pair! {
-                    self.hd_keypaths <= <raw_key: PublicKey>|<raw_value: KeySource>
+                    self.bip32_derivation <= <raw_key: PublicKey>|<raw_value: KeySource>
                 }
             }
             10u8 => {
@@ -182,7 +182,7 @@ impl Map for Input {
         }
 
         impl_psbt_get_pair! {
-            rv.push(self.hd_keypaths as <6u8, PublicKey>|<KeySource>)
+            rv.push(self.bip32_derivation as <6u8, PublicKey>|<KeySource>)
         }
 
         impl_psbt_get_pair! {
@@ -228,7 +228,7 @@ impl Map for Input {
         }
 
         self.partial_sigs.extend(other.partial_sigs);
-        self.hd_keypaths.extend(other.hd_keypaths);
+        self.bip32_derivation.extend(other.bip32_derivation);
         self.ripemd_preimages.extend(other.ripemd_preimages);
         self.sha256_preimages.extend(other.sha256_preimages);
         self.hash160_preimages.extend(other.hash160_preimages);

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -57,8 +57,8 @@ pub struct Input {
     /// other scripts necessary for this input to pass validation.
     pub final_script_witness: Option<Vec<Vec<u8>>>,
     /// TODO: Proof of reserves commitment
-    /// RIPEMD hash to preimage map
-    pub ripemd_preimages: BTreeMap<ripemd160::Hash, Vec<u8>>,
+    /// RIPEMD160 hash to preimage map
+    pub ripemd160_preimages: BTreeMap<ripemd160::Hash, Vec<u8>>,
     /// SHA256 hash to preimage map
     pub sha256_preimages: BTreeMap<sha256::Hash, Vec<u8>>,
     /// HSAH160 hash to preimage map
@@ -72,7 +72,7 @@ serde_struct_impl!(
     Input, non_witness_utxo, witness_utxo, partial_sigs,
     sighash_type, redeem_script, witness_script, bip32_derivation,
     final_script_sig, final_script_witness,
-    ripemd_preimages, sha256_preimages, hash160_preimages, hash256_preimages,
+    ripemd160_preimages, sha256_preimages, hash160_preimages, hash256_preimages,
     unknown
 );
 
@@ -130,7 +130,7 @@ impl Map for Input {
                 }
             }
             10u8 => {
-                psbt_insert_hash_pair(&mut self.ripemd_preimages, raw_key, raw_value, error::PsbtHash::Ripemd)?;
+                psbt_insert_hash_pair(&mut self.ripemd160_preimages, raw_key, raw_value, error::PsbtHash::Ripemd)?;
             }
             11u8 => {
                 psbt_insert_hash_pair(&mut self.sha256_preimages, raw_key, raw_value, error::PsbtHash::Sha256)?;
@@ -194,7 +194,7 @@ impl Map for Input {
         }
 
         impl_psbt_get_pair! {
-            rv.push(self.ripemd_preimages as <10u8, ripemd160::Hash>|<Vec<u8>>)
+            rv.push(self.ripemd160_preimages as <10u8, ripemd160::Hash>|<Vec<u8>>)
         }
 
         impl_psbt_get_pair! {
@@ -229,7 +229,7 @@ impl Map for Input {
 
         self.partial_sigs.extend(other.partial_sigs);
         self.bip32_derivation.extend(other.bip32_derivation);
-        self.ripemd_preimages.extend(other.ripemd_preimages);
+        self.ripemd160_preimages.extend(other.ripemd160_preimages);
         self.sha256_preimages.extend(other.sha256_preimages);
         self.hash160_preimages.extend(other.hash160_preimages);
         self.hash256_preimages.extend(other.hash256_preimages);

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -34,12 +34,12 @@ pub struct Output {
     pub witness_script: Option<Script>,
     /// A map from public keys needed to spend this output to their
     /// corresponding master key fingerprints and derivation paths.
-    pub hd_keypaths: BTreeMap<PublicKey, KeySource>,
+    pub bip32_derivation: BTreeMap<PublicKey, KeySource>,
     /// Unknown key-value pairs for this output.
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 }
 serde_struct_impl!(
-    Output, redeem_script, witness_script, hd_keypaths, unknown
+    Output, redeem_script, witness_script, bip32_derivation, unknown
 );
 
 impl Map for Output {
@@ -62,7 +62,7 @@ impl Map for Output {
             }
             2u8 => {
                 impl_psbt_insert_pair! {
-                    self.hd_keypaths <= <raw_key: PublicKey>|<raw_value: KeySource>
+                    self.bip32_derivation <= <raw_key: PublicKey>|<raw_value: KeySource>
                 }
             }
             _ => match self.unknown.entry(raw_key) {
@@ -86,7 +86,7 @@ impl Map for Output {
         }
 
         impl_psbt_get_pair! {
-            rv.push(self.hd_keypaths as <2u8, PublicKey>|<KeySource>)
+            rv.push(self.bip32_derivation as <2u8, PublicKey>|<KeySource>)
         }
 
         for (key, value) in self.unknown.iter() {
@@ -100,7 +100,7 @@ impl Map for Output {
     }
 
     fn merge(&mut self, other: Self) -> Result<(), psbt::Error> {
-        self.hd_keypaths.extend(other.hd_keypaths);
+        self.bip32_derivation.extend(other.bip32_derivation);
         self.unknown.extend(other.unknown);
 
         merge!(redeem_script, self, other);

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -238,7 +238,7 @@ mod tests {
             witness_script: Some(hex_script!(
                 "a9143545e6e33b832c47050f24d3eeb93c9c03948bc787"
             )),
-            hd_keypaths: hd_keypaths,
+            bip32_derivation: hd_keypaths,
             ..Default::default()
         };
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -669,7 +669,7 @@ mod tests {
         // Now add an ripemd160 with incorrect preimage
         let mut ripemd160_preimages = BTreeMap::new();
         ripemd160_preimages.insert(ripemd160::Hash::hash(&[17u8]), vec![18u8]);
-        unserialized.inputs[0].ripemd_preimages = ripemd160_preimages;
+        unserialized.inputs[0].ripemd160_preimages = ripemd160_preimages;
 
         // Now the roundtrip should fail as the preimage is incorrect.
         let rtt : Result<PartiallySignedTransaction, _> = hex_psbt!(&serialize_hex(&unserialized));


### PR DESCRIPTION
Nit, but since we have 100% of other key names matching the BIP names, and this one does not, I think it is nice to have.

This is API breaking change, but still not hard to adopt by downstream dependencies.

PS Based on #512 since otherwise fails to build due to a bug in the master