### PR TITLE
Make Map trait private

### DIFF
--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -75,7 +75,7 @@ macro_rules! impl_psbtmap_consensus_decoding {
 
                 loop {
                     match $crate::consensus::Decodable::consensus_decode(&mut d) {
-                        Ok(pair) => $crate::util::psbt::Map::insert_pair(&mut rv, pair)?,
+                        Ok(pair) => rv.insert_pair(pair)?,
                         Err($crate::consensus::encode::Error::Psbt($crate::util::psbt::Error::NoMorePairs)) => return Ok(rv),
                         Err(e) => return Err(e),
                     }

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -45,12 +45,19 @@ impl Map for PartiallySignedTransaction {
 
         match raw_key.type_value {
             PSBT_GLOBAL_UNSIGNED_TX => return Err(Error::DuplicateKey(raw_key).into()),
-            PSBT_GLOBAL_PROPRIETARY => match self.proprietary.entry(raw::ProprietaryKey::from_key(raw_key.clone())?) {
-                btree_map::Entry::Vacant(empty_key) => {empty_key.insert(raw_value);},
-                btree_map::Entry::Occupied(_) => return Err(Error::DuplicateKey(raw_key).into()),
+            PSBT_GLOBAL_PROPRIETARY => {
+                let key = raw::ProprietaryKey::from_key(raw_key.clone())?;
+                match self.proprietary.entry(key) {
+                    btree_map::Entry::Vacant(empty_key) => {
+                        empty_key.insert(raw_value);
+                    },
+                    btree_map::Entry::Occupied(_) => return Err(Error::DuplicateKey(raw_key).into()),
+                }
             }
             _ => match self.unknown.entry(raw_key) {
-                btree_map::Entry::Vacant(empty_key) => {empty_key.insert(raw_value);},
+                btree_map::Entry::Vacant(empty_key) => {
+                    empty_key.insert(raw_value);
+                },
                 btree_map::Entry::Occupied(k) => return Err(Error::DuplicateKey(k.key().clone()).into()),
             }
         }
@@ -278,11 +285,15 @@ impl PartiallySignedTransaction {
                             }
                         }
                         PSBT_GLOBAL_PROPRIETARY => match proprietary.entry(raw::ProprietaryKey::from_key(pair.key.clone())?) {
-                            btree_map::Entry::Vacant(empty_key) => {empty_key.insert(pair.value);},
+                            btree_map::Entry::Vacant(empty_key) => {
+                                empty_key.insert(pair.value);
+                            },
                             btree_map::Entry::Occupied(_) => return Err(Error::DuplicateKey(pair.key).into()),
                         }
                         _ => match unknowns.entry(pair.key) {
-                            btree_map::Entry::Vacant(empty_key) => {empty_key.insert(pair.value);},
+                            btree_map::Entry::Vacant(empty_key) => {
+                                empty_key.insert(pair.value);
+                            },
                             btree_map::Entry::Occupied(k) => return Err(Error::DuplicateKey(k.key().clone()).into()),
                         }
                     }

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -37,34 +37,6 @@ const PSBT_GLOBAL_VERSION: u8 = 0xFB;
 const PSBT_GLOBAL_PROPRIETARY: u8 = 0xFC;
 
 impl Map for PartiallySignedTransaction {
-    fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), encode::Error> {
-        let raw::Pair {
-            key: raw_key,
-            value: raw_value,
-        } = pair;
-
-        match raw_key.type_value {
-            PSBT_GLOBAL_UNSIGNED_TX => return Err(Error::DuplicateKey(raw_key).into()),
-            PSBT_GLOBAL_PROPRIETARY => {
-                let key = raw::ProprietaryKey::from_key(raw_key.clone())?;
-                match self.proprietary.entry(key) {
-                    btree_map::Entry::Vacant(empty_key) => {
-                        empty_key.insert(raw_value);
-                    },
-                    btree_map::Entry::Occupied(_) => return Err(Error::DuplicateKey(raw_key).into()),
-                }
-            }
-            _ => match self.unknown.entry(raw_key) {
-                btree_map::Entry::Vacant(empty_key) => {
-                    empty_key.insert(raw_value);
-                },
-                btree_map::Entry::Occupied(k) => return Err(Error::DuplicateKey(k.key().clone()).into()),
-            }
-        }
-
-        Ok(())
-    }
-
     fn get_pairs(&self) -> Result<Vec<raw::Pair>, io::Error> {
         let mut rv: Vec<raw::Pair> = Default::default();
 

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -108,32 +108,32 @@ pub struct Input {
     /// other scripts necessary for this input to pass validation.
     pub final_script_witness: Option<Witness>,
     /// TODO: Proof of reserves commitment
-    /// RIPEMD160 hash to preimage map
+    /// RIPEMD160 hash to preimage map.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
     pub ripemd160_preimages: BTreeMap<ripemd160::Hash, Vec<u8>>,
-    /// SHA256 hash to preimage map
+    /// SHA256 hash to preimage map.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
     pub sha256_preimages: BTreeMap<sha256::Hash, Vec<u8>>,
-    /// HSAH160 hash to preimage map
+    /// HSAH160 hash to preimage map.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
     pub hash160_preimages: BTreeMap<hash160::Hash, Vec<u8>>,
-    /// HAS256 hash to preimage map
+    /// HAS256 hash to preimage map.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
     pub hash256_preimages: BTreeMap<sha256d::Hash, Vec<u8>>,
-    /// Serialized schnorr signature with sighash type for key spend
+    /// Serialized schnorr signature with sighash type for key spend.
     pub tap_key_sig: Option<SchnorrSig>,
-    /// Map of <xonlypubkey>|<leafhash> with signature
+    /// Map of <xonlypubkey>|<leafhash> with signature.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
     pub tap_script_sigs: BTreeMap<(XOnlyPublicKey, TapLeafHash), SchnorrSig>,
-    /// Map of Control blocks to Script version pair
+    /// Map of Control blocks to Script version pair.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
     pub tap_scripts: BTreeMap<ControlBlock, (Script, LeafVersion)>,
-    /// Map of tap root x only keys to origin info and leaf hashes contained in it
+    /// Map of tap root x only keys to origin info and leaf hashes contained in it.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
     pub tap_key_origins: BTreeMap<XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
-    /// Taproot Internal key
+    /// Taproot Internal key.
     pub tap_internal_key : Option<XOnlyPublicKey>,
-    /// Taproot Merkle root
+    /// Taproot Merkle root.
     pub tap_merkle_root : Option<TapBranchHash>,
     /// Proprietary key-value pairs for this input.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -189,8 +189,8 @@ impl PsbtSigHashType {
     }
 }
 
-impl Map for Input {
-    fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), encode::Error> {
+impl Input {
+    pub(super) fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), encode::Error> {
         let raw::Pair {
             key: raw_key,
             value: raw_value,
@@ -303,7 +303,9 @@ impl Map for Input {
 
         Ok(())
     }
+}
 
+impl Map for Input {
     fn get_pairs(&self) -> Result<Vec<raw::Pair>, io::Error> {
         let mut rv: Vec<raw::Pair> = Default::default();
 

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -284,17 +284,20 @@ impl Map for Input {
                     self.tap_merkle_root <= <raw_key: _>|< raw_value: TapBranchHash>
                 }
             }
-            PSBT_IN_PROPRIETARY => match self.proprietary.entry(raw::ProprietaryKey::from_key(raw_key.clone())?) {
-                btree_map::Entry::Vacant(empty_key) => {empty_key.insert(raw_value);},
-                btree_map::Entry::Occupied(_) => return Err(Error::DuplicateKey(raw_key).into()),
+            PSBT_IN_PROPRIETARY => {
+                let key = raw::ProprietaryKey::from_key(raw_key.clone())?;
+                match self.proprietary.entry(key) {
+                    btree_map::Entry::Vacant(empty_key) => {
+                        empty_key.insert(raw_value);
+                    },
+                    btree_map::Entry::Occupied(_) => return Err(Error::DuplicateKey(raw_key).into()),
+                }
             }
             _ => match self.unknown.entry(raw_key) {
                 btree_map::Entry::Vacant(empty_key) => {
                     empty_key.insert(raw_value);
                 }
-                btree_map::Entry::Occupied(k) => {
-                    return Err(Error::DuplicateKey(k.key().clone()).into())
-                }
+                btree_map::Entry::Occupied(k) => return Err(Error::DuplicateKey(k.key().clone()).into()),
             },
         }
 

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -38,7 +38,7 @@ pub trait Map {
     /// Attempt to merge with another key-value map of the same type.
     fn merge(&mut self, other: Self) -> Result<(), psbt::Error>;
 
-    /// Encodes map data with bitcoin consensus encoding
+    /// Encodes map data with bitcoin consensus encoding.
     fn consensus_encode_map<S: io::Write>(
         &self,
         mut s: S,

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -28,7 +28,7 @@ pub use self::input::{Input, PsbtSigHashType};
 pub use self::output::{Output, TapTree};
 
 /// A trait that describes a PSBT key-value map.
-pub trait Map {
+pub(super) trait Map {
     /// Attempt to insert a key-value pair.
     fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), encode::Error>;
 

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -20,6 +20,13 @@ use consensus::encode;
 use util::psbt;
 use util::psbt::raw;
 
+mod global;
+mod input;
+mod output;
+
+pub use self::input::{Input, PsbtSigHashType};
+pub use self::output::{Output, TapTree};
+
 /// A trait that describes a PSBT key-value map.
 pub trait Map {
     /// Attempt to insert a key-value pair.
@@ -47,12 +54,3 @@ pub trait Map {
         Ok(len + encode::Encodable::consensus_encode(&0x00_u8, s)?)
     }
 }
-
-// place at end to pick up macros
-mod global;
-mod input;
-mod output;
-
-pub use self::input::{Input, PsbtSigHashType};
-pub use self::output::Output;
-pub use self::output::TapTree;

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -29,9 +29,6 @@ pub use self::output::{Output, TapTree};
 
 /// A trait that describes a PSBT key-value map.
 pub(super) trait Map {
-    /// Attempt to insert a key-value pair.
-    fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), encode::Error>;
-
     /// Attempt to get all key-value pairs.
     fn get_pairs(&self) -> Result<Vec<raw::Pair>, io::Error>;
 

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -93,7 +93,7 @@ impl PartialEq for TapTree {
 impl Eq for TapTree {}
 
 impl TapTree {
-    // get the inner node info as the builder is finalized
+    /// Gets the inner node info as the builder is finalized.
     fn node_info(&self) -> &NodeInfo {
         // The builder algorithm invariant guarantees that is_complete builder
         // have only 1 element in branch and that is not None.
@@ -102,8 +102,10 @@ impl TapTree {
         self.0.branch()[0].as_ref().expect("from_inner only parses is_complete builders")
     }
 
-    /// Convert a [`TaprootBuilder`] into a tree if it is complete binary tree.
-    /// Returns the inner as Err if it is not a complete tree.
+    /// Converts a [`TaprootBuilder`] into a tree if it is complete binary tree.
+    ///
+    /// # Return
+    /// A `TapTree` iff the `inner` builder is complete, otherwise return the inner as `Err`.
     pub fn from_inner(inner: TaprootBuilder) -> Result<Self, TaprootBuilder> {
         if inner.is_complete() {
             Ok(TapTree(inner))
@@ -112,8 +114,7 @@ impl TapTree {
         }
     }
 
-    /// Convert self into builder [`TaprootBuilder`]. The builder is guaranteed to
-    /// be finalized.
+    /// Converts self into builder [`TaprootBuilder`]. The builder is guaranteed to be finalized.
     pub fn into_inner(self) -> TaprootBuilder {
         self.0
     }

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -120,8 +120,8 @@ impl TapTree {
     }
 }
 
-impl Map for Output {
-    fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), encode::Error> {
+impl Output {
+    pub(super) fn insert_pair(&mut self, pair: raw::Pair) -> Result<(), encode::Error> {
         let raw::Pair {
             key: raw_key,
             value: raw_value,
@@ -177,7 +177,9 @@ impl Map for Output {
 
         Ok(())
     }
+}
 
+impl Map for Output {
     fn get_pairs(&self) -> Result<Vec<raw::Pair>, io::Error> {
         let mut rv: Vec<raw::Pair> = Default::default();
 

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -58,11 +58,11 @@ pub struct Output {
     /// corresponding master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
     pub bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
-    /// The internal pubkey
+    /// The internal pubkey.
     pub tap_internal_key: Option<XOnlyPublicKey>,
-    /// Taproot Output tree
+    /// Taproot Output tree.
     pub tap_tree: Option<TapTree>,
-    /// Map of tap root x only keys to origin info and leaf hashes contained in it
+    /// Map of tap root x only keys to origin info and leaf hashes contained in it.
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
     pub tap_key_origins: BTreeMap<XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
     /// Proprietary key-value pairs for this output.
@@ -79,7 +79,7 @@ pub struct Output {
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 }
 
-/// Taproot Tree representing a finalized [`TaprootBuilder`] (a complete binary tree)
+/// Taproot Tree representing a finalized [`TaprootBuilder`] (a complete binary tree).
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TapTree(pub(crate) TaprootBuilder);
@@ -103,7 +103,7 @@ impl TapTree {
     }
 
     /// Convert a [`TaprootBuilder`] into a tree if it is complete binary tree.
-    /// Returns the inner as Err if it is not a complete tree
+    /// Returns the inner as Err if it is not a complete tree.
     pub fn from_inner(inner: TaprootBuilder) -> Result<Self, TaprootBuilder> {
         if inner.is_complete() {
             Ok(TapTree(inner))

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -39,7 +39,8 @@ mod macros;
 pub mod serialize;
 
 mod map;
-pub use self::map::{Map, Input, Output, TapTree};
+pub use self::map::{Input, Output, TapTree};
+use self::map::Map;
 
 use util::bip32::{ExtendedPubKey, KeySource};
 


### PR DESCRIPTION
The `Map` method `insert_pair` is never called for `PartiallySignedTransaction`. Separate the method into its own trait (`Insert`) and delete dead code. The dead code contains the alleged bug in #576. 

- Patch 1: Preparatory cleanup
- Patch 2: Preparatory refactor 
- Patch 3 and 4: Improve docs in the module that this PR touches
- Patch 5: Make `Map` trait private to the `psbt` module
- ~Patch 6: Make `concensus_decode_global` method into a function~
- Patch ~7~ 6: Pull `insert_pair` method out of `Map` trait into newly create `Insert` trait 

Resolves: https://github.com/rust-bitcoin/rust-bitcoin/issues/576

(Title of PR is `Make Map trait private` because that is the API break.)