### PR TITLE
Use fn name to_ instead of into_ 

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -465,7 +465,7 @@ impl Payload {
         let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
         Payload::WitnessProgram {
             version: WitnessVersion::V1,
-            program: output_key.into_inner().serialize().to_vec(),
+            program: output_key.to_inner().serialize().to_vec(),
         }
     }
 

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -264,7 +264,7 @@ impl Serialize for (Script, LeafVersion) {
     fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.0.len() + 1);
         buf.extend(self.0.as_bytes());
-        buf.push(self.1.into_consensus());
+        buf.push(self.1.to_consensus());
         buf
     }
 }
@@ -312,7 +312,7 @@ impl Serialize for TapTree {
                     // TaprootMerkleBranch can only have len atmost 128(TAPROOT_CONTROL_MAX_NODE_COUNT).
                     // safe to cast from usize to u8
                     buf.push(leaf_info.merkle_branch.as_inner().len() as u8);
-                    buf.push(leaf_info.ver.into_consensus());
+                    buf.push(leaf_info.ver.to_consensus());
                     leaf_info.script.consensus_encode(&mut buf).expect("Vecs dont err");
                 }
                 buf

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -161,7 +161,7 @@ impl TweakedPublicKey {
     }
 
     /// Returns the underlying public key.
-    pub fn into_inner(self) -> ::XOnlyPublicKey {
+    pub fn to_inner(self) -> ::XOnlyPublicKey {
         self.0
     }
 

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -235,7 +235,7 @@ impl<'s> ScriptPath<'s> {
     pub fn leaf_hash(&self) -> TapLeafHash {
         let mut enc = TapLeafHash::engine();
 
-        self.leaf_version.into_consensus().consensus_encode(&mut enc).expect("Writing to hash enging should never fail");
+        self.leaf_version.to_consensus().consensus_encode(&mut enc).expect("Writing to hash enging should never fail");
         self.script.consensus_encode(&mut enc).expect("Writing to hash enging should never fail");
 
         TapLeafHash::from_engine(enc)

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -120,7 +120,7 @@ impl TapLeafHash {
     /// function to compute leaf hash from components
     pub fn from_script(script: &Script, ver: LeafVersion) -> TapLeafHash {
         let mut eng = TapLeafHash::engine();
-        ver.into_consensus()
+        ver.to_consensus()
             .consensus_encode(&mut eng)
             .expect("engines don't error");
         script
@@ -703,7 +703,7 @@ impl ControlBlock {
 
     /// Serialize to a writer. Returns the number of bytes written
     pub fn encode<Write: io::Write>(&self, mut writer: Write) -> io::Result<usize> {
-        let first_byte: u8 = i32::from(self.output_key_parity) as u8 | self.leaf_version.into_consensus();
+        let first_byte: u8 = i32::from(self.output_key_parity) as u8 | self.leaf_version.to_consensus();
         let mut bytes_written = 0;
         bytes_written += writer.write(&[first_byte])?;
         bytes_written += writer.write(&self.internal_key.serialize())?;
@@ -778,7 +778,7 @@ impl FutureLeafVersion {
 
     /// Get consensus representation of the future leaf version.
     #[inline]
-    pub fn into_consensus(self) -> u8 {
+    pub fn to_consensus(self) -> u8 {
         self.0
     }
 }
@@ -838,10 +838,10 @@ impl LeafVersion {
     }
 
     /// Get consensus representation of the [`LeafVersion`].
-    pub fn into_consensus(self) -> u8 {
+    pub fn to_consensus(self) -> u8 {
         match self {
             LeafVersion::TapScript => TAPROOT_LEAF_TAPSCRIPT,
-            LeafVersion::Future(version) => version.into_consensus(),
+            LeafVersion::Future(version) => version.to_consensus(),
         }
     }
 }
@@ -859,13 +859,13 @@ impl fmt::Display for LeafVersion {
 
 impl fmt::LowerHex for LeafVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.into_consensus(), f)
+        fmt::LowerHex::fmt(&self.to_consensus(), f)
     }
 }
 
 impl fmt::UpperHex for LeafVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::UpperHex::fmt(&self.into_consensus(), f)
+        fmt::UpperHex::fmt(&self.to_consensus(), f)
     }
 }
 
@@ -877,7 +877,7 @@ impl ::serde::Serialize for LeafVersion {
         where
             S: ::serde::Serializer,
     {
-        serializer.serialize_u8(self.into_consensus())
+        serializer.serialize_u8(self.to_consensus())
     }
 }
 
@@ -1293,7 +1293,7 @@ mod test {
             let addr = Address::p2tr(&secp, internal_key, merkle_root, Network::Bitcoin);
             let spk = addr.script_pubkey();
 
-            assert_eq!(expected_output_key, output_key.into_inner());
+            assert_eq!(expected_output_key, output_key.to_inner());
             assert_eq!(expected_tweak, tweak);
             assert_eq!(expected_addr, addr);
             assert_eq!(expected_spk, spk);


### PR DESCRIPTION
Rust convention is to use `to_` for conversion methods that convert from
an owned type to an owned `Copy` type. `into_` is for owned to owned
non-`Copy` types.

Re-name conversion methods that use `into_` for `Copy` types to use
`to_`, no need to deprecate these ones because they are unreleased.

**Note to maintainers**

This is similar in concept to #798 but only touches new code introduced in this release. Has been labelled 'RC fix' for that reason. Please feel free to remove the label if you disagree.


From the docs: https://rust-lang.github.io/api-guidelines/naming.html

<h2><a class="header" href="https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv" id="ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv">Ad-hoc conversions follow <code>as_</code>, <code>to_</code>, <code>into_</code> conventions (C-CONV)</a></h2>
<p>Conversions should be provided as methods, with names prefixed as follows:</p>


Prefix | Cost | Ownership
-- | -- | --
as_ | Free | borrowed -> borrowed
to_ | Expensive | borrowed -> borrowed 
| | | borrowed -> owned (non-Copy types)  
| | | owned -> owned (Copy types)
into_ | Variable | owned -> owned (non-Copy types)


