### PR TITLE
WIP: Add `Error::Io` in order to bubble up write erros to users

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -198,7 +198,9 @@ impl Block {
                     // witness reserved value is in coinbase input witness
                     if coinbase.input[0].witness.len() == 1 && coinbase.input[0].witness[0].len() == 32 {
                         let witness_root = self.witness_root();
-                        return commitment == Self::compute_witness_commitment(&witness_root, coinbase.input[0].witness[0].as_slice())
+                        if let Ok(computed) = Self::compute_witness_commitment(&witness_root, coinbase.input[0].witness[0].as_slice()) {
+                            return commitment == computed
+                        }
                     }
                 }
             }
@@ -213,11 +215,11 @@ impl Block {
     }
 
     /// compute witness commitment for the transaction list
-    pub fn compute_witness_commitment (witness_root: &WitnessMerkleNode, witness_reserved_value: &[u8]) -> WitnessCommitment {
+    pub fn compute_witness_commitment (witness_root: &WitnessMerkleNode, witness_reserved_value: &[u8]) -> Result<WitnessCommitment, util::Error> {
         let mut encoder = WitnessCommitment::engine();
-        witness_root.consensus_encode(&mut encoder).unwrap();
+        witness_root.consensus_encode(&mut encoder)?;
         encoder.input(witness_reserved_value);
-        WitnessCommitment::from_engine(encoder)
+        Ok(WitnessCommitment::from_engine(encoder))
     }
 
     /// Merkle root of transactions hashed for witness

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -78,6 +78,8 @@ pub enum Error {
     BlockBadProofOfWork,
     /// The `target` field of a block header did not match the expected difficulty
     BlockBadTarget,
+    /// IO error.
+    Io(io::Error),
 }
 
 impl fmt::Display for Error {
@@ -87,6 +89,7 @@ impl fmt::Display for Error {
             Error::Network(ref e) => fmt::Display::fmt(e, f),
             Error::BlockBadProofOfWork => f.write_str("block target correct but not attained"),
             Error::BlockBadTarget => f.write_str("block target incorrect"),
+            Error::Io(ref e) => fmt::Display::fmt(e, f),
         }
     }
 }
@@ -97,6 +100,7 @@ impl ::std::error::Error for Error {
         match *self {
             Error::Encode(ref e) => Some(e),
             Error::Network(ref e) => Some(e),
+            Error::Io(ref e) => Some(e),
             Error::BlockBadProofOfWork | Error::BlockBadTarget => None
         }
     }
@@ -113,6 +117,13 @@ impl From<encode::Error> for Error {
 impl From<network::Error> for Error {
     fn from(e: network::Error) -> Error {
         Error::Network(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Error {
+        Error::Io(e)
     }
 }
 


### PR DESCRIPTION
This is a demonstration of one solution to #714. Only required if #714 is deemed to be a real issue.