### PR TITLE
tests: improve coverage for P2tr and AddressType

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -963,6 +963,26 @@ mod tests {
     }
 
     #[test]
+    fn test_address_type() {
+        let addresses = [
+            ("1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY", Some(AddressType::P2pkh)),
+            ("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k", Some(AddressType::P2sh)),
+            ("bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw", Some(AddressType::P2wpkh)),
+            ("bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej", Some(AddressType::P2wsh)),
+            ("bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr", Some(AddressType::P2tr)),
+            // Related to future extensions, addresses are valid but have no type
+            // segwit v1 and len != 32
+            ("bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y", None),
+            // segwit v2
+            ("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", None),
+        ];
+        for (address, expected_type) in &addresses {
+            let addr = Address::from_str(&address).unwrap();
+            assert_eq!(&addr.address_type(), expected_type);
+        }
+    }
+
+    #[test]
     fn test_bip173_350_vectors() {
         // Test vectors valid under both BIP-173 and BIP-350
         let valid_vectors = [
@@ -1179,5 +1199,7 @@ mod tests {
         let internal_key = schnorrsig::PublicKey::from_str("cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115").unwrap();
         let address = Address::p2tr(Secp256k1::new(), internal_key,None, Network::Bitcoin);
         assert_eq!(address.to_string(), "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr");
+        assert_eq!(address.address_type(), Some(AddressType::P2tr));
+        roundtrips(&address);
     }
 }


### PR DESCRIPTION
The new AddressType test shows addresses that are valid but have
no type. If in the future some of those get a type or become
invalid (either voluntarily or due to a regression), this will
highlight it.