### PR TITLE
Bump version to v0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
Pending PRs from https://github.com/rust-bitcoin/rust-bitcoin/milestone/10, specifically:
- #776
- #587

Draft for the release info is autogenerated by GitHub, so we have to edit it. Please feel free to edit it right here, in place. Once we will be happy with it, I will add it to the `CHANLELOG.md` to the release commit.

## What's Changed

### Breaking changes

* Script serialization/deserialization in serde non-human-readable format by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/596
* use Amount type in verify by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/621
* Add OP_CHECKSIGADD and OP_SUCCESSxxx by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/644
* WitnessVersion type by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/617
* Taproot P2TR address by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/563
* Improvements to Error types (part 4) by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/625
* Add Bloom filter network messages by @benthecarman in https://github.com/rust-bitcoin/rust-bitcoin/pull/580
* Adds Taproot BIP341 signature message and create a unified sighash cache for legacy, segwit and taproot inputs by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/628
* ~Changes for checking script size and returning Result<Address, Error> for p2sh by @vss96 in https://github.com/rust-bitcoin/rust-bitcoin/pull/655~
* Add taproot data structures by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/677
* P2TR address from untweaked key by @nlanson in https://github.com/rust-bitcoin/rust-bitcoin/pull/691
* Making globals part of PSBT struct. Closes #652 by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/654
* New Witness struct to improve ser/de perfomance by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/672

#### Theoretically non-breaking

These are things people shouldn't have depended on in the first place but may be considered breaking in some contexts.

* Removed fuzztarget feature by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/634

### New APIs/features

* Implement possible_networks function for Address by @elsirion in https://github.com/rust-bitcoin/rust-bitcoin/pull/618
* Super-trivial: Implement `FusedIterator` for `Instructions` by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/733
* Implement `Sum` for amount types by @sgeisler in https://github.com/rust-bitcoin/rust-bitcoin/pull/615
* Implement `Block.get_strippedsize()` and `Transaction.get_vsize()` by @visvirial in https://github.com/rust-bitcoin/rust-bitcoin/pull/626
* util/address: make address encoding more modular by @benma in https://github.com/rust-bitcoin/rust-bitcoin/pull/643

### Bug fixes

* Fixing no_std for Amount sum iterator by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/651
* Fix `Uint256::increment` panics by @TheBlueMatt in https://github.com/rust-bitcoin/rust-bitcoin/pull/612
* Hotfix for secp256k1 alloc feature by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/694

### Mildly interesting improvements

These improvements are mainly internal or documentation but may have noticeable impact on the quality of the crate.

* Document cargo features by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/633
* Add i686 to tested architectures by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/659

### Other/uncategorized changes

