### PR TITLE
Improve rustdocs for *_hash_ty methods

### DIFF
--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -191,22 +191,24 @@ impl PsbtSigHashType {
 }
 
 impl Input {
-    /// Obtains the [`EcdsaSigHashType`] for this input if one is specified.
-    /// If no sighash type is specified, returns ['EcdsaSigHashType::All']
+    /// Obtains the [`EcdsaSigHashType`] for this input if one is specified. If no sighash type is
+    /// specified, returns [`EcdsaSigHashType::All`].
     ///
-    /// Errors:
-    /// If the sighash type is not a standard ecdsa sighash type
+    /// # Errors
+    ///
+    /// If the `sighash_type` field is set to a non-standard ECDSA sighash value.
     pub fn ecdsa_hash_ty(&self) -> Result<EcdsaSigHashType, NonStandardSigHashType> {
         self.sighash_type
             .map(|sighash_type| sighash_type.ecdsa_hash_ty())
             .unwrap_or(Ok(EcdsaSigHashType::All))
     }
 
-    /// Obtains the [`SchnorrSigHashType`] for this input if one is specified.
-    /// If no sighash type is specified, returns ['SchnorrSigHashType::Default']
+    /// Obtains the [`SchnorrSigHashType`] for this input if one is specified. If no sighash type is
+    /// specified, returns [`SchnorrSigHashType::Default`].
     ///
-    /// Errors:
-    /// If the sighash type is an invalid schnorr sighash type
+    /// # Errors
+    ///
+    /// If the `sighash_type` field is set to a invalid Schnorr sighash value.
     pub fn schnorr_hash_ty(&self) -> Result<SchnorrSigHashType, sighash::Error> {
         self.sighash_type
             .map(|sighash_type| sighash_type.schnorr_hash_ty())


### PR DESCRIPTION
Recently we added two new methods with rustdocs. The rustdocs have a few minor things that can be improved.

- Use 'Returns' section for both success and error path returns
- Use markdown heading for section
- [Subjectively] improve wording of docs

@rish-singhal this PR is minor rustdocs stuff that I have recently been learning myself. I hope this makes your future patches easier to do in regards to the docs. FTR there are `# Returns` sections and `# Examples` sections that one can use, no set rules as far as I can tell. I chose `# Returns` in this case because it seemed to work. Please feel free to NACK the wording changes if you do not agree.