### PR TITLE
Use write_all instead of write

### DIFF
--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -770,7 +770,7 @@ impl ExtendedPubKey {
     /// Returns the HASH160 of the chaincode
     pub fn identifier(&self) -> XpubIdentifier {
         let mut engine = XpubIdentifier::engine();
-        engine.write(&self.public_key.serialize()).expect("engines don't error");
+        engine.write_all(&self.public_key.serialize()).expect("engines don't error");
         XpubIdentifier::from_engine(engine)
     }
 

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -147,7 +147,8 @@ impl<Subtype> Encodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u
     fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, io::Error> {
         let mut len = self.prefix.consensus_encode(&mut e)? + 1;
         e.emit_u8(self.subtype.into())?;
-        len += e.write(&self.key)?;
+        e.write_all(&self.key)?;
+        len += self.key.len();
         Ok(len)
     }
 }

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -615,11 +615,10 @@ impl TaprootMerkleBranch {
 
     /// Serialize to a writer. Returns the number of bytes written
     pub fn encode<Write: io::Write>(&self, mut writer: Write) -> io::Result<usize> {
-        let mut written = 0;
         for hash in self.0.iter() {
-            written += writer.write(hash)?;
+            writer.write_all(hash)?;
         }
-        Ok(written)
+        Ok(self.0.len() * sha256::Hash::LEN)
     }
 
     /// Serialize self as bytes
@@ -704,11 +703,10 @@ impl ControlBlock {
     /// Serialize to a writer. Returns the number of bytes written
     pub fn encode<Write: io::Write>(&self, mut writer: Write) -> io::Result<usize> {
         let first_byte: u8 = i32::from(self.output_key_parity) as u8 | self.leaf_version.to_consensus();
-        let mut bytes_written = 0;
-        bytes_written += writer.write(&[first_byte])?;
-        bytes_written += writer.write(&self.internal_key.serialize())?;
-        bytes_written += self.merkle_branch.encode(&mut writer)?;
-        Ok(bytes_written)
+        writer.write_all(&[first_byte])?;
+        writer.write_all(&self.internal_key.serialize())?;
+        self.merkle_branch.encode(&mut writer)?;
+        Ok(self.size())
     }
 
     /// Serialize the control block. This would be required when


### PR DESCRIPTION
write() could write only a part of the given buffer, the caller should
check the numbers of byte written (which is what write_all does)