### PR TITLE
Hotfix for secp256k1 alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustc-args = ["--cfg", "docsrs"]
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }
 bitcoin_hashes = { version = "0.10.0", default-features = false }
-secp256k1 = { version = "0.20.2", default-features = false }
+secp256k1 = { version = "0.20.3", default-features = false }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64-compat = { version = "1.0.0", optional = true }


### PR DESCRIPTION
Latest merges has broken builds since they have introduced `alloc` feature in `secp256k1` which appeared only in `0.20.3` version, while `Cargo.toml` here still required `0.20.2`

This was not caught by CI since it always runs with `cargo update`