### PR TITLE
PSBTv2

### DIFF
--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -14,7 +14,7 @@
 
 use prelude::*;
 
-use io;
+use ::{io, TxIn};
 
 use blockdata::script::Script;
 use blockdata::transaction::{SigHashType, Transaction, TxOut};
@@ -62,6 +62,9 @@ const PSBT_IN_PROPRIETARY: u8 = 0xFC;
 #[derive(Clone, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Input {
+    /// Transaction input, either reconstructed through PSBT v2 fields, or
+    /// cloned from the original transaction data.
+    pub txin: TxIn,
     /// The non-witness transaction this input spends from. Should only be
     /// [std::option::Option::Some] for inputs which spend non-segwit outputs or
     /// if it is unknown whether an input spends a segwit output.

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -14,7 +14,7 @@
 
 use prelude::*;
 
-use io;
+use ::{io, TxOut};
 
 use blockdata::script::Script;
 use consensus::encode;
@@ -39,6 +39,9 @@ const PSBT_OUT_PROPRIETARY: u8 = 0xFC;
 #[derive(Clone, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Output {
+    /// Transaction output, either reconstructed through PSBT v2 fields, or
+    /// cloned from the original transaction data.
+    pub txout: TxOut,
     /// The redeem script for this output.
     pub redeem_script: Option<Script>,
     /// The witness script for this output.

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -90,9 +90,17 @@ impl PartiallySignedTransaction {
     /// Create a PartiallySignedTransaction from an unsigned transaction, error
     /// if not unsigned
     pub fn from_unsigned_tx(tx: Transaction) -> Result<Self, Error> {
+        let inputs = tx.input.iter().map(|txin| Input {
+            txin: txin.clone(),
+            ..Default::default()
+        }).collect();
+        let outputs = tx.output.iter().map(|txout| Output {
+            txout: txout.clone(),
+            ..Default::default()
+        }).collect();
         let psbt = PartiallySignedTransaction {
-            inputs: vec![Default::default(); tx.input.len()],
-            outputs: vec![Default::default(); tx.output.len()],
+            inputs: inputs,
+            outputs: outputs,
 
             unsigned_tx: tx,
             xpub: Default::default(),
@@ -215,8 +223,10 @@ impl Decodable for PartiallySignedTransaction {
 
             let mut inputs: Vec<Input> = Vec::with_capacity(inputs_len);
 
-            for _ in 0..inputs_len {
-                inputs.push(Decodable::consensus_decode(&mut d)?);
+            for i in 0..inputs_len {
+                let mut input = Input::consensus_decode(&mut d)?;
+                input.txin = global.unsigned_tx.input[i].clone();
+                inputs.push(input);
             }
 
             inputs
@@ -227,8 +237,10 @@ impl Decodable for PartiallySignedTransaction {
 
             let mut outputs: Vec<Output> = Vec::with_capacity(outputs_len);
 
-            for _ in 0..outputs_len {
-                outputs.push(Decodable::consensus_decode(&mut d)?);
+            for i in 0..outputs_len {
+                let mut output = Output::consensus_decode(&mut d)?;
+                output.txout = global.unsigned_tx.output[i].clone();
+                outputs.push(output);
             }
 
             outputs


### PR DESCRIPTION
This is draft work without full implementation, seeking concept ACK from this description (do not review the code yet):

The idea of adding support for PSBTv2 (which gets rid of global unsigned `Tranasction` and reconstructs it via input- and output-specific new fields0 is not to do another struct, but to re-utilize the same existing structure and have just different serialization/deserialization methods. So in fact, internally, each PSBT will be a v2, distributing data on the unsigned transaction across input/output fields and reconstructing unsigned transaction on serialization in v0 variant only.