### PR TITLE
Cleanup transaction docs

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -86,7 +86,7 @@ impl OutPoint {
     /// let tx = &block.txdata[0];
     ///
     /// // Coinbase transactions don't have any previous output.
-    /// assert_eq!(tx.input[0].previous_output.is_null(), true);
+    /// assert!(tx.input[0].previous_output.is_null());
     /// ```
     #[inline]
     pub fn is_null(&self) -> bool {

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -588,6 +588,8 @@ impl Encodable for Transaction {
     ) -> Result<usize, io::Error> {
         let mut len = 0;
         len += self.version.consensus_encode(&mut s)?;
+        // To avoid serialization ambiguity, no inputs means we use BIP141 serialization (see
+        // `Transaction` docs for full explanation).
         let mut have_witness = self.input.is_empty();
         for input in &self.input {
             if !input.witness.is_empty() {

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -310,20 +310,23 @@ impl Transaction {
     }
 
     /// Encodes the signing data from which a signature hash for a given input index with a given
-    /// sighash flag can be computed.  To actually produce a scriptSig, this hash needs to be run
-    /// through an ECDSA signer, the SigHashType appended to the resulting sig, and a script
-    /// written around this, but this is the general (and hard) part.
+    /// sighash flag can be computed.
     ///
-    /// The `sighash_type` supports arbitrary `u32` value, instead of just [`SigHashType`],
-    /// because internally 4 bytes are being hashed, even though only lowest byte
-    /// is appended to signature in a transaction.
+    /// To actually produce a scriptSig, this hash needs to be run through an ECDSA signer, the
+    /// [`EcdsaSigHashType`] appended to the resulting sig, and a script written around this, but
+    /// this is the general (and hard) part.
     ///
-    /// *Warning* This does NOT attempt to support OP_CODESEPARATOR. In general this would require
-    /// evaluating `script_pubkey` to determine which separators get evaluated and which don't,
-    /// which we don't have the information to determine.
+    /// The `sighash_type` supports an arbitrary `u32` value, instead of just [`EcdsaSigHashType`],
+    /// because internally 4 bytes are being hashed, even though only lowest byte is appended to
+    /// signature in a transaction.
+    ///
+    /// **Warning**: This does NOT attempt to support OP_CODESEPARATOR. In general this would
+    /// require evaluating `script_pubkey` to determine which separators get evaluated and which
+    /// don't, which we don't have the information to determine.
     ///
     /// # Panics
-    /// Panics if `input_index` is greater than or equal to `self.input.len()`
+    ///
+    /// If `input_index` is out of bounds (greater than or equal to `self.input.len()`).
     pub fn encode_signing_data_to<Write: io::Write, U: Into<u32>>(
         &self,
         mut writer: Write,
@@ -392,18 +395,8 @@ impl Transaction {
     }
 
     /// Computes a signature hash for a given input index with a given sighash flag.
-    /// To actually produce a scriptSig, this hash needs to be run through an
-    /// ECDSA signer, the SigHashType appended to the resulting sig, and a
-    /// script written around this, but this is the general (and hard) part.
     ///
-    /// *Warning* This does NOT attempt to support OP_CODESEPARATOR. In general
-    /// this would require evaluating `script_pubkey` to determine which separators
-    /// get evaluated and which don't, which we don't have the information to
-    /// determine.
-    ///
-    /// # Panics
-    /// Panics if `input_index` is greater than or equal to `self.input.len()`
-    ///
+    /// Please refer [`Self::encode_signing_data_to`] for full documentation of this method.
     pub fn signature_hash(
         &self,
         input_index: usize,


### PR DESCRIPTION
Do some cleanups to the docs in `blockdata::transaction`. Patch 1 needs the most careful review please. The rest should not be too controversial.