### PR TITLE
Removed fuzztarget feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 [features]
 default = [ "std", "secp-recovery" ]
 base64 = [ "base64-compat" ]
-fuzztarget = []
 unstable = []
 rand = ["secp256k1/rand-std"]
 use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ honggfuzz_fuzz = ["honggfuzz"]
 [dependencies]
 honggfuzz = { version = "0.5", optional = true }
 afl = { version = "0.4", optional = true }
-bitcoin = { path = "..", features = ["fuzztarget"] }
+bitcoin = { path = ".." }
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
It seems to be unused and when there's a need for it it's better to use
`--cfg fuzzing` as in `rust-secp256k1 ` and `bitcoin_hashes`.

See https://github.com/rust-bitcoin/rust-bitcoin/pull/633#discussion_r678624842 for context