### PR TITLE
Making globals part of PSBT struct. Closes #652

### DIFF
--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -57,17 +57,9 @@ macro_rules! impl_psbtmap_consensus_encoding {
         impl $crate::consensus::Encodable for $thing {
             fn consensus_encode<S: $crate::io::Write>(
                 &self,
-                mut s: S,
+                s: S,
             ) -> Result<usize, $crate::io::Error> {
-                let mut len = 0;
-                for pair in $crate::util::psbt::Map::get_pairs(self)? {
-                    len += $crate::consensus::Encodable::consensus_encode(
-                        &pair,
-                        &mut s,
-                    )?;
-                }
-
-                Ok(len + $crate::consensus::Encodable::consensus_encode(&0x00_u8, s)?)
+                self.consensus_encode_map(s)
             }
         }
     };

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -21,11 +21,11 @@ use blockdata::transaction::Transaction;
 use consensus::{encode, Encodable, Decodable};
 use consensus::encode::MAX_VEC_SIZE;
 use util::psbt::map::Map;
-use util::psbt::raw;
+use util::psbt::{raw, PartiallySignedTransaction};
 use util::psbt;
 use util::psbt::Error;
 use util::endian::u32_to_array_le;
-use util::bip32::{ExtendedPubKey, KeySource, Fingerprint, DerivationPath, ChildNumber};
+use util::bip32::{ExtendedPubKey, Fingerprint, DerivationPath, ChildNumber};
 
 /// Type: Unsigned Transaction PSBT_GLOBAL_UNSIGNED_TX = 0x00
 const PSBT_GLOBAL_UNSIGNED_TX: u8 = 0x00;
@@ -36,50 +36,7 @@ const PSBT_GLOBAL_VERSION: u8 = 0xFB;
 /// Type: Proprietary Use Type PSBT_GLOBAL_PROPRIETARY = 0xFC
 const PSBT_GLOBAL_PROPRIETARY: u8 = 0xFC;
 
-/// A key-value map for global data.
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Global {
-    /// The unsigned transaction, scriptSigs and witnesses for each input must be
-    /// empty.
-    pub unsigned_tx: Transaction,
-    /// The version number of this PSBT. If omitted, the version number is 0.
-    pub version: u32,
-    /// A global map from extended public keys to the used key fingerprint and
-    /// derivation path as defined by BIP 32
-    pub xpub: BTreeMap<ExtendedPubKey, KeySource>,
-    /// Global proprietary key-value pairs.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
-    pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
-    /// Unknown global key-value pairs.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
-    pub unknown: BTreeMap<raw::Key, Vec<u8>>,
-}
-
-impl Global {
-    /// Create a Global from an unsigned transaction, error if not unsigned
-    pub fn from_unsigned_tx(tx: Transaction) -> Result<Self, psbt::Error> {
-        for txin in &tx.input {
-            if !txin.script_sig.is_empty() {
-                return Err(Error::UnsignedTxHasScriptSigs);
-            }
-
-            if !txin.witness.is_empty() {
-                return Err(Error::UnsignedTxHasScriptWitnesses);
-            }
-        }
-
-        Ok(Global {
-            unsigned_tx: tx,
-            xpub: Default::default(),
-            version: 0,
-            proprietary: Default::default(),
-            unknown: Default::default(),
-        })
-    }
-}
-
-impl Map for Global {
+impl Map for PartiallySignedTransaction {
     fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), encode::Error> {
         let raw::Pair {
             key: raw_key,
@@ -220,14 +177,21 @@ impl Map for Global {
 
         self.proprietary.extend(other.proprietary);
         self.unknown.extend(other.unknown);
+
+        for (self_input, other_input) in self.inputs.iter_mut().zip(other.inputs.into_iter()) {
+            self_input.merge(other_input)?;
+        }
+
+        for (self_output, other_output) in self.outputs.iter_mut().zip(other.outputs.into_iter()) {
+            self_output.merge(other_output)?;
+        }
+
         Ok(())
     }
 }
 
-impl_psbtmap_consensus_encoding!(Global);
-
-impl Decodable for Global {
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+impl PartiallySignedTransaction {
+    pub(crate) fn consensus_decode_global<D: io::Read>(d: D) -> Result<Self, encode::Error> {
         let mut d = d.take(MAX_VEC_SIZE as u64);
         let mut tx: Option<Transaction> = None;
         let mut version: Option<u32> = None;
@@ -334,12 +298,15 @@ impl Decodable for Global {
         }
 
         if let Some(tx) = tx {
-            let mut rv: Global = Global::from_unsigned_tx(tx)?;
-            rv.version = version.unwrap_or(0);
-            rv.xpub = xpub_map;
-            rv.unknown = unknowns;
-            rv.proprietary = proprietary;
-            Ok(rv)
+            Ok(PartiallySignedTransaction {
+                unsigned_tx: tx,
+                version: version.unwrap_or(0),
+                xpub: xpub_map,
+                proprietary,
+                unknown: unknowns,
+                inputs: vec![],
+                outputs: vec![]
+            })
         } else {
             Err(Error::MustHaveUnsignedTx.into())
         }

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -30,6 +30,22 @@ pub trait Map {
 
     /// Attempt to merge with another key-value map of the same type.
     fn merge(&mut self, other: Self) -> Result<(), psbt::Error>;
+
+    /// Encodes map data with bitcoin consensus encoding
+    fn consensus_encode_map<S: io::Write>(
+        &self,
+        mut s: S,
+    ) -> Result<usize, io::Error> {
+        let mut len = 0;
+        for pair in Map::get_pairs(self)? {
+            len += encode::Encodable::consensus_encode(
+                &pair,
+                &mut s,
+            )?;
+        }
+
+        Ok(len + encode::Encodable::consensus_encode(&0x00_u8, s)?)
+    }
 }
 
 // place at end to pick up macros
@@ -37,6 +53,5 @@ mod global;
 mod input;
 mod output;
 
-pub use self::global::Global;
 pub use self::input::Input;
 pub use self::output::Output;


### PR DESCRIPTION
I took the most non-invasive approach to reduce diff size. Many parts of the code can be improved in style or further refactored (like some functions are not necessary and can be just moved to be part of other functions), but I'd prefer to do that as a separate PR once this will be merged.

My approach with this PR:
1. Remove `Global` struct by moving its fields right into `PartiallySignedTransaction` - but keep the `util/psbt/map/global.rs` file with all its logic
2. Keep existing `Map for Global` implementation in the same file, but just change it to `Map for PartiallySignedTransaction` 
3. With serialization, convert `Global` deserialization into crate-private function and use it from `PartiallySignedTransaction` deserialization
4. Refactor the tests and imports as required to get the thing compile and pass tests

The refactoring will be followed by PR(s) adding support for Taproot