### PR TITLE
Migration from io::Error to io::ErrrorKind

### DIFF
--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -47,7 +47,7 @@ use network::message_blockdata::Inventory;
 use network::address::{Address, AddrV2Message};
 
 /// Encoding error
-#[derive(Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// And I/O error
     Io(io::ErrorKind),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -33,7 +33,7 @@ pub mod message_filter;
 pub mod stream_reader;
 
 /// Network error
-#[derive(Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// And I/O error
     Io(io::ErrorKind),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -36,7 +36,7 @@ pub mod stream_reader;
 #[derive(Debug)]
 pub enum Error {
     /// And I/O error
-    Io(io::Error),
+    Io(io::ErrorKind),
     /// Socket mutex was poisoned
     SocketMutexPoisoned,
     /// Not connected to peer
@@ -46,26 +46,18 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Io(ref e) => fmt::Display::fmt(e, f),
+            Error::Io(ref e) => fmt::Display::fmt(&io::Error::from(*e), f),
             Error::SocketMutexPoisoned => f.write_str("socket mutex was poisoned"),
             Error::SocketNotConnectedToPeer => f.write_str("not connected to peer"),
         }
     }
 }
 
+impl error::Error for Error {}
+
 #[doc(hidden)]
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        Error::Io(err)
-    }
-}
-
-impl error::Error for Error {
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Io(ref e) => Some(e),
-            Error::SocketMutexPoisoned | Error::SocketNotConnectedToPeer => None,
-        }
+        Error::Io(err.kind())
     }
 }

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -59,13 +59,13 @@ impl<R: Read> StreamReader<R> {
         loop {
             match encode::deserialize_partial::<D>(&self.unparsed) {
                 // In this case we just have an incomplete data, so we need to read more
-                Err(encode::Error::Io(ref err)) if err.kind () == io::ErrorKind::UnexpectedEof => {
+                Err(encode::Error::Io(ref err)) if *err == io::ErrorKind::UnexpectedEof => {
                     let count = self.stream.read(&mut self.data)?;
                     if count > 0 {
                         self.unparsed.extend(self.data[0..count].iter());
                     }
                     else {
-                        return Err(encode::Error::Io(io::Error::from(io::ErrorKind::UnexpectedEof)));
+                        return Err(encode::Error::Io(io::ErrorKind::UnexpectedEof));
                     }
                 },
                 Err(err) => return Err(err),

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -70,7 +70,7 @@ pub enum Error {
     /// missing UTXO, can not calculate script filter
     UtxoMissing(OutPoint),
     /// some IO error reading or writing binary serialization of the filter
-    Io(io::Error),
+    Io(io::ErrorKind),
 }
 
 impl ::std::error::Error for Error {}
@@ -79,14 +79,14 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         match *self {
             Error::UtxoMissing(ref coin) => write!(f, "unresolved UTXO {}", coin),
-            Error::Io(ref io) => write!(f, "{}", io)
+            Error::Io(ref kind) => write!(f, "{}", io::Error::from(*kind))
         }
     }
 }
 
 impl From<io::Error> for Error {
     fn from(io: io::Error) -> Self {
-        Error::Io(io)
+        Error::Io(io.kind())
     }
 }
 

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -65,7 +65,7 @@ const P: u8 = 19;
 const M: u64 = 784931;
 
 /// Errors for blockfilter
-#[derive(Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// missing UTXO, can not calculate script filter
     UtxoMissing(OutPoint),

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -427,7 +427,7 @@ pub enum Error {
     /// A pk->pk derivation was attempted on a hardened key
     CannotDeriveFromHardenedKey,
     /// A secp256k1 error occurred
-    Ecdsa(secp256k1::Error), // TODO: This is not necessary ECDSA error and should be renamed
+    Secp256k1(secp256k1::Error),
     /// A child number was provided that was out of range
     InvalidChildNumber(u32),
     /// Invalid childnumber format.
@@ -446,7 +446,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::CannotDeriveFromHardenedKey => f.write_str("cannot derive hardened key from public key"),
-            Error::Ecdsa(ref e) => fmt::Display::fmt(e, f),
+            Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
             Error::InvalidChildNumber(ref n) => write!(f, "child number {} is invalid (not within [0, 2^31 - 1])", n),
             Error::InvalidChildNumberFormat => f.write_str("invalid child number format"),
             Error::InvalidDerivationPathFormat => f.write_str("invalid derivation path format"),
@@ -459,7 +459,7 @@ impl fmt::Display for Error {
 
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
-       if let Error::Ecdsa(ref e) = *self {
+       if let Error::Secp256k1(ref e) = *self {
            Some(e)
        } else {
            None
@@ -471,13 +471,13 @@ impl From<key::Error> for Error {
     fn from(err: key::Error) -> Self {
         match err {
             key::Error::Base58(e) => Error::Base58(e),
-            key::Error::Secp256k1(e) => Error::Ecdsa(e),
+            key::Error::Secp256k1(e) => Error::Secp256k1(e),
         }
     }
 }
 
 impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error { Error::Ecdsa(e) }
+    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
 }
 
 impl From<base58::Error> for Error {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -64,7 +64,7 @@ pub trait BitArray {
 
 /// A general error code, other errors should implement conversions to/from this
 /// if appropriate.
-#[derive(Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Error {
     /// Encoding error
     Encode(encode::Error),

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -20,6 +20,7 @@ use consensus::encode;
 use util::psbt::raw;
 
 use hashes;
+use util::bip32::ExtendedPubKey;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 /// Enum for marking psbt hash error
@@ -72,8 +73,9 @@ pub enum Error {
         /// Hash value
         hash: Box<[u8]>,
     },
-    /// Data inconsistency/conflicting data during merge procedure
-    MergeConflict(String),
+    /// Conflicting data during merge procedure:
+    /// global extended public key has inconsistent key sources
+    MergeInconsistentKeySources(ExtendedPubKey),
     /// Serialization error in bitcoin consensus-encoded structures
     ConsensusEncoding,
 }
@@ -99,7 +101,7 @@ impl fmt::Display for Error {
                 // directly using debug forms of psbthash enums
                 write!(f, "Preimage {:?} does not match {:?} hash {:?}", preimage, hash_type, hash )
             }
-            Error::MergeConflict(ref s) => { write!(f, "Merge conflict: {}", s) }
+            Error::MergeInconsistentKeySources(ref s) => { write!(f, "merge conflict: {}", s) }
             Error::ConsensusEncoding => f.write_str("bitcoin consensus or BIP-174 encoding error"),
         }
     }

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -213,9 +213,7 @@ impl Map for Global {
                         entry.insert((fingerprint1, derivation1));
                         continue
                     }
-                    return Err(psbt::Error::MergeConflict(format!(
-                        "global xpub {} has inconsistent key sources", xpub
-                    ).to_owned()));
+                    return Err(psbt::Error::MergeInconsistentKeySources(xpub));
                 }
             }
         }


### PR DESCRIPTION
This completes Error derives work from #558 and #559 with API-breaking changes, including
- Move from `io::Error` to `io::ErrorKind` type, which is `Copy`, `Eq`, `Ord` & `Hash` and is easier to handle. The cost of this is the need to get rid of deprecated `Error::cause` implementations, which I think is also beneficial (and at least one of Error types hadn't it anyway)
- Renaming some of error variants, removing unused ones & improving inner type representation