### PR TITLE
Build the docs with test.sh

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ jobs:
               DO_BENCH: true
               AS_DEPENDENCY: true
               DO_NO_STD: true
+              DO_DOCS: true
           - rust: 1.29.0
             env:
               AS_DEPENDENCY: true
@@ -82,20 +83,6 @@ jobs:
       - name: run cross test
         run: cross test --target s390x-unknown-linux-gnu
 
-  Docs:
-    name: Docs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Crate
-        uses: actions/checkout@v2
-      - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Create Doc
-        run: cargo doc
   Embedded:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ PR authors may also find it useful to run the following script locally in order
 to check that each of the commits within the PR satisfies the requirements
 above, before submitting the PR to review:
 ```shell script
-BITCOIN_MSRV=1.29.0 ./contrib/ci.sh
+BITCOIN_MSRV=1.29.0 ./contrib/test.sh
 ```
 Please replace the value in `BITCOIN_MSRV=1.29.0` with the current MSRV from
 [README.md].

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -37,27 +37,27 @@ cargo test --verbose
 
 if [ "$DO_NO_STD" = true ]
 then
-echo "********* Testing no-std build *************"
-  # Build no_std, to make sure that cfg(test) doesn't hide any issues
-  cargo build --verbose --features="no-std" --no-default-features
+    echo "********* Testing no-std build *************"
+    # Build no_std, to make sure that cfg(test) doesn't hide any issues
+    cargo build --verbose --features="no-std" --no-default-features
 
-  # Build std + no_std, to make sure they are not incompatible
-  cargo build --verbose --features="no-std"
+    # Build std + no_std, to make sure they are not incompatible
+    cargo build --verbose --features="no-std"
 
-  # Test no_std
-  cargo test --verbose --features="no-std" --no-default-features
+    # Test no_std
+    cargo test --verbose --features="no-std" --no-default-features
 
-  # Build all features
-  cargo build --verbose --features="no-std $FEATURES" --no-default-features
+    # Build all features
+    cargo build --verbose --features="no-std $FEATURES" --no-default-features
 
-  # Build specific features
-  for feature in ${FEATURES}
-  do
-      cargo build --verbose --features="no-std $feature"
-  done
+    # Build specific features
+    for feature in ${FEATURES}
+    do
+        cargo build --verbose --features="no-std $feature"
+    done
 
-  cargo run --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
-  cargo run --no-default-features --features no-std --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+    cargo run --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+    cargo run --no-default-features --features no-std --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
 fi
 
 # Test each feature

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -67,6 +67,11 @@ do
     cargo test --verbose --features="$feature"
 done
 
+# Build the docs if told to (this only works with the nightly toolchain)
+if [ "$DO_DOCS" = true ]; then
+    RUSTDOCFLAGS="--cfg docsrs" cargo doc --all --features="$FEATURES"
+fi
+
 # Fuzz if told to
 if [ "$DO_FUZZ" = true ]
 then


### PR DESCRIPTION
We currently build the docs as a separate CI job, we can however just do it as part of the `Tests` job using the nightly toolchain.

Conditionally build the docs based on a `DO_DOCS` env var.

Note, uses `--cfg docsrs` so can only be built run with nightly toolchain.

- Patch 1: Fixes the incorrect file naming `ci.sh` -> `test.sh` in `CONTRIBUTING.md`.
- Patch 2 - 4: Do trivial cleanup of `test.sh`.
- Patch 5: Does the fix described above.

Resolves: #850