### PR TITLE
Flush unrecognized network messages from the read buffer

### DIFF
--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -80,10 +80,12 @@ pub enum Error {
     ParseFailed(&'static str),
     /// Unsupported Segwit flag
     UnsupportedSegwitFlag(u8),
-    /// Unrecognized network command
-    UnrecognizedNetworkCommand(String),
+    /// Unrecognized network command with its length
+    UnrecognizedNetworkCommand(String, usize),
     /// Invalid Inventory type
     UnknownInventoryType(u32),
+    /// The network command is longer than the maximum allowed (12 chars)
+    NetworkCommandTooLong(String),
 }
 
 impl fmt::Display for Error {
@@ -102,9 +104,10 @@ impl fmt::Display for Error {
             Error::ParseFailed(ref e) => write!(f, "parse failed: {}", e),
             Error::UnsupportedSegwitFlag(ref swflag) => write!(f,
                 "unsupported segwit version: {}", swflag),
-            Error::UnrecognizedNetworkCommand(ref nwcmd) => write!(f,
+            Error::UnrecognizedNetworkCommand(ref nwcmd, _) => write!(f,
                 "unrecognized network command: {}", nwcmd),
             Error::UnknownInventoryType(ref tp) => write!(f, "Unknown Inventory type: {}", tp),
+            Error::NetworkCommandTooLong(ref cmd) => write!(f, "Network Command too long: {}", cmd),
         }
     }
 }
@@ -122,7 +125,8 @@ impl error::Error for Error {
             | Error::ParseFailed(..)
             | Error::UnsupportedSegwitFlag(..)
             | Error::UnrecognizedNetworkCommand(..)
-            | Error::UnknownInventoryType(..) => None,
+            | Error::UnknownInventoryType(..)
+            | Error::NetworkCommandTooLong(..) => None,
         }
     }
 }

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -68,6 +68,10 @@ impl<R: Read> StreamReader<R> {
                         return Err(encode::Error::Io(io::Error::from(io::ErrorKind::UnexpectedEof)));
                     }
                 },
+                Err(encode::Error::UnrecognizedNetworkCommand(message, len)) => {
+                    self.unparsed.drain(..len);
+                    return Err(encode::Error::UnrecognizedNetworkCommand(message, len))
+                },
                 Err(err) => return Err(err),
                 // We have successfully read from the buffer
                 Ok((message, index)) => {


### PR DESCRIPTION
Currently whenever an unrecognized network message is received, it is never flushed from the read buffer, meaning that unless the stream is closed and recreated it will keep returning the same error every time `read_next()` is called.

This commit adds the length of the message to `UnrecognizedNetworkCommand`, so that the `StreamReader` can flush those bytes before returning the error to the caller.

@RCasatta and I encountered this issue while connecting to a Bitcoin Core 0.21-rc2 node using the latest release of `rust-bitcoin`. The specific error we were getting about `sendaddrv2` being unrecognized should already be fixed here in `master`, but still this is probably an issue worth fixing for messages that could be added in the future to the P2P protocol.