### PR TITLE
Re-export psbt module from root level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ pub use util::sighash::SchnorrSigHashType;
 pub use util::ecdsa::{self, EcdsaSig, EcdsaSigError};
 pub use util::schnorr::{self, SchnorrSig, SchnorrSigError};
 pub use util::key::{PrivateKey, PublicKey, XOnlyPublicKey, KeyPair};
+pub use util::psbt;
 #[allow(deprecated)]
 pub use blockdata::transaction::SigHashType;
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -39,7 +39,7 @@ mod macros;
 pub mod serialize;
 
 mod map;
-pub use self::map::{Input, Output, TapTree};
+pub use self::map::{Input, Output, TapTree, PsbtSigHashType};
 use self::map::Map;
 
 use util::bip32::{ExtendedPubKey, KeySource};


### PR DESCRIPTION
We currently have the `map` module private but containing a bunch of types that are needed in the public API (specifically in a `PartiallySignedTransaction`).

To give access to them re-export the `util::psbt` module at the root level.

Found while testing `master` with `rust-miniscript`.