### PR TITLE
std -> core

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -20,7 +20,7 @@
 //! these blocks and the blockchain.
 //!
 
-use std::fmt;
+use core::fmt;
 
 use util;
 use util::Error::{BlockBadTarget, BlockBadProofOfWork};

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -19,7 +19,7 @@
 //! single transaction
 //!
 
-use std::default::Default;
+use core::default::Default;
 
 use hashes::hex::FromHex;
 use hashes::sha256d;
@@ -160,7 +160,7 @@ pub fn genesis_block(network: Network) -> Block {
 
 #[cfg(test)]
 mod test {
-    use std::default::Default;
+    use core::default::Default;
     use hashes::hex::FromHex;
 
     use network::constants::Network;

--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -22,7 +22,7 @@
 
 #[cfg(feature = "serde")] use serde;
 
-use std::fmt;
+use core::{fmt, convert::From};
 
 // Note: I am deliberately not implementing PartialOrd or Ord on the
 //       opcode enum. If you want to check ranges of opcodes, etc.,

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -24,8 +24,9 @@
 //! This module provides the structures and functions needed to support scripts.
 //!
 
-use std::default::Default;
-use std::{error, fmt, io, str};
+use io;
+
+use core::{fmt, default::Default};
 
 #[cfg(feature = "serde")] use serde;
 
@@ -91,7 +92,8 @@ impl hex::FromHex for Script {
         Vec::from_byte_iter(iter).map(|v| Script(Box::<[u8]>::from(v)))
     }
 }
-impl str::FromStr for Script {
+
+impl ::core::str::FromStr for Script {
     type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, hex::Error> {
         hex::FromHex::from_hex(s)
@@ -143,7 +145,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {}
+impl ::std::error::Error for Error {}
 
 #[cfg(feature="bitcoinconsensus")]
 #[doc(hidden)]
@@ -820,7 +822,7 @@ impl<'de> serde::Deserialize<'de> for Script {
     where
         D: serde::Deserializer<'de>,
     {
-        use std::fmt::Formatter;
+        use core::fmt::Formatter;
         use hashes::hex::FromHex;
 
         struct Visitor;
@@ -889,7 +891,7 @@ impl Decodable for Script {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     use super::*;
     use super::build_scriptint;

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -23,8 +23,9 @@
 //! This module provides the structures and functions needed to support transactions.
 //!
 
-use std::default::Default;
-use std::{error, fmt, io, str};
+use io;
+use core::{fmt, str, default::Default};
+use std::error;
 
 use hashes::{self, Hash, sha256d};
 use hashes::hex::FromHex;
@@ -108,7 +109,7 @@ pub enum ParseOutPointError {
     /// Error in TXID part.
     Txid(hashes::hex::Error),
     /// Error in vout part.
-    Vout(::std::num::ParseIntError),
+    Vout(::core::num::ParseIntError),
     /// Error in general format.
     Format,
     /// Size exceeds max.
@@ -151,7 +152,7 @@ fn parse_vout(s: &str) -> Result<u32, ParseOutPointError> {
     Ok(s.parse().map_err(ParseOutPointError::Vout)?)
 }
 
-impl ::std::str::FromStr for OutPoint {
+impl ::core::str::FromStr for OutPoint {
     type Err = ParseOutPointError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -755,7 +756,7 @@ impl From<SigHashType> for u32 {
 mod tests {
     use super::{OutPoint, ParseOutPointError, Transaction, TxIn, NonStandardSigHashType};
 
-    use std::str::FromStr;
+    use core::str::FromStr;
     use blockdata::constants::WITNESS_SCALE_FACTOR;
     use blockdata::script::Script;
     use consensus::encode::serialize;

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -29,13 +29,15 @@
 //! big-endian decimals, etc.)
 //!
 
-use std::{fmt, error, io, mem, u32};
+use core::{fmt, mem, u32, convert::From};
 use std::borrow::Cow;
-use std::io::{Cursor, Read, Write};
+use std::error;
 use hashes::hex::ToHex;
 
 use hashes::{sha256d, Hash};
 use hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};
+
+use io::{self, Cursor, Read, Write};
 
 use util::endian;
 use util::psbt;
@@ -754,8 +756,8 @@ impl Decodable for sha256d::Hash {
 // Tests
 #[cfg(test)]
 mod tests {
-    use std::{io, mem, fmt};
-    use std::mem::discriminant;
+    use super::*;
+    use core::{mem::{self, discriminant}, fmt};
     use super::{deserialize, serialize, Error, CheckedData, VarInt};
     use super::{Transaction, BlockHash, FilterHash, TxMerkleNode, TxOut, TxIn};
     use consensus::{Encodable, deserialize_partial, Decodable};

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -21,13 +21,13 @@ use hashes::{Hash, sha256, sha256d, hash160};
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {
         impl $crate::consensus::Encodable for $hashtype {
-            fn consensus_encode<S: ::std::io::Write>(&self, s: S) -> Result<usize, ::std::io::Error> {
+            fn consensus_encode<S: $crate::io::Write>(&self, s: S) -> Result<usize, $crate::io::Error> {
                 self.0.consensus_encode(s)
             }
         }
 
         impl $crate::consensus::Decodable for $hashtype {
-            fn consensus_decode<D: ::std::io::Read>(d: D) -> Result<Self, $crate::consensus::encode::Error> {
+            fn consensus_decode<D: $crate::io::Read>(d: D) -> Result<Self, $crate::consensus::encode::Error> {
                 use $crate::hashes::Hash;
                 Ok(Self::from_inner(<<$hashtype as $crate::hashes::Hash>::Inner>::consensus_decode(d)?))
             }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -20,10 +20,10 @@ macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl $crate::consensus::Encodable for $thing {
             #[inline]
-            fn consensus_encode<S: ::std::io::Write>(
+            fn consensus_encode<S: $crate::io::Write>(
                 &self,
                 mut s: S,
-            ) -> Result<usize, ::std::io::Error> {
+            ) -> Result<usize, $crate::io::Error> {
                 let mut len = 0;
                 $(len += self.$field.consensus_encode(&mut s)?;)+
                 Ok(len)
@@ -32,7 +32,7 @@ macro_rules! impl_consensus_encoding {
 
         impl $crate::consensus::Decodable for $thing {
             #[inline]
-            fn consensus_decode<D: ::std::io::Read>(
+            fn consensus_decode<D: $crate::io::Read>(
                 d: D,
             ) -> Result<$thing, $crate::consensus::encode::Error> {
                 let mut d = d.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
@@ -83,7 +83,7 @@ macro_rules! impl_array_newtype {
             pub fn into_bytes(self) -> [$ty; $len] { self.0 }
         }
 
-        impl<'a> ::std::convert::From<&'a [$ty]> for $thing {
+        impl<'a> ::core::convert::From<&'a [$ty]> for $thing {
             fn from(data: &'a [$ty]) -> $thing {
                 assert_eq!(data.len(), $len);
                 let mut ret = [0; $len];
@@ -100,7 +100,7 @@ macro_rules! impl_array_newtype {
 macro_rules! impl_index_newtype {
     ($thing:ident, $ty:ty) => {
 
-        impl ::std::ops::Index<usize> for $thing {
+        impl ::core::ops::Index<usize> for $thing {
             type Output = $ty;
 
             #[inline]
@@ -109,38 +109,38 @@ macro_rules! impl_index_newtype {
             }
         }
 
-        impl ::std::ops::Index<::std::ops::Range<usize>> for $thing {
+        impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: ::std::ops::Range<usize>) -> &[$ty] {
+            fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
                 &self.0[index]
             }
         }
 
-        impl ::std::ops::Index<::std::ops::RangeTo<usize>> for $thing {
+        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: ::std::ops::RangeTo<usize>) -> &[$ty] {
+            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
                 &self.0[index]
             }
         }
 
-        impl ::std::ops::Index<::std::ops::RangeFrom<usize>> for $thing {
+        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, index: ::std::ops::RangeFrom<usize>) -> &[$ty] {
+            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
                 &self.0[index]
             }
         }
 
-        impl ::std::ops::Index<::std::ops::RangeFull> for $thing {
+        impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
             type Output = [$ty];
 
             #[inline]
-            fn index(&self, _: ::std::ops::RangeFull) -> &[$ty] {
+            fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
                 &self.0[..]
             }
         }
@@ -150,16 +150,16 @@ macro_rules! impl_index_newtype {
 
 macro_rules! display_from_debug {
     ($thing:ident) => {
-        impl ::std::fmt::Display for $thing {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-                ::std::fmt::Debug::fmt(self, f)
+        impl ::core::fmt::Display for $thing {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
+                ::core::fmt::Debug::fmt(self, f)
             }
         }
     }
 }
 
 #[cfg(test)]
-macro_rules! hex_script (($s:expr) => (<$crate::Script as ::std::str::FromStr>::from_str($s).unwrap()));
+macro_rules! hex_script (($s:expr) => (<$crate::Script as ::core::str::FromStr>::from_str($s).unwrap()));
 
 #[cfg(test)]
 macro_rules! hex_hash (($h:ident, $s:expr) => ($h::from_slice(&<Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()).unwrap()));
@@ -172,8 +172,8 @@ macro_rules! serde_string_impl {
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
-                use ::std::fmt::{self, Formatter};
-                use ::std::str::FromStr;
+                use ::core::fmt::{self, Formatter};
+                use ::core::str::FromStr;
 
                 struct Visitor;
                 impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
@@ -232,8 +232,8 @@ macro_rules! serde_struct_human_string_impl {
                 D: $crate::serde::de::Deserializer<'de>,
             {
                 if deserializer.is_human_readable() {
-                    use ::std::fmt::{self, Formatter};
-                    use ::std::str::FromStr;
+                    use ::core::fmt::{self, Formatter};
+                    use ::core::str::FromStr;
 
                     struct Visitor;
                     impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
@@ -267,7 +267,7 @@ macro_rules! serde_struct_human_string_impl {
 
                     deserializer.deserialize_str(Visitor)
                 } else {
-                    use ::std::fmt::{self, Formatter};
+                    use ::core::fmt::{self, Formatter};
                     use $crate::serde::de::IgnoredAny;
 
                     #[allow(non_camel_case_types)]
@@ -408,15 +408,15 @@ macro_rules! serde_struct_human_string_impl {
 
 /// Implements several traits for byte-based newtypes.
 /// Implements:
-/// - std::fmt::LowerHex (implies hashes::hex::ToHex)
-/// - std::fmt::Display
-/// - std::str::FromStr
+/// - core::fmt::LowerHex (implies hashes::hex::ToHex)
+/// - core::fmt::Display
+/// - core::str::FromStr
 /// - hashes::hex::FromHex
 macro_rules! impl_bytes_newtype {
     ($t:ident, $len:expr) => (
 
-        impl ::std::fmt::LowerHex for $t {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::LowerHex for $t {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 for &ch in self.0.iter() {
                     write!(f, "{:02x}", ch)?;
                 }
@@ -424,23 +424,23 @@ macro_rules! impl_bytes_newtype {
             }
         }
 
-        impl ::std::fmt::Display for $t {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Display for $t {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 fmt::LowerHex::fmt(self, f)
             }
         }
 
-        impl ::std::fmt::Debug for $t {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Debug for $t {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 fmt::LowerHex::fmt(self, f)
             }
         }
 
         impl $crate::hashes::hex::FromHex for $t {
             fn from_byte_iter<I>(iter: I) -> Result<Self, $crate::hashes::hex::Error>
-                where I: ::std::iter::Iterator<Item=Result<u8, $crate::hashes::hex::Error>> +
-                    ::std::iter::ExactSizeIterator +
-                    ::std::iter::DoubleEndedIterator,
+                where I: ::core::iter::Iterator<Item=Result<u8, $crate::hashes::hex::Error>> +
+                    ::core::iter::ExactSizeIterator +
+                    ::core::iter::DoubleEndedIterator,
             {
                 if iter.len() == $len {
                     let mut ret = [0; $len];
@@ -454,7 +454,7 @@ macro_rules! impl_bytes_newtype {
             }
         }
 
-        impl ::std::str::FromStr for $t {
+        impl ::core::str::FromStr for $t {
             type Err = $crate::hashes::hex::Error;
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 $crate::hashes::hex::FromHex::from_hex(s)
@@ -481,7 +481,7 @@ macro_rules! impl_bytes_newtype {
                     impl<'de> $crate::serde::de::Visitor<'de> for HexVisitor {
                         type Value = $t;
 
-                        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                        fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                             formatter.write_str("an ASCII hex string")
                         }
 
@@ -489,7 +489,7 @@ macro_rules! impl_bytes_newtype {
                         where
                             E: $crate::serde::de::Error,
                         {
-                            if let Ok(hex) = ::std::str::from_utf8(v) {
+                            if let Ok(hex) = ::core::str::from_utf8(v) {
                                 $crate::hashes::hex::FromHex::from_hex(hex).map_err(E::custom)
                             } else {
                                 return Err(E::invalid_value($crate::serde::de::Unexpected::Bytes(v), &self));
@@ -511,7 +511,7 @@ macro_rules! impl_bytes_newtype {
                     impl<'de> $crate::serde::de::Visitor<'de> for BytesVisitor {
                         type Value = $t;
 
-                        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                        fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                             formatter.write_str("a bytestring")
                         }
 
@@ -549,22 +549,22 @@ macro_rules! user_enum {
             $(#[$doc] $elem),*
         }
 
-        impl ::std::fmt::Display for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 f.pad(match *self {
                     $($name::$elem => $txt),*
                 })
             }
         }
 
-        impl ::std::str::FromStr for $name {
-            type Err = ::std::io::Error;
+        impl ::core::str::FromStr for $name {
+            type Err = $crate::io::Error;
             #[inline]
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {
                     $($txt => Ok($name::$elem)),*,
-                    _ => Err(::std::io::Error::new(
-                        ::std::io::ErrorKind::InvalidInput,
+                    _ => Err($crate::io::Error::new(
+                        $crate::io::ErrorKind::InvalidInput,
                         format!("Unknown network (type {})", s),
                     )),
                 }
@@ -578,7 +578,7 @@ macro_rules! user_enum {
             where
                 D: $crate::serde::Deserializer<'de>,
             {
-                use ::std::fmt::{self, Formatter};
+                use ::core::fmt::{self, Formatter};
 
                 struct Visitor;
                 impl<'de> $crate::serde::de::Visitor<'de> for Visitor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@
 #![deny(unused_must_use)]
 #![deny(broken_intra_doc_links)]
 
+extern crate core;
+
 // Re-exported dependencies.
 #[macro_use] pub extern crate bitcoin_hashes as hashes;
 pub extern crate secp256k1;
@@ -95,6 +97,8 @@ pub use util::schnorr;
 pub use util::ecdsa::PrivateKey;
 #[deprecated(since = "0.26.1", note = "Please use `ecdsa::PublicKey` instead")]
 pub use util::ecdsa::PublicKey;
+
+use std::io;
 
 #[cfg(all(test, feature = "unstable"))] use tests::EmptyWrite;
 

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -18,9 +18,10 @@
 //! network addresses in Bitcoin messages.
 //!
 
-use std::{fmt, io, iter};
+use core::{fmt, iter};
 use std::net::{SocketAddr, Ipv6Addr, SocketAddrV4, SocketAddrV6, Ipv4Addr, ToSocketAddrs};
 
+use io;
 use network::constants::ServiceFlags;
 use consensus::encode::{self, Decodable, Encodable, VarInt, ReadExt, WriteExt};
 
@@ -291,7 +292,7 @@ impl ToSocketAddrs for AddrV2Message {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    use core::str::FromStr;
     use super::{AddrV2Message, AddrV2, Address};
     use network::constants::ServiceFlags;
     use std::net::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr};

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -37,8 +37,9 @@
 //! assert_eq!(&bytes[..], &[0xF9, 0xBE, 0xB4, 0xD9]);
 //! ```
 
-use std::{fmt, io, ops};
+use core::{fmt, ops, convert::From};
 
+use io;
 use consensus::encode::{self, Encodable, Decodable};
 
 /// Version of the protocol as appearing in network message headers

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -19,10 +19,10 @@
 //! also defines (de)serialization routines for many primitives.
 //!
 
-use std::{fmt, io, iter, mem, str};
+use core::{mem, fmt, iter};
 use std::borrow::Cow;
-use std::io::Cursor;
 
+use io;
 use blockdata::block;
 use blockdata::transaction;
 use network::address::{Address, AddrV2Message};
@@ -337,7 +337,7 @@ impl Decodable for RawNetworkMessage {
         let cmd = CommandString::consensus_decode(&mut d)?;
         let raw_payload = CheckedData::consensus_decode(&mut d)?.0;
 
-        let mut mem_d = Cursor::new(raw_payload);
+        let mut mem_d = io::Cursor::new(raw_payload);
         let payload = match &cmd.0[..] {
             "version" => NetworkMessage::Version(Decodable::consensus_decode(&mut mem_d)?),
             "verack"  => NetworkMessage::Verack,

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -18,7 +18,7 @@
 //! Bitcoin data (blocks and transactions) around.
 //!
 
-use std::io;
+use io;
 
 use hashes::sha256d;
 
@@ -154,7 +154,7 @@ mod tests {
     use hashes::hex::FromHex;
 
     use consensus::encode::{deserialize, serialize};
-    use std::default::Default;
+    use core::default::Default;
 
     #[test]
     fn getblocks_message_test() {

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -18,7 +18,7 @@
 //! capabilities
 //!
 
-use std::io;
+use io;
 use std::borrow::Cow;
 
 use network::address::Address;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -18,8 +18,8 @@
 //! of Bitcoin data and network messages.
 //!
 
-use std::fmt;
-use std::io;
+use io;
+use core::fmt;
 use std::error;
 
 pub mod constants;

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -20,8 +20,8 @@
 //! (like can happen with reading from TCP socket)
 //!
 
-use std::fmt;
-use std::io::{self, Read};
+use core::fmt;
+use io::{self, Read};
 
 use consensus::{encode, Decodable};
 
@@ -83,7 +83,7 @@ impl<R: Read> StreamReader<R> {
 mod test {
     use std::thread;
     use std::time::Duration;
-    use std::io::{self, BufReader, Write};
+    use io::{self, BufReader, Write};
     use std::net::{TcpListener, TcpStream, Shutdown};
     use std::thread::JoinHandle;
     use network::constants::ServiceFlags;
@@ -313,7 +313,7 @@ mod test {
 
     #[test]
     fn read_block_from_file_test() {
-        use std::io;
+        use io;
         use consensus::serialize;
         use hashes::hex::FromHex;
         use Block;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -24,7 +24,7 @@
 //! These values were taken from bitcoind v0.21.1 (194b9b8792d9b0798fdb570b79fa51f1d1f5ebaf).
 
 use super::blockdata::constants::{MAX_BLOCK_SIGOPS_COST, WITNESS_SCALE_FACTOR};
-use std::cmp;
+use core::cmp;
 
 /// Maximum weight of a transaction for it to be relayed by most nodes on the network
 pub const MAX_STANDARD_TX_WEIGHT: u32 = 400_000;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -33,8 +33,8 @@
 //! let address = Address::p2pkh(&public_key, Network::Bitcoin);
 //! ```
 
-use std::fmt;
-use std::str::FromStr;
+use core::fmt;
+use core::str::FromStr;
 use std::error;
 
 use bech32;
@@ -525,8 +525,7 @@ impl ::std::fmt::Debug for Address {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-    use std::string::ToString;
+    use core::str::FromStr;
 
     use hashes::hex::{FromHex, ToHex};
 

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -14,12 +14,8 @@
 //! We refer to the documentation on the types for more information.
 //!
 
-use std::default;
-use std::error;
-use std::fmt::{self, Write};
-use std::ops;
-use std::str::FromStr;
-use std::cmp::Ordering;
+use core::{ops, default, str::FromStr, cmp::Ordering};
+use core::fmt::{self, Write};
 
 /// A set of denominations in which amounts can be expressed.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -115,7 +111,7 @@ impl fmt::Display for ParseAmountError {
     }
 }
 
-impl error::Error for ParseAmountError {}
+impl ::std::error::Error for ParseAmountError {}
 
 fn is_too_precise(s: &str, precision: usize) -> bool {
     s.contains('.') || precision >= s.len() || s.chars().rev().take(precision).any(|d| d != '0')
@@ -251,10 +247,10 @@ fn fmt_satoshi_in(
 ///
 /// Warning!
 ///
-/// This type implements several arithmetic operations from [std::ops].
+/// This type implements several arithmetic operations from [core::ops].
 /// To prevent errors due to overflow or underflow when using these operations,
 /// it is advised to instead use the checked arithmetic methods whose names
-/// start with `checked_`.  The operations from [std::ops] that [Amount]
+/// start with `checked_`.  The operations from [core::ops] that [Amount]
 /// implements will panic when overflow or underflow occurs.  Also note that
 /// since the internal representation of amounts is unsigned, subtracting below
 /// zero is considered an underflow and will cause a panic if you're not using
@@ -381,7 +377,7 @@ impl Amount {
         buf
     }
 
-    // Some arithmetic that doesn't fit in `std::ops` traits.
+    // Some arithmetic that doesn't fit in `core::ops` traits.
 
     /// Checked addition.
     /// Returns [None] if overflow occurred.
@@ -532,10 +528,10 @@ impl FromStr for Amount {
 ///
 /// Warning!
 ///
-/// This type implements several arithmetic operations from [std::ops].
+/// This type implements several arithmetic operations from [core::ops].
 /// To prevent errors due to overflow or underflow when using these operations,
 /// it is advised to instead use the checked arithmetic methods whose names
-/// start with `checked_`.  The operations from [std::ops] that [Amount]
+/// start with `checked_`.  The operations from [core::ops] that [Amount]
 /// implements will panic when overflow or underflow occurs.
 ///
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -663,7 +659,7 @@ impl SignedAmount {
         buf
     }
 
-    // Some arithmetic that doesn't fit in `std::ops` traits.
+    // Some arithmetic that doesn't fit in `core::ops` traits.
 
     /// Get the absolute value of this [SignedAmount].
     pub fn abs(self) -> SignedAmount {
@@ -1086,7 +1082,7 @@ pub mod serde {
 mod tests {
     use super::*;
     use std::panic;
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     #[cfg(feature = "serde")]
     use serde_test;

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -14,7 +14,8 @@
 
 //! Base58 encoder and decoder
 
-use std::{error, fmt, str, slice, iter};
+use std::error;
+use core::{fmt, str, iter, slice};
 
 use hashes::{sha256d, Hash};
 

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -25,8 +25,8 @@ use blockdata::script::Script;
 use blockdata::transaction::{Transaction, TxIn, SigHashType};
 use consensus::{encode, Encodable};
 
-use std::io;
-use std::ops::{Deref, DerefMut};
+use io;
+use core::ops::{Deref, DerefMut};
 
 /// Parts of a sighash which are common across inputs or signatures, and which are
 /// sufficient (in conjunction with a private key) to sign the transaction

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -45,13 +45,10 @@
 //!  ```
 //!  
 
-use std::{cmp, fmt, io};
 use std::collections::HashSet;
-use std::error;
-use std::fmt::{Display, Formatter};
-use std::io::Cursor;
-use std::cmp::Ordering;
-
+use io::{self as io, Cursor};
+use core::fmt::{self, Display, Formatter};
+use core::cmp::{self, Ordering};
 
 use hashes::{Hash, siphash24};
 use hash_types::{BlockHash, FilterHash, FilterHeader};
@@ -76,7 +73,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-impl error::Error for Error {}
+impl ::std::error::Error for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -16,9 +16,8 @@
 //! Implementation of BIP32 hierarchical deterministic wallets, as defined
 //! at <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>
 
-use std::default::Default;
-use std::{error, fmt};
-use std::str::FromStr;
+use core::{fmt, str::FromStr, default::Default};
+use std::error;
 #[cfg(feature = "serde")] use serde;
 
 use hash_types::XpubIdentifier;
@@ -267,13 +266,13 @@ impl<'a> From<&'a [ChildNumber]> for DerivationPath {
     }
 }
 
-impl ::std::iter::FromIterator<ChildNumber> for DerivationPath {
+impl ::core::iter::FromIterator<ChildNumber> for DerivationPath {
     fn from_iter<T>(iter: T) -> Self where T: IntoIterator<Item = ChildNumber> {
         DerivationPath(Vec::from_iter(iter))
     }
 }
 
-impl<'a> ::std::iter::IntoIterator for &'a DerivationPath {
+impl<'a> ::core::iter::IntoIterator for &'a DerivationPath {
     type Item = &'a ChildNumber;
     type IntoIter = ::std::slice::Iter<'a, ChildNumber>;
     fn into_iter(self) -> Self::IntoIter {
@@ -770,8 +769,7 @@ mod tests {
     use super::*;
     use super::ChildNumber::{Hardened, Normal};
 
-    use std::str::FromStr;
-    use std::string::ToString;
+    use core::str::FromStr;
 
     use secp256k1::{self, Secp256k1};
     use hashes::hex::FromHex;

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -20,13 +20,14 @@
 
 #![cfg_attr(not(test), deprecated)]
 
+use core::fmt;
+use std::error;
+
 use secp256k1::{self, Secp256k1};
 use PrivateKey;
 use PublicKey;
 use hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
 use blockdata::{opcodes, script};
-
-use std::{error, fmt};
 
 use hash_types::ScriptHash;
 use network::constants::Network;
@@ -71,7 +72,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
+impl ::std::error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Secp(ref e) => Some(e),
@@ -278,7 +279,7 @@ mod tests {
     use secp256k1::Secp256k1;
     use hashes::hex::FromHex;
     use secp256k1::rand::thread_rng;
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     use blockdata::script::Script;
     use network::constants::Network;

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -16,9 +16,9 @@
 //! ECDSA keys used in Bitcoin that can be roundtrip (de)serialized.
 //!
 
-use std::fmt::{self, Write};
-use std::{io, ops};
-use std::str::FromStr;
+use core::{ops, str::FromStr};
+use core::fmt::{self, Write as _fmtWrite};
+use io;
 
 use secp256k1::{self, Secp256k1};
 use network::constants::Network;
@@ -398,9 +398,9 @@ impl<'de> ::serde::Deserialize<'de> for PublicKey {
 
 #[cfg(test)]
 mod tests {
+    use io;
     use super::{PrivateKey, PublicKey};
     use secp256k1::Secp256k1;
-    use std::io;
     use std::str::FromStr;
     use hashes::hex::ToHex;
     use network::constants::Network::Testnet;

--- a/src/util/endian.rs
+++ b/src/util/endian.rs
@@ -2,10 +2,10 @@ macro_rules! define_slice_to_be {
     ($name: ident, $type: ty) => {
         #[inline]
         pub fn $name(slice: &[u8]) -> $type {
-            assert_eq!(slice.len(), ::std::mem::size_of::<$type>());
+            assert_eq!(slice.len(), ::core::mem::size_of::<$type>());
             let mut res = 0;
-            for i in 0..::std::mem::size_of::<$type>() {
-                res |= (slice[i] as $type) << (::std::mem::size_of::<$type>() - i - 1)*8;
+            for i in 0..::core::mem::size_of::<$type>() {
+                res |= (slice[i] as $type) << (::core::mem::size_of::<$type>() - i - 1)*8;
             }
             res
         }
@@ -15,9 +15,9 @@ macro_rules! define_slice_to_le {
     ($name: ident, $type: ty) => {
         #[inline]
         pub fn $name(slice: &[u8]) -> $type {
-            assert_eq!(slice.len(), ::std::mem::size_of::<$type>());
+            assert_eq!(slice.len(), ::core::mem::size_of::<$type>());
             let mut res = 0;
-            for i in 0..::std::mem::size_of::<$type>() {
+            for i in 0..::core::mem::size_of::<$type>() {
                 res |= (slice[i] as $type) << i*8;
             }
             res
@@ -28,7 +28,7 @@ macro_rules! define_be_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
         pub fn $name(val: $type) -> [u8; $byte_len] {
-            debug_assert_eq!(::std::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            debug_assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
             let mut res = [0; $byte_len];
             for i in 0..$byte_len {
                 res[i] = ((val >> ($byte_len - i - 1)*8) & 0xff) as u8;
@@ -41,7 +41,7 @@ macro_rules! define_le_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
         pub fn $name(val: $type) -> [u8; $byte_len] {
-            debug_assert_eq!(::std::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            debug_assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
             let mut res = [0; $byte_len];
             for i in 0..$byte_len {
                 res[i] = ((val >> i*8) & 0xff) as u8;
@@ -91,8 +91,8 @@ macro_rules! define_chunk_slice_to_int {
     ($name: ident, $type: ty, $converter: ident) => {
         #[inline]
         pub fn $name(inp: &[u8], outp: &mut [$type]) {
-            assert_eq!(inp.len(), outp.len() * ::std::mem::size_of::<$type>());
-            for (outp_val, data_bytes) in outp.iter_mut().zip(inp.chunks(::std::mem::size_of::<$type>())) {
+            assert_eq!(inp.len(), outp.len() * ::core::mem::size_of::<$type>());
+            for (outp_val, data_bytes) in outp.iter_mut().zip(inp.chunks(::core::mem::size_of::<$type>())) {
                 *outp_val = $converter(data_bytes);
             }
         }

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -15,8 +15,8 @@
 //!
 //! Utility functions related to hashing data, including merkleization
 
-use std::cmp::min;
-use std::io;
+use io;
+use core::cmp::min;
 
 use hashes::Hash;
 use consensus::encode::Encodable;

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -19,7 +19,7 @@
 #[deprecated(since = "0.26.1", note = "Please use `util::ecdsa` instead")]
 pub use util::ecdsa::{PrivateKey, PublicKey};
 
-use std::fmt;
+use core::fmt;
 use std::error;
 
 use secp256k1;

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -51,9 +51,8 @@
 //! assert_eq!(1, index.len());
 //! assert_eq!(1, index[0]);
 //! ```
-
 use std::collections::HashSet;
-use std::io;
+use io;
 
 use hashes::Hash;
 use hash_types::{Txid, TxMerkleNode};
@@ -496,7 +495,7 @@ impl Decodable for MerkleBlock {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::min;
+    use core::cmp::min;
 
     use hashes::Hash;
     use hashes::hex::{FromHex, ToHex};

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -29,7 +29,8 @@ pub const BITCOIN_SIGNED_MSG_PREFIX: &[u8] = b"\x18Bitcoin Signed Message:\n";
 
 #[cfg(feature = "secp-recovery")]
 mod message_signing {
-    use std::{error, fmt};
+    use core::fmt;
+    use std::error;
 
     use hashes::sha256d;
     use secp256k1;
@@ -188,7 +189,7 @@ mod message_signing {
     }
 
     #[cfg(feature = "base64")]
-    impl ::std::str::FromStr for MessageSignature {
+    impl ::core::str::FromStr for MessageSignature {
         type Err = MessageSignatureError;
         fn from_str(s: &str) -> Result<MessageSignature, MessageSignatureError> {
             MessageSignature::from_base64(s)
@@ -295,7 +296,7 @@ mod tests {
     #[test]
     #[cfg(all(feature = "secp-recovery", feature = "base64"))]
     fn test_message_signature() {
-        use std::str::FromStr;
+        use core::str::FromStr;
         use secp256k1;
 
         let secp = secp256k1::Secp256k1::new();

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -35,7 +35,8 @@ pub mod bip158;
 
 pub(crate) mod endian;
 
-use std::{error, fmt};
+use core::fmt;
+use std::error;
 
 use network;
 use consensus::encode;

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -13,7 +13,7 @@
 //
 
 use std::error;
-use std::fmt;
+use core::fmt;
 
 use blockdata::transaction::Transaction;
 use consensus::encode;

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -55,10 +55,10 @@ macro_rules! impl_psbt_serialize {
 macro_rules! impl_psbtmap_consensus_encoding {
     ($thing:ty) => {
         impl $crate::consensus::Encodable for $thing {
-            fn consensus_encode<S: ::std::io::Write>(
+            fn consensus_encode<S: $crate::io::Write>(
                 &self,
                 mut s: S,
-            ) -> Result<usize, ::std::io::Error> {
+            ) -> Result<usize, $crate::io::Error> {
                 let mut len = 0;
                 for pair in $crate::util::psbt::Map::get_pairs(self)? {
                     len += $crate::consensus::Encodable::consensus_encode(
@@ -76,10 +76,10 @@ macro_rules! impl_psbtmap_consensus_encoding {
 macro_rules! impl_psbtmap_consensus_decoding {
     ($thing:ty) => {
         impl $crate::consensus::Decodable for $thing {
-            fn consensus_decode<D: ::std::io::Read>(
+            fn consensus_decode<D: $crate::io::Read>(
                 mut d: D,
             ) -> Result<Self, $crate::consensus::encode::Error> {
-                let mut rv: Self = ::std::default::Default::default();
+                let mut rv: Self = ::core::default::Default::default();
 
                 loop {
                     match $crate::consensus::Decodable::consensus_decode(&mut d) {

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -14,8 +14,8 @@
 
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
-use std::io::{self, Cursor, Read};
-use std::cmp;
+use io::{self, Cursor, Read};
+use core::cmp;
 
 use blockdata::transaction::Transaction;
 use consensus::{encode, Encodable, Decodable};

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use std::io;
+use io;
 use std::collections::btree_map::{BTreeMap, Entry};
 
 use blockdata::script::Script;

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use std::io;
+use io;
 
 use consensus::encode;
 use util::psbt;

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use std::io;
+use io;
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -23,7 +23,7 @@ use blockdata::transaction::Transaction;
 use consensus::{encode, Encodable, Decodable};
 use consensus::encode::MAX_VEC_SIZE;
 
-use std::io;
+use io;
 
 mod error;
 pub use self::error::Error;

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -17,7 +17,8 @@
 //! Raw PSBT key-value pairs as defined at
 //! <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki>.
 
-use std::{fmt, io};
+use core::fmt;
+use io;
 
 use consensus::encode::{self, ReadExt, WriteExt, Decodable, Encodable, VarInt, serialize, deserialize, MAX_VEC_SIZE};
 use hashes::hex;

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -17,7 +17,7 @@
 //! Defines traits used for (de)serializing PSBT values into/from raw
 //! bytes in PSBT key-value pairs.
 
-use std::io;
+use io;
 
 use blockdata::script::Script;
 use blockdata::transaction::{SigHashType, Transaction, TxOut};

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -166,26 +166,26 @@ macro_rules! construct_uint {
 
         impl PartialOrd for $name {
             #[inline]
-            fn partial_cmp(&self, other: &$name) -> Option<::std::cmp::Ordering> {
+            fn partial_cmp(&self, other: &$name) -> Option<::core::cmp::Ordering> {
                 Some(self.cmp(&other))
             }
         }
 
         impl Ord for $name {
             #[inline]
-            fn cmp(&self, other: &$name) -> ::std::cmp::Ordering {
+            fn cmp(&self, other: &$name) -> ::core::cmp::Ordering {
                 // We need to manually implement ordering because we use little-endian
                 // and the auto derive is a lexicographic ordering(i.e. memcmp)
                 // which with numbers is equivilant to big-endian
                 for i in 0..$n_words {
-                    if self[$n_words - 1 - i] < other[$n_words - 1 - i] { return ::std::cmp::Ordering::Less; }
-                    if self[$n_words - 1 - i] > other[$n_words - 1 - i] { return ::std::cmp::Ordering::Greater; }
+                    if self[$n_words - 1 - i] < other[$n_words - 1 - i] { return ::core::cmp::Ordering::Less; }
+                    if self[$n_words - 1 - i] > other[$n_words - 1 - i] { return ::core::cmp::Ordering::Greater; }
                 }
-                ::std::cmp::Ordering::Equal
+                ::core::cmp::Ordering::Equal
             }
         }
 
-        impl ::std::ops::Add<$name> for $name {
+        impl ::core::ops::Add<$name> for $name {
             type Output = $name;
 
             fn add(self, other: $name) -> $name {
@@ -205,7 +205,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::Sub<$name> for $name {
+        impl ::core::ops::Sub<$name> for $name {
             type Output = $name;
 
             #[inline]
@@ -214,7 +214,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::Mul<$name> for $name {
+        impl ::core::ops::Mul<$name> for $name {
             type Output = $name;
 
             fn mul(self, other: $name) -> $name {
@@ -229,7 +229,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::Div<$name> for $name {
+        impl ::core::ops::Div<$name> for $name {
             type Output = $name;
 
             fn div(self, other: $name) -> $name {
@@ -237,7 +237,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::Rem<$name> for $name {
+        impl ::core::ops::Rem<$name> for $name {
             type Output = $name;
 
             fn rem(self, other: $name) -> $name {
@@ -287,7 +287,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::BitAnd<$name> for $name {
+        impl ::core::ops::BitAnd<$name> for $name {
             type Output = $name;
 
             #[inline]
@@ -302,7 +302,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::BitXor<$name> for $name {
+        impl ::core::ops::BitXor<$name> for $name {
             type Output = $name;
 
             #[inline]
@@ -317,7 +317,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::BitOr<$name> for $name {
+        impl ::core::ops::BitOr<$name> for $name {
             type Output = $name;
 
             #[inline]
@@ -332,7 +332,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::Not for $name {
+        impl ::core::ops::Not for $name {
             type Output = $name;
 
             #[inline]
@@ -346,7 +346,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::Shl<usize> for $name {
+        impl ::core::ops::Shl<usize> for $name {
             type Output = $name;
 
             fn shl(self, shift: usize) -> $name {
@@ -368,7 +368,7 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::ops::Shr<usize> for $name {
+        impl ::core::ops::Shr<usize> for $name {
             type Output = $name;
 
             fn shr(self, shift: usize) -> $name {
@@ -388,8 +388,8 @@ macro_rules! construct_uint {
             }
         }
 
-        impl ::std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 let &$name(ref data) = self;
                 write!(f, "0x")?;
                 for ch in data.iter().rev() {
@@ -403,10 +403,10 @@ macro_rules! construct_uint {
 
         impl $crate::consensus::Encodable for $name {
             #[inline]
-            fn consensus_encode<S: ::std::io::Write>(
+            fn consensus_encode<S: $crate::io::Write>(
                 &self,
                 mut s: S,
-            ) -> Result<usize, ::std::io::Error> {
+            ) -> Result<usize, $crate::io::Error> {
                 let &$name(ref data) = self;
                 let mut len = 0;
                 for word in data.iter() {
@@ -417,7 +417,7 @@ macro_rules! construct_uint {
         }
 
         impl $crate::consensus::Decodable for $name {
-            fn consensus_decode<D: ::std::io::Read>(
+            fn consensus_decode<D: $crate::io::Read>(
                 mut d: D,
             ) -> Result<$name, $crate::consensus::encode::Error> {
                 use $crate::consensus::Decodable;
@@ -503,8 +503,8 @@ pub struct ParseLengthError {
     pub expected: usize,
 }
 
-impl ::std::fmt::Display for ParseLengthError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl ::core::fmt::Display for ParseLengthError {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "Invalid length: got {}, expected {}", self.actual, self.expected)
     }
 }


### PR DESCRIPTION
Use the core crate when possible, in preparation for `no_std` mode.

See #603 and #409