### PR TITLE
Use expect instead of unwrap for calls to consensus_encode

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -215,7 +215,7 @@ impl Block {
     /// compute witness commitment for the transaction list
     pub fn compute_witness_commitment (witness_root: &WitnessMerkleNode, witness_reserved_value: &[u8]) -> WitnessCommitment {
         let mut encoder = WitnessCommitment::engine();
-        witness_root.consensus_encode(&mut encoder).unwrap();
+        witness_root.consensus_encode(&mut encoder).expect("engines don't error");
         encoder.input(witness_reserved_value);
         WitnessCommitment::from_engine(encoder)
     }

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -464,11 +464,11 @@ impl Script {
         } else if self.is_witness_program() {
             32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
             8 + // The serialized size of the TxOut's amount field
-            self.consensus_encode(&mut sink()).unwrap() as u64 // The serialized size of this script_pubkey
+            self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
         } else {
             32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
             8 + // The serialized size of the TxOut's amount field
-            self.consensus_encode(&mut sink()).unwrap() as u64 // The serialized size of this script_pubkey
+            self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
         };
 
         ::Amount::from_sat(sats)

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -292,10 +292,10 @@ impl Transaction {
     /// will also hash witnesses.
     pub fn txid(&self) -> Txid {
         let mut enc = Txid::engine();
-        self.version.consensus_encode(&mut enc).unwrap();
-        self.input.consensus_encode(&mut enc).unwrap();
-        self.output.consensus_encode(&mut enc).unwrap();
-        self.lock_time.consensus_encode(&mut enc).unwrap();
+        self.version.consensus_encode(&mut enc).expect("engines don't error");
+        self.input.consensus_encode(&mut enc).expect("engines don't error");
+        self.output.consensus_encode(&mut enc).expect("engines don't error");
+        self.lock_time.consensus_encode(&mut enc).expect("engines don't error");
         Txid::from_engine(enc)
     }
 
@@ -304,7 +304,7 @@ impl Transaction {
     /// value returned by txid() function.
     pub fn wtxid(&self) -> Wtxid {
         let mut enc = Wtxid::engine();
-        self.consensus_encode(&mut enc).unwrap();
+        self.consensus_encode(&mut enc).expect("engines don't error");
         Wtxid::from_engine(enc)
     }
 

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -138,7 +138,7 @@ impl From<psbt::Error> for Error {
 /// Encode an object into a vector
 pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
     let mut encoder = Vec::new();
-    let len = data.consensus_encode(&mut encoder).unwrap();
+    let len = data.consensus_encode(&mut encoder).expect("in-memory writers don't error");
     debug_assert_eq!(len, encoder.len());
     encoder
 }

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -56,7 +56,7 @@ impl SighashComponents {
         let hash_prevouts = {
             let mut enc = SigHash::engine();
             for txin in &tx.input {
-                txin.previous_output.consensus_encode(&mut enc).unwrap();
+                txin.previous_output.consensus_encode(&mut enc).expect("engines don't error");
             }
             SigHash::from_engine(enc)
         };
@@ -64,7 +64,7 @@ impl SighashComponents {
         let hash_sequence = {
             let mut enc = SigHash::engine();
             for txin in &tx.input {
-                txin.sequence.consensus_encode(&mut enc).unwrap();
+                txin.sequence.consensus_encode(&mut enc).expect("engines don't error");
             }
             SigHash::from_engine(enc)
         };
@@ -72,7 +72,7 @@ impl SighashComponents {
         let hash_outputs = {
             let mut enc = SigHash::engine();
             for txout in &tx.output {
-                txout.consensus_encode(&mut enc).unwrap();
+                txout.consensus_encode(&mut enc).expect("engines don't error");
             }
             SigHash::from_engine(enc)
         };
@@ -90,19 +90,19 @@ impl SighashComponents {
     /// input.
     pub fn sighash_all(&self, txin: &TxIn, script_code: &Script, value: u64) -> SigHash {
         let mut enc = SigHash::engine();
-        self.tx_version.consensus_encode(&mut enc).unwrap();
-        self.hash_prevouts.consensus_encode(&mut enc).unwrap();
-        self.hash_sequence.consensus_encode(&mut enc).unwrap();
+        self.tx_version.consensus_encode(&mut enc).expect("engines don't error");
+        self.hash_prevouts.consensus_encode(&mut enc).expect("engines don't error");
+        self.hash_sequence.consensus_encode(&mut enc).expect("engines don't error");
         txin
             .previous_output
             .consensus_encode(&mut enc)
-            .unwrap();
-        script_code.consensus_encode(&mut enc).unwrap();
-        value.consensus_encode(&mut enc).unwrap();
-        txin.sequence.consensus_encode(&mut enc).unwrap();
-        self.hash_outputs.consensus_encode(&mut enc).unwrap();
-        self.tx_locktime.consensus_encode(&mut enc).unwrap();
-        1u32.consensus_encode(&mut enc).unwrap(); // hashtype
+            .expect("engines don't error");
+        script_code.consensus_encode(&mut enc).expect("engines don't error");
+        value.consensus_encode(&mut enc).expect("engines don't error");
+        txin.sequence.consensus_encode(&mut enc).expect("engines don't error");
+        self.hash_outputs.consensus_encode(&mut enc).expect("engines don't error");
+        self.tx_locktime.consensus_encode(&mut enc).expect("engines don't error");
+        1u32.consensus_encode(&mut enc).expect("engines don't error"); // hashtype
         SigHash::from_engine(enc)
     }
 }

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -365,7 +365,7 @@ impl<'a> GCSFilterWriter<'a> {
 
         // write number of elements as varint
         let mut encoder = Vec::new();
-        VarInt(mapped.len() as u64).consensus_encode(&mut encoder).unwrap();
+        VarInt(mapped.len() as u64).consensus_encode(&mut encoder).expect("in-memory writers don't error");
         let mut wrote = self.writer.write(encoder.as_slice())?;
 
         // write out deltas of sorted values into a Golonb-Rice coded bit stream

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -45,8 +45,8 @@ pub fn bitcoin_merkle_root_inline<T>(data: &mut [T]) -> T
         let idx1 = 2 * idx;
         let idx2 = min(idx1 + 1, data.len() - 1);
         let mut encoder = T::engine();
-        data[idx1].consensus_encode(&mut encoder).unwrap();
-        data[idx2].consensus_encode(&mut encoder).unwrap();
+        data[idx1].consensus_encode(&mut encoder).expect("in-memory writers don't error");
+        data[idx2].consensus_encode(&mut encoder).expect("in-memory writers don't error");
         data[idx] = T::from_engine(encoder);
     }
     let half_len = data.len() / 2 + data.len() % 2;
@@ -73,8 +73,8 @@ pub fn bitcoin_merkle_root<T, I>(mut iter: I) -> T
         // If the size is odd, use the last element twice.
         let hash2 = iter.next().unwrap_or(hash1);
         let mut encoder = T::engine();
-        hash1.consensus_encode(&mut encoder).unwrap();
-        hash2.consensus_encode(&mut encoder).unwrap();
+        hash1.consensus_encode(&mut encoder).expect("in-memory writers don't error");
+        hash2.consensus_encode(&mut encoder).expect("in-memory writers don't error");
         alloc.push(T::from_engine(encoder));
     }
     bitcoin_merkle_root_inline(&mut alloc)

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -341,8 +341,8 @@ impl PartialMerkleTree {
     /// Helper method to produce SHA256D(left + right)
     fn parent_hash(left: TxMerkleNode, right: TxMerkleNode) -> TxMerkleNode {
         let mut encoder = TxMerkleNode::engine();
-        left.consensus_encode(&mut encoder).unwrap();
-        right.consensus_encode(&mut encoder).unwrap();
+        left.consensus_encode(&mut encoder).expect("engines don't error");
+        right.consensus_encode(&mut encoder).expect("engines don't error");
         TxMerkleNode::from_engine(encoder)
     }
 }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -252,7 +252,7 @@ pub fn signed_msg_hash(msg: &str) -> sha256d::Hash {
     let mut engine = sha256d::Hash::engine();
     engine.input(BITCOIN_SIGNED_MSG_PREFIX);
     let msg_len = encode::VarInt(msg.len() as u64);
-    msg_len.consensus_encode(&mut engine).unwrap();
+    msg_len.consensus_encode(&mut engine).expect("engines don't error");
     engine.input(msg.as_bytes());
     sha256d::Hash::from_engine(engine)
 }

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -122,10 +122,10 @@ impl TapLeafHash {
         let mut eng = TapLeafHash::engine();
         ver.as_u8()
             .consensus_encode(&mut eng)
-            .expect("engines don't err");
+            .expect("engines don't error");
         script
             .consensus_encode(&mut eng)
-            .expect("engines don't err");
+            .expect("engines don't error");
         TapLeafHash::from_engine(eng)
     }
 }


### PR DESCRIPTION
Calls to `unwrap` outside of tests are generally unfavourable. We currently call `unwrap` in a bunch of places on calls to `consensus_encode` when passing writers that do not fail.

Remove `unwrap` calls on all calls to `consensus_encode` that pass a writer argument for which write functions do not fail. Use `expect` with a descriptive string instead.

Fixes: #714 