### PR TITLE
Change type of final script witness to Witness from Vec<Vec<u8>>

### DIFF
--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -18,6 +18,7 @@ use ::{EcdsaSig, io};
 
 use secp256k1;
 use blockdata::script::Script;
+use blockdata::witness::Witness;
 use blockdata::transaction::{EcdsaSigHashType, Transaction, TxOut};
 use consensus::encode;
 use hashes::{self, hash160, ripemd160, sha256, sha256d};
@@ -105,7 +106,7 @@ pub struct Input {
     pub final_script_sig: Option<Script>,
     /// The finalized, fully-constructed scriptWitness with signatures and any
     /// other scripts necessary for this input to pass validation.
-    pub final_script_witness: Option<Vec<Vec<u8>>>,
+    pub final_script_witness: Option<Witness>,
     /// TODO: Proof of reserves commitment
     /// RIPEMD160 hash to preimage map
     #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
@@ -192,7 +193,7 @@ impl Map for Input {
             }
             PSBT_IN_FINAL_SCRIPTWITNESS => {
                 impl_psbt_insert_pair! {
-                    self.final_script_witness <= <raw_key: _>|<raw_value: Vec<Vec<u8>>>
+                    self.final_script_witness <= <raw_key: _>|<raw_value: Witness>
                 }
             }
             PSBT_IN_RIPEMD160 => {
@@ -290,7 +291,7 @@ impl Map for Input {
         }
 
         impl_psbt_get_pair! {
-            rv.push(self.final_script_witness as <PSBT_IN_FINAL_SCRIPTWITNESS, _>|<Script>)
+            rv.push(self.final_script_witness as <PSBT_IN_FINAL_SCRIPTWITNESS, _>|<Witness>)
         }
 
         impl_psbt_get_pair! {

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -27,7 +27,6 @@ use consensus::encode::MAX_VEC_SIZE;
 use prelude::*;
 
 use io;
-use blockdata::witness::Witness;
 
 mod error;
 pub use self::error::Error;
@@ -112,7 +111,7 @@ impl PartiallySignedTransaction {
 
         for (vin, psbtin) in tx.input.iter_mut().zip(self.inputs.into_iter()) {
             vin.script_sig = psbtin.final_script_sig.unwrap_or_else(Script::new);
-            vin.witness = Witness::from_vec(psbtin.final_script_witness.unwrap_or_else(Vec::new));
+            vin.witness = psbtin.final_script_witness.unwrap_or_default();
         }
 
         tx
@@ -478,7 +477,7 @@ mod tests {
                     "304402204f67e2afb76142d44fae58a2495d33a3419daa26cd0db8d04f3452b63289ac0f022010762a9fb67e94cc5cad9026f6dc99ff7f070f4278d30fbc7d0c869dd38c7fe701".parse().unwrap(),
                 )].into_iter().collect(),
                 bip32_derivation: keypaths.clone(),
-                final_script_witness: Some(vec![vec![1, 3], vec![5]]),
+                final_script_witness: Some(Witness::from_vec(vec![vec![1, 3], vec![5]])),
                 ripemd160_preimages: vec![(ripemd160::Hash::hash(&[]), vec![1, 2])].into_iter().collect(),
                 sha256_preimages: vec![(sha256::Hash::hash(&[]), vec![1, 2])].into_iter().collect(),
                 hash160_preimages: vec![(hash160::Hash::hash(&[]), vec![1, 2])].into_iter().collect(),

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -23,6 +23,7 @@ use prelude::*;
 use io;
 
 use blockdata::script::Script;
+use blockdata::witness::Witness;
 use blockdata::transaction::{EcdsaSigHashType, Transaction, TxOut};
 use consensus::encode::{self, serialize, Decodable, Encodable, deserialize_partial};
 use secp256k1::{self, XOnlyPublicKey};
@@ -51,7 +52,7 @@ pub trait Deserialize: Sized {
 
 impl_psbt_de_serialize!(Transaction);
 impl_psbt_de_serialize!(TxOut);
-impl_psbt_de_serialize!(Vec<Vec<u8>>); // scriptWitness
+impl_psbt_de_serialize!(Witness);
 impl_psbt_hash_de_serialize!(ripemd160::Hash);
 impl_psbt_hash_de_serialize!(sha256::Hash);
 impl_psbt_hash_de_serialize!(TapLeafHash);


### PR DESCRIPTION
Doing this would certainly help APIs downstream that operate on &Witness because they would not conversion from &Vec<Vec<u8>> to &Witness.