### PR TITLE
Fixing hashes core dependency and fuzz feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [features]
 default = [ "secp-recovery" ]
 base64 = [ "base64-compat" ]
-fuzztarget = ["bitcoin_hashes/fuzztarget"]
+fuzztarget = []
 unstable = []
 rand = ["secp256k1/rand-std"]
 use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]
@@ -23,7 +23,7 @@ secp-recovery = ["secp256k1/recovery"]
 
 [dependencies]
 bech32 = "0.7.2"
-bitcoin_hashes = "0.9.1"
+bitcoin_hashes = "0.9.6"
 secp256k1 = "0.20.0"
 
 base64-compat = { version = "1.0.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ pub use util::ecdsa::PublicKey;
 
 #[cfg(all(test, feature = "unstable"))]
 mod tests {
-    use hashes::core::fmt::Arguments;
     use std::io::{IoSlice, Result, Write};
+    use std::fmt::Arguments;
 
     #[derive(Default, Clone, Debug, PartialEq, Eq)]
     pub struct EmptyWrite;


### PR DESCRIPTION
Caused by the latest `bitcoin_hashes` release