### PR TITLE
Cleanup opcodes module

### DIFF
--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -660,8 +660,10 @@ impl fmt::Debug for All {
 }
 
 
-/// Classification context for the opcode. Some opcodes like `OP_RESERVED`
-/// abort the script in [`ClassifyContext::Legacy`] context, but will act as OP_SUCCESS in tapscript
+/// Classification context for the opcode.
+///
+/// Some opcodes like `OP_RESERVED` abort the script in [`ClassifyContext::Legacy`] context, but
+/// will act as `OP_SUCCESS` in tapscript.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ClassifyContext {
     /// Opcode used in tapscript context

--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -30,7 +30,7 @@ use core::{fmt, convert::From};
 //       opcode enum. If you want to check ranges of opcodes, etc.,
 //       write an #[inline] helper function which casts to u8s.
 
-/// A script Opcode
+/// A script Opcode.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct All {
     code: u8,
@@ -40,522 +40,522 @@ pub mod all {
     //! Constants associated with All type
     use super::All;
 
-    /// Push an empty array onto the stack
+    /// Push an empty array onto the stack.
     pub const OP_PUSHBYTES_0: All = All {code: 0x00};
-    /// Push the next byte as an array onto the stack
+    /// Push the next byte as an array onto the stack.
     pub const OP_PUSHBYTES_1: All = All {code: 0x01};
-    /// Push the next 2 bytes as an array onto the stack
+    /// Push the next 2 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_2: All = All {code: 0x02};
-    /// Push the next 2 bytes as an array onto the stack
+    /// Push the next 2 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_3: All = All {code: 0x03};
-    /// Push the next 4 bytes as an array onto the stack
+    /// Push the next 4 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_4: All = All {code: 0x04};
-    /// Push the next 5 bytes as an array onto the stack
+    /// Push the next 5 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_5: All = All {code: 0x05};
-    /// Push the next 6 bytes as an array onto the stack
+    /// Push the next 6 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_6: All = All {code: 0x06};
-    /// Push the next 7 bytes as an array onto the stack
+    /// Push the next 7 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_7: All = All {code: 0x07};
-    /// Push the next 8 bytes as an array onto the stack
+    /// Push the next 8 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_8: All = All {code: 0x08};
-    /// Push the next 9 bytes as an array onto the stack
+    /// Push the next 9 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_9: All = All {code: 0x09};
-    /// Push the next 10 bytes as an array onto the stack
+    /// Push the next 10 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_10: All = All {code: 0x0a};
-    /// Push the next 11 bytes as an array onto the stack
+    /// Push the next 11 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_11: All = All {code: 0x0b};
-    /// Push the next 12 bytes as an array onto the stack
+    /// Push the next 12 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_12: All = All {code: 0x0c};
-    /// Push the next 13 bytes as an array onto the stack
+    /// Push the next 13 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_13: All = All {code: 0x0d};
-    /// Push the next 14 bytes as an array onto the stack
+    /// Push the next 14 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_14: All = All {code: 0x0e};
-    /// Push the next 15 bytes as an array onto the stack
+    /// Push the next 15 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_15: All = All {code: 0x0f};
-    /// Push the next 16 bytes as an array onto the stack
+    /// Push the next 16 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_16: All = All {code: 0x10};
-    /// Push the next 17 bytes as an array onto the stack
+    /// Push the next 17 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_17: All = All {code: 0x11};
-    /// Push the next 18 bytes as an array onto the stack
+    /// Push the next 18 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_18: All = All {code: 0x12};
-    /// Push the next 19 bytes as an array onto the stack
+    /// Push the next 19 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_19: All = All {code: 0x13};
-    /// Push the next 20 bytes as an array onto the stack
+    /// Push the next 20 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_20: All = All {code: 0x14};
-    /// Push the next 21 bytes as an array onto the stack
+    /// Push the next 21 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_21: All = All {code: 0x15};
-    /// Push the next 22 bytes as an array onto the stack
+    /// Push the next 22 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_22: All = All {code: 0x16};
-    /// Push the next 23 bytes as an array onto the stack
+    /// Push the next 23 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_23: All = All {code: 0x17};
-    /// Push the next 24 bytes as an array onto the stack
+    /// Push the next 24 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_24: All = All {code: 0x18};
-    /// Push the next 25 bytes as an array onto the stack
+    /// Push the next 25 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_25: All = All {code: 0x19};
-    /// Push the next 26 bytes as an array onto the stack
+    /// Push the next 26 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_26: All = All {code: 0x1a};
-    /// Push the next 27 bytes as an array onto the stack
+    /// Push the next 27 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_27: All = All {code: 0x1b};
-    /// Push the next 28 bytes as an array onto the stack
+    /// Push the next 28 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_28: All = All {code: 0x1c};
-    /// Push the next 29 bytes as an array onto the stack
+    /// Push the next 29 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_29: All = All {code: 0x1d};
-    /// Push the next 30 bytes as an array onto the stack
+    /// Push the next 30 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_30: All = All {code: 0x1e};
-    /// Push the next 31 bytes as an array onto the stack
+    /// Push the next 31 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_31: All = All {code: 0x1f};
-    /// Push the next 32 bytes as an array onto the stack
+    /// Push the next 32 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_32: All = All {code: 0x20};
-    /// Push the next 33 bytes as an array onto the stack
+    /// Push the next 33 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_33: All = All {code: 0x21};
-    /// Push the next 34 bytes as an array onto the stack
+    /// Push the next 34 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_34: All = All {code: 0x22};
-    /// Push the next 35 bytes as an array onto the stack
+    /// Push the next 35 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_35: All = All {code: 0x23};
-    /// Push the next 36 bytes as an array onto the stack
+    /// Push the next 36 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_36: All = All {code: 0x24};
-    /// Push the next 37 bytes as an array onto the stack
+    /// Push the next 37 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_37: All = All {code: 0x25};
-    /// Push the next 38 bytes as an array onto the stack
+    /// Push the next 38 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_38: All = All {code: 0x26};
-    /// Push the next 39 bytes as an array onto the stack
+    /// Push the next 39 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_39: All = All {code: 0x27};
-    /// Push the next 40 bytes as an array onto the stack
+    /// Push the next 40 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_40: All = All {code: 0x28};
-    /// Push the next 41 bytes as an array onto the stack
+    /// Push the next 41 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_41: All = All {code: 0x29};
-    /// Push the next 42 bytes as an array onto the stack
+    /// Push the next 42 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_42: All = All {code: 0x2a};
-    /// Push the next 43 bytes as an array onto the stack
+    /// Push the next 43 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_43: All = All {code: 0x2b};
-    /// Push the next 44 bytes as an array onto the stack
+    /// Push the next 44 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_44: All = All {code: 0x2c};
-    /// Push the next 45 bytes as an array onto the stack
+    /// Push the next 45 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_45: All = All {code: 0x2d};
-    /// Push the next 46 bytes as an array onto the stack
+    /// Push the next 46 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_46: All = All {code: 0x2e};
-    /// Push the next 47 bytes as an array onto the stack
+    /// Push the next 47 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_47: All = All {code: 0x2f};
-    /// Push the next 48 bytes as an array onto the stack
+    /// Push the next 48 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_48: All = All {code: 0x30};
-    /// Push the next 49 bytes as an array onto the stack
+    /// Push the next 49 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_49: All = All {code: 0x31};
-    /// Push the next 50 bytes as an array onto the stack
+    /// Push the next 50 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_50: All = All {code: 0x32};
-    /// Push the next 51 bytes as an array onto the stack
+    /// Push the next 51 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_51: All = All {code: 0x33};
-    /// Push the next 52 bytes as an array onto the stack
+    /// Push the next 52 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_52: All = All {code: 0x34};
-    /// Push the next 53 bytes as an array onto the stack
+    /// Push the next 53 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_53: All = All {code: 0x35};
-    /// Push the next 54 bytes as an array onto the stack
+    /// Push the next 54 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_54: All = All {code: 0x36};
-    /// Push the next 55 bytes as an array onto the stack
+    /// Push the next 55 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_55: All = All {code: 0x37};
-    /// Push the next 56 bytes as an array onto the stack
+    /// Push the next 56 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_56: All = All {code: 0x38};
-    /// Push the next 57 bytes as an array onto the stack
+    /// Push the next 57 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_57: All = All {code: 0x39};
-    /// Push the next 58 bytes as an array onto the stack
+    /// Push the next 58 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_58: All = All {code: 0x3a};
-    /// Push the next 59 bytes as an array onto the stack
+    /// Push the next 59 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_59: All = All {code: 0x3b};
-    /// Push the next 60 bytes as an array onto the stack
+    /// Push the next 60 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_60: All = All {code: 0x3c};
-    /// Push the next 61 bytes as an array onto the stack
+    /// Push the next 61 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_61: All = All {code: 0x3d};
-    /// Push the next 62 bytes as an array onto the stack
+    /// Push the next 62 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_62: All = All {code: 0x3e};
-    /// Push the next 63 bytes as an array onto the stack
+    /// Push the next 63 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_63: All = All {code: 0x3f};
-    /// Push the next 64 bytes as an array onto the stack
+    /// Push the next 64 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_64: All = All {code: 0x40};
-    /// Push the next 65 bytes as an array onto the stack
+    /// Push the next 65 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_65: All = All {code: 0x41};
-    /// Push the next 66 bytes as an array onto the stack
+    /// Push the next 66 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_66: All = All {code: 0x42};
-    /// Push the next 67 bytes as an array onto the stack
+    /// Push the next 67 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_67: All = All {code: 0x43};
-    /// Push the next 68 bytes as an array onto the stack
+    /// Push the next 68 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_68: All = All {code: 0x44};
-    /// Push the next 69 bytes as an array onto the stack
+    /// Push the next 69 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_69: All = All {code: 0x45};
-    /// Push the next 70 bytes as an array onto the stack
+    /// Push the next 70 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_70: All = All {code: 0x46};
-    /// Push the next 71 bytes as an array onto the stack
+    /// Push the next 71 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_71: All = All {code: 0x47};
-    /// Push the next 72 bytes as an array onto the stack
+    /// Push the next 72 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_72: All = All {code: 0x48};
-    /// Push the next 73 bytes as an array onto the stack
+    /// Push the next 73 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_73: All = All {code: 0x49};
-    /// Push the next 74 bytes as an array onto the stack
+    /// Push the next 74 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_74: All = All {code: 0x4a};
-    /// Push the next 75 bytes as an array onto the stack
+    /// Push the next 75 bytes as an array onto the stack.
     pub const OP_PUSHBYTES_75: All = All {code: 0x4b};
-    /// Read the next byte as N; push the next N bytes as an array onto the stack
+    /// Read the next byte as N; push the next N bytes as an array onto the stack.
     pub const OP_PUSHDATA1: All = All {code: 0x4c};
-    /// Read the next 2 bytes as N; push the next N bytes as an array onto the stack
+    /// Read the next 2 bytes as N; push the next N bytes as an array onto the stack.
     pub const OP_PUSHDATA2: All = All {code: 0x4d};
-    /// Read the next 4 bytes as N; push the next N bytes as an array onto the stack
+    /// Read the next 4 bytes as N; push the next N bytes as an array onto the stack.
     pub const OP_PUSHDATA4: All = All {code: 0x4e};
-    /// Push the array `0x81` onto the stack
+    /// Push the array `0x81` onto the stack.
     pub const OP_PUSHNUM_NEG1: All = All {code: 0x4f};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RESERVED: All = All {code: 0x50};
-    /// Push the array `0x01` onto the stack
+    /// Push the array `0x01` onto the stack.
     pub const OP_PUSHNUM_1: All = All {code: 0x51};
-    /// Push the array `0x02` onto the stack
+    /// Push the array `0x02` onto the stack.
     pub const OP_PUSHNUM_2: All = All {code: 0x52};
-    /// Push the array `0x03` onto the stack
+    /// Push the array `0x03` onto the stack.
     pub const OP_PUSHNUM_3: All = All {code: 0x53};
-    /// Push the array `0x04` onto the stack
+    /// Push the array `0x04` onto the stack.
     pub const OP_PUSHNUM_4: All = All {code: 0x54};
-    /// Push the array `0x05` onto the stack
+    /// Push the array `0x05` onto the stack.
     pub const OP_PUSHNUM_5: All = All {code: 0x55};
-    /// Push the array `0x06` onto the stack
+    /// Push the array `0x06` onto the stack.
     pub const OP_PUSHNUM_6: All = All {code: 0x56};
-    /// Push the array `0x07` onto the stack
+    /// Push the array `0x07` onto the stack.
     pub const OP_PUSHNUM_7: All = All {code: 0x57};
-    /// Push the array `0x08` onto the stack
+    /// Push the array `0x08` onto the stack.
     pub const OP_PUSHNUM_8: All = All {code: 0x58};
-    /// Push the array `0x09` onto the stack
+    /// Push the array `0x09` onto the stack.
     pub const OP_PUSHNUM_9: All = All {code: 0x59};
-    /// Push the array `0x0a` onto the stack
+    /// Push the array `0x0a` onto the stack.
     pub const OP_PUSHNUM_10: All = All {code: 0x5a};
-    /// Push the array `0x0b` onto the stack
+    /// Push the array `0x0b` onto the stack.
     pub const OP_PUSHNUM_11: All = All {code: 0x5b};
-    /// Push the array `0x0c` onto the stack
+    /// Push the array `0x0c` onto the stack.
     pub const OP_PUSHNUM_12: All = All {code: 0x5c};
-    /// Push the array `0x0d` onto the stack
+    /// Push the array `0x0d` onto the stack.
     pub const OP_PUSHNUM_13: All = All {code: 0x5d};
-    /// Push the array `0x0e` onto the stack
+    /// Push the array `0x0e` onto the stack.
     pub const OP_PUSHNUM_14: All = All {code: 0x5e};
-    /// Push the array `0x0f` onto the stack
+    /// Push the array `0x0f` onto the stack.
     pub const OP_PUSHNUM_15: All = All {code: 0x5f};
-    /// Push the array `0x10` onto the stack
+    /// Push the array `0x10` onto the stack.
     pub const OP_PUSHNUM_16: All = All {code: 0x60};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP: All = All {code: 0x61};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_VER: All = All {code: 0x62};
-    /// Pop and execute the next statements if a nonzero element was popped
+    /// Pop and execute the next statements if a nonzero element was popped.
     pub const OP_IF: All = All {code: 0x63};
-    /// Pop and execute the next statements if a zero element was popped
+    /// Pop and execute the next statements if a zero element was popped.
     pub const OP_NOTIF: All = All {code: 0x64};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_VERIF: All = All {code: 0x65};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_VERNOTIF: All = All {code: 0x66};
     /// Execute statements if those after the previous OP_IF were not, and vice-versa.
     /// If there is no previous OP_IF, this acts as a RETURN.
     pub const OP_ELSE: All = All {code: 0x67};
-    /// Pop and execute the next statements if a zero element was popped
+    /// Pop and execute the next statements if a zero element was popped.
     pub const OP_ENDIF: All = All {code: 0x68};
-    /// If the top value is zero or the stack is empty, fail; otherwise, pop the stack
+    /// If the top value is zero or the stack is empty, fail; otherwise, pop the stack.
     pub const OP_VERIFY: All = All {code: 0x69};
-    /// Fail the script immediately. (Must be executed.)
+    /// Fail the script immediately. (Must be executed.).
     pub const OP_RETURN: All = All {code: 0x6a};
-    /// Pop one element from the main stack onto the alt stack
+    /// Pop one element from the main stack onto the alt stack.
     pub const OP_TOALTSTACK: All = All {code: 0x6b};
-    /// Pop one element from the alt stack onto the main stack
+    /// Pop one element from the alt stack onto the main stack.
     pub const OP_FROMALTSTACK: All = All {code: 0x6c};
-    /// Drops the top two stack items
+    /// Drops the top two stack items.
     pub const OP_2DROP: All = All {code: 0x6d};
-    /// Duplicates the top two stack items as AB -> ABAB
+    /// Duplicates the top two stack items as AB -> ABAB.
     pub const OP_2DUP: All = All {code: 0x6e};
-    /// Duplicates the two three stack items as ABC -> ABCABC
+    /// Duplicates the two three stack items as ABC -> ABCABC.
     pub const OP_3DUP: All = All {code: 0x6f};
     /// Copies the two stack items of items two spaces back to
-    /// the front, as xxAB -> ABxxAB
+    /// the front, as xxAB -> ABxxAB.
     pub const OP_2OVER: All = All {code: 0x70};
     /// Moves the two stack items four spaces back to the front,
-    /// as xxxxAB -> ABxxxx
+    /// as xxxxAB -> ABxxxx.
     pub const OP_2ROT: All = All {code: 0x71};
-    /// Swaps the top two pairs, as ABCD -> CDAB
+    /// Swaps the top two pairs, as ABCD -> CDAB.
     pub const OP_2SWAP: All = All {code: 0x72};
-    /// Duplicate the top stack element unless it is zero
+    /// Duplicate the top stack element unless it is zero.
     pub const OP_IFDUP: All = All {code: 0x73};
-    /// Push the current number of stack items onto the stack
+    /// Push the current number of stack items onto the stack.
     pub const OP_DEPTH: All = All {code: 0x74};
-    /// Drops the top stack item
+    /// Drops the top stack item.
     pub const OP_DROP: All = All {code: 0x75};
-    /// Duplicates the top stack item
+    /// Duplicates the top stack item.
     pub const OP_DUP: All = All {code: 0x76};
-    /// Drops the second-to-top stack item
+    /// Drops the second-to-top stack item.
     pub const OP_NIP: All = All {code: 0x77};
-    /// Copies the second-to-top stack item, as xA -> AxA
+    /// Copies the second-to-top stack item, as xA -> AxA.
     pub const OP_OVER: All = All {code: 0x78};
-    /// Pop the top stack element as N. Copy the Nth stack element to the top
+    /// Pop the top stack element as N. Copy the Nth stack element to the top.
     pub const OP_PICK: All = All {code: 0x79};
-    /// Pop the top stack element as N. Move the Nth stack element to the top
+    /// Pop the top stack element as N. Move the Nth stack element to the top.
     pub const OP_ROLL: All = All {code: 0x7a};
-    /// Rotate the top three stack items, as [top next1 next2] -> [next2 top next1]
+    /// Rotate the top three stack items, as [top next1 next2] -> [next2 top next1].
     pub const OP_ROT: All = All {code: 0x7b};
-    /// Swap the top two stack items
+    /// Swap the top two stack items.
     pub const OP_SWAP: All = All {code: 0x7c};
-    /// Copy the top stack item to before the second item, as [top next] -> [top next top]
+    /// Copy the top stack item to before the second item, as [top next] -> [top next top].
     pub const OP_TUCK: All = All {code: 0x7d};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_CAT: All = All {code: 0x7e};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_SUBSTR: All = All {code: 0x7f};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_LEFT: All = All {code: 0x80};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_RIGHT: All = All {code: 0x81};
-    /// Pushes the length of the top stack item onto the stack
+    /// Pushes the length of the top stack item onto the stack.
     pub const OP_SIZE: All = All {code: 0x82};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_INVERT: All = All {code: 0x83};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_AND: All = All {code: 0x84};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_OR: All = All {code: 0x85};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_XOR: All = All {code: 0x86};
-    /// Pushes 1 if the inputs are exactly equal, 0 otherwise
+    /// Pushes 1 if the inputs are exactly equal, 0 otherwise.
     pub const OP_EQUAL: All = All {code: 0x87};
-    /// Returns success if the inputs are exactly equal, failure otherwise
+    /// Returns success if the inputs are exactly equal, failure otherwise.
     pub const OP_EQUALVERIFY: All = All {code: 0x88};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RESERVED1: All = All {code: 0x89};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RESERVED2: All = All {code: 0x8a};
-    /// Increment the top stack element in place
+    /// Increment the top stack element in place.
     pub const OP_1ADD: All = All {code: 0x8b};
-    /// Decrement the top stack element in place
+    /// Decrement the top stack element in place.
     pub const OP_1SUB: All = All {code: 0x8c};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_2MUL: All = All {code: 0x8d};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_2DIV: All = All {code: 0x8e};
-    /// Multiply the top stack item by -1 in place
+    /// Multiply the top stack item by -1 in place.
     pub const OP_NEGATE: All = All {code: 0x8f};
-    /// Absolute value the top stack item in place
+    /// Absolute value the top stack item in place.
     pub const OP_ABS: All = All {code: 0x90};
-    /// Map 0 to 1 and everything else to 0, in place
+    /// Map 0 to 1 and everything else to 0, in place.
     pub const OP_NOT: All = All {code: 0x91};
-    /// Map 0 to 0 and everything else to 1, in place
+    /// Map 0 to 0 and everything else to 1, in place.
     pub const OP_0NOTEQUAL: All = All {code: 0x92};
-    /// Pop two stack items and push their sum
+    /// Pop two stack items and push their sum.
     pub const OP_ADD: All = All {code: 0x93};
-    /// Pop two stack items and push the second minus the top
+    /// Pop two stack items and push the second minus the top.
     pub const OP_SUB: All = All {code: 0x94};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_MUL: All = All {code: 0x95};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_DIV: All = All {code: 0x96};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_MOD: All = All {code: 0x97};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_LSHIFT: All = All {code: 0x98};
-    /// Fail the script unconditionally, does not even need to be executed
+    /// Fail the script unconditionally, does not even need to be executed.
     pub const OP_RSHIFT: All = All {code: 0x99};
-    /// Pop the top two stack items and push 1 if both are nonzero, else push 0
+    /// Pop the top two stack items and push 1 if both are nonzero, else push 0.
     pub const OP_BOOLAND: All = All {code: 0x9a};
-    /// Pop the top two stack items and push 1 if either is nonzero, else push 0
+    /// Pop the top two stack items and push 1 if either is nonzero, else push 0.
     pub const OP_BOOLOR: All = All {code: 0x9b};
-    /// Pop the top two stack items and push 1 if both are numerically equal, else push 0
+    /// Pop the top two stack items and push 1 if both are numerically equal, else push 0.
     pub const OP_NUMEQUAL: All = All {code: 0x9c};
-    /// Pop the top two stack items and return success if both are numerically equal, else return failure
+    /// Pop the top two stack items and return success if both are numerically equal, else return failure.
     pub const OP_NUMEQUALVERIFY: All = All {code: 0x9d};
-    /// Pop the top two stack items and push 0 if both are numerically equal, else push 1
+    /// Pop the top two stack items and push 0 if both are numerically equal, else push 1.
     pub const OP_NUMNOTEQUAL: All = All {code: 0x9e};
-    /// Pop the top two items; push 1 if the second is less than the top, 0 otherwise
+    /// Pop the top two items; push 1 if the second is less than the top, 0 otherwise.
     pub const OP_LESSTHAN : All = All {code: 0x9f};
-    /// Pop the top two items; push 1 if the second is greater than the top, 0 otherwise
+    /// Pop the top two items; push 1 if the second is greater than the top, 0 otherwise.
     pub const OP_GREATERTHAN : All = All {code: 0xa0};
-    /// Pop the top two items; push 1 if the second is <= the top, 0 otherwise
+    /// Pop the top two items; push 1 if the second is <= the top, 0 otherwise.
     pub const OP_LESSTHANOREQUAL : All = All {code: 0xa1};
-    /// Pop the top two items; push 1 if the second is >= the top, 0 otherwise
+    /// Pop the top two items; push 1 if the second is >= the top, 0 otherwise.
     pub const OP_GREATERTHANOREQUAL : All = All {code: 0xa2};
-    /// Pop the top two items; push the smaller
+    /// Pop the top two items; push the smaller.
     pub const OP_MIN: All = All {code: 0xa3};
-    /// Pop the top two items; push the larger
+    /// Pop the top two items; push the larger.
     pub const OP_MAX: All = All {code: 0xa4};
-    /// Pop the top three items; if the top is >= the second and < the third, push 1, otherwise push 0
+    /// Pop the top three items; if the top is >= the second and < the third, push 1, otherwise push 0.
     pub const OP_WITHIN: All = All {code: 0xa5};
-    /// Pop the top stack item and push its RIPEMD160 hash
+    /// Pop the top stack item and push its RIPEMD160 hash.
     pub const OP_RIPEMD160: All = All {code: 0xa6};
-    /// Pop the top stack item and push its SHA1 hash
+    /// Pop the top stack item and push its SHA1 hash.
     pub const OP_SHA1: All = All {code: 0xa7};
-    /// Pop the top stack item and push its SHA256 hash
+    /// Pop the top stack item and push its SHA256 hash.
     pub const OP_SHA256: All = All {code: 0xa8};
-    /// Pop the top stack item and push its RIPEMD(SHA256) hash
+    /// Pop the top stack item and push its RIPEMD(SHA256) hash.
     pub const OP_HASH160: All = All {code: 0xa9};
-    /// Pop the top stack item and push its SHA256(SHA256) hash
+    /// Pop the top stack item and push its SHA256(SHA256) hash.
     pub const OP_HASH256: All = All {code: 0xaa};
-    /// Ignore this and everything preceding when deciding what to sign when signature-checking
+    /// Ignore this and everything preceding when deciding what to sign when signature-checking.
     pub const OP_CODESEPARATOR: All = All {code: 0xab};
-    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for success/failure
+    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for success/failure.
     pub const OP_CHECKSIG: All = All {code: 0xac};
-    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> returning success/failure
+    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> returning success/failure.
     pub const OP_CHECKSIGVERIFY: All = All {code: 0xad};
     /// Pop N, N pubkeys, M, M signatures, a dummy (due to bug in reference code), and verify that all M signatures are valid.
-    /// Push 1 for "all valid", 0 otherwise
+    /// Push 1 for "all valid", 0 otherwise.
     pub const OP_CHECKMULTISIG: All = All {code: 0xae};
-    /// Like the above but return success/failure
+    /// Like the above but return success/failure.
     pub const OP_CHECKMULTISIGVERIFY: All = All {code: 0xaf};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP1: All = All {code: 0xb0};
     /// <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
     pub const OP_CLTV: All = All {code: 0xb1};
     /// <https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki>
     pub const OP_CSV: All = All {code: 0xb2};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP4: All = All {code: 0xb3};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP5: All = All {code: 0xb4};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP6: All = All {code: 0xb5};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP7: All = All {code: 0xb6};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP8: All = All {code: 0xb7};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP9: All = All {code: 0xb8};
-    /// Does nothing
+    /// Does nothing.
     pub const OP_NOP10: All = All {code: 0xb9};
     // Every other opcode acts as OP_RETURN
-    /// OP_CHECKSIGADD post tapscript
+    /// OP_CHECKSIGADD post tapscript.
     pub const OP_CHECKSIGADD: All = All {code: 0xba};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_187: All = All {code: 0xbb};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_188: All = All {code: 0xbc};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_189: All = All {code: 0xbd};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_190: All = All {code: 0xbe};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_191: All = All {code: 0xbf};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_192: All = All {code: 0xc0};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_193: All = All {code: 0xc1};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_194: All = All {code: 0xc2};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_195: All = All {code: 0xc3};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_196: All = All {code: 0xc4};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_197: All = All {code: 0xc5};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_198: All = All {code: 0xc6};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_199: All = All {code: 0xc7};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_200: All = All {code: 0xc8};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_201: All = All {code: 0xc9};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_202: All = All {code: 0xca};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_203: All = All {code: 0xcb};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_204: All = All {code: 0xcc};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_205: All = All {code: 0xcd};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_206: All = All {code: 0xce};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_207: All = All {code: 0xcf};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_208: All = All {code: 0xd0};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_209: All = All {code: 0xd1};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_210: All = All {code: 0xd2};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_211: All = All {code: 0xd3};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_212: All = All {code: 0xd4};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_213: All = All {code: 0xd5};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_214: All = All {code: 0xd6};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_215: All = All {code: 0xd7};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_216: All = All {code: 0xd8};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_217: All = All {code: 0xd9};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_218: All = All {code: 0xda};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_219: All = All {code: 0xdb};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_220: All = All {code: 0xdc};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_221: All = All {code: 0xdd};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_222: All = All {code: 0xde};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_223: All = All {code: 0xdf};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_224: All = All {code: 0xe0};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_225: All = All {code: 0xe1};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_226: All = All {code: 0xe2};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_227: All = All {code: 0xe3};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_228: All = All {code: 0xe4};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_229: All = All {code: 0xe5};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_230: All = All {code: 0xe6};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_231: All = All {code: 0xe7};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_232: All = All {code: 0xe8};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_233: All = All {code: 0xe9};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_234: All = All {code: 0xea};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_235: All = All {code: 0xeb};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_236: All = All {code: 0xec};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_237: All = All {code: 0xed};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_238: All = All {code: 0xee};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_239: All = All {code: 0xef};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_240: All = All {code: 0xf0};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_241: All = All {code: 0xf1};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_242: All = All {code: 0xf2};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_243: All = All {code: 0xf3};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_244: All = All {code: 0xf4};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_245: All = All {code: 0xf5};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_246: All = All {code: 0xf6};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_247: All = All {code: 0xf7};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_248: All = All {code: 0xf8};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_249: All = All {code: 0xf9};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_250: All = All {code: 0xfa};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_251: All = All {code: 0xfb};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_252: All = All {code: 0xfc};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_253: All = All {code: 0xfd};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_RETURN_254: All = All {code: 0xfe};
-    /// Synonym for OP_RETURN
+    /// Synonym for OP_RETURN.
     pub const OP_INVALIDOPCODE: All = All {code: 0xff};
 }
 
