### PR TITLE
Bump version to 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.27 - 2020-07-21
+
+- [Bigendian fixes and CI test](https://github.com/rust-bitcoin/rust-bitcoin/pull/627)
+- [no_std support, keeping MSRV](https://github.com/rust-bitcoin/rust-bitcoin/pull/603)
+- [Bech32m adoption](https://github.com/rust-bitcoin/rust-bitcoin/pull/601)
+- [Use Amount type for dust value calculation](https://github.com/rust-bitcoin/rust-bitcoin/pull/616)
+- [Errors enum improvements](https://github.com/rust-bitcoin/rust-bitcoin/pull/521)
+- [std -> core](https://github.com/rust-bitcoin/rust-bitcoin/pull/614)
 
 # 0.26.2 - 2021-06-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.26.2"
+version = "0.27.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
The minor version increment is due to the breaking changes in #601 and #521