### PR TITLE
Don't fail CI if base image's apt db is outdated

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
               PIN_VERSIONS: true
     steps:
       - name: Install test dependencies
-        run: sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
+        run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
       - name: Checkout Crate
         uses: actions/checkout@v2
       - name: Checkout Toolchain


### PR DESCRIPTION
[CI fails](https://github.com/rust-bitcoin/rust-bitcoin/pull/582/checks?check_run_id=2263509700) in PR #582 although no code changes happened. My theory is that the base image's apt database is outdated and contains old paths to packages. If that's the case this PR should fix it.