### PR TITLE
Fix/error derives 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 
 [dependencies]
-bech32 = "0.7.2"
+bech32 = "0.7.3"
 bitcoin_hashes = "0.9.6"
-secp256k1 = "0.20.0"
+secp256k1 = "0.20.2"
 
 base64-compat = { version = "1.0.0", optional = true }
-bitcoinconsensus = { version = "0.19.0-1", optional = true }
+bitcoinconsensus = { version = "0.19.0-3", optional = true }
 serde = { version = "1", features = [ "derive" ], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [features]
 default = [ "secp-recovery" ]
 base64 = [ "base64-compat" ]
-fuzztarget = ["bitcoin_hashes/fuzztarget"]
+fuzztarget = []
 unstable = []
 rand = ["secp256k1/rand-std"]
 use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]
@@ -23,7 +23,7 @@ secp-recovery = ["secp256k1/recovery"]
 
 [dependencies]
 bech32 = "0.7.2"
-bitcoin_hashes = "0.9.1"
+bitcoin_hashes = "0.9.6"
 secp256k1 = "0.20.0"
 
 base64-compat = { version = "1.0.0", optional = true }

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -105,7 +105,7 @@ display_from_debug!(Builder);
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
 /// would help you.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub enum Error {
     /// Something did a non-minimal push; for more information see
     /// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ pub use util::ecdsa::PublicKey;
 
 #[cfg(all(test, feature = "unstable"))]
 mod tests {
-    use hashes::core::fmt::Arguments;
     use std::io::{IoSlice, Result, Write};
+    use std::fmt::Arguments;
 
     #[derive(Default, Clone, Debug, PartialEq, Eq)]
     pub struct EmptyWrite;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -49,7 +49,7 @@ use util::base58;
 use util::ecdsa;
 
 /// Address error.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum Error {
     /// Base58 encoding error
     Base58(base58::Error),

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -423,16 +423,16 @@ impl fmt::Debug for DerivationPath {
 pub type KeySource = (Fingerprint, DerivationPath);
 
 /// A BIP32 error
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// A pk->pk derivation was attempted on a hardened key
     CannotDeriveFromHardenedKey,
     /// A secp256k1 error occurred
-    Ecdsa(secp256k1::Error),
+    Ecdsa(secp256k1::Error), // TODO: This is not necessary ECDSA error and should be renamed
     /// A child number was provided that was out of range
     InvalidChildNumber(u32),
     /// Error creating a master seed --- for application use
-    RngError(String),
+    RngError(String), // TODO: This option seems unused and should be removed, opening a way to make this type copiable
     /// Invalid childnumber format.
     InvalidChildNumberFormat,
     /// Invalid derivation path format.

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -36,7 +36,7 @@ use util::address;
 static PUBKEY: u8 = 0xFE;
 
 /// A contract-hash error
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub enum Error {
     /// Other secp256k1 related error
     Secp(secp256k1::Error),

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -26,7 +26,7 @@ use secp256k1;
 use util::base58;
 
 /// A key-related error.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// Base58 encoding error
     Base58(base58::Error),

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -21,7 +21,7 @@ use util::psbt::raw;
 
 use hashes;
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 /// Enum for marking psbt hash error
 pub enum PsbtHash {
     Ripemd,
@@ -30,7 +30,7 @@ pub enum PsbtHash {
     Hash256,
 }
 /// Ways that a Partially Signed Transaction might fail.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// Magic bytes for a PSBT must be the ASCII for "psbt" serialized in most
     /// significant byte order.


### PR DESCRIPTION
This continues (and is based on the work from) #558 and is a part of #555 epic for Error types within rust-bitcoin. This PR is also non-API breaking, but unline #558 depends on PRs in upstream repos:
- [x] https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/22 (this one is merged, but no new version is published yet, so this is a blocker here)
- [x] https://github.com/rust-bitcoin/rust-secp256k1/pull/277
- [x] https://github.com/rust-bitcoin/bitcoin_hashes/pull/110

Once they got merged & a new versions of the crates will be published, CI will not be failing anymore here and PR will be ready for reviews