### PR TITLE
Rename inner key field in PrivateKey and PublicKey

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -815,9 +815,9 @@ impl Builder {
     /// Pushes a public key
     pub fn push_key(self, key: &PublicKey) -> Builder {
         if key.compressed {
-            self.push_slice(&key.key.serialize()[..])
+            self.push_slice(&key.inner.serialize()[..])
         } else {
-            self.push_slice(&key.key.serialize_uncompressed()[..])
+            self.push_slice(&key.inner.serialize_uncompressed()[..])
         }
     }
 
@@ -1038,10 +1038,10 @@ mod test {
         let pubkey = PublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e").unwrap();
         assert!(Script::new_p2pk(&pubkey).is_p2pk());
 
-        let pubkey_hash = PubkeyHash::hash(&pubkey.key.serialize());
+        let pubkey_hash = PubkeyHash::hash(&pubkey.inner.serialize());
         assert!(Script::new_p2pkh(&pubkey_hash).is_p2pkh());
 
-        let wpubkey_hash = WPubkeyHash::hash(&pubkey.key.serialize());
+        let wpubkey_hash = WPubkeyHash::hash(&pubkey.inner.serialize());
         assert!(Script::new_v0_wpkh(&wpubkey_hash).is_v0_p2wpkh());
 
         let script = Builder::new().push_opcode(opcodes::all::OP_NUMEQUAL)

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -532,7 +532,7 @@ impl ExtendedPrivKey {
         ecdsa::PrivateKey {
             compressed: true,
             network: self.network,
-            key: self.private_key
+            inner: self.private_key
         }
     }
 
@@ -663,7 +663,7 @@ impl ExtendedPubKey {
     pub fn to_pub(&self) -> ecdsa::PublicKey {
         ecdsa::PublicKey {
             compressed: true,
-            key: self.public_key
+            inner: self.public_key
         }
     }
 

--- a/src/util/contracthash.rs
+++ b/src/util/contracthash.rs
@@ -160,7 +160,7 @@ impl<'a> From<&'a [u8]> for Template {
 /// Tweak a single key using some arbitrary data
 pub fn tweak_key<C: secp256k1::Verification>(secp: &Secp256k1<C>, mut key: PublicKey, contract: &[u8]) -> PublicKey {
     let hmac_result = compute_tweak(&key, contract);
-    key.key.add_exp_assign(secp, &hmac_result[..]).expect("HMAC cannot produce invalid tweak");
+    key.inner.add_exp_assign(secp, &hmac_result[..]).expect("HMAC cannot produce invalid tweak");
     key
 }
 
@@ -172,9 +172,9 @@ pub fn tweak_keys<C: secp256k1::Verification>(secp: &Secp256k1<C>, keys: &[Publi
 /// Compute a tweak from some given data for the given public key
 pub fn compute_tweak(pk: &PublicKey, contract: &[u8]) -> Hmac<sha256::Hash> {
     let mut hmac_engine: HmacEngine<sha256::Hash> = if pk.compressed {
-        HmacEngine::new(&pk.key.serialize())
+        HmacEngine::new(&pk.inner.serialize())
     } else {
-        HmacEngine::new(&pk.key.serialize_uncompressed())
+        HmacEngine::new(&pk.inner.serialize_uncompressed())
     };
     hmac_engine.input(contract);
     Hmac::from_engine(hmac_engine)
@@ -188,7 +188,7 @@ pub fn tweak_secret_key<C: secp256k1::Signing>(secp: &Secp256k1<C>, key: &Privat
     let hmac_sk = compute_tweak(&pk, contract);
     // Execute the tweak
     let mut key = *key;
-    key.key.add_assign(&hmac_sk[..]).map_err(Error::Secp)?;
+    key.inner.add_assign(&hmac_sk[..]).map_err(Error::Secp)?;
     // Return
     Ok(key)
 }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -148,7 +148,7 @@ mod message_signing {
             let msg = secp256k1::Message::from_slice(&msg_hash[..])?;
             let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
             Ok(PublicKey {
-                key: pubkey,
+                inner: pubkey,
                 compressed: self.compressed,
             })
         }
@@ -330,7 +330,7 @@ mod tests {
         let signature2 = super::MessageSignature::from_str(&signature.to_string()).unwrap();
         let pubkey = signature2.recover_pubkey(&secp, msg_hash).unwrap();
         assert_eq!(pubkey.compressed, true);
-        assert_eq!(pubkey.key, secp256k1::PublicKey::from_secret_key(&secp, &privkey));
+        assert_eq!(pubkey.inner, secp256k1::PublicKey::from_secret_key(&secp, &privkey));
 
         let p2pkh = ::Address::p2pkh(&pubkey, ::Network::Bitcoin);
         assert_eq!(signature2.is_signed_by_address(&secp, &p2pkh, msg_hash), Ok(true));


### PR DESCRIPTION
Since we already broke all possible key-related APIs with this release, I think this one is good to have with 0.28.

Closes #532