### PR TITLE
Include proprietary key in deserialized PSBT

### DIFF
--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -339,6 +339,7 @@ impl Decodable for Global {
             rv.version = version.unwrap_or(0);
             rv.xpub = xpub_map;
             rv.unknown = unknowns;
+            rv.proprietary = proprietary;
             Ok(rv)
         } else {
             Err(Error::MustHaveUnsignedTx.into())

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -181,6 +181,7 @@ mod tests {
     use util::psbt::raw;
 
     use super::PartiallySignedTransaction;
+    use util::psbt::raw::ProprietaryKey;
 
     #[test]
     fn trivial_psbt() {
@@ -787,4 +788,18 @@ mod tests {
         let rtt : Result<PartiallySignedTransaction, _> = hex_psbt!(&serialize_hex(&unserialized));
         assert!(rtt.is_err());
     }
+
+    #[test]
+    fn serialize_and_deserialize_proprietary() {
+        let mut psbt: PartiallySignedTransaction = hex_psbt!("70736274ff0100a00200000002ab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40000000000feffffffab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40100000000feffffff02603bea0b000000001976a914768a40bbd740cbe81d988e71de2a4d5c71396b1d88ac8e240000000000001976a9146f4620b553fa095e721b9ee0efe9fa039cca459788ac000000000001076a47304402204759661797c01b036b25928948686218347d89864b719e1f7fcf57d1e511658702205309eabf56aa4d8891ffd111fdf1336f3a29da866d7f8486d75546ceedaf93190121035cdc61fc7ba971c0b501a646a2a83b102cb43881217ca682dc86e2d73fa882920001012000e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787010416001485d13537f2e265405a34dbafa9e3dda01fb82308000000").unwrap();
+        psbt.global.proprietary.insert(ProprietaryKey {
+            prefix: b"test".to_vec(),
+            subtype: 0u8,
+            key: b"test".to_vec(),
+        }, b"test".to_vec());
+        assert!(!psbt.global.proprietary.is_empty());
+        let rtt : PartiallySignedTransaction = hex_psbt!(&serialize_hex(&psbt)).unwrap();
+        assert!(!rtt.global.proprietary.is_empty());
+    }
+
 }


### PR DESCRIPTION
Fix bug introduced in #471

Proprietary keys in PSBT were not deserialized back

first commit introduce a failing test, second commit fix the test