### PR TITLE
no-std cleanup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,6 @@ jobs:
       - name: Run
         env:
           RUSTFLAGS: "-C link-arg=-Tlink.x"
-          CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -m 1G -nographic -semihosting-config enable=on,target=native -kernel"
+          CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
         run: cd embedded && cargo run --target thumbv7m-none-eabi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ secp-recovery = ["secp256k1/recovery"]
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
 std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std"]
-no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc"]
+no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
 
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }

--- a/embedded/scripts/env.sh
+++ b/embedded/scripts/env.sh
@@ -1,2 +1,2 @@
 export RUSTFLAGS="-C link-arg=-Tlink.x"
-export CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER="qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -m 1G -nographic -semihosting-config enable=on,target=native -kernel"
+export CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER="qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"

--- a/embedded/src/main.rs
+++ b/embedded/src/main.rs
@@ -25,7 +25,7 @@ use cortex_m_semihosting::{debug, hprintln};
 #[global_allocator]
 static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
 
-const HEAP_SIZE: usize = 1024 * 512; // 512 KB
+const HEAP_SIZE: usize = 1024 * 256; // 256 KB
 
 #[entry]
 fn main() -> ! {


### PR DESCRIPTION
- cleanup embedded test memory based on comments under https://github.com/rust-bitcoin/rust-bitcoin/pull/603#pullrequestreview-708333388
- pull in `secp256k1/alloc` for no-std use
