### PR TITLE
Use rustdoc::broken_intra_doc_links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 #![deny(unused_must_use)]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 #[cfg(not(any(feature = "std", feature = "no-std")))]
 compile_error!("at least one of the `std` or `no-std` features must be enabled");


### PR DESCRIPTION
Building the docs emits warning:

  warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`

Use rustdoc::broken_intra_doc_links as suggested.