### PR TITLE
improve example: take hex-encoded seed instead of WIF in bip32 example

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -56,8 +56,8 @@ echo "********* Testing no-std build *************"
       cargo build --verbose --features="no-std $feature"
   done
 
-  cargo run --example bip32 L1HKVVLHXiUhecWnwFYF6L3shkf1E12HUmuZTESvBXUdx3yqVP1D
-  cargo run --no-default-features --features no-std --example bip32 L1HKVVLHXiUhecWnwFYF6L3shkf1E12HUmuZTESvBXUdx3yqVP1D
+  cargo run --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+  cargo run --no-default-features --features no-std --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
 fi
 
 # Test each feature

--- a/examples/bip32.rs
+++ b/examples/bip32.rs
@@ -4,37 +4,37 @@ use std::{env, process};
 use std::str::FromStr;
 
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::{PrivateKey, PublicKey};
+use bitcoin::PublicKey;
 use bitcoin::util::bip32::ExtendedPrivKey;
 use bitcoin::util::bip32::ExtendedPubKey;
 use bitcoin::util::bip32::DerivationPath;
 use bitcoin::util::bip32::ChildNumber;
 use bitcoin::util::address::Address;
 use bitcoin::secp256k1::ffi::types::AlignedType;
+use bitcoin::hashes::hex::FromHex;
 
 fn main() {
-    // This example derives root xprv
-    // from a 32-byte secret of the input WIF string,
+    // This example derives root xprv from a 32-byte seed,
     // derives the child xprv with path m/84h/0h/0h,
     // prints out corresponding xpub,
     // calculates and prints out the first receiving segwit address.
-    // Run this example with cargo and WIF argument:
-    // cargo run --example bip32 L1HKVVLHXiUhecWnwFYF6L3shkf1E12HUmuZTESvBXUdx3yqVP1D
+    // Run this example with cargo and seed(hex-encoded) argument:
+    // cargo run --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
 
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("not enough arguments. usage: {} <WIF>", &args[0]);
+        eprintln!("not enough arguments. usage: {} <hex-encoded 32-byte seed>", &args[0]);
         process::exit(1);
     }
 
-    let wif = PrivateKey::from_wif(&args[1]).unwrap();
-    println!("Seed WIF: {}", wif);
+    let seed_hex = &args[1];
+    println!("Seed: {}", seed_hex);
 
-    // use the network from WIF key
-    let network = wif.network;
+    // default network as mainnet
+    let network = bitcoin::Network::Bitcoin;
     println!("Network: {:?}", network);
-    // seed is a 32-byte secret in WIF
-    let seed = wif.to_bytes();
+
+    let seed = Vec::from_hex(seed_hex).unwrap();
 
     // we need secp256k1 context for key derivation
     let mut buf: Vec<AlignedType> = Vec::new();


### PR DESCRIPTION
This is my understanding of what we want to fix the confusing bip32 example. Apologize in advance if I misunderstand it.

Closes #748 