### PR TITLE
Re-export SigHashType in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,8 @@ pub use util::schnorr::{self, SchnorrSig, SchnorrSigError};
 pub use util::ecdsa::PrivateKey;
 #[deprecated(since = "0.26.1", note = "Please use `ecdsa::PublicKey` instead")]
 pub use util::ecdsa::PublicKey;
+#[allow(deprecated)]
+pub use blockdata::transaction::SigHashType;
 
 #[cfg(feature = "std")]
 use std::io;


### PR DESCRIPTION
Using the latest version of rust-bitcoin master on rust-miniscript
errors on bitcoin::SigHashType not found. In the original PR, I only
renamed the export to ECDSASigHashType, but original re-export should
also be there in lib.rs to avoid breaking changes downstream.

Fixup to #702 

Before this PR,

```
   |
89 |         required: bitcoin::SigHashType,
   |                            ^^^^^^^^^^^ not found in `bitcoin

```

After this PR, 

```
warning: use of deprecated type alias `bitcoin::SigHashType`: Please use [`EcdsaSigHashType`] instead
  --> src/psbt/mod.rs:89:28
   |
89 |         required: bitcoin::SigHashType,

```