### PR TITLE
Refactor Script::bytes_to_asm_fmt to use iterator

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fuzz_target: [deser_net_msg, deserialize_address, deserialize_amount, deserialize_block, deserialize_psbt, deserialize_script, deserialize_transaction, outpoint_string, uint128_fuzz]
+        fuzz_target: [deser_net_msg, deserialize_address, deserialize_amount, deserialize_block, deserialize_psbt, deserialize_script, deserialize_transaction, outpoint_string, uint128_fuzz, script_bytes_to_asm_fmt]
     steps:
       - name: Install test dependencies
         run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -55,3 +55,7 @@ path = "fuzz_targets/deser_net_msg.rs"
 [[bin]]
 name = "uint128_fuzz"
 path = "fuzz_targets/uint128_fuzz.rs"
+
+[[bin]]
+name = "script_bytes_to_asm_fmt"
+path = "fuzz_targets/script_bytes_to_asm_fmt.rs"

--- a/fuzz/fuzz_targets/script_bytes_to_asm_fmt.rs
+++ b/fuzz/fuzz_targets/script_bytes_to_asm_fmt.rs
@@ -1,0 +1,41 @@
+extern crate bitcoin;
+
+use std::fmt;
+
+// faster than String, we don't need to actually produce the value, just check absence of panics
+struct NullWriter;
+
+impl fmt::Write for NullWriter {
+    fn write_str(&mut self, _s: &str) -> fmt::Result {
+        Ok(())
+    }
+
+    fn write_char(&mut self, _c: char) -> fmt::Result {
+        Ok(())
+    }
+}
+
+fn do_test(data: &[u8]) {
+    let mut writer = NullWriter;
+    bitcoin::Script::bytes_to_asm_fmt(data, &mut writer);
+}
+
+#[cfg(feature = "afl")]
+#[macro_use] extern crate afl;
+#[cfg(feature = "afl")]
+fn main() {
+    fuzz!(|data| {
+        do_test(&data);
+    });
+}
+
+#[cfg(feature = "honggfuzz")]
+#[macro_use] extern crate honggfuzz;
+#[cfg(feature = "honggfuzz")]
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}


### PR DESCRIPTION
*Because of this change being somewhat large I didn't do it together with #658.
I also don't mind if this is merged after Taproot (feel free to put off review).*

This refactors `Script::bytes_to_asm_fmt`` function to use an iterator
instead of index. Such change makes it easier to reason about overflows
or out-of-bounds accesses. As a result this also fixes three unlikely
overflows and happens to improve formatting to not output space at the
beginning in some weird cases.

To improve robustness even better it also moves `read_uint`
implementation to internal function which returns a more specific error
type which can be exhaustively matched on to guarantee correct error
handling. Probably because of lack of this the code was previously
checking the same condition twice, the second time being unreachable and
attempting to behave differently than the first one.

Finally this uses macro to deduplicate code which differs only in single
number, ensuring the code stays in sync across all branches.


I also attempted to get this work with `no_panic` crate to prove absence of panic but looks
like the compiler can not do that. (Yes, I did change writer to be trivial and a bunch of other things.)
If someone wants to give it a try I can publish that change.

**Unresolved question**

Since `Error` seems to be related to script execution maybe `UintError` should be public?
At least `NumericOverflow` variant is strange.