### PR TITLE
Separate signature hash types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub use blockdata::transaction::Transaction;
 pub use blockdata::transaction::TxIn;
 pub use blockdata::transaction::TxOut;
 pub use blockdata::transaction::OutPoint;
-pub use blockdata::transaction::SigHashType;
+pub use blockdata::transaction::EcdsaSigHashType;
 pub use consensus::encode::VarInt;
 pub use network::constants::Network;
 pub use util::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,8 @@ pub use util::amount::SignedAmount;
 pub use util::merkleblock::MerkleBlock;
 pub use util::sighash::SchnorrSigHashType;
 
-pub use util::ecdsa;
-pub use util::schnorr;
+pub use util::ecdsa::{self, EcdsaSig, EcdsaSigError};
+pub use util::schnorr::{self, SchnorrSig, SchnorrSigError};
 #[deprecated(since = "0.26.1", note = "Please use `ecdsa::PrivateKey` instead")]
 pub use util::ecdsa::PrivateKey;
 #[deprecated(since = "0.26.1", note = "Please use `ecdsa::PublicKey` instead")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ pub use util::amount::Amount;
 pub use util::amount::Denomination;
 pub use util::amount::SignedAmount;
 pub use util::merkleblock::MerkleBlock;
+pub use util::sighash::SchnorrSigHashType;
 
 pub use util::ecdsa;
 pub use util::schnorr;

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -22,7 +22,7 @@
 use hashes::Hash;
 use hash_types::SigHash;
 use blockdata::script::Script;
-use blockdata::transaction::{Transaction, TxIn, SigHashType};
+use blockdata::transaction::{Transaction, TxIn, EcdsaSigHashType};
 use consensus::{encode, Encodable};
 
 use prelude::*;
