### PR TITLE
Re-export all types inside the network module

### DIFF
--- a/fuzz/fuzz_targets/deserialize_script.rs
+++ b/fuzz/fuzz_targets/deserialize_script.rs
@@ -1,7 +1,7 @@
 extern crate bitcoin;
 
 use bitcoin::util::address::Address;
-use bitcoin::network::constants::Network;
+use bitcoin::network::Network;
 use bitcoin::blockdata::script;
 use bitcoin::consensus::encode;
 

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -29,7 +29,7 @@ use hashes::{Hash, HashEngine};
 use hash_types::{Wtxid, BlockHash, TxMerkleNode, WitnessMerkleNode, WitnessCommitment};
 use util::uint::Uint256;
 use consensus::encode::Encodable;
-use network::constants::Network;
+use network::Network;
 use blockdata::transaction::Transaction;
 use blockdata::constants::{max_target, WITNESS_SCALE_FACTOR};
 use blockdata::script;

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -27,7 +27,7 @@ use blockdata::opcodes;
 use blockdata::script;
 use blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn};
 use blockdata::block::{Block, BlockHeader};
-use network::constants::Network;
+use network::Network;
 use util::uint::Uint256;
 
 /// The maximum allowable sequence number
@@ -162,7 +162,7 @@ mod test {
     use std::default::Default;
     use hashes::hex::FromHex;
 
-    use network::constants::Network;
+    use network::Network;
     use consensus::encode::serialize;
     use blockdata::constants::{genesis_block, bitcoin_genesis_tx};
     use blockdata::constants::{MAX_SEQUENCE, COIN_VALUE};

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -75,7 +75,7 @@ impl OutPoint {
     ///
     /// ```rust
     /// use bitcoin::blockdata::constants::genesis_block;
-    /// use bitcoin::network::constants::Network;
+    /// use bitcoin::network::Network;
     ///
     /// let block = genesis_block(Network::Bitcoin);
     /// let tx = &block.txdata[0];
@@ -749,7 +749,7 @@ mod tests {
 
     #[test]
     fn test_is_coinbase () {
-        use network::constants::Network;
+        use network::Network;
         use blockdata::constants;
 
         let genesis = constants::genesis_block(Network::Bitcoin);

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -41,8 +41,7 @@ use util::endian;
 use util::psbt;
 
 use blockdata::transaction::{TxOut, Transaction, TxIn};
-use network::message_blockdata::Inventory;
-use network::address::{Address, AddrV2Message};
+use network::{Address, AddrV2Message, Inventory};
 
 /// Encoding error
 #[derive(Debug)]
@@ -742,8 +741,7 @@ mod tests {
     use consensus::{Encodable, deserialize_partial, Decodable};
     use util::endian::{u64_to_array_le, u32_to_array_le, u16_to_array_le};
     use secp256k1::rand::{thread_rng, Rng};
-    use network::message_blockdata::Inventory;
-    use network::Address;
+    use network::{Address, Inventory};
 
     #[test]
     fn serialize_int_test() {

--- a/src/consensus/params.rs
+++ b/src/consensus/params.rs
@@ -17,7 +17,7 @@
 //! This module provides predefined set of parameters for different chains.
 //!
 
-use network::constants::Network;
+use network::Network;
 use util::uint::Uint256;
 
 /// Lowest possible difficulty for Mainnet. See comment on Params::pow_limit for more info.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub use blockdata::transaction::TxOut;
 pub use blockdata::transaction::OutPoint;
 pub use blockdata::transaction::SigHashType;
 pub use consensus::encode::VarInt;
-pub use network::constants::Network;
+pub use network::Network;
 pub use util::Error;
 pub use util::address::Address;
 pub use util::address::AddressType;

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -22,7 +22,7 @@ use std::io;
 use std::fmt;
 use std::net::{SocketAddr, Ipv6Addr, SocketAddrV4, SocketAddrV6, Ipv4Addr};
 
-use network::constants::ServiceFlags;
+use network::ServiceFlags;
 use consensus::encode::{self, Decodable, Encodable, VarInt, ReadExt, WriteExt};
 
 /// A message which can be sent on the Bitcoin network
@@ -268,7 +268,7 @@ impl Decodable for AddrV2Message {
 mod test {
     use std::str::FromStr;
     use super::{AddrV2Message, AddrV2, Address};
-    use network::constants::ServiceFlags;
+    use network::ServiceFlags;
     use std::net::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr};
     use hashes::hex::FromHex;
 

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -28,7 +28,7 @@
 //! # Example: encoding a network's magic bytes
 //!
 //! ```rust
-//! use bitcoin::network::constants::Network;
+//! use bitcoin::Network;
 //! use bitcoin::consensus::encode::serialize;
 //!
 //! let network = Network::Bitcoin;
@@ -79,7 +79,7 @@ impl Network {
     /// # Examples
     ///
     /// ```rust
-    /// use bitcoin::network::constants::Network;
+    /// use bitcoin::network::Network;
     ///
     /// assert_eq!(Some(Network::Bitcoin), Network::from_magic(0xD9B4BEF9));
     /// assert_eq!(None, Network::from_magic(0xFFFFFFFF));
@@ -101,7 +101,7 @@ impl Network {
     /// # Examples
     ///
     /// ```rust
-    /// use bitcoin::network::constants::Network;
+    /// use bitcoin::network::Network;
     ///
     /// let network = Network::Bitcoin;
     /// assert_eq!(network.magic(), 0xD9B4BEF9);

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -353,7 +353,7 @@ mod test {
     use std::io;
     use std::net::Ipv4Addr;
     use super::{RawNetworkMessage, NetworkMessage, CommandString};
-    use network::constants::ServiceFlags;
+    use network::ServiceFlags;
     use consensus::encode::{Encodable, deserialize, deserialize_partial, serialize};
     use hashes::hex::FromHex;
     use hashes::sha256d::Hash;

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -22,7 +22,7 @@ use std::io;
 
 use hashes::sha256d;
 
-use network::constants;
+use network::PROTOCOL_VERSION;
 use consensus::encode::{self, Decodable, Encodable};
 use hash_types::{BlockHash, Txid, Wtxid};
 
@@ -114,7 +114,7 @@ impl GetBlocksMessage {
     /// Construct a new `getblocks` message
     pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetBlocksMessage {
         GetBlocksMessage {
-            version: constants::PROTOCOL_VERSION,
+            version: PROTOCOL_VERSION,
             locator_hashes: locator_hashes,
             stop_hash: stop_hash
         }
@@ -127,7 +127,7 @@ impl GetHeadersMessage {
     /// Construct a new `getheaders` message
     pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetHeadersMessage {
         GetHeadersMessage {
-            version: constants::PROTOCOL_VERSION,
+            version: PROTOCOL_VERSION,
             locator_hashes: locator_hashes,
             stop_hash: stop_hash
         }

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -21,11 +21,9 @@
 use std::io;
 use std::borrow::Cow;
 
-use network::address::Address;
-use network::constants::{self, ServiceFlags};
+use network::{Address, CommandString, PROTOCOL_VERSION, ServiceFlags};
 use consensus::{Encodable, Decodable, ReadExt};
 use consensus::encode;
-use network::message::CommandString;
 use hashes::sha256d;
 
 /// Some simple messages
@@ -67,7 +65,7 @@ impl VersionMessage {
         start_height: i32,
     ) -> VersionMessage {
         VersionMessage {
-            version: constants::PROTOCOL_VERSION,
+            version: PROTOCOL_VERSION,
             services: services,
             timestamp: timestamp,
             receiver: receiver,
@@ -148,7 +146,7 @@ mod tests {
     use super::VersionMessage;
 
     use hashes::hex::FromHex;
-    use network::constants::ServiceFlags;
+    use network::ServiceFlags;
 
     use consensus::encode::{deserialize, serialize};
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -22,15 +22,24 @@ use std::fmt;
 use std::io;
 use std::error;
 
-pub mod constants;
+mod address;
+mod constants;
+mod message;
+mod message_blockdata;
+mod message_network;
+mod message_filter;
+mod stream_reader;
 
-pub mod address;
-pub use self::address::Address;
-pub mod message;
-pub mod message_blockdata;
-pub mod message_network;
-pub mod message_filter;
-pub mod stream_reader;
+// Re-export all network types.
+pub use self::address::{Address, AddrV2, AddrV2Message};
+pub use self::constants::{Network, PROTOCOL_VERSION, ServiceFlags};
+pub use self::message::{CommandString, NetworkMessage, RawNetworkMessage};
+pub use self::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};
+pub use self::message_network::{Reject, RejectReason, VersionMessage};
+pub use self::message_filter::{
+    CFCheckpt, CFHeaders, CFilter, GetCFCheckpt, GetCFHeaders, GetCFilters,
+};
+pub use self::stream_reader::StreamReader;
 
 /// Network error
 #[derive(Debug)]
@@ -61,7 +70,6 @@ impl From<io::Error> for Error {
 }
 
 impl error::Error for Error {
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -86,7 +86,7 @@ mod test {
     use std::io::{self, BufReader, Write};
     use std::net::{TcpListener, TcpStream, Shutdown};
     use std::thread::JoinHandle;
-    use network::constants::ServiceFlags;
+    use network::ServiceFlags;
 
     use super::StreamReader;
     use network::message::{NetworkMessage, RawNetworkMessage};

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -19,7 +19,7 @@
 //!
 //! ```rust
 //!
-//! use bitcoin::network::constants::Network;
+//! use bitcoin::network::Network;
 //! use bitcoin::util::address::Address;
 //! use bitcoin::util::key;
 //! use bitcoin::secp256k1::Secp256k1;
@@ -44,7 +44,7 @@ use bech32;
 use hashes::Hash;
 use hash_types::{PubkeyHash, WPubkeyHash, ScriptHash, WScriptHash};
 use blockdata::script;
-use network::constants::Network;
+use network::Network;
 use util::base58;
 use util::key;
 
@@ -499,7 +499,7 @@ mod tests {
     use hashes::hex::{FromHex, ToHex};
 
     use blockdata::script::Script;
-    use network::constants::Network::{Bitcoin, Testnet};
+    use network::Network::{Bitcoin, Testnet};
     use util::key::PublicKey;
 
     use super::*;

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -272,7 +272,7 @@ mod tests {
     use blockdata::script::Script;
     use blockdata::transaction::Transaction;
     use consensus::encode::deserialize;
-    use network::constants::Network;
+    use network::Network;
     use util::address::Address;
     use util::key::PublicKey;
     use hashes::hex::FromHex;

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -25,7 +25,7 @@ use hash_types::XpubIdentifier;
 use hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine};
 use secp256k1::{self, Secp256k1};
 
-use network::constants::Network;
+use network::Network;
 use util::{base58, endian};
 use util::key::{self, PublicKey, PrivateKey};
 
@@ -747,7 +747,7 @@ mod tests {
     use secp256k1::{self, Secp256k1};
     use hashes::hex::FromHex;
 
-    use network::constants::Network::{self, Bitcoin};
+    use network::Network::{self, Bitcoin};
 
     #[test]
     fn test_parse_derivation_path() {

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -29,7 +29,7 @@ use blockdata::{opcodes, script};
 use std::{error, fmt};
 
 use hash_types::ScriptHash;
-use network::constants::Network;
+use network::Network;
 use util::address;
 
 /// Encoding of "pubkey here" in script; from Bitcoin Core `src/script/script.h`
@@ -281,7 +281,7 @@ mod tests {
     use std::str::FromStr;
 
     use blockdata::script::Script;
-    use network::constants::Network;
+    use network::Network;
 
     use super::*;
     use PublicKey;

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -21,7 +21,7 @@ use std::{io, ops, error};
 use std::str::FromStr;
 
 use secp256k1::{self, Secp256k1};
-use network::constants::Network;
+use network::Network;
 use hashes::{Hash, hash160};
 use hash_types::{PubkeyHash, WPubkeyHash};
 use util::base58;
@@ -380,8 +380,7 @@ mod tests {
     use secp256k1::Secp256k1;
     use std::str::FromStr;
     use hashes::hex::ToHex;
-    use network::constants::Network::Testnet;
-    use network::constants::Network::Bitcoin;
+    use network::Network::{Bitcoin, Testnet};
     use util::address::Address;
 
     #[test]

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -173,7 +173,7 @@ mod tests {
 
     use blockdata::script::Script;
     use blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint};
-    use network::constants::Network::Bitcoin;
+    use network::Network::Bitcoin;
     use consensus::encode::{deserialize, serialize, serialize_hex};
     use util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource};
     use util::key::PublicKey;


### PR DESCRIPTION
It's really quite confusing which network messages are in which submodules etc. I've been doing some work on [rust-bitcoin-p2p](https://github.com/stevenroose/rust-bitcoin-p2p/) over the weekend and this re-export would really simplify things a lot!