### PR TITLE
More complete `MessageSignature.is_signed_by_address`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -332,8 +332,7 @@ pub fn base58_check_decode(address: &Address) -> Vec<u8> {
     match &address.payload {
         Payload::ScriptHash(hash) => hash.to_vec(),
         Payload::PubkeyHash(hash) => hash.to_vec(),
-        // Payload::WitnessProgram { program, .. } => program,
-        _ => vec![]
+        Payload::WitnessProgram { program, .. } => program.clone(),
     }
 }
 

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -91,12 +91,10 @@ mod message_signing {
         pub fn from_flag_byte(byte: u8) -> Option<SegwitType> {
             if (byte & 8) == 0 {
                 None
+            } else if (byte & 4) == 0 {
+                Some(SegwitType::P2shwpkh)
             } else {
-                if (byte & 4) == 0 {
-                    Some(SegwitType::P2shwpkh)
-                } else {
-                    Some(SegwitType::P2wpkh)
-                }
+                Some(SegwitType::P2wpkh)
             }
         }
     }
@@ -309,7 +307,7 @@ pub fn signed_msg_hash(msg: &str) -> sha256d::Hash {
 }
 
 /// Ripemd160 hash of sha256 hash of given data
-pub fn hash160(data: &Vec<u8>) -> ripemd160::Hash {
+pub fn hash160(data: &[u8]) -> ripemd160::Hash {
     let mut sha_engine = sha256::Hash::engine();
     sha_engine.input(data);
     let inner = sha256::Hash::from_engine(sha_engine);
@@ -320,9 +318,9 @@ pub fn hash160(data: &Vec<u8>) -> ripemd160::Hash {
 }
 
 /// Convert a byte array of a pubkey hash into a segwit redeem hash
-pub fn segwit_redeem_hash(pubkey_hash: &Vec<u8>) -> ripemd160::Hash {
+pub fn segwit_redeem_hash(pubkey_hash: &[u8]) -> ripemd160::Hash {
     let mut redeem_script: Vec<u8> = vec![0, 20];
-    redeem_script.append(&mut pubkey_hash.clone());
+    redeem_script.append(&mut pubkey_hash.to_vec());
     hash160(&redeem_script)
 }
 

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -219,7 +219,7 @@ mod message_signing {
                     let expected = get_payload_bytes(address);
                     Ok(actual == expected)
                 },
-                Some(_) => {
+                Some(SegwitType::P2wpkh) => {
                     let expected = bech32_decode(address).unwrap();
                     Ok(pubkey_hash == expected)
                 },

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -46,7 +46,7 @@ mod message_signing {
     use util::ecdsa::PublicKey;
     use util::address::{Address};
 
-    use super::{bech32_decode, segwit_redeem_hash, base58_check_decode};
+    use super::{bech32_decode, segwit_redeem_hash, get_payload_bytes};
 
     /// An error used for dealing with Bitcoin Signed Messages.
     #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
@@ -206,7 +206,7 @@ mod message_signing {
                         Ok(data) => data,
                         Err(_) => {
                             let redeem_hash = segwit_redeem_hash(&pubkey_hash).to_vec();
-                            let base58_check = base58_check_decode(address);
+                            let base58_check = get_payload_bytes(address);
                             return Ok(
                                 (pubkey_hash == base58_check) ||
                                 (redeem_hash == base58_check)
@@ -217,7 +217,7 @@ mod message_signing {
                 },
                 Some(SegwitType::P2shwpkh) => {
                     let actual = segwit_redeem_hash(&pubkey_hash).to_vec();
-                    let expected = base58_check_decode(address);
+                    let expected = get_payload_bytes(address);
                     Ok(actual == expected)
                 },
                 Some(_) => {
@@ -327,8 +327,8 @@ pub fn segwit_redeem_hash(pubkey_hash: &Vec<u8>) -> ripemd160::Hash {
     hash160(&redeem_script)
 }
 
-/// docs
-pub fn base58_check_decode(address: &Address) -> Vec<u8> {
+/// Pull out payload as byte array
+pub fn get_payload_bytes(address: &Address) -> Vec<u8> {
     match &address.payload {
         Payload::ScriptHash(hash) => hash.to_vec(),
         Payload::PubkeyHash(hash) => hash.to_vec(),

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -17,6 +17,7 @@
 //! Various utility functions
 
 use prelude::*;
+use bech32;
 
 use hashes::{sha256, sha256d, Hash, HashEngine};
 
@@ -46,7 +47,7 @@ mod message_signing {
     use util::ecdsa::PublicKey;
     use util::address::{Address};
 
-    use crate::util::misc::{bech32_decode, segwit_redeem_hash, hash160, get_payload_bytes};
+    use util::misc::{bech32_decode, segwit_redeem_hash, hash160, get_payload_bytes};
 
     /// An error used for dealing with Bitcoin Signed Messages.
     #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
@@ -343,7 +344,7 @@ pub enum Bech32DecodingError {
 }
 
 /// decode address to Bech32 u8 byte array
-pub fn bech32_decode(address: &crate::Address) -> Result<Vec<u8>, Bech32DecodingError> {
+pub fn bech32_decode(address: &Address) -> Result<Vec<u8>, Bech32DecodingError> {
     match bech32::decode(&address.to_string()) {
         Ok((_, u5_vec, _)) => bech32_from_words(&u5_vec[1..]),
         Err(e) => Err(Bech32DecodingError::InvalidEncoding(e))
@@ -465,11 +466,13 @@ mod tests {
 
     #[cfg(all(feature = "secp-recovery"))]
     mod is_signed_by_address {
+        use secp256k1;
         use std::str::FromStr;
 
         use hashes::hex::FromHex;
         use super::super::MessageSignature;
-        use crate::{Address, util::misc::signed_msg_hash};
+        use util::address::Address;
+        use util::misc::signed_msg_hash;
 
         #[test]
         fn test_p2wpkh() {

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -155,10 +155,6 @@ mod message_signing {
             if bytes.len() != 65 {
                 return Err(MessageSignatureError::InvalidLength);
             }
-            // We just check this here so we can safely subtract further.
-            if bytes[0] < 27 {
-                return Err(MessageSignatureError::InvalidEncoding(secp256k1::Error::InvalidRecoveryId));
-            };
             // array access safe because of the check above
             let flag_byte = bytes[0]
                 .checked_sub(27)

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -345,7 +345,7 @@ pub enum Bech32DecodingError {
 }
 
 /// decode address to Bech32 u8 byte array
-fn bech32_decode(address: &crate::Address) -> Result<Vec<u8>, Bech32DecodingError> {
+pub fn bech32_decode(address: &crate::Address) -> Result<Vec<u8>, Bech32DecodingError> {
     match bech32::decode(&address.to_string()) {
         Ok((_, u5_vec, _)) => bech32_from_words(&u5_vec[1..]),
         Err(e) => Err(Bech32DecodingError::InvalidEncoding(e))
@@ -465,6 +465,7 @@ mod tests {
         assert_eq!(signature2.is_signed_by_address(&secp, &p2shwpkh, msg_hash), Ok(true));
     }
 
+    #[cfg(all(feature = "secp-recovery"))]
     mod is_signed_by_address {
         use std::str::FromStr;
 

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -345,6 +345,7 @@ pub enum Bech32DecodingError {
     /// The Bech32 is invalidly encoded
     InvalidEncoding(bech32::Error),
 }
+
 /// decode address to Bech32 u8 byte array
 fn bech32_decode(address: &crate::Address) -> Result<Vec<u8>, Bech32DecodingError> {
     match bech32::decode(&address.to_string()) {


### PR DESCRIPTION
I noticed that the current version only seems to support p2pkh and all other address types default to false with no error thrown.

I effectively just ported this piece from bitcoinjs-message: https://github.com/bitcoinjs/bitcoinjs-message/blob/c43430f4c03c292c719e7801e425d887cbdf7464/index.js#L181-L233

I'm fairly new to rust, but I'm open to all suggestions to learn and to get this merged.

# Testing

I included unit tests for
- p2pkh
- p2wpkh
- p2shwph

I also amended the `test_message_signature` test which was asserting `false` on values that should clearly be `true`, but were just returning `false` due to lack of support.