### PR TITLE
Allow unknown lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+// Unknown lint warnings occur when linting with an old version of clippy and
+// hitting code that allows a lint that exists only in newer versions of clippy.
+#![allow(unknown_lints)]
 // Coding conventions
 #![forbid(unsafe_code)]
 #![deny(non_upper_case_globals)]


### PR DESCRIPTION
We support many versions of rustc by design, this puts us in the following predicament:

1. Linting with a newer version of clippy throws a warning for a newly introduced default lint.
2. In order to allow the lint we must use the lint by name but this lint does not exist in earlier versions of clippy, so we get a warning `unknown lint` when linting with the earlier version.

We want to have our cake and eat it too, we can do this by allowing unknown lints. Doing so enables (1) while preventing (2).

This will help us introduce clippy into the CI pipeline because we can better control lint output for different versions of the toolchain.

Before this patch was applied `cargo +1.36 check` emits:

    warning: unknown lint: `broken_intra_doc_links`

With this patch applied the warning is removed.

I have also raised PRs, doing the same thing, in:
- [bitcoin_hashes](https://github.com/rust-bitcoin/bitcoin_hashes/pull/137)
- [rust-secp256k1](https://github.com/rust-bitcoin/rust-secp256k1/pull/337)
- [rust-miniscript](https://github.com/rust-bitcoin/rust-miniscript/pull/279)