@@ -665,14 +665,14 @@ impl fmt::Debug for All {
 /// will act as `OP_SUCCESS` in tapscript.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ClassifyContext {
-    /// Opcode used in tapscript context
+    /// Opcode used in tapscript context.
     TapScript,
-    /// Opcode used in legacy context
+    /// Opcode used in legacy context.
     Legacy,
 }
 
 impl All {
-    /// Classifies an Opcode into a broad class
+    /// Classifies an Opcode into a broad class.
     #[inline]
     pub fn classify(self, ctx: ClassifyContext) -> Class {
         use self::all::*;
@@ -761,31 +761,31 @@ impl serde::Serialize for All {
     }
 }
 
-/// Empty stack is also FALSE
+/// Empty stack is also FALSE.
 pub static OP_FALSE: All = all::OP_PUSHBYTES_0;
-/// Number 1 is also TRUE
+/// Number 1 is also TRUE.
 pub static OP_TRUE: All = all::OP_PUSHNUM_1;
-/// previously called OP_NOP2
+/// Previously called OP_NOP2.
 pub static OP_NOP2: All = all::OP_CLTV;
-/// previously called OP_NOP3
+/// Previously called OP_NOP3.
 pub static OP_NOP3: All = all::OP_CSV;
 
-/// Broad categories of opcodes with similar behavior
+/// Broad categories of opcodes with similar behavior.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Class {
-    /// Pushes the given number onto the stack
+    /// Pushes the given number onto the stack.
     PushNum(i32),
-    /// Pushes the given number of bytes onto the stack
+    /// Pushes the given number of bytes onto the stack.
     PushBytes(u32),
-    /// Fails the script if executed
+    /// Fails the script if executed.
     ReturnOp,
-    /// Succeeds the script even if not executed
+    /// Succeeds the script even if not executed.
     SuccessOp,
-    /// Fails the script even if not executed
+    /// Fails the script even if not executed.
     IllegalOp,
-    /// Does nothing
+    /// Does nothing.
     NoOp,
-    /// Any opcode not covered above
+    /// Any opcode not covered above.
     Ordinary(Ordinary)
 }
 

--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -659,7 +659,6 @@ impl fmt::Debug for All {
     }
 }
 
-
 /// Classification context for the opcode.
 ///
 /// Some opcodes like `OP_RESERVED` abort the script in [`ClassifyContext::Legacy`] context, but
@@ -748,7 +747,6 @@ impl From<u8> for All {
         All {code: b}
     }
 }
-
 
 display_from_debug!(All);
 
@@ -1165,4 +1163,3 @@ mod tests {
         assert_eq!(unique.len(), 256);
     }
 }
-


### PR DESCRIPTION
Do some clean ups to the `blockdata::opcodes` module. Patch 3 is big but it should be quick to review because I made all the boring 'add full stops' changes in a single commit.