### PR TITLE
Use TapTweakHash::from_key_and_tweak() method in computing tweak for UntweakedPublicKey

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -524,7 +524,7 @@ impl Address {
     pub fn p2tr<C: Verification>(
         secp: &Secp256k1<C>,
         internal_key: UntweakedPublicKey,
-        merkle_root: Option<&TapBranchHash>,
+        merkle_root: Option<TapBranchHash>,
         network: Network
     ) -> Address {
         Address {


### PR DESCRIPTION
Quick follow up PR to #691 using a method from #677.

### Changes
- Updated `UntweakedPublicKey::tap_tweak(...)` to use `TapTweakHash::from_key_and_tweak(...)`