### PR TITLE
Taproot: BIP32 extended keys using Scep256k1 keys instead of bitcoin ECDSA

### DIFF
--- a/examples/bip32.rs
+++ b/examples/bip32.rs
@@ -49,7 +49,7 @@ fn main() {
     let path = DerivationPath::from_str("m/84h/0h/0h").unwrap();
     let child = root.derive_priv(&secp, &path).unwrap();
     println!("Child at {}: {}", path, child);
-    let xpub = ExtendedPubKey::from_private(&secp, &child);
+    let xpub = ExtendedPubKey::from_priv(&secp, &child);
     println!("Public key at {}: {}", path, xpub);
 
     // generate first receiving address at m/0/0

--- a/examples/bip32.rs
+++ b/examples/bip32.rs
@@ -4,7 +4,7 @@ use std::{env, process};
 use std::str::FromStr;
 
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::util::ecdsa::PrivateKey;
+use bitcoin::{PrivateKey, PublicKey};
 use bitcoin::util::bip32::ExtendedPrivKey;
 use bitcoin::util::bip32::ExtendedPubKey;
 use bitcoin::util::bip32::DerivationPath;
@@ -58,7 +58,7 @@ fn main() {
     let public_key = xpub.derive_pub(&secp, &vec![zero, zero])
                          .unwrap()
                          .public_key;
-    let address = Address::p2wpkh(&public_key, network).unwrap();
+    let address = Address::p2wpkh(&PublicKey::new(public_key), network).unwrap();
     println!("First receiving address: {}", address);
 
 }

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -1131,5 +1131,42 @@ mod tests {
         assert_eq!("42", &format!("{}", ChildNumber::from_normal_idx(42).unwrap()));
         assert_eq!("000042", &format!("{:06}", ChildNumber::from_normal_idx(42).unwrap()));
     }
+
+    #[test]
+    #[should_panic(expected = "Secp256k1(InvalidSecretKey)")]
+    fn schnorr_broken_privkey_zeros() {
+        /* this is how we generate key:
+        let mut sk = secp256k1::key::ONE_KEY;
+
+        let zeros = [0u8; 32];
+        unsafe {
+            sk.as_mut_ptr().copy_from(zeros.as_ptr(), 32);
+        }
+
+        let xpriv = ExtendedPrivKey {
+            network: Network::Bitcoin,
+            depth: 0,
+            parent_fingerprint: Default::default(),
+            child_number: ChildNumber::Normal { index: 0 },
+            private_key: sk,
+            chain_code: ChainCode::from(&[0u8; 32][..])
+        };
+
+        println!("{}", xpriv);
+         */
+
+        // Xpriv having secret key set to all zeros
+        let xpriv_str = "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx";
+        ExtendedPrivKey::from_str(xpriv_str).unwrap();
+    }
+
+
+    #[test]
+    #[should_panic(expected = "Secp256k1(InvalidSecretKey)")]
+    fn schnorr_broken_privkey_ffs() {
+        // Xpriv having secret key set to all 0xFF's
+        let xpriv_str = "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fENZ3QzxW";
+        ExtendedPrivKey::from_str(xpriv_str).unwrap();
+    }
 }
 

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -173,6 +173,7 @@ impl FromStr for PublicKey {
 
 /// A Bitcoin ECDSA private key
 #[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Debug))]
 pub struct PrivateKey {
     /// Whether this private key should be serialized as compressed
     pub compressed: bool,
@@ -279,6 +280,7 @@ impl fmt::Display for PrivateKey {
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl fmt::Debug for PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[private key data]")

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -310,7 +310,7 @@ mod tests {
 
         sk = sk.derive_priv(secp, &dpath).unwrap();
 
-        let pk: ExtendedPubKey = ExtendedPubKey::from_private(&secp, &sk);
+        let pk: ExtendedPubKey = ExtendedPubKey::from_priv(&secp, &sk);
 
         hd_keypaths.insert(pk.public_key, (fprint, dpath.into()));
 


### PR DESCRIPTION
This is third step required to introduce Schnorr key support according to #588. This PR starts API-breaking changes and is follow-up to non-API breaking #589, which is already merged.

PR rationale: BIP32 does not support uncompressed keys and using type with compression flag was a mistake