### PR TITLE
Implement `Block.get_strippedsize()` and `Transaction.get_vsize()`

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -245,14 +245,7 @@ impl Block {
 
     /// Get the strippedsize of the block
     pub fn get_strippedsize(&self) -> usize {
-        let txs_size: usize = self.txdata.iter().map(|tx| {
-            // size = non_witness_size + witness_size.
-            let size = tx.get_size();
-            // weight = WITNESS_SCALE_FACTOR * non_witness_size + witness_size.
-            let weight = tx.get_weight();
-            // weight - size = (WITNESS_SCALE_FACTOR - 1) * non_witness_size.
-            (weight - size) / (WITNESS_SCALE_FACTOR - 1)
-        }).sum();
+        let txs_size: usize = self.txdata.iter().map(Transaction::get_strippedsize).sum();
         self.get_base_size() + txs_size
     }
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -426,6 +426,13 @@ impl Transaction {
         self.get_scaled_size(1)
     }
 
+    /// Gets the "vsize" of this transaction. Will be `ceil(weight / 4.0)`.
+    #[inline]
+    pub fn get_vsize(&self) -> usize {
+        let weight = self.get_weight();
+        (weight / WITNESS_SCALE_FACTOR) + if weight % WITNESS_SCALE_FACTOR == 0 { 0 } else { 1 }
+    }
+
     /// Internal utility function for get_{size,weight}
     fn get_scaled_size(&self, scale_factor: usize) -> usize {
         let mut input_weight = 0;
@@ -853,6 +860,7 @@ mod tests {
                    "a6eab3c14ab5272a58a5ba91505ba1a4b6d7a3a9fcbd187b6cd99a7b6d548cb7".to_string());
         assert_eq!(realtx.get_weight(), tx_bytes.len()*WITNESS_SCALE_FACTOR);
         assert_eq!(realtx.get_size(), tx_bytes.len());
+        assert_eq!(realtx.get_vsize(), tx_bytes.len());
     }
 
     #[test]
@@ -885,6 +893,7 @@ mod tests {
                    "80b7d8a82d5d5bf92905b06f2014dd699e03837ca172e3a59d51426ebbe3e7f5".to_string());
         assert_eq!(realtx.get_weight(), 442);
         assert_eq!(realtx.get_size(), tx_bytes.len());
+        assert_eq!(realtx.get_vsize(), 111);
     }
 
     #[test]

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -927,7 +927,15 @@ mod tests {
         //     weight = WITNESS_SCALE_FACTOR * stripped_size + witness_size
         // then,
         //     stripped_size = (weight - size) / (WITNESS_SCALE_FACTOR - 1)
-        assert_eq!(realtx.get_strippedsize(), (EXPECTED_WEIGHT - tx_bytes.len()) / (WITNESS_SCALE_FACTOR - 1));
+        let expected_strippedsize = (EXPECTED_WEIGHT - tx_bytes.len()) / (WITNESS_SCALE_FACTOR - 1);
+        assert_eq!(realtx.get_strippedsize(), expected_strippedsize);
+        // Construct a transaction without the witness data.
+        let mut tx_without_witness = realtx.clone();
+        tx_without_witness.input.iter_mut().for_each(|input| input.witness.clear());
+        assert_eq!(tx_without_witness.get_weight(), expected_strippedsize*WITNESS_SCALE_FACTOR);
+        assert_eq!(tx_without_witness.get_size(), expected_strippedsize);
+        assert_eq!(tx_without_witness.get_vsize(), expected_strippedsize);
+        assert_eq!(tx_without_witness.get_strippedsize(), expected_strippedsize);
     }
 
     #[test]

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -434,7 +434,6 @@ impl Transaction {
     }
 
     /// Gets the size of this transaction excluding the witness data.
-    #[inline]
     pub fn get_strippedsize(&self) -> usize {
         let mut input_size = 0;
         for input in &self.input {

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -430,7 +430,7 @@ impl Transaction {
     #[inline]
     pub fn get_vsize(&self) -> usize {
         let weight = self.get_weight();
-        (weight / WITNESS_SCALE_FACTOR) + if weight % WITNESS_SCALE_FACTOR == 0 { 0 } else { 1 }
+        (weight + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR
     }
 
     /// Internal utility function for get_{size,weight}


### PR DESCRIPTION
I implemented the following methods:

- `block.get_strippedsize()`: gets the "strippedsize" of a block.
- `tx.get_vsize()`: gets the "virtual" size of a transaction.

The test values added for this code match the values comes from Bitcoin Core.

Edit: `block.get_strippedsize()` will call `tx.get_scaled_size()` twice for every transactions in a block, which cannot be prevented without exposing an extra function in `Transaction` which produces the non-segwit data bytes. This will impact the performance, while the exposed API kept simple.

Edit 2: If you prefer performance over smaller API change, let me know. I will modify my PR (will add `tx.get_strippedsize()`).