### PR TITLE
Bug: Change type of pbst partial sig from secp key to bitcoin key

### DIFF
--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -28,6 +28,7 @@ use util::psbt::map::Map;
 use util::psbt::raw;
 use util::psbt::serialize::Deserialize;
 use util::psbt::{Error, error};
+use util::key::PublicKey;
 
 use util::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapBranchHash};
 use util::sighash;
@@ -89,7 +90,7 @@ pub struct Input {
     pub witness_utxo: Option<TxOut>,
     /// A map from public keys to their corresponding signature as would be
     /// pushed to the stack from a scriptSig or witness for a non-taproot inputs.
-    pub partial_sigs: BTreeMap<secp256k1::PublicKey, EcdsaSig>,
+    pub partial_sigs: BTreeMap<PublicKey, EcdsaSig>,
     /// The sighash type to be used for this input. Signatures for this input
     /// must use the sighash type.
     pub sighash_type: Option<PsbtSigHashType>,
@@ -209,7 +210,7 @@ impl Input {
             }
             PSBT_IN_PARTIAL_SIG => {
                 impl_psbt_insert_pair! {
-                    self.partial_sigs <= <raw_key: secp256k1::PublicKey>|<raw_value: EcdsaSig>
+                    self.partial_sigs <= <raw_key: PublicKey>|<raw_value: EcdsaSig>
                 }
             }
             PSBT_IN_SIGHASH_TYPE => {

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -33,6 +33,7 @@ use util::ecdsa::{EcdsaSig, EcdsaSigError};
 use util::psbt;
 use util::taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
 use schnorr;
+use util::key::PublicKey;
 
 use super::map::{TapTree, PsbtSigHashType};
 
@@ -72,6 +73,21 @@ impl Serialize for Script {
 impl Deserialize for Script {
     fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
         Ok(Self::from(bytes.to_vec()))
+    }
+}
+
+impl Serialize for PublicKey {
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.write_into(&mut buf).expect("vecs don't error");
+        buf
+    }
+}
+
+impl Deserialize for PublicKey {
+    fn deserialize(bytes: &[u8]) -> Result<Self, encode::Error> {
+        PublicKey::from_slice(bytes)
+            .map_err(|_| encode::Error::ParseFailed("invalid public key"))
     }
 }
 


### PR DESCRIPTION
This changes the type of secp signature from secp256k1::Signature to
bitcoin::PublicKey. Psbt allows storing signatures for both compressed
as well as uncompressed keys. This bug was introduced in #591 while
trying to change the type of BIP32 keys from bitcoin::PublicKey to
secp256k1::PublicKey.