### PR TITLE
Bech32m adoption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 
 [dependencies]
-bech32 = "0.7.3"
+bech32 = "0.8.0"
 bitcoin_hashes = "0.9.6"
 secp256k1 = "0.20.2"
 

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -689,7 +689,8 @@ mod tests {
     }
 
     #[test]
-    fn test_bip173_vectors() {
+    fn test_bip173_350_vectors() {
+        // Test vectors valid under both BIP-173 and BIP-350
         let valid_vectors = [
             ("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", "0014751e76e8199196d454941c45d1b3a323f1433bd6"),
             ("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"),
@@ -697,6 +698,8 @@ mod tests {
             ("BC1SW50QGDZ25J", "6002751e"),
             ("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", "5210751e76e8199196d454941c45d1b3a323"),
             ("tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"),
+            ("tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c", "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"),
+            ("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
         ];
         for vector in &valid_vectors {
             let addr: Address = vector.0.parse().unwrap();
@@ -705,16 +708,59 @@ mod tests {
         }
 
         let invalid_vectors = [
-            "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
-            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
-            "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
-            "bc1rw5uspcuh",
-            "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+            // 1. BIP-350 test vectors
+            // Invalid human-readable part
+            "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
+            // Invalid checksums (Bech32 instead of Bech32m):
+            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
+            "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
+            "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL",
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh",
+            "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
+            // Invalid character in checksum
+            "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
+            // Invalid witness version
+            "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
+            // Invalid program length (1 byte)
+            "bc1pw5dgrnzv",
+            // Invalid program length (41 bytes)
+            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
+            // Invalid program length for witness version 0 (per BIP141)
             "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-            "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
-            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+            // Mixed case
+            "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
+            // zero padding of more than 4 bits
+            "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
+            // Non-zero padding in 8-to-5 conversion
+            "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
+            // Empty data section
             "bc1gmk9yu",
+
+            // 2. BIP-173 test vectors
+            // Invalid human-readable part
+            "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+            // Invalid checksum
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+            // Invalid witness version
+            "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+            // Invalid program length
+            "bc1rw5uspcuh",
+            // Invalid program length
+            "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+            // Invalid program length for witness version 0 (per BIP141)
+            "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+            // Mixed case
+            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+            // zero padding of more than 4 bits
+            "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
+            // Non-zero padding in 8-to-5 conversion
+            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+            // Final test for empty data section is the same as above in BIP-350
+
+            // 3. BIP-173 valid test vectors obsolete by BIP-350
+            "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+            "BC1SW50QA3JX3S",
+            "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
         ];
         for vector in &invalid_vectors {
             assert!(vector.parse::<Address>().is_err());


### PR DESCRIPTION
This adds support for Bech32m and fixes test vectors according to BIP-350. All changes non-API breaking, which allow to introduce them in `0.26.1` such that we will be able to parse Taproot addresses before `0.27` and #563

Since we do not want to break API I re-used existing error type in https://github.com/rust-bitcoin/rust-bitcoin/pull/601/files#diff-c55d0186f3d5990b5e223c1a8aa1bbe60988201c452dd13b3324e892bc33119eR447 to mark failed Bech32(m) encoding variant. This should not be a problem since with  #563 it will be solved anyway by `0.27` release