* fix changelog date by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/640
* ~Use consts for address prefix values by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/632~
* Fix documentation referencing macro var by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/623
* ~~Check for overflow in Script::bytes_to_asm_fmt() by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/658~~ (this was released in point release)
* ~~Document lack of support for 16-bit pointers by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/663~~
* Improve Fuzz CI by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/664
* ~~Refactor Script::bytes_to_asm_fmt to use iterator by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/662~~
* no-std cleanup by @devrandom in https://github.com/rust-bitcoin/rust-bitcoin/pull/637
* util/address: remove unused generic type by @benma in https://github.com/rust-bitcoin/rust-bitcoin/pull/698
* ~Clean up module level rustdocs by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/689~
* tests: improve coverage for P2tr and AddressType by @LeoComandini in https://github.com/rust-bitcoin/rust-bitcoin/pull/683
* ~Return the correct `LeafVersion` when building a Taproot `ControlBlock` by @afilini in https://github.com/rust-bitcoin/rust-bitcoin/pull/703~
* ~Add unit test for bitcoin_merkle_root functions by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/711~
* P2tr fixes by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/707
* ~util/address: Improve docs by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/704~
* Huffman Bug Fix by @JeremyRubin in https://github.com/rust-bitcoin/rust-bitcoin/pull/699
* Huffman Encoding Bug Test by @JeremyRubin in https://github.com/rust-bitcoin/rust-bitcoin/pull/700
* ~Use expect instead of unwrap for calls to consensus_encode by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/719~
* Use TapTweakHash::from_key_and_tweak() method in computing tweak for UntweakedPublicKey by @nlanson in https://github.com/rust-bitcoin/rust-bitcoin/pull/697
* Decrease Huffman Weights to u32 by @JeremyRubin in https://github.com/rust-bitcoin/rust-bitcoin/pull/701
* ~Use un/tweaked public key types by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/728~
* Improvements to script methods related to Taproot by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/721
* add helpful message to division-by-zero panic by @z8674558 in https://github.com/rust-bitcoin/rust-bitcoin/pull/743
* Separate signature hash types by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/702
* add MAX_MONEY public constant to Amount by @z8674558 in https://github.com/rust-bitcoin/rust-bitcoin/pull/742
* ~Refactor bitcoin_merkle_root functions by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/710~
* BIP341 test vectors by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/695
* ~~Fixed a bunch of clippy lints, added clippy.toml by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/686~~
* Re-export SigHashType in lib.rs by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/749
* ~~Fixed docs.rs metadata by @Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/744~~
* Improve parsing of `Denomination` string by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/731
* ~transactions: add a note about `get_vsize` and standardness rules by @darosior in https://github.com/rust-bitcoin/rust-bitcoin/pull/665~
* ~Allow specifing a raw `TapLeafHash` in sighash computation by @afilini in https://github.com/rust-bitcoin/rust-bitcoin/pull/722~
* Add support for taproot psbt fields BIP 371 by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/681
* Tapsighash test vectors by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/705
* Deprecate `StreamReader` by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/680
* ~Put rustdocs above attributes by @tcharding in https://github.com/rust-bitcoin/rust-bitcoin/pull/753~
* Update to secp256k1 0.21.2 by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/755
* Use `test_data` for big objects, add big block for benchmarking by @RCasatta in https://github.com/rust-bitcoin/rust-bitcoin/pull/750
* PSBT: partial sig data type by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/669
* Converting LeafVersion into an enum by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/718
* Taproot: BIP32 extended keys using Scep256k1 keys instead of bitcoin ECDSA by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/590
* Taproot trivial post-merge fixups by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/761
* wrap u8 and LeafVersion in backticks and square bracket in doc by @bruteforcecat in https://github.com/rust-bitcoin/rust-bitcoin/pull/766
* improve example: take hex-encoded seed instead of WIF in bip32 example by @bruteforcecat in https://github.com/rust-bitcoin/rust-bitcoin/pull/760
* PSBT BIP32 keys using to Secp256k1 keys instead of bitcoin ECDSA by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/591
* Rename inner key field in PrivateKey and PublicKey by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/762
* Add Witness::new() by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/771
* Change type of final script witness to Witness from Vec<Vec<u8>> by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/774
* Taproot tweaks generalization & KeyPair support by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/696
* Issue #394 - Refactor Block::merkle_root()  by @nilswloewen in https://github.com/rust-bitcoin/rust-bitcoin/pull/775
* Fixups for taproot improvements by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/778
* Introduce PsbtSigHashType by @sanket1729 in https://github.com/rust-bitcoin/rust-bitcoin/pull/779
* add nano and pico BTC to Denomination enum by @bruteforcecat in https://github.com/rust-bitcoin/rust-bitcoin/pull/768
* replace unncessary closure with function pointer in FromStr::from_str for Deonomation by @bruteforcecat in https://github.com/rust-bitcoin/rust-bitcoin/pull/784
* Minimally-invasive separation of bitcoin keys from ECDSA signature types by @dr-orlovsky in https://github.com/rust-bitcoin/rust-bitcoin/pull/757

## New Contributors
* @Kixunil made his first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/634
* @elsirion made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/618
* @tcharding made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/632
* @visvirial made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/626
* @benthecarman made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/580
* @vss96 made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/655
* @nlanson made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/691
* @benma made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/698
* @LeoComandini made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/683
* @z8674558 made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/743
* @bruteforcecat made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/766
* @nilswloewen made their first contribution in https://github.com/rust-bitcoin/rust-bitcoin/pull/775

**Full Changelog**: https://github.com/rust-bitcoin/rust-bitcoin/compare/0.27.0...0.28.0