### PR TITLE
Add verify_with_flags to Script and Transaction

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -449,13 +449,20 @@ impl Script {
     }
 
     #[cfg(feature="bitcoinconsensus")]
-    /// verify spend of an input script
-    /// # Parameters
-    ///  * index - the input index in spending which is spending this transaction
-    ///  * amount - the amount this script guards
-    ///  * spending - the transaction that attempts to spend the output holding this script
+    /// Shorthand for [Self::verify_with_flags] with flag [bitcoinconsensus::VERIFY_ALL]
     pub fn verify (&self, index: usize, amount: u64, spending: &[u8]) -> Result<(), Error> {
-        Ok(bitcoinconsensus::verify (&self.0[..], amount, spending, index)?)
+        self.verify_with_flags(index, amount, spending, ::bitcoinconsensus::VERIFY_ALL)
+    }
+
+    #[cfg(feature="bitcoinconsensus")]
+    /// Verify spend of an input script
+    /// # Parameters
+    ///  * `index` - the input index in spending which is spending this transaction
+    ///  * `amount` - the amount this script guards
+    ///  * `spending` - the transaction that attempts to spend the output holding this script
+    ///  * `flags` - verification flags, see [bitcoinconsensus::VERIFY_ALL] and similar
+    pub fn verify_with_flags<F: Into<u32>>(&self, index: usize, amount: u64, spending: &[u8], flags: F) -> Result<(), Error> {
+        Ok(bitcoinconsensus::verify_with_flags (&self.0[..], amount, spending, index, flags.into())?)
     }
 
     /// Write the assembly decoding of the script bytes to the formatter.

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -451,7 +451,7 @@ impl Script {
     #[cfg(feature="bitcoinconsensus")]
     /// Shorthand for [Self::verify_with_flags] with flag [bitcoinconsensus::VERIFY_ALL]
     pub fn verify (&self, index: usize, amount: u64, spending: &[u8]) -> Result<(), Error> {
-        self.verify_with_flags(index, amount, spending, ::bitcoinconsensus::VERIFY_ALL)
+        self.verify_with_flags(index, ::Amount::from_sat(amount), spending, ::bitcoinconsensus::VERIFY_ALL)
     }
 
     #[cfg(feature="bitcoinconsensus")]
@@ -461,8 +461,8 @@ impl Script {
     ///  * `amount` - the amount this script guards
     ///  * `spending` - the transaction that attempts to spend the output holding this script
     ///  * `flags` - verification flags, see [bitcoinconsensus::VERIFY_ALL] and similar
-    pub fn verify_with_flags<F: Into<u32>>(&self, index: usize, amount: u64, spending: &[u8], flags: F) -> Result<(), Error> {
-        Ok(bitcoinconsensus::verify_with_flags (&self.0[..], amount, spending, index, flags.into())?)
+    pub fn verify_with_flags<F: Into<u32>>(&self, index: usize, amount: ::Amount, spending: &[u8], flags: F) -> Result<(), Error> {
+        Ok(bitcoinconsensus::verify_with_flags (&self.0[..], amount.as_sat(), spending, index, flags.into())?)
     }
 
     /// Write the assembly decoding of the script bytes to the formatter.

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -473,8 +473,9 @@ impl Transaction {
     /// Verify that this transaction is able to spend its inputs
     /// The lambda spent should not return the same TxOut twice!
     pub fn verify_with_flags<S, F>(&self, mut spent: S, flags: F) -> Result<(), script::Error>
-        where S: FnMut(&OutPoint) -> Option<TxOut>, F : Into<u32> + Copy {
+        where S: FnMut(&OutPoint) -> Option<TxOut>, F : Into<u32> {
         let tx = encode::serialize(&*self);
+        let flags: u32 = flags.into();
         for (idx, input) in self.input.iter().enumerate() {
             if let Some(output) = spent(&input.previous_output) {
                 output.script_pubkey.verify_with_flags(idx, output.value, tx.as_slice(), flags)?;

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -463,14 +463,21 @@ impl Transaction {
     }
 
     #[cfg(feature="bitcoinconsensus")]
+    /// Shorthand for [Self::verify_with_flags] with flag [bitcoinconsensus::VERIFY_ALL]
+    pub fn verify<S>(&self, spent: S) -> Result<(), script::Error>
+        where S: FnMut(&OutPoint) -> Option<TxOut> {
+        self.verify_with_flags(spent, ::bitcoinconsensus::VERIFY_ALL)
+    }
+
+    #[cfg(feature="bitcoinconsensus")]
     /// Verify that this transaction is able to spend its inputs
     /// The lambda spent should not return the same TxOut twice!
-    pub fn verify<S>(&self, mut spent: S) -> Result<(), script::Error>
-        where S: FnMut(&OutPoint) -> Option<TxOut> {
+    pub fn verify_with_flags<S, F>(&self, mut spent: S, flags: F) -> Result<(), script::Error>
+        where S: FnMut(&OutPoint) -> Option<TxOut>, F : Into<u32> + Copy {
         let tx = encode::serialize(&*self);
         for (idx, input) in self.input.iter().enumerate() {
             if let Some(output) = spent(&input.previous_output) {
-                output.script_pubkey.verify(idx, output.value, tx.as_slice())?;
+                output.script_pubkey.verify_with_flags(idx, output.value, tx.as_slice(), flags)?;
             } else {
                 return Err(script::Error::UnknownSpentOutput(input.previous_output.clone()));
             }

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -478,7 +478,7 @@ impl Transaction {
         let flags: u32 = flags.into();
         for (idx, input) in self.input.iter().enumerate() {
             if let Some(output) = spent(&input.previous_output) {
-                output.script_pubkey.verify_with_flags(idx, output.value, tx.as_slice(), flags)?;
+                output.script_pubkey.verify_with_flags(idx, ::Amount::from_sat(output.value), tx.as_slice(), flags)?;
             } else {
                 return Err(script::Error::UnknownSpentOutput(input.previous_output.clone()));
             }


### PR DESCRIPTION
In https://github.com/RCasatta/blocks_iterator/blob/verify/examples/verify.rs I would like to verify mainnet and testnet blocks. However, at the moment the verify flag is not exposed in the API so it's not possible (without using bitcoinconsensus directly).

I preserved the original method and added `verify_with_flags` so that it should not be a breaking change.

The flag parameter is taken as `Into<u32>` so that if we introduce a VerifyFlags type/builder in bitcoinconsensus the migration should be more smooth.