### PR TITLE
Fix service flags warning

### DIFF
--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -312,9 +312,10 @@ mod test {
 
     #[test]
     fn debug_format_test() {
+        let mut flags = ServiceFlags::NETWORK;
         assert_eq!(
             format!("The address is: {:?}", Address {
-                services: ServiceFlags::NETWORK.add(ServiceFlags::WITNESS),
+                services: flags.add(ServiceFlags::WITNESS),
                 address: [0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001],
                 port: 8333
             }), 


### PR DESCRIPTION
Building the latest master gives the following warning. 
```
warning: taking a mutable reference to a `const` item
   --> src/network/address.rs:317:27
    |
317 |                 services: ServiceFlags::NETWORK.add(ServiceFlags::WITNESS),
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(const_item_mutation)]` on by default
    = note: each usage of a `const` item creates a new temporary
    = note: the mutable reference will refer to this temporary, not the original `const` item
note: mutable reference created due to call to this method
   --> src/network/constants.rs:161:5
    |
161 |     pub fn add(&mut self, other: ServiceFlags) -> ServiceFlags {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: `const` item defined here
   --> src/network/constants.rs:131:5
    |
131 |     pub const NETWORK: ServiceFlags = ServiceFlags(1 << 0);

```

