### PR TITLE
Script for testing PRs locally on a per-commit basis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 target
 Cargo.lock
 
+#tests
+dep_test
+
 #fuzz
 fuzz/hfuzz_target
 fuzz/hfuzz_workspace

--- a/contrib/ci.sh
+++ b/contrib/ci.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -ex
+
+git rebase -x 'AS_DEPENDENCY=true TOOLCHAIN=stable ./contrib/test.sh' master &&
+  PIN_VERSIONS=true AS_DEPENDENCY=true TOOLCHAIN="${BITCOIN_MSRV:-1.29.0}" ./contrib/test.sh &&
+  AS_DEPENDENCY=true DO_FUZZ=true TOOLCHAIN=nightly ./contrib/test.sh

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,10 +2,12 @@
 
 FEATURES="base64 bitcoinconsensus use-serde rand secp-recovery"
 
+# Old cargo format is incompatible with a newer ones, so we need to clean this up
+rm -f Cargo.lock
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]
 then
-    alias cargo="cargo +$TOOLCHAIN"
+    alias cargo='cargo +"${TOOLCHAIN}"'
 fi
 
 pin_common_verions() {
@@ -96,4 +98,7 @@ then
     fi
 
     cargo test --verbose
+
+    cd ..
+    rm -rf dep_test
 fi


### PR DESCRIPTION
This adds a script which allows testing branches on a per-commit basis. This helps both repo maintainers and contributors and may become part of the CI workflow.

This is extracted from Contributing PR #587 since it can be merged faster before the rest of discussions there.