### PR TITLE
infallible conversions from hashes to secp256k1 message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }
 bitcoin_hashes = { version = "0.10.0", default-features = false }
-secp256k1 = { version = "0.21.2", default-features = false }
+secp256k1 = { version = "0.21.2", features = ["bitcoin_hashes"] }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64-compat = { version = "1.0.0", optional = true }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -148,8 +148,7 @@ mod message_signing {
             secp_ctx: &secp256k1::Secp256k1<C>,
             msg_hash: sha256d::Hash
         ) -> Result<PublicKey, MessageSignatureError> {
-            let msg = secp256k1::Message::from_slice(&msg_hash[..])
-                .expect("cannot fail");
+            let msg = secp256k1::Message::from(msg_hash);
             let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
             Ok(PublicKey {
                 inner: pubkey,
@@ -320,7 +319,7 @@ mod tests {
         let secp = secp256k1::Secp256k1::new();
         let message = "rust-bitcoin MessageSignature test";
         let msg_hash = super::signed_msg_hash(&message);
-        let msg = secp256k1::Message::from_slice(&msg_hash).expect("message");
+        let msg = secp256k1::Message::from(msg_hash);
 
 
         let privkey = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -1088,7 +1088,7 @@ mod tests {
                 hash_ty
             ).unwrap();
 
-            let msg = secp256k1::Message::from_slice(&sig_hash).unwrap();
+            let msg = secp256k1::Message::from(sig_hash);
             let key_spend_sig = secp.sign_schnorr_with_aux_rand(&msg, &tweaked_keypair, &[0u8; 32]);
 
             assert_eq!(expected_internal_pk, internal_key);

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -79,6 +79,12 @@ macro_rules! sha256t_hash_newtype {
             }
         }
 
+        impl secp256k1::ThirtyTwoByteHash for $newtype {
+            fn into_32(self) -> [u8; 32] {
+                self.into_inner()
+            }
+        }
+
         hash_newtype!($newtype, sha256t::Hash<$tag>, 32, $docs, $reverse);
     };
 }


### PR DESCRIPTION
Close [824](https://github.com/rust-bitcoin/rust-bitcoin/issues/824)

Updated
The CI will be fixed after updating to new secp256k1 version including this change https://github.com/rust-bitcoin/rust-secp256k1/pull/410