### PR TITLE
Improvements to Error types (part 4)

### DIFF
--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -429,7 +429,7 @@ pub enum Error {
     /// A pk->pk derivation was attempted on a hardened key
     CannotDeriveFromHardenedKey,
     /// A secp256k1 error occurred
-    Ecdsa(secp256k1::Error), // TODO: This is not necessary ECDSA error and should be renamed
+    Secp256k1(secp256k1::Error),
     /// A child number was provided that was out of range
     InvalidChildNumber(u32),
     /// Invalid childnumber format.
@@ -448,7 +448,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::CannotDeriveFromHardenedKey => f.write_str("cannot derive hardened key from public key"),
-            Error::Ecdsa(ref e) => fmt::Display::fmt(e, f),
+            Error::Secp256k1(ref e) => fmt::Display::fmt(e, f),
             Error::InvalidChildNumber(ref n) => write!(f, "child number {} is invalid (not within [0, 2^31 - 1])", n),
             Error::InvalidChildNumberFormat => f.write_str("invalid child number format"),
             Error::InvalidDerivationPathFormat => f.write_str("invalid derivation path format"),
@@ -462,7 +462,7 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
-       if let Error::Ecdsa(ref e) = *self {
+       if let Error::Secp256k1(ref e) = *self {
            Some(e)
        } else {
            None
@@ -474,13 +474,13 @@ impl From<key::Error> for Error {
     fn from(err: key::Error) -> Self {
         match err {
             key::Error::Base58(e) => Error::Base58(e),
-            key::Error::Secp256k1(e) => Error::Ecdsa(e),
+            key::Error::Secp256k1(e) => Error::Secp256k1(e),
         }
     }
 }
 
 impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error { Error::Ecdsa(e) }
+    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
 }
 
 impl From<base58::Error> for Error {

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -21,6 +21,7 @@ use consensus::encode;
 use util::psbt::raw;
 
 use hashes;
+use util::bip32::ExtendedPubKey;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 /// Enum for marking psbt hash error
@@ -73,8 +74,9 @@ pub enum Error {
         /// Hash value
         hash: Box<[u8]>,
     },
-    /// Data inconsistency/conflicting data during merge procedure
-    MergeConflict(String),
+    /// Conflicting data during merge procedure:
+    /// global extended public key has inconsistent key sources
+    MergeInconsistentKeySources(ExtendedPubKey),
     /// Serialization error in bitcoin consensus-encoded structures
     ConsensusEncoding,
 }
@@ -100,7 +102,7 @@ impl fmt::Display for Error {
                 // directly using debug forms of psbthash enums
                 write!(f, "Preimage {:?} does not match {:?} hash {:?}", preimage, hash_type, hash )
             }
-            Error::MergeConflict(ref s) => { write!(f, "Merge conflict: {}", s) }
+            Error::MergeInconsistentKeySources(ref s) => { write!(f, "merge conflict: {}", s) }
             Error::ConsensusEncoding => f.write_str("bitcoin consensus or BIP-174 encoding error"),
         }
     }

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -213,9 +213,7 @@ impl Map for Global {
                         entry.insert((fingerprint1, derivation1));
                         continue
                     }
-                    return Err(psbt::Error::MergeConflict(format!(
-                        "global xpub {} has inconsistent key sources", xpub
-                    )));
+                    return Err(psbt::Error::MergeInconsistentKeySources(xpub));
                 }
             }
         }


### PR DESCRIPTION
Removes controversial aspects from #560 (all `io::Error`-related changes) and leaves the rest