### PR TITLE
Tempararily pin fuzzer on rust 1.58

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,7 +27,7 @@ jobs:
           key: cache-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.58
           override: true
           profile: minimal
       - run: cargo install honggfuzz


### PR DESCRIPTION
I think this might take a while to resolve and we should move ahead with
1.58. Looks like the fresh release of 1.59 added LLVM 13.0 that broke
some things.