### PR TITLE
Non-API breaking derives for error & transaction types

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -173,7 +173,7 @@ impl ::std::str::FromStr for OutPoint {
 }
 
 /// A transaction input, which defines old coins to be consumed
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxIn {
     /// The reference to the previous output that is being used an an input
@@ -206,7 +206,7 @@ impl Default for TxIn {
 }
 
 /// A transaction output, which defines new coins to be created from old ones.
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxOut {
     /// The value of the output, in satoshis
@@ -252,7 +252,7 @@ impl Default for TxOut {
 ///
 /// We therefore deviate from the spec by always using the Segwit witness encoding
 /// for 0-input transactions, which results in unambiguously parseable transactions.
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Transaction {
     /// The protocol version, is currently expected to be 1 or 2 (BIP 68).

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -119,8 +119,6 @@ impl error::Error for Error {
 }
 
 #[doc(hidden)]
-
-#[doc(hidden)]
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {
         Error::Io(error)

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -21,7 +21,7 @@ use hashes::{sha256d, Hash};
 use util::endian;
 
 /// An error that might occur during base58 decoding
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum Error {
     /// Invalid character encountered
     BadByte(u8),


### PR DESCRIPTION
This implements first part of #555 recommendations for Error types within rust-bitcoin. This PR is (a) non-API breaking & (b) can be applied before similar PRs in other repos. It will be followed by more PRs that are (1) depend on error type derives from downstream repos & (2) will be API-breaking

PS: depends on https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/22 merge & new version release