### PR TITLE
Taproot tweaks generalization & KeyPair support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - rust: stable

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -315,12 +315,24 @@ impl Script {
     }
 
     /// Generates P2WPKH-type of scriptPubkey
+    #[deprecated(since = "0.28.0", note = "use Script::new_v0_p2wpkh method instead")]
     pub fn new_v0_wpkh(pubkey_hash: &WPubkeyHash) -> Script {
+        Script::new_v0_p2wpkh(pubkey_hash)
+    }
+
+    /// Generates P2WPKH-type of scriptPubkey
+    pub fn new_v0_p2wpkh(pubkey_hash: &WPubkeyHash) -> Script {
         Script::new_witness_program(WitnessVersion::V0, &pubkey_hash[..])
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
+    #[deprecated(since = "0.28.0", note = "use Script::new_v0_p2wsh method instead")]
     pub fn new_v0_wsh(script_hash: &WScriptHash) -> Script {
+        Script::new_v0_p2wsh(script_hash)
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
+    pub fn new_v0_p2wsh(script_hash: &WScriptHash) -> Script {
         Script::new_witness_program(WitnessVersion::V0, &script_hash[..])
     }
 
@@ -388,7 +400,7 @@ impl Script {
     /// Compute the P2WSH output corresponding to this witnessScript (aka the "witness redeem
     /// script")
     pub fn to_v0_p2wsh(&self) -> Script {
-        Script::new_v0_wsh(&self.wscript_hash())
+        Script::new_v0_p2wsh(&self.wscript_hash())
     }
 
     /// Compute P2TR output with a given internal key and a single script spending path equal to the
@@ -461,7 +473,7 @@ impl Script {
     pub fn is_v0_p2wsh(&self) -> bool {
         self.0.len() == 34 &&
             self.witness_version() == Some(WitnessVersion::V0) &&
-        self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
+            self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
     }
 
     /// Checks whether a script pubkey is a p2wpkh output
@@ -1082,7 +1094,7 @@ mod test {
         assert!(Script::new_p2pkh(&pubkey_hash).is_p2pkh());
 
         let wpubkey_hash = WPubkeyHash::hash(&pubkey.inner.serialize());
-        assert!(Script::new_v0_wpkh(&wpubkey_hash).is_v0_p2wpkh());
+        assert!(Script::new_v0_p2wpkh(&wpubkey_hash).is_v0_p2wpkh());
 
         let script = Builder::new().push_opcode(opcodes::all::OP_NUMEQUAL)
                                    .push_verify()
@@ -1093,7 +1105,7 @@ mod test {
         assert_eq!(script.to_p2sh(), p2sh);
 
         let wscript_hash = WScriptHash::hash(&script.serialize());
-        let p2wsh = Script::new_v0_wsh(&wscript_hash);
+        let p2wsh = Script::new_v0_p2wsh(&wscript_hash);
         assert!(p2wsh.is_v0_p2wsh());
         assert_eq!(script.to_v0_p2wsh(), p2wsh);
 

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -41,6 +41,9 @@ use policy::DUST_RELAY_TX_FEE;
 
 use util::ecdsa::PublicKey;
 use util::address::WitnessVersion;
+use util::taproot::{LeafVersion, TapBranchHash, TapLeafHash};
+use secp256k1::{Secp256k1, Verification};
+use schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
 
 /// A Bitcoin script.
 #[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -313,12 +316,27 @@ impl Script {
 
     /// Generates P2WPKH-type of scriptPubkey
     pub fn new_v0_wpkh(pubkey_hash: &WPubkeyHash) -> Script {
-        Script::new_witness_program(WitnessVersion::V0, &pubkey_hash.to_vec())
+        Script::new_witness_program(WitnessVersion::V0, &pubkey_hash[..])
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
     pub fn new_v0_wsh(script_hash: &WScriptHash) -> Script {
-        Script::new_witness_program(WitnessVersion::V0, &script_hash.to_vec())
+        Script::new_witness_program(WitnessVersion::V0, &script_hash[..])
+    }
+
+    /// Generates P2TR for script spending path using an internal public key and some optional
+    /// script tree merkle root.
+    pub fn new_v1_p2tr<C: Verification>(secp: &Secp256k1<C>, internal_key: UntweakedPublicKey, merkle_root: Option<TapBranchHash>) -> Script {
+        let (output_key, _) = internal_key.tap_tweak(secp, merkle_root);
+        Script::new_witness_program(WitnessVersion::V1, &output_key.serialize())
+    }
+
+    /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].
+    ///
+    /// NB: Make sure that the used key is indeed tweaked (for instance, it comes from `rawtr`
+    /// descriptor content); otherwise please use [`Script::new_v1_p2tr`] method.
+    pub fn new_v1_p2tr_tweaked(output_key: TweakedPublicKey) -> Script {
+        Script::new_witness_program(WitnessVersion::V1, &output_key.serialize())
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
@@ -371,6 +389,20 @@ impl Script {
     /// script")
     pub fn to_v0_p2wsh(&self) -> Script {
         Script::new_v0_wsh(&self.wscript_hash())
+    }
+
+    /// Compute P2TR output with a given internal key and a single script spending path equal to the
+    /// current script, assuming that the script is a Tapscript
+    #[inline]
+    pub fn to_v1_p2tr<C: Verification>(&self, secp: &Secp256k1<C>, internal_key: UntweakedPublicKey) -> Script {
+        let leaf_hash = TapLeafHash::from_script(&self, LeafVersion::TapScript);
+        let merkle_root = TapBranchHash::from_inner(leaf_hash.into_inner());
+        Script::new_v1_p2tr(&secp, internal_key, Some(merkle_root))
+    }
+
+    #[inline]
+    fn witness_version(&self) -> Option<WitnessVersion> {
+        WitnessVersion::from_opcode(self.0[0].into()).ok()
     }
 
     /// Checks whether a script pubkey is a p2sh output
@@ -428,7 +460,7 @@ impl Script {
     #[inline]
     pub fn is_v0_p2wsh(&self) -> bool {
         self.0.len() == 34 &&
-        self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
+            self.witness_version() == Some(WitnessVersion::V0) &&
         self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
     }
 
@@ -436,8 +468,16 @@ impl Script {
     #[inline]
     pub fn is_v0_p2wpkh(&self) -> bool {
         self.0.len() == 22 &&
-            self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
+            self.witness_version() == Some(WitnessVersion::V0) &&
             self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8()
+    }
+
+    /// Checks whether a script pubkey is a P2TR output
+    #[inline]
+    pub fn is_v1_p2tr(&self) -> bool {
+        self.0.len() == 34 &&
+            self.witness_version() == Some(WitnessVersion::V1) &&
+            self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
     }
 
     /// Check if this is an OP_RETURN output

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -320,7 +320,7 @@ mod tests {
         let msg = secp256k1::Message::from_slice(&msg_hash).unwrap();
 
         let privkey = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());
-        let secp_sig = secp.sign_recoverable(&msg, &privkey);
+        let secp_sig = secp.sign_ecdsa_recoverable(&msg, &privkey);
         let signature = super::MessageSignature {
             signature: secp_sig,
             compressed: true,


### PR DESCRIPTION
* Adds taproot-related methods to `Script`
* Fixes API for existing taproot methods
* Generalizes `TapTweak` trait to work with both public keys and key pairs

~~UPD: PR is pending https://github.com/rust-bitcoin/rust-secp256k1/pull/342~~