### PR TITLE
wrap u8 and LeafVersion in backticks and square bracket in doc

### DIFF
--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -276,7 +276,7 @@ impl SchnorrSigHashType {
         }
     }
 
-    /// Create a [`SchnorrSigHashType`] from raw u8
+    /// Create a [`SchnorrSigHashType`] from raw `u8`
     pub fn from_u8(hash_ty: u8) -> Result<Self, Error> {
         match hash_ty {
             0x00 => Ok(SchnorrSigHashType::Default),

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -762,7 +762,7 @@ impl ControlBlock {
 /// Inner type representing future (non-tapscript) leaf versions. See [`LeafVersion::Future`].
 ///
 /// NB: NO PUBLIC CONSTRUCTOR!
-/// The only way to construct this is by converting u8 to LeafVersion and then extracting it.
+/// The only way to construct this is by converting `u8` to [`LeafVersion`] and then extracting it.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct FutureLeafVersion(u8);
 


### PR DESCRIPTION
Found this minor doc issue while reviewing(learning) previous merged PR.

Close https://github.com/rust-bitcoin/rust-bitcoin/issues/763