### PR TITLE
BUG: Does not work with `no_std` under 1.29 (MSRV)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,10 @@ jobs:
           - rust: 1.41.1
             env:
               AS_DEPENDENCY: true
+          - rust: 1.47
+            env:
+              AS_DEPENDENCY: true
+              DO_NO_STD: true
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 Cargo.lock
+dep_test
 
 #fuzz
 fuzz/hfuzz_target

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ please join us in
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features on **Rust 1.29**.
+This library should always compile with any combination of features (minus
+`no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
 
 Because some dependencies have broken the build in minor/patch releases, to
 compile with 1.29.0 you will need to run the following version-pinning command:

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -74,7 +74,8 @@ impl fmt::Debug for ExtendedPrivKey {
             .field("parent_fingerprint", &self.parent_fingerprint)
             .field("child_number", &self.child_number)
             .field("chain_code", &self.chain_code)
-            .finish_non_exhaustive()
+            .field("private_key", &"[SecretKey]")
+            .finish()
     }
 }
 


### PR DESCRIPTION
`rust-bitcoin` does not work with rust 1.29 under a `no_std` environment. This could be considered a bug. However, `no_std` support is a recent addition and this is likely not breaking anyone's builds.

A decision needs to be made, either `no_std` MSRV is the current stable version while keeping the `std` MSRV as 1.29, or it needs to be fixed.

This pr adds `no_std` to the 1.29 test suite.

This came as I try to get rust-bitcoin/rust-miniscript#277 working and got stuck on the issue of testing `no_std` under 1.29.