### PR TITLE
Add Custom Signet support

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -145,7 +145,7 @@ pub fn genesis_block(network: Network) -> Block {
                 txdata: txdata
             }
         }
-        Network::Signet => {
+        Network::Signet | Network::CSignet => {
             Block {
                 header: BlockHeader {
                     version: 1,

--- a/src/consensus/params.rs
+++ b/src/consensus/params.rs
@@ -49,6 +49,13 @@ const MAX_BITS_REGTEST: Uint256 = Uint256([
     0x0000000000000000u64,
     0x7fffff0000000000u64,
 ]);
+/// Lowest possible difficulty for Custom Signet. See comment on Params::pow_limit for more info.
+const MAX_BITS_CSIGNET: Uint256 = Uint256([
+    0x0000000000000000u64,
+    0x0000000000000000u64,
+    0x0000000000000000u64,
+    0x00000377ae000000u64,
+]);
 
 #[derive(Debug, Clone)]
 /// Parameters that influence chain consensus.
@@ -147,6 +154,20 @@ impl Params {
                 pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
                 allow_min_difficulty_blocks: true,
                 no_pow_retargeting: true,
+            },
+            Network::CSignet => Params {
+                network: Network::CSignet,
+                bip16_time: 1333238400,                 // Apr 1 2012
+                bip34_height: 1,
+                bip65_height: 1,
+                bip66_height: 1,
+                rule_change_activation_threshold: 1916, // 95%
+                miner_confirmation_window: 2016,
+                pow_limit: MAX_BITS_CSIGNET,
+                pow_target_spacing: 10 * 60,            // 10 minutes.
+                pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+                allow_min_difficulty_blocks: false,
+                no_pow_retargeting: false,
             },
         }
     }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -644,7 +644,7 @@ impl Address {
             (a, b) if a == b => true,
             (Network::Bitcoin, _) | (_, Network::Bitcoin) => false,
             (Network::Regtest, _) | (_, Network::Regtest) if !is_legacy => false,
-            (Network::Testnet, _) | (Network::Regtest, _) | (Network::Signet, _) => true
+            (Network::Testnet, _) | (Network::Regtest, _) | (Network::Signet, _) | (Network::CSignet, _) => true
         }
     }
 }
@@ -658,7 +658,7 @@ impl fmt::Display for Address {
                 let mut prefixed = [0; 21];
                 prefixed[0] = match self.network {
                     Network::Bitcoin => PUBKEY_ADDRESS_PREFIX_MAIN,
-                    Network::Testnet | Network::Signet | Network::Regtest => PUBKEY_ADDRESS_PREFIX_TEST,
+                    Network::Testnet | Network::Signet | Network::Regtest | Network::CSignet => PUBKEY_ADDRESS_PREFIX_TEST,
                 };
                 prefixed[1..].copy_from_slice(&hash[..]);
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
@@ -667,7 +667,7 @@ impl fmt::Display for Address {
                 let mut prefixed = [0; 21];
                 prefixed[0] = match self.network {
                     Network::Bitcoin => SCRIPT_ADDRESS_PREFIX_MAIN,
-                    Network::Testnet | Network::Signet | Network::Regtest => SCRIPT_ADDRESS_PREFIX_TEST,
+                    Network::Testnet | Network::Signet | Network::Regtest | Network::CSignet => SCRIPT_ADDRESS_PREFIX_TEST,
                 };
                 prefixed[1..].copy_from_slice(&hash[..]);
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
@@ -678,7 +678,7 @@ impl fmt::Display for Address {
             } => {
                 let hrp = match self.network {
                     Network::Bitcoin => "bc",
-                    Network::Testnet | Network::Signet => "tb",
+                    Network::Testnet | Network::Signet | Network::CSignet => "tb",
                     Network::Regtest => "bcrt",
                 };
                 let mut upper_writer;

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -586,7 +586,7 @@ impl ExtendedPrivKey {
         let mut ret = [0; 78];
         ret[0..4].copy_from_slice(&match self.network {
             Network::Bitcoin => [0x04, 0x88, 0xAD, 0xE4],
-            Network::Testnet | Network::Signet | Network::Regtest => [0x04, 0x35, 0x83, 0x94],
+            Network::Testnet | Network::Signet | Network::Regtest | Network::CSignet => [0x04, 0x35, 0x83, 0x94],
         }[..]);
         ret[4] = self.depth as u8;
         ret[5..9].copy_from_slice(&self.parent_fingerprint[..]);
@@ -705,7 +705,7 @@ impl ExtendedPubKey {
         let mut ret = [0; 78];
         ret[0..4].copy_from_slice(&match self.network {
             Network::Bitcoin => [0x04u8, 0x88, 0xB2, 0x1E],
-            Network::Testnet | Network::Signet | Network::Regtest => [0x04u8, 0x35, 0x87, 0xCF],
+            Network::Testnet | Network::Signet | Network::Regtest | Network::CSignet => [0x04u8, 0x35, 0x87, 0xCF],
         }[..]);
         ret[4] = self.depth as u8;
         ret[5..9].copy_from_slice(&self.parent_fingerprint[..]);

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -227,7 +227,7 @@ impl PrivateKey {
         let mut ret = [0; 34];
         ret[0] = match self.network {
             Network::Bitcoin => 128,
-            Network::Testnet | Network::Signet | Network::Regtest => 239,
+            Network::Testnet | Network::Signet | Network::Regtest | Network::CSignet => 239,
         };
         ret[1..33].copy_from_slice(&self.key[..]);
         let privkey = if self.compressed {


### PR DESCRIPTION
The PR is to add [Custom Signet](https://en.bitcoin.it/wiki/Signet#Custom_Signet) to the Network enum using the Signet configuration but with a network magic bytes defined by an environment variable of the operative system.

One way to define the environment variable on GNU/Linux:
```bash
echo "export SIGNET_MAGIC=\"SIGNET_MAGIC\" ">> $HOME/.bashrc
source $HOME/.bashrc
``` 