### PR TITLE
Fixed docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
 
 [package.metadata.docs.rs]
 features = [ "std", "secp-recovery", "base64", "rand", "use-serde", "bitcoinconsensus" ]
-rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }


### PR DESCRIPTION
This changes `rustc-args`, which doesn't do what we want, to `rustdoc-args`,
which does.

Because of huge value/effort ratio assigning medium priority and 0.28 milestone - would be a real shame to release without this.