### PR TITLE
Add proc macros for consensus encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ features = [ "std", "secp-recovery", "base64", "rand", "use-serde", "bitcoincons
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+bitcoin-derive = { path = "./rust-bitcoin-derive" }
 bech32 = { version = "0.8.1", default-features = false }
 bitcoin_hashes = { version = "0.10.0", default-features = false }
 secp256k1 = { version = "0.21.2", default-features = false }

--- a/rust-bitcoin-derive/Cargo.toml
+++ b/rust-bitcoin-derive/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bitcoin-derive"
+version = "0.1.0"
+authors = [""]   # FIXME: Can we have a string here for "The rust-bitcoin devs"?
+license = "CC0-1.0"
+homepage = "https://github.com/rust-bitcoin/rust-bitcoin/rust-bitcoin-derive"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
+documentation = "https://docs.rs/bitcoin-derive/"
+description = "Procedural macros for the rust-bitcoin project."
+keywords = [ "crypto", "bitcoin" ]
+readme = "README.md"            # TODO: Write README
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["derive"] }

--- a/rust-bitcoin-derive/src/lib.rs
+++ b/rust-bitcoin-derive/src/lib.rs
@@ -1,0 +1,87 @@
+//! Custom derive macros for the rust-bitcoin project.
+//!
+
+extern crate proc_macro;
+extern crate syn;
+extern crate quote;
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+use quote::quote;
+
+#[proc_macro_derive(Encodable)]
+pub fn encodable_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let ident = input.ident;
+    let data = input.data;
+
+    let fields = match data {
+        Data::Struct(ref data) => {
+            match data.fields {
+                Fields::Named(_) => &data.fields,
+                Fields::Unnamed(_) | Fields::Unit => {
+                    panic!("Encodable only implemented for named structs");
+                }
+            }
+        }
+        Data::Enum(_) | Data::Union(_) => panic!("Encodable only implemented for structs"),
+    };
+
+    let consensus_encode_fields = fields.iter().map(|f| {
+        let ident = f.ident.clone().unwrap();
+        quote! {
+            len += self.#ident.consensus_encode(&mut s)?;
+        }
+    });
+
+    let gen = quote! {
+        impl Encodable for #ident {
+            fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
+                let mut len = 0;
+                #(#consensus_encode_fields)*
+                Ok(len)
+            }
+        }
+    };
+    gen.into()
+}
+
+#[proc_macro_derive(Decodable)]
+pub fn decodable_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let ident = input.ident;
+    let data = input.data;
+
+    let fields = match data {
+        Data::Struct(ref data) => {
+            match data.fields {
+                Fields::Named(_) => &data.fields,
+                Fields::Unnamed(_) | Fields::Unit => {
+                    panic!("Decodable only implemented for named structs");
+                }
+            }
+        }
+        Data::Enum(_) | Data::Union(_) => panic!("Decodable only implemented for structs"),
+    };
+
+    let consensus_decode_fields = fields.iter().map(|f| {
+        let ident = f.ident.clone().unwrap();
+        quote! {
+            #ident: Decodable::consensus_decode(&mut d)?
+        }
+    });
+
+    let gen = quote! {
+        impl Decodable for #ident {
+            fn consensus_decode<D: io::Read>(d: D) -> Result<#ident, encode::Error> {
+                let mut d = d.take(MAX_VEC_SIZE as u64);
+                Ok(#ident {
+                    #(#consensus_decode_fields),*
+                })
+            }
+        }
+    };
+    gen.into()
+}

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -23,6 +23,9 @@
 use prelude::*;
 
 use core::fmt;
+use io;
+
+use bitcoin_derive::{Decodable, Encodable};
 
 use util;
 use util::Error::{BlockBadTarget, BlockBadProofOfWork};
@@ -30,7 +33,7 @@ use util::hash::bitcoin_merkle_root;
 use hashes::{Hash, HashEngine};
 use hash_types::{Wtxid, BlockHash, TxMerkleNode, WitnessMerkleNode, WitnessCommitment};
 use util::uint::Uint256;
