### PR TITLE
Add OP_CHECKSIGADD and OP_SUCCESSxxx

### DIFF
--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -889,6 +889,17 @@ mod tests {
     }
 
     #[test]
+    fn classify_test() {
+        let op186 = all::OP_CHECKSIGADD;
+        assert_eq!(op186.classify(ClassifyContext::Legacy), Class::ReturnOp);
+        assert_eq!(op186.classify(ClassifyContext::TapScript), Class::Ordinary(Ordinary::OP_CHECKSIGADD));
+
+        let op187 = all::OP_RETURN_187;
+        assert_eq!(op187.classify(ClassifyContext::Legacy), Class::ReturnOp);
+        assert_eq!(op187.classify(ClassifyContext::TapScript), Class::SuccessOp);
+    }
+
+    #[test]
     fn str_roundtrip() {
         let mut unique = HashSet::new();
         roundtrip!(unique, OP_PUSHBYTES_0);

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -407,8 +407,9 @@ impl Script {
 
     /// Whether a script can be proven to have no satisfying input
     pub fn is_provably_unspendable(&self) -> bool {
-        !self.0.is_empty() && (opcodes::All::from(self.0[0]).classify() == opcodes::Class::ReturnOp ||
-                               opcodes::All::from(self.0[0]).classify() == opcodes::Class::IllegalOp)
+        !self.0.is_empty() &&
+            (opcodes::All::from(self.0[0]).classify(opcodes::ClassifyContext::Legacy) == opcodes::Class::ReturnOp ||
+            opcodes::All::from(self.0[0]).classify(opcodes::ClassifyContext::Legacy) == opcodes::Class::IllegalOp)
     }
 
     /// Gets the minimum value an output with this script should have in order to be
@@ -479,7 +480,7 @@ impl Script {
             let opcode = opcodes::All::from(script[index]);
             index += 1;
 
-            let data_len = if let opcodes::Class::PushBytes(n) = opcode.classify() {
+            let data_len = if let opcodes::Class::PushBytes(n) = opcode.classify(opcodes::ClassifyContext::Legacy) {
                 n as usize
             } else {
                 match opcode {
@@ -589,7 +590,9 @@ impl<'a> Iterator for Instructions<'a> {
             return None;
         }
 
-        match opcodes::All::from(self.data[0]).classify() {
+        // classify parameter does not really matter here since we are only using
+        // it for pushes and nums
+        match opcodes::All::from(self.data[0]).classify(opcodes::ClassifyContext::Legacy) {
             opcodes::Class::PushBytes(n) => {
                 let n = n as usize;
                 if self.data.len() < n + 1 {

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -132,7 +132,7 @@ impl Template {
     pub fn first_push_as_number(&self) -> Option<usize> {
         if !self.0.is_empty() {
             if let TemplateElement::Op(op) = self.0[0] {
-                if let opcodes::Class::PushNum(n) = op.classify() {
+                if let opcodes::Class::PushNum(n) = op.classify(opcodes::ClassifyContext::Legacy) {
                     if n >= 0 {
                         return Some(n as usize);
                     }
@@ -248,7 +248,7 @@ pub fn untemplate(script: &script::Script) -> Result<(Template, Vec<PublicKey>),
                 }
             }
             script::Instruction::Op(op) => {
-                match op.classify() {
+                match op.classify(opcodes::ClassifyContext::Legacy) {
                     // CHECKSIG should only come after a list of keys
                     opcodes::Class::Ordinary(opcodes::Ordinary::OP_CHECKSIG) |
                     opcodes::Class::Ordinary(opcodes::Ordinary::OP_CHECKSIGVERIFY) => {

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -223,7 +223,7 @@ pub fn script_find_and_remove(haystack: &mut Vec<u8>, needle: &[u8]) -> usize {
             top = top.wrapping_sub(needle.len());
             if overflow { break; }
         } else {
-            i += match opcodes::All::from((*haystack)[i]).classify() {
+            i += match opcodes::All::from((*haystack)[i]).classify(opcodes::ClassifyContext::Legacy) {
                 opcodes::Class::PushBytes(n) => n as usize + 1,
                 opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA1) => 2,
                 opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA2) => 3,


### PR DESCRIPTION
Adds support for `CHECKSIGADD` and `OP_SUCCESSxxx`. BIP 342 link for reference https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki#specification .

Also makes a minor change to add `INVALIDOPCODE` (was previously `OP_RETURN`)