### PR TITLE
Fix bip158 example formatting

### DIFF
--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -23,26 +23,27 @@
 //! The filter construction proposed is an alternative to Bloom filters, as used in BIP 37,
 //! that minimizes filter size by using Golomb-Rice coding for compression.
 //!
-//!  USE :
-//!   // create a block filter for a block (server side)
+//! ## Example
 //!
-//!   fn get_script_for_coin (coin: &OutPoint) -> Result<Script, BlockFilterError> {
-//!     // get utxo ...
-//!   }
+//! ```ignore
+//! fn get_script_for_coin(coin: &OutPoint) -> Result<Script, BlockFilterError> {
+//!   // get utxo ...
+//! }
+//!  
+//! // create a block filter for a block (server side)
+//! let filter = BlockFilter::new_script_filter(&block, get_script_for_coin)?;
 //!
-//!   let filter = BlockFilter::new_script_filter (&block, get_script_for_coin)?;
-//!
-//!   // or create a filter from known raw data
-//!   let filter = BlockFilter::new(content);
-//!
-//!   // read and evaluate a filter
-//!
-//!   let query: Iterator<Item=Script> = // .. some scripts you care about
-//!   if filter.match_any (&block_hash, &mut query.map(|s| s.as_bytes())) {
-//!     // get this block
-//!   }
-//!
-//!
+//! // or create a filter from known raw data
+//! let filter = BlockFilter::new(content);
+//!  
+//! // read and evaluate a filter
+//!  
+//! let query: Iterator<Item=Script> = // .. some scripts you care about
+//! if filter.match_any(&block_hash, &mut query.map(|s| s.as_bytes())) {
+//!   // get this block
+//! }
+//!  ```
+//!  
 
 use std::{cmp, fmt, io};
 use std::collections::HashSet;


### PR DESCRIPTION
Current example seems to be not formatted correctly in https://docs.rs/bitcoin/0.26.0/bitcoin/util/bip158/index.html:
![image](https://user-images.githubusercontent.com/9900/119982221-3f84d880-bfc7-11eb-85de-7d1c1863a6a6.png)

