### PR TITLE
Taproot PublicKey refactoring

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -37,7 +37,7 @@ use hashes::{Hash, hex};
 #[cfg(feature="bitcoinconsensus")] use std::convert;
 #[cfg(feature="bitcoinconsensus")] use OutPoint;
 
-use util::key::PublicKey;
+use util::key::EcdsaPublicKey;
 
 #[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
 /// A Bitcoin script
@@ -228,7 +228,7 @@ impl Script {
     pub fn new() -> Script { Script(vec![].into_boxed_slice()) }
 
     /// Generates P2PK-type of scriptPubkey
-    pub fn new_p2pk(pubkey: &PublicKey) -> Script {
+    pub fn new_p2pk(pubkey: &EcdsaPublicKey) -> Script {
         Builder::new()
             .push_key(pubkey)
             .push_opcode(opcodes::all::OP_CHECKSIG)
@@ -705,7 +705,7 @@ impl Builder {
     }
 
     /// Pushes a public key
-    pub fn push_key(self, key: &PublicKey) -> Builder {
+    pub fn push_key(self, key: &EcdsaPublicKey) -> Builder {
         if key.compressed {
             self.push_slice(&key.key.serialize()[..])
         } else {
@@ -853,7 +853,7 @@ mod test {
     use hashes::hex::{FromHex, ToHex};
     use consensus::encode::{deserialize, serialize};
     use blockdata::opcodes;
-    use util::key::PublicKey;
+    use util::key::EcdsaPublicKey;
     use util::psbt::serialize::Serialize;
 
     #[test]
@@ -881,10 +881,10 @@ mod test {
 
         // keys
         let keystr = "21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";
-        let key = PublicKey::from_str(&keystr[2..]).unwrap();
+        let key = EcdsaPublicKey::from_str(&keystr[2..]).unwrap();
         script = script.push_key(&key); comp.extend(Vec::from_hex(keystr).unwrap().iter().cloned()); assert_eq!(&script[..], &comp[..]);
         let keystr = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
-        let key = PublicKey::from_str(&keystr[2..]).unwrap();
+        let key = EcdsaPublicKey::from_str(&keystr[2..]).unwrap();
         script = script.push_key(&key); comp.extend(Vec::from_hex(keystr).unwrap().iter().cloned()); assert_eq!(&script[..], &comp[..]);
 
         // opcodes
@@ -906,7 +906,7 @@ mod test {
 
     #[test]
     fn script_generators() {
-        let pubkey = PublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e").unwrap();
+        let pubkey = EcdsaPublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e").unwrap();
         assert!(Script::new_p2pk(&pubkey).is_p2pk());
 
         let pubkey_hash = PubkeyHash::hash(&pubkey.serialize());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ pub use util::amount::Amount;
 pub use util::amount::Denomination;
 pub use util::amount::SignedAmount;
 pub use util::key::PrivateKey;
+pub use util::key::Key;
+pub use util::key::PublicKey;
 pub use util::key::EcdsaPublicKey;
 pub use util::merkleblock::MerkleBlock;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub use util::amount::Amount;
 pub use util::amount::Denomination;
 pub use util::amount::SignedAmount;
 pub use util::key::PrivateKey;
-pub use util::key::PublicKey;
+pub use util::key::EcdsaPublicKey;
 pub use util::merkleblock::MerkleBlock;
 
 #[cfg(all(test, feature = "unstable"))] use tests::EmptyWrite;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -27,7 +27,7 @@
 //!
 //! // Generate random key pair
 //! let s = Secp256k1::new();
-//! let public_key = key::PublicKey {
+//! let public_key = key::EcdsaPublicKey {
 //!     compressed: true,
 //!     key: s.generate_keypair(&mut thread_rng()).1,
 //! };
@@ -220,7 +220,7 @@ impl Address {
     /// Creates a pay to (compressed) public key hash address from a public key
     /// This is the preferred non-witness type address
     #[inline]
-    pub fn p2pkh(pk: &key::PublicKey, network: Network) -> Address {
+    pub fn p2pkh(pk: &key::EcdsaPublicKey, network: Network) -> Address {
         let mut hash_engine = PubkeyHash::engine();
         pk.write_into(&mut hash_engine).expect("engines don't error");
 
@@ -244,7 +244,7 @@ impl Address {
     /// This is the native segwit address type for an output redeemable with a single signature
     ///
     /// Will only return an Error when an uncompressed public key is provided.
-    pub fn p2wpkh(pk: &key::PublicKey, network: Network) -> Result<Address, Error> {
+    pub fn p2wpkh(pk: &key::EcdsaPublicKey, network: Network) -> Result<Address, Error> {
         if !pk.compressed {
             return Err(Error::UncompressedPubkey);
         }
@@ -265,7 +265,7 @@ impl Address {
     /// This is a segwit address type that looks familiar (as p2sh) to legacy clients
     ///
     /// Will only return an Error when an uncompressed public key is provided.
-    pub fn p2shwpkh(pk: &key::PublicKey, network: Network) -> Result<Address, Error> {
+    pub fn p2shwpkh(pk: &key::EcdsaPublicKey, network: Network) -> Result<Address, Error> {
         if !pk.compressed {
             return Err(Error::UncompressedPubkey);
         }
@@ -500,12 +500,12 @@ mod tests {
 
     use blockdata::script::Script;
     use network::constants::Network::{Bitcoin, Testnet};
-    use util::key::PublicKey;
+    use util::key::EcdsaPublicKey;
 
     use super::*;
 
     macro_rules! hex (($hex:expr) => (Vec::from_hex($hex).unwrap()));
-    macro_rules! hex_key (($hex:expr) => (PublicKey::from_slice(&hex!($hex)).unwrap()));
+    macro_rules! hex_key (($hex:expr) => (EcdsaPublicKey::from_slice(&hex!($hex)).unwrap()));
     macro_rules! hex_script (($hex:expr) => (Script::from(hex!($hex))));
     macro_rules! hex_pubkeyhash (($hex:expr) => (PubkeyHash::from_hex(&$hex).unwrap()));
     macro_rules! hex_scripthash (($hex:expr) => (ScriptHash::from_hex($hex).unwrap()));

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -46,7 +46,7 @@ use hash_types::{PubkeyHash, WPubkeyHash, ScriptHash, WScriptHash};
 use blockdata::script;
 use network::constants::Network;
 use util::base58;
-use util::key;
+use util::key::{self, Key};
 
 /// Address error.
 #[derive(Debug, PartialEq)]

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -274,7 +274,7 @@ mod tests {
     use consensus::encode::deserialize;
     use network::constants::Network;
     use util::address::Address;
-    use util::key::EcdsaPublicKey;
+    use util::key::{EcdsaPublicKey, Key};
     use hashes::hex::FromHex;
 
     use super::*;

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -274,14 +274,14 @@ mod tests {
     use consensus::encode::deserialize;
     use network::constants::Network;
     use util::address::Address;
-    use util::key::PublicKey;
+    use util::key::EcdsaPublicKey;
     use hashes::hex::FromHex;
 
     use super::*;
 
     fn p2pkh_hex(pk: &str) -> Script {
         let pk = Vec::from_hex(pk).unwrap();
-        let pk = PublicKey::from_slice(pk.as_slice()).unwrap();
+        let pk = EcdsaPublicKey::from_slice(pk.as_slice()).unwrap();
         let witness_script = Address::p2pkh(&pk, Network::Bitcoin).script_pubkey();
         witness_script
     }

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -27,7 +27,7 @@ use secp256k1::{self, Secp256k1};
 
 use network::constants::Network;
 use util::{base58, endian};
-use util::key::{self, EcdsaPublicKey, PrivateKey};
+use util::key::{self, EcdsaPublicKey, PrivateKey, Key};
 
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -472,6 +472,7 @@ impl From<key::Error> for Error {
         match err {
             key::Error::Base58(e) => Error::Base58(e),
             key::Error::Secp256k1(e) => Error::Ecdsa(e),
+            key::Error::InvalidLength(len) => Error::WrongExtendedKeyLength(len),
         }
     }
 }

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -27,7 +27,7 @@ use secp256k1::{self, Secp256k1};
 
 use network::constants::Network;
 use util::{base58, endian};
-use util::key::{self, PublicKey, PrivateKey};
+use util::key::{self, EcdsaPublicKey, PrivateKey};
 
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -75,7 +75,7 @@ pub struct ExtendedPubKey {
     /// Child number of the key used to derive from parent (0 for master)
     pub child_number: ChildNumber,
     /// Public key
-    pub public_key: PublicKey,
+    pub public_key: EcdsaPublicKey,
     /// Chain code
     pub chain_code: ChainCode
 }
@@ -530,7 +530,7 @@ impl ExtendedPrivKey {
         match i {
             ChildNumber::Normal { .. } => {
                 // Non-hardened key: compute public data and use that
-                hmac_engine.input(&PublicKey::from_private_key(secp, &self.private_key).key.serialize()[..]);
+                hmac_engine.input(&EcdsaPublicKey::from_private_key(secp, &self.private_key).key.serialize()[..]);
             }
             ChildNumber::Hardened { .. } => {
                 // Hardened key: use only secret data to prevent public derivation
@@ -625,7 +625,7 @@ impl ExtendedPubKey {
             depth: sk.depth,
             parent_fingerprint: sk.parent_fingerprint,
             child_number: sk.child_number,
-            public_key: PublicKey::from_private_key(secp, &sk.private_key),
+            public_key: EcdsaPublicKey::from_private_key(secp, &sk.private_key),
             chain_code: sk.chain_code
         }
     }
@@ -709,7 +709,7 @@ impl ExtendedPubKey {
             parent_fingerprint: Fingerprint::from(&data[5..9]),
             child_number: endian::slice_to_u32_be(&data[9..13]).into(),
             chain_code: ChainCode::from(&data[13..45]),
-            public_key: PublicKey::from_slice(&data[45..78])?,
+            public_key: EcdsaPublicKey::from_slice(&data[45..78])?,
         })
     }
 

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -23,6 +23,7 @@
 use secp256k1::{self, Secp256k1};
 use PrivateKey;
 use EcdsaPublicKey;
+use Key;
 use hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
 use blockdata::{opcodes, script};
 

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -244,6 +244,7 @@ impl EcdsaPublicKey {
     }
 
     /// Returns bitcoin 160-bit hash of the public key
+    #[inline]
     pub fn pubkey_hash(&self) -> PubkeyHash {
         if self.compressed {
             PubkeyHash::hash(&self.key.serialize())
@@ -253,6 +254,7 @@ impl EcdsaPublicKey {
     }
 
     /// Returns bitcoin 160-bit hash of the public key for witness program
+    #[inline]
     pub fn wpubkey_hash(&self) -> Option<WPubkeyHash> {
         if self.compressed {
             Some(WPubkeyHash::from_inner(
@@ -266,6 +268,7 @@ impl EcdsaPublicKey {
     }
 
     /// Computes the public key as supposed to be used with this secret
+    #[inline]
     pub fn from_private_key<C: secp256k1::Signing>(secp: &Secp256k1<C>, sk: &PrivateKey) -> EcdsaPublicKey {
         sk.public_key(secp)
     }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -35,7 +35,7 @@ mod message_signing {
     use secp256k1;
     use secp256k1::recovery::{RecoveryId, RecoverableSignature};
 
-    use util::key::PublicKey;
+    use util::key::EcdsaPublicKey;
     use util::address::{Address, AddressType};
 
     /// An error used for dealing with Bitcoin Signed Messages.
@@ -133,10 +133,10 @@ mod message_signing {
             &self,
             secp_ctx: &secp256k1::Secp256k1<C>,
             msg_hash: sha256d::Hash
-        ) -> Result<PublicKey, secp256k1::Error> {
+        ) -> Result<EcdsaPublicKey, secp256k1::Error> {
             let msg = secp256k1::Message::from_slice(&msg_hash[..])?;
             let pubkey = secp_ctx.recover(&msg, &self.signature)?;
-            Ok(PublicKey {
+            Ok(EcdsaPublicKey {
                 key: pubkey,
                 compressed: self.compressed,
             })

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -20,7 +20,7 @@ use blockdata::transaction::{SigHashType, Transaction, TxOut};
 use consensus::encode;
 use util::bip32::KeySource;
 use hashes::{self, hash160, ripemd160, sha256, sha256d};
-use util::key::PublicKey;
+use util::key::EcdsaPublicKey;
 use util::psbt;
 use util::psbt::map::Map;
 use util::psbt::raw;
@@ -72,7 +72,7 @@ pub struct Input {
     /// A map from public keys to their corresponding signature as would be
     /// pushed to the stack from a scriptSig or witness.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
-    pub partial_sigs: BTreeMap<PublicKey, Vec<u8>>,
+    pub partial_sigs: BTreeMap<EcdsaPublicKey, Vec<u8>>,
     /// The sighash type to be used for this input. Signatures for this input
     /// must use the sighash type.
     pub sighash_type: Option<SigHashType>,
@@ -83,7 +83,7 @@ pub struct Input {
     /// A map from public keys needed to sign this input to their corresponding
     /// master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
-    pub bip32_derivation: BTreeMap<PublicKey, KeySource>,
+    pub bip32_derivation: BTreeMap<EcdsaPublicKey, KeySource>,
     /// The finalized, fully-constructed scriptSig with signatures and any other
     /// scripts necessary for this input to pass validation.
     pub final_script_sig: Option<Script>,
@@ -131,7 +131,7 @@ impl Map for Input {
             }
             PSBT_IN_PARTIAL_SIG => {
                 impl_psbt_insert_pair! {
-                    self.partial_sigs <= <raw_key: PublicKey>|<raw_value: Vec<u8>>
+                    self.partial_sigs <= <raw_key: EcdsaPublicKey>|<raw_value: Vec<u8>>
                 }
             }
             PSBT_IN_SIGHASH_TYPE => {
@@ -151,7 +151,7 @@ impl Map for Input {
             }
             PSBT_IN_BIP32_DERIVATION => {
                 impl_psbt_insert_pair! {
-                    self.bip32_derivation <= <raw_key: PublicKey>|<raw_value: KeySource>
+                    self.bip32_derivation <= <raw_key: EcdsaPublicKey>|<raw_value: KeySource>
                 }
             }
             PSBT_IN_FINAL_SCRIPTSIG => {

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -19,7 +19,7 @@ use std::collections::btree_map::Entry;
 use blockdata::script::Script;
 use consensus::encode;
 use util::bip32::KeySource;
-use util::key::PublicKey;
+use util::key::EcdsaPublicKey;
 use util::psbt;
 use util::psbt::map::Map;
 use util::psbt::raw;
@@ -46,7 +46,7 @@ pub struct Output {
     /// A map from public keys needed to spend this output to their
     /// corresponding master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
-    pub bip32_derivation: BTreeMap<PublicKey, KeySource>,
+    pub bip32_derivation: BTreeMap<EcdsaPublicKey, KeySource>,
     /// Proprietary key-value pairs for this output.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
     pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
@@ -75,7 +75,7 @@ impl Map for Output {
             }
             PSBT_OUT_BIP32_DERIVATION => {
                 impl_psbt_insert_pair! {
-                    self.bip32_derivation <= <raw_key: PublicKey>|<raw_value: KeySource>
+                    self.bip32_derivation <= <raw_key: EcdsaPublicKey>|<raw_value: KeySource>
                 }
             }
             PSBT_OUT_PROPRIETARY => match self.proprietary.entry(raw::ProprietaryKey::from_key(raw_key.clone())?) {

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -176,7 +176,7 @@ mod tests {
     use network::constants::Network::Bitcoin;
     use consensus::encode::{deserialize, serialize, serialize_hex};
     use util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource};
-    use util::key::PublicKey;
+    use util::key::EcdsaPublicKey;
     use util::psbt::map::{Global, Output, Input};
     use util::psbt::raw;
 
@@ -211,7 +211,7 @@ mod tests {
         let secp = &Secp256k1::new();
         let seed = Vec::from_hex("000102030405060708090a0b0c0d0e0f").unwrap();
 
-        let mut hd_keypaths: BTreeMap<PublicKey, KeySource> = Default::default();
+        let mut hd_keypaths: BTreeMap<EcdsaPublicKey, KeySource> = Default::default();
 
         let mut sk: ExtendedPrivKey = ExtendedPrivKey::new_master(Bitcoin, &seed).unwrap();
 
@@ -347,7 +347,7 @@ mod tests {
             vec![3, 4 ,5],
         )].into_iter().collect();
         let key_source = ("deadbeef".parse().unwrap(), "m/0'/1".parse().unwrap());
-        let keypaths: BTreeMap<PublicKey, KeySource> = vec![(
+        let keypaths: BTreeMap<EcdsaPublicKey, KeySource> = vec![(
             "0339880dc92394b7355e3d0439fa283c31de7590812ea011c4245c0674a685e883".parse().unwrap(),
             key_source.clone(),
         )].into_iter().collect();

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -24,7 +24,7 @@ use blockdata::transaction::{SigHashType, Transaction, TxOut};
 use consensus::encode::{self, serialize, Decodable};
 use util::bip32::{ChildNumber, Fingerprint, KeySource};
 use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
-use util::key::EcdsaPublicKey;
+use util::key::{EcdsaPublicKey, Key};
 use util::psbt;
 
 /// A trait for serializing a value as raw data for insertion into PSBT

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -24,7 +24,7 @@ use blockdata::transaction::{SigHashType, Transaction, TxOut};
 use consensus::encode::{self, serialize, Decodable};
 use util::bip32::{ChildNumber, Fingerprint, KeySource};
 use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
-use util::key::PublicKey;
+use util::key::EcdsaPublicKey;
 use util::psbt;
 
 /// A trait for serializing a value as raw data for insertion into PSBT
@@ -60,7 +60,7 @@ impl Deserialize for Script {
     }
 }
 
-impl Serialize for PublicKey {
+impl Serialize for EcdsaPublicKey {
     fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         self.write_into(&mut buf).expect("vecs don't error");
@@ -68,9 +68,9 @@ impl Serialize for PublicKey {
     }
 }
 
-impl Deserialize for PublicKey {
+impl Deserialize for EcdsaPublicKey {
     fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
-        PublicKey::from_slice(bytes)
+        EcdsaPublicKey::from_slice(bytes)
             .map_err(|_| encode::Error::ParseFailed("invalid public key"))
     }
 }


### PR DESCRIPTION
First attempt to fit in Taproot keys into current public key type system. Consists of:
1. Renaming `PublicKey` into `EcdsaPublicKey`, otherwise leaving the type intact. This will simplify migration (ppl can just do `use bitcoin::EcdsaPublicKey as PublicKey` and that's all), however will not allow enforcing of compressed keys as a part of API as was discussed in https://github.com/rust-bitcoin/rust-bitcoin/issues/554
2. Making new `PublicKey` type: an enum with two options for older ECDSA public keys and Schorr public keys (however considering of naming them `Taproot` and `Secp`, since the encoding format is a part of either Taproot-related BIP-340 and Secp paper and not Schnorr signature or ECDSA standard)

This also includes a number of improvements to existing API, including making simple `PublicKey` methods inline, extracting `Key` trait for  public (and in future private) key functionality shared across types, and additional `key::Error` variant which was previously incorrectly mapped to `base58` error (since it has nothing to do with Base58 and is about binary-encoded data).

The largest question however is the universal deserialization for the new `PublicKey` type, since there is no unambiguous way to distinguish Taproot and Secp keys when read from stream: https://github.com/rust-bitcoin/rust-bitcoin/pull/561/files#diff-6e396f6881bb94d1206a4d0d1b3e582f16bbd098c091b07afd8a6a95b450c199R215-R241. Not sure how to solve that w/o abandoning shared API. Had created discussion on the matter here: https://github.com/rust-bitcoin/rust-bitcoin/issues/554