### PR TITLE
refactor(blockdata/transaction): use nested paths

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -34,7 +34,7 @@ use blockdata::constants::WITNESS_SCALE_FACTOR;
 #[cfg(feature="bitcoinconsensus")] use blockdata::script;
 use blockdata::script::Script;
 use consensus::{encode, Decodable, Encodable};
-use hash_types::*;
+use hash_types::{SigHash, Txid, Wtxid};
 use VarInt;
 
 /// A reference to a transaction output


### PR DESCRIPTION
Instead of using a wildcard path for the `hash_types` module,
be explicit about what types we're using by using nested paths.

There are many benefits to this, including not polluting the namespace
and clearly demarcating the types' location.