### PR TITLE
Fixing no_std for Amount sum iterator

### DIFF
--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -523,7 +523,7 @@ impl FromStr for Amount {
     }
 }
 
-impl ::std::iter::Sum for Amount {
+impl ::core::iter::Sum for Amount {
     fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
         let sats: u64 = iter.map(|amt| amt.0).sum();
         Amount::from_sat(sats)
@@ -855,7 +855,7 @@ impl FromStr for SignedAmount {
     }
 }
 
-impl ::std::iter::Sum for SignedAmount {
+impl ::core::iter::Sum for SignedAmount {
     fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
         let sats: i64 = iter.map(|amt| amt.0).sum();
         SignedAmount::from_sat(sats)


### PR DESCRIPTION
The latest merge of https://github.com/rust-bitcoin/rust-bitcoin/pull/615 broke the master b/c it didn't run new `no_std` CI. This PR fixes the problem.