### PR TITLE
Relax `Script::dust_value` to yield 0 on `MAX_SCRIPT_SIZE`

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -50,6 +50,8 @@ pub const MIN_TRANSACTION_WEIGHT: u32 = 4 * 60;
 pub const WITNESS_SCALE_FACTOR: usize = 4;
 /// The maximum allowed number of signature check operations in a block
 pub const MAX_BLOCK_SIGOPS_COST: i64 = 80_000;
+/// The maximum script length in bytes.
+pub const MAX_SCRIPT_SIZE: usize = 10_000;
 
 /// In Bitcoind this is insanely described as ~((u256)0 >> 32)
 pub fn max_target(_: Network) -> Uint256 {


### PR DESCRIPTION
I thin our `dust_value` helper has a small divergence with Core's `GetDustThreshold()`. Unspendable scripts for which the dust threshold is uplifted encompass outputs script pubkeys with a size superior at`MAX_SCRIPT_SIZE`:
https://github.com/bitcoin/bitcoin/blob/f2e41d11097dde1c841bcaa8615886c984f71632/src/policy/policy.cpp#L30 and https://github.com/bitcoin/bitcoin/blob/f2e41d11097dde1c841bcaa8615886c984f71632/src/script/script.h#L543

This change should not be disruptive for our users as previously marked not valid for broadcast transactions with `MAX_SCRIPT_SIZE` script pubkeys though dust output should from now on be marked good for broadcast.