### PR TITLE
Make secp256k1 optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ base64 = [ "base64-compat" ]
 fuzztarget = ["secp256k1/fuzztarget", "bitcoin_hashes/fuzztarget"]
 unstable = []
 rand = ["secp256k1/rand-std"]
-use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]
+use-serde = ["serde", "bitcoin_hashes/serde"]
 secp-endomorphism = ["secp256k1/endomorphism"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
@@ -26,7 +26,7 @@ secp-recovery = ["secp256k1/recovery"]
 base64-compat = { version = "1.0.0", optional = true }
 bech32 = "0.7.2"
 bitcoin_hashes = "0.9.0"
-secp256k1 = { version = "0.19.0", features = [ "recovery" ] }
+secp256k1 = { version = "0.19.0", features = [ "recovery" ], optional = true }
 
 bitcoinconsensus = { version = "0.19.0-1", optional = true }
 serde = { version = "1", optional = true }

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -37,6 +37,7 @@ use hashes::Hash;
 #[cfg(feature="bitcoinconsensus")] use std::convert;
 #[cfg(feature="bitcoinconsensus")] use OutPoint;
 
+#[cfg(feature = "secp256k1")]
 use util::key::PublicKey;
 
 #[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -212,6 +213,7 @@ impl Script {
     pub fn new() -> Script { Script(vec![].into_boxed_slice()) }
 
     /// Generates P2PK-type of scriptPubkey
+    #[cfg(feature = "secp256k1")]
     pub fn new_p2pk(pubkey: &PublicKey) -> Script {
         Builder::new()
             .push_key(pubkey)
@@ -689,6 +691,7 @@ impl Builder {
     }
 
     /// Pushes a public key
+    #[cfg(feature = "secp256k1")]
     pub fn push_key(self, key: &PublicKey) -> Builder {
         if key.compressed {
             self.push_slice(&key.key.serialize()[..])

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -38,7 +38,7 @@ use hashes::{sha256d, Hash};
 use hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};
 
 use util::endian;
-use util::psbt;
+use util::psbt_no_key;
 
 use blockdata::transaction::{TxOut, Transaction, TxIn};
 use network::message_blockdata::Inventory;
@@ -50,7 +50,7 @@ pub enum Error {
     /// And I/O error
     Io(io::Error),
     /// PSBT-related error
-    Psbt(psbt::Error),
+    Psbt(psbt_no_key::Error),
     /// Network magic was not expected
     UnexpectedNetworkMagic {
         /// The expected network magic
@@ -137,8 +137,8 @@ impl From<io::Error> for Error {
 }
 
 #[doc(hidden)]
-impl From<psbt::Error> for Error {
-    fn from(e: psbt::Error) -> Error {
+impl From<psbt_no_key::Error> for Error {
+    fn from(e: psbt_no_key::Error) -> Error {
         Error::Psbt(e)
     }
 }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -96,6 +96,7 @@ macro_rules! impl_array_newtype {
 }
 
 /// Implements debug formatting for a given wrapper type
+#[cfg(feature = "secp256k1")]
 macro_rules! impl_array_newtype_show {
     ($thing:ident) => {
         impl ::std::fmt::Debug for $thing {
@@ -565,6 +566,7 @@ macro_rules! serde_struct_human_string_impl {
 /// - std::fmt::Display
 /// - std::str::FromStr
 /// - hashes::hex::FromHex
+#[cfg(feature = "secp256k1")]
 macro_rules! impl_bytes_newtype {
     ($t:ident, $len:expr) => (
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 
 // Re-exported dependencies.
 #[macro_use] pub extern crate bitcoin_hashes as hashes;
+#[cfg(feature = "secp256k1")]
 pub extern crate secp256k1;
 pub extern crate bech32;
 #[cfg(feature = "base64")] pub extern crate base64;
@@ -82,8 +83,8 @@ pub use util::address::AddressType;
 pub use util::amount::Amount;
 pub use util::amount::Denomination;
 pub use util::amount::SignedAmount;
-pub use util::key::PrivateKey;
-pub use util::key::PublicKey;
+#[cfg(feature = "secp256k1")]
+pub use util::key::{PrivateKey, PublicKey};
 pub use util::merkleblock::MerkleBlock;
 
 #[cfg(all(test, feature = "unstable"))] use tests::EmptyWrite;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -42,10 +42,13 @@ use std::error;
 
 use bech32;
 use hashes::Hash;
-use hash_types::{PubkeyHash, WPubkeyHash, ScriptHash, WScriptHash};
+use hash_types::{PubkeyHash, ScriptHash, WScriptHash};
+#[cfg(feature = "secp256k1")]
+use hash_types::WPubkeyHash;
 use blockdata::script;
 use network::constants::Network;
 use util::base58;
+#[cfg(feature = "secp256k1")]
 use util::key;
 
 /// Address error.
@@ -219,6 +222,7 @@ serde_string_impl!(Address, "a Bitcoin address");
 impl Address {
     /// Creates a pay to (compressed) public key hash address from a public key
     /// This is the preferred non-witness type address
+    #[cfg(feature = "secp256k1")]
     #[inline]
     pub fn p2pkh(pk: &key::PublicKey, network: Network) -> Address {
         let mut hash_engine = PubkeyHash::engine();
@@ -244,6 +248,7 @@ impl Address {
     /// This is the native segwit address type for an output redeemable with a single signature
     ///
     /// Will only return an Error when an uncompressed public key is provided.
+    #[cfg(feature = "secp256k1")]
     pub fn p2wpkh(pk: &key::PublicKey, network: Network) -> Result<Address, Error> {
         if !pk.compressed {
             return Err(Error::UncompressedPubkey);
@@ -265,6 +270,7 @@ impl Address {
     /// This is a segwit address type that looks familiar (as p2sh) to legacy clients
     ///
     /// Will only return an Error when an uncompressed public key is provided.
+    #[cfg(feature = "secp256k1")]
     pub fn p2shwpkh(pk: &key::PublicKey, network: Network) -> Result<Address, Error> {
         if !pk.compressed {
             return Err(Error::UncompressedPubkey);

--- a/src/util/endian.rs
+++ b/src/util/endian.rs
@@ -24,6 +24,7 @@ macro_rules! define_slice_to_le {
         }
     }
 }
+#[cfg(feature = "secp256k1")]
 macro_rules! define_be_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
@@ -51,8 +52,10 @@ macro_rules! define_le_to_array {
     }
 }
 
+#[cfg(feature = "secp256k1")]
 define_slice_to_be!(slice_to_u32_be, u32);
 define_slice_to_be!(slice_to_u64_be, u64);
+#[cfg(feature = "secp256k1")]
 define_be_to_array!(u32_to_array_be, u32, 4);
 define_slice_to_le!(slice_to_u16_le, u16);
 define_slice_to_le!(slice_to_u32_le, u32);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,21 +16,27 @@
 //!
 //! Functions needed by all parts of the Bitcoin library
 
+#[cfg(feature = "secp256k1")]
 pub mod key;
 pub mod address;
 pub mod amount;
 pub mod base58;
+#[cfg(feature = "secp256k1")]
 pub mod bip32;
 pub mod bip143;
+#[cfg(feature = "secp256k1")]
 pub mod contracthash;
 pub mod hash;
 pub mod merkleblock;
 pub mod misc;
+#[cfg(feature = "secp256k1")]
 pub mod psbt;
 pub mod uint;
 pub mod bip158;
 
 pub(crate) mod endian;
+// A trick to make cutting-out secp256k1 easy
+pub(crate) mod psbt_no_key;
 
 use std::{error, fmt};
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -24,10 +24,10 @@ use consensus::{encode, Encodable, Decodable};
 
 use std::io;
 
-mod error;
+use super::psbt_no_key::error;
 pub use self::error::Error;
 
-pub mod raw;
+pub use super::psbt_no_key::raw;
 
 #[macro_use]
 mod macros;

--- a/src/util/psbt_no_key/error.rs
+++ b/src/util/psbt_no_key/error.rs
@@ -16,7 +16,7 @@ use std::error;
 use std::fmt;
 
 use blockdata::transaction::Transaction;
-use util::psbt::raw;
+use util::psbt_no_key::raw;
 
 use hashes;
 

--- a/src/util/psbt_no_key/mod.rs
+++ b/src/util/psbt_no_key/mod.rs
@@ -1,0 +1,32 @@
+// Rust Bitcoin Library
+// Written by
+//   The Rust Bitcoin developers
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # A trick that makes cutting-out `secp256k1` easy.
+//!
+//! One issue with cutting out secp256k1 is that we can't just blindly `#[cfg]`
+//! all items that depend on it. Such would include removing enum variants and
+//! that would be a huge footgun. Suppose a dependent library of rust-bitcoin
+//! would not require secp256k1 and exhaustively match on an enum returned from
+//! a function. If another crate depended on `rust-bitcoin` **with**
+//! `secp256k1 ` got included in a same project, it would cause breakage.
+//!
+//! A sane approach is to keep the enum variants and just don't construct them.
+//! This works but we want to avoid a sea of `#[cfg]` attributes. So the easiest
+//! way to do that is to have a separate module not requiring `secp256k1` and
+//! `pub use` its submodules in backwards-compatible way.
+
+pub mod raw;
+pub(crate) mod error;
+
+pub(crate) use self::error::Error;

--- a/src/util/psbt_no_key/raw.rs
+++ b/src/util/psbt_no_key/raw.rs
@@ -21,7 +21,7 @@ use std::{fmt, io};
 
 use consensus::encode::{self, Decodable, Encodable, VarInt, MAX_VEC_SIZE};
 use hashes::hex::ToHex;
-use util::psbt::Error;
+use util::psbt_no_key::error::Error;
 
 /// A PSBT key in its raw byte form.
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]


### PR DESCRIPTION
This change makes `secp256k1` an optional dependency so that
applications requiring chain parsing but not doing any validation nor
signing do not have to compile `secp256k1`. This is a breaking change
because dependencies of this crate must fix their feature settings but
apart from that they don't need to do anything.

There are two things which may be surprising: moving of some modules and
removing `secp256k1/serde` from `use-serde`. The former one is explained
in the doc of `src/util/psbt_no_key/mod.rs`. The latter is due to
inability to avoid compiling `secp256k1` when not needed. (`electrs` hit
this)

Closes #526 