### PR TITLE
Remove impl_index_newtype macro

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -27,6 +27,7 @@ use prelude::*;
 
 use io;
 use core::{fmt, default::Default};
+use core::ops::Index;
 
 #[cfg(feature = "serde")] use serde;
 
@@ -48,6 +49,18 @@ use schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
 /// A Bitcoin script.
 #[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Script(Box<[u8]>);
+
+impl<I> Index<I> for Script
+where
+    [u8]: Index<I>,
+{
+    type Output = <[u8] as Index<I>>::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl AsRef<[u8]> for Script {
     fn as_ref(&self) -> &[u8] {
@@ -108,6 +121,18 @@ impl ::core::str::FromStr for Script {
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Builder(Vec<u8>, Option<opcodes::All>);
 display_from_debug!(Builder);
+
+impl<I> Index<I> for Builder
+where
+    Vec<u8>: Index<I>,
+{
+    type Output = <Vec<u8> as Index<I>>::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
@@ -686,8 +711,6 @@ impl From<Vec<u8>> for Script {
     fn from(v: Vec<u8>) -> Script { Script(v.into_boxed_slice()) }
 }
 
-impl_index_newtype!(Script, u8);
-
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Instruction<'a> {
@@ -942,8 +965,6 @@ impl From<Vec<u8>> for Builder {
         Builder(script.into_bytes(), last_op)
     }
 }
-
-impl_index_newtype!(Builder, u8);
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -93,59 +93,17 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl_index_newtype!($thing, $ty);
-    }
-}
-
-/// Implements standard indexing methods for a given wrapper type
-macro_rules! impl_index_newtype {
-    ($thing:ident, $ty:ty) => {
-
-        impl ::core::ops::Index<usize> for $thing {
-            type Output = $ty;
+        impl<I> $crate::core::ops::Index<I> for $thing
+        where
+            [$ty]: $crate::core::ops::Index<I>,
+        {
+            type Output = <[$ty] as $crate::core::ops::Index<I>>::Output;
 
             #[inline]
-            fn index(&self, index: usize) -> &$ty {
+            fn index(&self, index: I) -> &Self::Output {
                 &self.0[index]
             }
         }
-
-        impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
-
-        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
-
-        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
-
-        impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
-                &self.0[..]
-            }
-        }
-
     }
 }
 

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -21,6 +21,7 @@ use prelude::*;
 
 use io::Write;
 use core::{fmt, str::FromStr, default::Default};
+use core::ops::Index;
 #[cfg(feature = "std")] use std::error;
 #[cfg(feature = "serde")] use serde;
 
@@ -238,8 +239,19 @@ pub trait IntoDerivationPath {
 /// A BIP-32 derivation path.
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct DerivationPath(Vec<ChildNumber>);
-impl_index_newtype!(DerivationPath, ChildNumber);
 serde_string_impl!(DerivationPath, "a BIP-32 derivation path");
+
+impl<I> Index<I> for DerivationPath
+where
+    Vec<ChildNumber>: Index<I>,
+{
+    type Output = <Vec<ChildNumber> as Index<I>>::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl Default for DerivationPath {
     fn default() -> DerivationPath {


### PR DESCRIPTION
This macro is no longer needed since we bumped MSRV to 1.29.

~We can implement `SliceIndex` to get the `Index` implementations.~
We can implement `core::ops::Index` directly since all the inner types implement `Index` already.

Original ~Idea shamelessly stolen from @elichai [in this comment](https://github.com/rust-bitcoin/rust-bitcoin/issues/352#issuecomment-560331856).~

New idea proposed by @Kixunil during review below. Thanks.