-use consensus::encode::Encodable;
+use consensus::{encode, Decodable, Encodable, MAX_VEC_SIZE};
 use network::constants::Network;
 use blockdata::transaction::Transaction;
 use blockdata::constants::{max_target, WITNESS_SCALE_FACTOR};
@@ -39,7 +42,7 @@ use VarInt;
 
 /// A block header, which contains all the block's information except
 /// the actual transactions
-#[derive(Copy, PartialEq, Eq, Clone, Debug)]
+#[derive(Copy, PartialEq, Eq, Clone, Debug, Encodable, Decodable)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlockHeader {
     /// The protocol version. Should always be 1.
@@ -56,8 +59,6 @@ pub struct BlockHeader {
     /// The nonce, selected to obtain a low enough blockhash
     pub nonce: u32,
 }
-
-impl_consensus_encoding!(BlockHeader, version, prev_blockhash, merkle_root, time, bits, nonce);
 
 impl BlockHeader {
     /// Return the block hash.
@@ -157,7 +158,7 @@ impl BlockHeader {
 
 /// A Bitcoin block, which is a collection of transactions with an attached
 /// proof of work.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Block {
     /// The block header
@@ -165,8 +166,6 @@ pub struct Block {
     /// List of transactions contained in the block
     pub txdata: Vec<Transaction>
 }
-
-impl_consensus_encoding!(Block, header, txdata);
 
 impl Block {
     /// Return the block hash.

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -29,6 +29,8 @@ use io;
 use core::{fmt, str, default::Default};
 #[cfg(feature = "std")] use std::error;
 
+use bitcoin_derive::{Decodable, Encodable};
+
 use hashes::{self, Hash, sha256d};
 use hashes::hex::FromHex;
 
@@ -37,8 +39,7 @@ use blockdata::constants::WITNESS_SCALE_FACTOR;
 #[cfg(feature="bitcoinconsensus")] use blockdata::script;
 use blockdata::script::Script;
 use blockdata::witness::Witness;
-use consensus::{encode, Decodable, Encodable};
-use consensus::encode::MAX_VEC_SIZE;
+use consensus::{encode, Decodable, Encodable, MAX_VEC_SIZE};
 use hash_types::{SigHash, Txid, Wtxid};
 use VarInt;
 
@@ -213,7 +214,7 @@ impl Default for TxIn {
 }
 
 /// A transaction output, which defines new coins to be created from old ones.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Decodable, Encodable)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TxOut {
     /// The value of the output, in satoshis
@@ -544,8 +545,6 @@ impl Transaction {
         self.input.iter().any(|input| input.sequence < (0xffffffff - 1))
     }
 }
-
-impl_consensus_encoding!(TxOut, value, script_pubkey);
 
 impl Encodable for OutPoint {
     fn consensus_encode<S: io::Write>(

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -21,6 +21,6 @@
 pub mod encode;
 pub mod params;
 
-pub use self::encode::{Encodable, Decodable, WriteExt, ReadExt};
+pub use self::encode::{Encodable, Decodable, WriteExt, ReadExt, MAX_VEC_SIZE};
 pub use self::encode::{serialize, deserialize, deserialize_partial};
 pub use self::params::Params;

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -17,34 +17,6 @@
 //! Macros meant to be used inside the Rust Bitcoin library.
 //!
 
-macro_rules! impl_consensus_encoding {
-    ($thing:ident, $($field:ident),+) => (
-        impl $crate::consensus::Encodable for $thing {
-            #[inline]
-            fn consensus_encode<S: $crate::io::Write>(
-                &self,
-                mut s: S,
-            ) -> Result<usize, $crate::io::Error> {
-                let mut len = 0;
-                $(len += self.$field.consensus_encode(&mut s)?;)+
-                Ok(len)
-            }
-        }
-
-        impl $crate::consensus::Decodable for $thing {
-            #[inline]
-            fn consensus_decode<D: $crate::io::Read>(
-                d: D,
-            ) -> Result<$thing, $crate::consensus::encode::Error> {
-                let mut d = d.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
-                Ok($thing {
-                    $($field: $crate::consensus::Decodable::consensus_decode(&mut d)?),+
-                })
-            }
-        }
-    );
-}
-
 /// Implements standard array methods for a given wrapper type
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ extern crate core2;
 #[cfg(any(feature = "std", test))]
 extern crate core; // for Rust 1.29 and no-std tests
 
+extern crate bitcoin_derive;
+
 // Re-exported dependencies.
 #[macro_use] pub extern crate bitcoin_hashes as hashes;
 pub extern crate secp256k1;

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -22,10 +22,12 @@ use prelude::*;
 
 use io;
 
+use bitcoin_derive::{Decodable, Encodable};
+
 use hashes::sha256d;
 
 use network::constants;
-use consensus::encode::{self, Decodable, Encodable};
+use consensus::{encode, Decodable, Encodable, MAX_VEC_SIZE};
 use hash_types::{BlockHash, Txid, Wtxid};
 
 /// An inventory item.
@@ -98,7 +100,7 @@ impl Decodable for Inventory {
 // Some simple messages
 
 /// The `getblocks` message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct GetBlocksMessage {
     /// The protocol version
     pub version: u32,
@@ -111,7 +113,7 @@ pub struct GetBlocksMessage {
 }
 
 /// The `getheaders` message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct GetHeadersMessage {
     /// The protocol version
     pub version: u32,
@@ -134,8 +136,6 @@ impl GetBlocksMessage {
     }
 }
 
-impl_consensus_encoding!(GetBlocksMessage, version, locator_hashes, stop_hash);
-
 impl GetHeadersMessage {
     /// Construct a new `getheaders` message
     pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetHeadersMessage {
@@ -146,8 +146,6 @@ impl GetHeadersMessage {
         }
     }
 }
-
-impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {

--- a/src/network/message_bloom.rs
+++ b/src/network/message_bloom.rs
@@ -3,12 +3,13 @@
 //! This module describes BIP37 Connection Bloom filtering network messages.
 //!
 
-use consensus::encode;
-use consensus::{Decodable, Encodable, ReadExt};
+use bitcoin_derive::{Decodable, Encodable};
+
+use consensus::{encode, Decodable, Encodable, MAX_VEC_SIZE, ReadExt};
 use std::io;
 
 /// `filterload` message sets the current bloom filter
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Decodable, Encodable)]
 pub struct FilterLoad {
     /// The filter itself
     pub filter: Vec<u8>,
@@ -19,8 +20,6 @@ pub struct FilterLoad {
     /// Controls how matched items are added to the filter
     pub flags: BloomFlags,
 }
-
-impl_consensus_encoding!(FilterLoad, filter, hash_funcs, tweak, flags);
 
 /// Bloom filter update flags
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -56,10 +55,8 @@ impl Decodable for BloomFlags {
 }
 
 /// `filteradd` message updates the current filter with new data
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Decodable, Encodable)]
 pub struct FilterAdd {
     /// The data element to add to the current filter.
     pub data: Vec<u8>,
 }
-
-impl_consensus_encoding!(FilterAdd, data);

--- a/src/network/message_filter.rs
+++ b/src/network/message_filter.rs
@@ -3,10 +3,14 @@
 //! This module describes BIP157 Client Side Block Filtering network messages.
 //!
 
+use bitcoin_derive::{Decodable, Encodable};
+
 use hash_types::{BlockHash, FilterHash, FilterHeader};
+use consensus::{encode, Decodable, Encodable, MAX_VEC_SIZE};
+use io;
 
 /// getcfilters message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct GetCFilters {
     /// Filter type for which headers are requested
     pub filter_type: u8,
@@ -15,10 +19,9 @@ pub struct GetCFilters {
     /// The hash of the last block in the requested range
     pub stop_hash: BlockHash,
 }
-impl_consensus_encoding!(GetCFilters, filter_type, start_height, stop_hash);
 
 /// cfilter message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct CFilter {
     /// Byte identifying the type of filter being returned
     pub filter_type: u8,
@@ -27,10 +30,9 @@ pub struct CFilter {
     /// The serialized compact filter for this block
     pub filter: Vec<u8>,
 }
-impl_consensus_encoding!(CFilter, filter_type, block_hash, filter);
 
 /// getcfheaders message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct GetCFHeaders {
     /// Byte identifying the type of filter being returned
     pub filter_type: u8,
@@ -39,10 +41,9 @@ pub struct GetCFHeaders {
     /// The hash of the last block in the requested range
     pub stop_hash: BlockHash,
 }
-impl_consensus_encoding!(GetCFHeaders, filter_type, start_height, stop_hash);
 
 /// cfheaders message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct CFHeaders {
     /// Filter type for which headers are requested
     pub filter_type: u8,
@@ -53,20 +54,18 @@ pub struct CFHeaders {
     /// The filter hashes for each block in the requested range
     pub filter_hashes: Vec<FilterHash>,
 }
-impl_consensus_encoding!(CFHeaders, filter_type, stop_hash, previous_filter_header, filter_hashes);
 
 /// getcfcheckpt message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct GetCFCheckpt {
     /// Filter type for which headers are requested
     pub filter_type: u8,
     /// The hash of the last block in the requested range
     pub stop_hash: BlockHash,
 }
-impl_consensus_encoding!(GetCFCheckpt, filter_type, stop_hash);
 
 /// cfcheckpt message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct CFCheckpt {
     /// Filter type for which headers are requested
     pub filter_type: u8,
@@ -75,4 +74,3 @@ pub struct CFCheckpt {
     /// The filter headers at intervals of 1,000
     pub filter_headers: Vec<FilterHeader>,
 }
-impl_consensus_encoding!(CFCheckpt, filter_type, stop_hash, filter_headers);

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -22,17 +22,18 @@ use prelude::*;
 
 use io;
 
+use bitcoin_derive::{Decodable, Encodable};
+
 use network::address::Address;
 use network::constants::{self, ServiceFlags};
-use consensus::{Encodable, Decodable, ReadExt};
-use consensus::encode;
+use consensus::{encode, Decodable, Encodable, MAX_VEC_SIZE, ReadExt};
 use network::message::CommandString;
 use hashes::sha256d;
 
 /// Some simple messages
 
 /// The `version` message
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct VersionMessage {
     /// The P2P network protocol version
     pub version: u32,
@@ -81,10 +82,6 @@ impl VersionMessage {
     }
 }
 
-impl_consensus_encoding!(VersionMessage, version, services, timestamp,
-                         receiver, sender, nonce,
-                         user_agent, start_height, relay);
-
 /// message rejection reason as a code
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum RejectReason {
@@ -130,7 +127,7 @@ impl Decodable for RejectReason {
 }
 
 /// Reject message might be sent by peers rejecting one of our messages
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Decodable, Encodable)]
 pub struct Reject {
     /// message type rejected
     pub message: CommandString,
@@ -141,8 +138,6 @@ pub struct Reject {
     /// reference to rejected item
     pub hash: sha256d::Hash
 }
-
-impl_consensus_encoding!(Reject, message, ccode, reason, hash);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This works but its my first proc macro so I'd love some improvements from the crew.

Currently we use declarative macros to implement the `Encodable` and `Decodable` traits.

It may be more ergonomic if we used custom derives for this.

Add a `rust-bitcoin-derive` crate and in it implement procedural macros used for deriving `Decodable` and `Encodable`.

If this work is deemed valuable we can do the rest of `internal_macros.rs` in a similar fashion ... hopefully :)

The idea to work on this came from: https://github.com/rust-bitcoin/rust-bitcoin/issues/352 