@@ -131,7 +131,7 @@ impl<R: Deref<Target=Transaction>> SigHashCache<R> {
         input_index: usize,
         script_code: &Script,
         value: u64,
-        sighash_type: SigHashType,
+        sighash_type: EcdsaSigHashType,
     ) -> Result<(), encode::Error> {
         self.cache
             .segwit_encode_signing_data_to(writer, input_index, script_code, value, sighash_type.into())
@@ -146,7 +146,7 @@ impl<R: Deref<Target=Transaction>> SigHashCache<R> {
         input_index: usize,
         script_code: &Script,
         value: u64,
-        sighash_type: SigHashType
+        sighash_type: EcdsaSigHashType
     ) -> SigHash {
         let mut enc = SigHash::engine();
         self.encode_signing_data_to(&mut enc, input_index, script_code, value, sighash_type)
@@ -165,7 +165,7 @@ impl<R: DerefMut<Target=Transaction>> SigHashCache<R> {
     /// panics if `input_index` is out of bounds with respect of the number of inputs
     ///
     /// ```
-    /// use bitcoin::blockdata::transaction::{Transaction, SigHashType};
+    /// use bitcoin::blockdata::transaction::{Transaction, EcdsaSigHashType};
     /// use bitcoin::util::bip143::SigHashCache;
     /// use bitcoin::Script;
     ///
@@ -175,7 +175,7 @@ impl<R: DerefMut<Target=Transaction>> SigHashCache<R> {
     /// let mut sig_hasher = SigHashCache::new(&mut tx_to_sign);
     /// for inp in 0..input_count {
     ///     let prevout_script = Script::new();
-    ///     let _sighash = sig_hasher.signature_hash(inp, &prevout_script, 42, SigHashType::All);
+    ///     let _sighash = sig_hasher.signature_hash(inp, &prevout_script, 42, EcdsaSigHashType::All);
     ///     // ... sign the sighash
     ///     sig_hasher.access_witness(inp).push(Vec::new());
     /// }
@@ -212,7 +212,7 @@ mod tests {
         let raw_expected = SigHash::from_hex(expected_result).unwrap();
         let expected_result = SigHash::from_slice(&raw_expected[..]).unwrap();
         let mut cache = SigHashCache::new(&tx);
-        let sighash_type = SigHashType::from_u32_consensus(hash_type);
+        let sighash_type = EcdsaSigHashType::from_u32_consensus(hash_type);
         let actual_result = cache.signature_hash(input_index, &script, value, sighash_type);
         assert_eq!(actual_result, expected_result);
     }

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -29,7 +29,7 @@ use hashes::{Hash, hash160};
 use hash_types::{PubkeyHash, WPubkeyHash};
 use util::base58;
 use util::key::Error;
-use blockdata::transaction::SigHashType;
+use blockdata::transaction::EcdsaSigHashType;
 
 
 /// A Bitcoin ECDSA public key
@@ -421,7 +421,7 @@ pub struct EcdsaSig {
     /// The underlying ECDSA Signature
     pub sig: secp256k1::Signature,
     /// The corresponding hash type
-    pub hash_ty: SigHashType,
+    pub hash_ty: EcdsaSigHashType,
 }
 
 impl EcdsaSig {
@@ -430,7 +430,7 @@ impl EcdsaSig {
     pub fn from_slice(sl: &[u8]) -> Result<Self, EcdsaSigError> {
         let (hash_ty, sig) = sl.split_last()
             .ok_or(EcdsaSigError::EmptySignature)?;
-        let hash_ty = SigHashType::from_u32_standard(*hash_ty as u32)
+        let hash_ty = EcdsaSigHashType::from_u32_standard(*hash_ty as u32)
             .map_err(|_| EcdsaSigError::NonStandardSigHashType(*hash_ty))?;
         let sig = secp256k1::Signature::from_der(sig)
             .map_err(EcdsaSigError::Secp256k1)?;

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -29,6 +29,8 @@ use hashes::{Hash, hash160};
 use hash_types::{PubkeyHash, WPubkeyHash};
 use util::base58;
 use util::key::Error;
+use blockdata::transaction::SigHashType;
+
 
 /// A Bitcoin ECDSA public key
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -410,6 +412,72 @@ impl<'de> ::serde::Deserialize<'de> for PublicKey {
 
             d.deserialize_bytes(BytesVisitor)
         }
+    }
+}
+
+/// An ECDSA signature with the corresponding hash type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EcdsaSig {
+    /// The underlying ECDSA Signature
+    pub sig: secp256k1::Signature,
+    /// The corresponding hash type
+    pub hash_ty: SigHashType,
+}
+
+impl EcdsaSig {
+
+    /// Deserialize from slice
+    pub fn from_slice(sl: &[u8]) -> Result<Self, EcdsaSigError> {
+        let (hash_ty, sig) = sl.split_last()
+            .ok_or(EcdsaSigError::EmptySignature)?;
+        let hash_ty = SigHashType::from_u32_standard(*hash_ty as u32)
+            .map_err(|_| EcdsaSigError::NonStandardSigHashType(*hash_ty))?;
+        let sig = secp256k1::Signature::from_der(sig)
+            .map_err(EcdsaSigError::Secp256k1)?;
+        Ok(EcdsaSig { sig, hash_ty })
+    }
+
+    /// Serialize EcdsaSig
+    pub fn to_vec(&self) -> Vec<u8> {
+        // TODO: add support to serialize to a writer to SerializedSig
+        let mut ser_sig = self.sig.serialize_der().to_vec();
+        ser_sig.push(self.hash_ty.as_u32() as u8);
+        ser_sig
+    }
+}
+
+/// A key-related error.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum EcdsaSigError {
+    /// Base58 encoding error
+    NonStandardSigHashType(u8),
+    /// Empty Signature
+    EmptySignature,
+    /// secp256k1-related error
+    Secp256k1(secp256k1::Error),
+}
+
+
+impl fmt::Display for EcdsaSigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            EcdsaSigError::NonStandardSigHashType(hash_ty) =>
+                write!(f, "Non standard signature hash type {}", hash_ty),
+            EcdsaSigError::Secp256k1(ref e) =>
+                write!(f, "Invalid Ecdsa signature: {}", e),
+            EcdsaSigError::EmptySignature =>
+                write!(f, "Empty ECDSA signature"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl ::std::error::Error for EcdsaSigError {}
+
+impl From<secp256k1::Error> for EcdsaSigError {
+    fn from(e: secp256k1::Error) -> EcdsaSigError {
+        EcdsaSigError::Secp256k1(e)
     }
 }
 

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -17,7 +17,7 @@ use prelude::*;
 use io;
 
 use blockdata::script::Script;
-use blockdata::transaction::{SigHashType, Transaction, TxOut};
+use blockdata::transaction::{EcdsaSigHashType, Transaction, TxOut};
 use consensus::encode;
 use util::bip32::KeySource;
 use hashes::{self, hash160, ripemd160, sha256, sha256d};
@@ -76,7 +76,7 @@ pub struct Input {
     pub partial_sigs: BTreeMap<PublicKey, Vec<u8>>,
     /// The sighash type to be used for this input. Signatures for this input
     /// must use the sighash type.
-    pub sighash_type: Option<SigHashType>,
+    pub sighash_type: Option<EcdsaSigHashType>,
     /// The redeem script for this input.
     pub redeem_script: Option<Script>,
     /// The witness script for this input.
@@ -137,7 +137,7 @@ impl Map for Input {
             }
             PSBT_IN_SIGHASH_TYPE => {
                 impl_psbt_insert_pair! {
-                    self.sighash_type <= <raw_key: _>|<raw_value: SigHashType>
+                    self.sighash_type <= <raw_key: _>|<raw_value: EcdsaSigHashType>
                 }
             }
             PSBT_IN_REDEEM_SCRIPT => {

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -507,7 +507,7 @@ mod tests {
         use hash_types::Txid;
 
         use blockdata::script::Script;
-        use blockdata::transaction::{SigHashType, Transaction, TxIn, TxOut, OutPoint};
+        use blockdata::transaction::{EcdsaSigHashType, Transaction, TxIn, TxOut, OutPoint};
         use consensus::encode::serialize_hex;
         use util::psbt::map::{Map, Input, Output};
         use util::psbt::raw;
@@ -733,7 +733,7 @@ mod tests {
             );
             assert_eq!(
                 (&psbt.inputs[0].sighash_type).as_ref().unwrap(),
-                &SigHashType::All
+                &EcdsaSigHashType::All
             );
         }
 

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -23,7 +23,7 @@ use prelude::*;
 use io;
 
 use blockdata::script::Script;
-use blockdata::transaction::{SigHashType, Transaction, TxOut};
+use blockdata::transaction::{EcdsaSigHashType, Transaction, TxOut};
 use consensus::encode::{self, serialize, Decodable};
 use util::bip32::{ChildNumber, Fingerprint, KeySource};
 use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
@@ -126,16 +126,16 @@ impl Deserialize for Vec<u8> {
     }
 }
 
-impl Serialize for SigHashType {
+impl Serialize for EcdsaSigHashType {
     fn serialize(&self) -> Vec<u8> {
         serialize(&self.as_u32())
     }
 }
 
-impl Deserialize for SigHashType {
+impl Deserialize for EcdsaSigHashType {
     fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
         let raw: u32 = encode::deserialize(bytes)?;
-        let rv: SigHashType = SigHashType::from_u32_consensus(raw);
+        let rv: EcdsaSigHashType = EcdsaSigHashType::from_u32_consensus(raw);
 
         if rv.as_u32() == raw {
             Ok(rv)

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -17,11 +17,14 @@
 //! Schnorr key types.
 //!
 
+use core::fmt;
+use prelude::*;
+
 pub use secp256k1::schnorrsig::{PublicKey, KeyPair};
-use secp256k1::{Secp256k1, Verification, constants};
+use secp256k1::{self, Secp256k1, Verification, constants};
 use hashes::Hash;
 use util::taproot::{TapBranchHash, TapTweakHash};
-use core::fmt;
+use SchnorrSigHashType;
 
 /// Untweaked Schnorr public key
 pub type UntweakedPublicKey = PublicKey;
@@ -102,5 +105,89 @@ impl TweakedPublicKey {
     #[inline]
     pub fn serialize(&self) -> [u8; constants::SCHNORRSIG_PUBLIC_KEY_SIZE] {
         self.0.serialize()
+    }
+}
+
+/// A BIP340-341 serialized schnorr signature with the corresponding hash type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SchnorrSig {
+    /// The underlying schnorr signature
+    pub sig: secp256k1::schnorrsig::Signature,
+    /// The corresponding hash type
+    pub hash_ty: SchnorrSigHashType,
+}
+
+impl SchnorrSig {
+
+    /// Deserialize from slice
+    pub fn from_slice(sl: &[u8]) -> Result<Self, SchnorrSigError> {
+        match sl.len() {
+            64 => {
+                // default type
+                let sig = secp256k1::schnorrsig::Signature::from_slice(sl)
+                    .map_err(SchnorrSigError::Secp256k1)?;
+                return Ok( SchnorrSig { sig, hash_ty : SchnorrSigHashType::Default });
+            },
+            65 => {
+                let (hash_ty, sig) = sl.split_last().expect("Slice len checked == 65");
+                let hash_ty = SchnorrSigHashType::from_u8(*hash_ty)
+                    .map_err(|_| SchnorrSigError::InvalidSighashType(*hash_ty))?;
+                let sig = secp256k1::schnorrsig::Signature::from_slice(sig)
+                    .map_err(SchnorrSigError::Secp256k1)?;
+                Ok(SchnorrSig { sig, hash_ty })
+            }
+            len => {
+                Err(SchnorrSigError::InvalidSchnorrSigSize(len))
+            }
+        }
+    }
+
+    /// Serialize SchnorrSig
+    pub fn to_vec(&self) -> Vec<u8> {
+        // TODO: add support to serialize to a writer to SerializedSig
+        let mut ser_sig = self.sig.as_ref().to_vec();
+        if self.hash_ty == SchnorrSigHashType::Default {
+            // default sighash type, don't add extra sighash byte
+        } else {
+            ser_sig.push(self.hash_ty as u8);
+        }
+        ser_sig
+    }
+
+}
+
+/// A schnorr sig related error.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum SchnorrSigError {
+    /// Base58 encoding error
+    InvalidSighashType(u8),
+    /// Signature has valid size but does not parse correctly
+    Secp256k1(secp256k1::Error),
+    /// Invalid schnorr signature size
+    InvalidSchnorrSigSize(usize),
+}
+
+
+impl fmt::Display for SchnorrSigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SchnorrSigError::InvalidSighashType(hash_ty) =>
+                write!(f, "Invalid signature hash type {}", hash_ty),
+            SchnorrSigError::Secp256k1(ref e) =>
+                write!(f, "Schnorr Signature has correct len, but is malformed : {}", e),
+            SchnorrSigError::InvalidSchnorrSigSize(sz) =>
+                write!(f, "Invalid Schnorr signature size: {}", sz),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl ::std::error::Error for SchnorrSigError {}
+
+impl From<secp256k1::Error> for SchnorrSigError {
+
+    fn from(e: secp256k1::Error) -> SchnorrSigError {
+        SchnorrSigError::Secp256k1(e)
     }
 }

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -164,6 +164,9 @@ pub enum Error {
 
     /// Annex must be at least one byte long and the first bytes must be `0x50`
     WrongAnnex,
+
+    /// Invalid Sighash type
+    InvalidSigHashType(u8),
 }
 
 impl fmt::Display for Error {
@@ -176,6 +179,7 @@ impl fmt::Display for Error {
             Error::PrevoutIndex => write!(f, "The index requested is greater than available prevouts or different from the provided [Provided::Anyone] index"),
             Error::PrevoutKind => write!(f, "A single prevout has been provided but all prevouts are needed without `ANYONECANPAY`"),
             Error::WrongAnnex => write!(f, "Annex must be at least one byte long and the first bytes must be `0x50`"),
+            Error::InvalidSigHashType(hash_ty) => write!(f, "Invalid schnorr Signature hash type : {} ", hash_ty),
         }
     }
 }
@@ -254,6 +258,20 @@ impl SchnorrSigHashType {
             SchnorrSigHashType::NonePlusAnyoneCanPay => (SchnorrSigHashType::None, true),
             SchnorrSigHashType::SinglePlusAnyoneCanPay => (SchnorrSigHashType::Single, true),
             SchnorrSigHashType::Reserved => (SchnorrSigHashType::Reserved, false),
+        }
+    }
+
+    /// Create a [`SchnorrSigHashType`] from raw u8
+    pub fn from_u8(hash_ty: u8) -> Result<Self, Error> {
+        match hash_ty {
+            0x00 => Ok(SchnorrSigHashType::Default),
+            0x01 => Ok(SchnorrSigHashType::All),
+            0x02 => Ok(SchnorrSigHashType::None),
+            0x03 => Ok(SchnorrSigHashType::Single),
+            0x81 => Ok(SchnorrSigHashType::AllPlusAnyoneCanPay),
+            0x82 => Ok(SchnorrSigHashType::NonePlusAnyoneCanPay),
+            0x83 => Ok(SchnorrSigHashType::SinglePlusAnyoneCanPay),
+            x => Err(Error::InvalidSigHashType(x)),
         }
     }
 }


### PR DESCRIPTION
Fixes #670 . Separates `SchnorrSigHashType` and `LegacySigHashType`. Also adds the following new structs:

```rust
pub struct SchnorrSig {
    /// The underlying schnorr signature
    pub sig: secp256k1::schnorrsig::Signature,
    /// The corresponding hash type
    pub hash_ty: SchnorrSigHashType,
}

pub struct EcdsaSig {
    /// The underlying DER serialized Signature
    pub sig: secp256k1::Signature,
    /// The corresponding hash type
    pub hash_ty: LegacySigHashType,
}
```

This code is currently minimal to aid reviews. We can at a later point implement (Encodeable, psbt::Serialize, FromHex, ToHex) etc in follow-up PRs. 