### PR TITLE
Trivial: Order impl_hashencode lines

### DIFF
--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -60,9 +60,11 @@ hash_newtype!(FilterHeader, sha256d::Hash, 32, doc="Filter header, as defined in
 
 impl_hashencode!(Txid);
 impl_hashencode!(Wtxid);
-impl_hashencode!(SigHash);
 impl_hashencode!(BlockHash);
+impl_hashencode!(SigHash);
+
 impl_hashencode!(TxMerkleNode);
 impl_hashencode!(WitnessMerkleNode);
+
 impl_hashencode!(FilterHash);
 impl_hashencode!(FilterHeader);


### PR DESCRIPTION
Put the calls to `impl_hashencode` in the same order, and with the same
whitespace, as the calls to `hash_newtype`. This makes groking the file
easier because its quick to glance down the types and see which ones
implement hashencode (consensus_encode/decode) and which ones do not.