### PR TITLE
P2TR address from untweaked key

### DIFF
--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -17,3 +17,67 @@
 //!
 
 pub use secp256k1::schnorrsig::{PublicKey, KeyPair};
+use secp256k1::{Secp256k1, Verification};
+use hashes::{Hash, HashEngine};
+use util::taproot::{TapBranchHash, TapTweakHash};
+
+/// Untweaked Schnorr public key
+pub type UntweakedPublicKey = PublicKey;
+
+/// Tweaked Schnorr public key
+pub struct TweakedPublicKey(PublicKey);
+
+/// A trait for tweaking Schnorr public keys
+pub trait TapTweak {
+    /// Tweaks an untweaked public key given an untweaked key and optional script tree merkle root.
+    /// 
+    /// This is done by using the equation Q = P + H(P|c)G, where 
+    ///  * Q is the tweaked key
+    ///  * P is the internal key
+    ///  * H is the hash function
+    ///  * c is the commitment data
+    ///  * G is the generator point
+    fn tap_tweak<C: Verification>(&self, secp: Secp256k1<C>, merkle_root: Option<TapBranchHash>) -> TweakedPublicKey;
+
+    /// Directly convert an UntweakedPublicKey to a TweakedPublicKey
+    /// 
+    /// This method is dangerous and can lead to loss of funds if used incorrectly.
+    /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
+    fn dangerous_assume_tweaked(self) -> TweakedPublicKey;
+}
+
+impl TapTweak for UntweakedPublicKey {
+    fn tap_tweak<C: Verification>(&self, secp: Secp256k1<C>, merkle_root: Option<TapBranchHash>) -> TweakedPublicKey {
+        // Compute the tweak
+        let mut engine = TapTweakHash::engine();
+        engine.input(&self.serialize());
+        merkle_root.map(|hash| engine.input(&hash));
+        let tweak_value: [u8; 32] = TapTweakHash::from_engine(engine).into_inner();
+            
+
+        //Tweak the internal key by the tweak value
+        let mut output_key = self.clone();
+        let parity = output_key.tweak_add_assign(&secp, &tweak_value).expect("Tap tweak failed");
+        if self.tweak_add_check(&secp, &output_key, parity, tweak_value) {
+            return TweakedPublicKey(output_key);
+        } else { unreachable!("Tap tweak failed") }
+    }
+
+    
+    fn dangerous_assume_tweaked(self) -> TweakedPublicKey {
+        TweakedPublicKey(self)
+    }
+}
+
+
+impl TweakedPublicKey {
+    /// Create a new [TweakedPublicKey] from a [PublicKey]. No tweak is applied.
+    pub fn new(key: PublicKey) -> TweakedPublicKey {
+        TweakedPublicKey(key)
+    }
+    
+    /// Returns the underlying public key 
+    pub fn into_inner(self) -> PublicKey {
+        self.0
+    }
+}


### PR DESCRIPTION
Addressing issue #687.

Changes:
- New method `Address::dangerous_p2tr` that creates an address given an untweaked internal key and optional merkle root of a script tree. The method utilizes existing hash methods from within the library and key tweaking from the `rust-secp256k1` library.
- Added a test to create a P2TR address from an internal key without a script tree. Test was taken from BIP-86.

Questions:
- Should key tweaking be a seperate function in it self? Since the `secp256k1` key tweaking method does not hash the data, there could be a method that does the tweaking and commitment part of the `Address::dangerous_p2tr` method. 
- What error should `Address::dangerous_p2tr` return if an error occurs while tweaking the internal key?

I would love feedback as this is my first PR to this repository.


## See updated changes below