### PR TITLE
Make Map Trait Visible

### DIFF
--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -28,7 +28,7 @@ pub use self::input::{Input, PsbtSigHashType};
 pub use self::output::{Output, TapTree};
 
 /// A trait that describes a PSBT key-value map.
-pub(super) trait Map {
+pub trait Map {
     /// Attempt to get all key-value pairs.
     fn get_pairs(&self) -> Result<Vec<raw::Pair>, io::Error>;
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -39,8 +39,7 @@ mod macros;
 pub mod serialize;
 
 mod map;
-pub use self::map::{Input, Output, TapTree, PsbtSigHashType};
-use self::map::Map;
+pub use self::map::{Input, Output, TapTree, PsbtSigHashType, Map};
 
 use util::bip32::{ExtendedPubKey, KeySource};
 


### PR DESCRIPTION
It seems like it is a clear mistake for the Map trait to not be externally visible since PSBTs cannot be merged otherwise.

This should be blocking for release!﻿
