### PR TITLE
Non standard ecdsa sig hash type

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -331,7 +331,7 @@ impl Transaction {
         script_pubkey: &Script,
         sighash_type: U,
     ) -> Result<(), encode::Error> {
-        let sighash_type : u32 = sighash_type.into();
+        let sighash_type: u32 = sighash_type.into();
         assert!(input_index < self.input.len());  // Panic on OOB
 
         let (sighash, anyone_can_pay) = EcdsaSigHashType::from_u32_consensus(sighash_type).split_anyonecanpay_flag();


### PR DESCRIPTION
Fix up the logic that handles correctly returning the special array 1,0,0,...,0 for signature hash when the sighash single bug is exploitable i.e., when signing a transaction with SIGHASH_SINGLE for an input index that does not have a corresponding transaction output of the same index.

Draft because I do not know _where_ the hard coded array comes from? I'd like to add docs and also amend the commit messages with this information. Does anyone know this please?

- Patch 1 and 2: Clean up
- Patch 2: Implements the fix
- Patch 3: Adds a passing test that fails if moved to before patch 3

Resolves: #817