### PR TITLE
Add i686 to tested architectures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,27 @@ jobs:
         env: ${{ matrix.env }}
         run: ./contrib/test.sh
 
+  Arch32bit:
+    name: Testing 32-bit version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v2
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Add architecture i386
+        run: sudo dpkg --add-architecture i386
+      - name: Install i686 gcc
+        run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib
+      - name: Install target
+        run: rustup target add i686-unknown-linux-gnu
+      - name: Run test on i686
+        run: cargo test --target i686-unknown-linux-gnu
+
   Cross:
     name: Cross testing
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds i686 to CI which can help catching pointer-size-related bugs
such as the one addressed by #658.

Opening a new PR seemed more appropriate than adding it to #658 I can change it if you disagree.