### PR TITLE
Remove `impl_array_newtype` macro

### DIFF
--- a/fuzz/fuzz_targets/uint128_fuzz.rs
+++ b/fuzz/fuzz_targets/uint128_fuzz.rs
@@ -23,7 +23,7 @@ fn do_test(data: &[u8]) {
     }
     macro_rules! check_eq {
         ($native: expr, $uint: expr) => { {
-            assert_eq!(&[$native as u64, ($native >> 8*8) as u64], $uint.as_bytes());
+            assert_eq!(&[$native as u64, ($native >> 8*8) as u64], $uint.as_ref());
         } }
     }
 

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -27,6 +27,8 @@ use prelude::*;
 
 use io;
 use core::{fmt, default::Default};
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 #[cfg(feature = "serde")] use serde;
 
@@ -48,6 +50,15 @@ use schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
 /// A Bitcoin script.
 #[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Script(Box<[u8]>);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Script {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl AsRef<[u8]> for Script {
     fn as_ref(&self) -> &[u8] {
@@ -108,6 +119,15 @@ impl ::core::str::FromStr for Script {
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Builder(Vec<u8>, Option<opcodes::All>);
 display_from_debug!(Builder);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Builder {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
@@ -686,8 +706,6 @@ impl From<Vec<u8>> for Script {
     fn from(v: Vec<u8>) -> Script { Script(v.into_boxed_slice()) }
 }
 
-impl_index_newtype!(Script, u8);
-
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Instruction<'a> {
@@ -942,8 +960,6 @@ impl From<Vec<u8>> for Builder {
         Builder(script.into_bytes(), last_op)
     }
 }
-
-impl_index_newtype!(Builder, u8);
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -93,56 +93,12 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl_index_newtype!($thing, $ty);
-    }
-}
-
-/// Implements standard indexing methods for a given wrapper type
-macro_rules! impl_index_newtype {
-    ($thing:ident, $ty:ty) => {
-
-        impl ::core::ops::Index<usize> for $thing {
-            type Output = $ty;
+        impl<I: $crate::core::slice::SliceIndex<[$ty]>> $crate::core::ops::Index<I> for $thing {
+            type Output = I::Output;
 
             #[inline]
-            fn index(&self, index: usize) -> &$ty {
+            fn index(&self, index: I) -> &Self::Output {
                 &self.0[index]
-            }
-        }
-
-        impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
-
-        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
-
-        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
-
-        impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
-                &self.0[..]
             }
         }
 

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -45,66 +45,6 @@ macro_rules! impl_consensus_encoding {
     );
 }
 
-/// Implements standard array methods for a given wrapper type
-macro_rules! impl_array_newtype {
-    ($thing:ident, $ty:ty, $len:expr) => {
-        impl $thing {
-            /// Converts the object to a raw pointer
-            #[inline]
-            pub fn as_ptr(&self) -> *const $ty {
-                let &$thing(ref dat) = self;
-                dat.as_ptr()
-            }
-
-            /// Converts the object to a mutable raw pointer
-            #[inline]
-            pub fn as_mut_ptr(&mut self) -> *mut $ty {
-                let &mut $thing(ref mut dat) = self;
-                dat.as_mut_ptr()
-            }
-
-            /// Returns the length of the object as an array
-            #[inline]
-            pub fn len(&self) -> usize { $len }
-
-            /// Returns whether the object, as an array, is empty. Always false.
-            #[inline]
-            pub fn is_empty(&self) -> bool { false }
-
-            /// Returns the underlying bytes.
-            #[inline]
-            pub fn as_bytes(&self) -> &[$ty; $len] { &self.0 }
-
-            /// Returns the underlying bytes.
-            #[inline]
-            pub fn to_bytes(&self) -> [$ty; $len] { self.0.clone() }
-
-            /// Returns the underlying bytes.
-            #[inline]
-            pub fn into_bytes(self) -> [$ty; $len] { self.0 }
-        }
-
-        impl<'a> ::core::convert::From<&'a [$ty]> for $thing {
-            fn from(data: &'a [$ty]) -> $thing {
-                assert_eq!(data.len(), $len);
-                let mut ret = [0; $len];
-                ret.copy_from_slice(&data[..]);
-                $thing(ret)
-            }
-        }
-
-        impl<I: $crate::core::slice::SliceIndex<[$ty]>> $crate::core::ops::Index<I> for $thing {
-            type Output = I::Output;
-
-            #[inline]
-            fn index(&self, index: I) -> &Self::Output {
-                &self.0[index]
-            }
-        }
-
-    }
-}
-
 macro_rules! display_from_debug {
     ($thing:ident) => {
         impl ::core::fmt::Display for $thing {
@@ -432,7 +372,7 @@ macro_rules! impl_bytes_newtype {
                 if s.is_human_readable() {
                     s.serialize_str(&$crate::hashes::hex::ToHex::to_hex(self))
                 } else {
-                    s.serialize_bytes(&self[..])
+                    s.serialize_bytes(&self.as_ref()[..])
                 }
             }
         }

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -21,6 +21,8 @@ use prelude::*;
 
 use io::Write;
 use core::{fmt, str::FromStr, default::Default};
+use core::ops::Index;
+use core::slice::SliceIndex;
 #[cfg(feature = "std")] use std::error;
 #[cfg(feature = "serde")] use serde;
 
@@ -238,8 +240,16 @@ pub trait IntoDerivationPath {
 /// A BIP-32 derivation path.
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct DerivationPath(Vec<ChildNumber>);
-impl_index_newtype!(DerivationPath, ChildNumber);
 serde_string_impl!(DerivationPath, "a BIP-32 derivation path");
+
+impl<I: SliceIndex<[ChildNumber]>> Index<I> for DerivationPath {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl Default for DerivationPath {
     fn default() -> DerivationPath {

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -63,7 +63,7 @@ impl Map for PartiallySignedTransaction {
                 },
                 value: {
                     let mut ret = Vec::with_capacity(4 + derivation.len() * 4);
-                    ret.extend(fingerprint.as_bytes());
+                    ret.extend(fingerprint.as_ref());
                     derivation.into_iter().for_each(|n| ret.extend(&u32_to_array_le((*n).into())));
                     ret
                 }

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -147,7 +147,7 @@ impl Serialize for KeySource {
     fn serialize(&self) -> Vec<u8> {
         let mut rv: Vec<u8> = Vec::with_capacity(key_source_len(&self));
 
-        rv.append(&mut self.0.to_bytes().to_vec());
+        rv.append(&mut self.0.as_ref().to_vec());
 
         for cnum in self.1.into_iter() {
             rv.append(&mut serialize(&u32::from(*cnum)))

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -23,7 +23,21 @@ macro_rules! construct_uint {
         /// Little-endian large integer type
         #[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
         pub struct $name(pub [u64; $n_words]);
-        impl_array_newtype!($name, u64, $n_words);
+
+        impl AsRef<[u64; $n_words]> for $name {
+            fn as_ref(&self) -> &[u64; $n_words] {
+                &self.0
+            }
+        }
+
+        impl<'a> From<&'a [u64]> for $name {
+            fn from(data: &'a [u64]) -> $name {
+                assert_eq!(data.len(), $n_words);
+                let mut buf = [0; $n_words];
+                buf.copy_from_slice(&data[..]);
+                $name(buf)
+            }
+        }
 
         impl $name {
             /// Conversion to u32
@@ -188,8 +202,8 @@ macro_rules! construct_uint {
                 // and the auto derive is a lexicographic ordering(i.e. memcmp)
                 // which with numbers is equivalent to big-endian
                 for i in 0..$n_words {
-                    if self[$n_words - 1 - i] < other[$n_words - 1 - i] { return ::core::cmp::Ordering::Less; }
-                    if self[$n_words - 1 - i] > other[$n_words - 1 - i] { return ::core::cmp::Ordering::Greater; }
+                    if self.as_ref()[$n_words - 1 - i] < other.as_ref()[$n_words - 1 - i] { return ::core::cmp::Ordering::Less; }
+                    if self.as_ref()[$n_words - 1 - i] > other.as_ref()[$n_words - 1 - i] { return ::core::cmp::Ordering::Greater; }
                 }
                 ::core::cmp::Ordering::Equal
             }


### PR DESCRIPTION
Just the second patch, patch 1 is from https://github.com/rust-bitcoin/rust-bitcoin/pull/805

We can get rid of the `impl_array_newtype` macro by implementing `AsRef` and `From`. Since types defined with the macro are all arrays we can use `AsRef` to get a reference to the underlying array which gives us everything we implement in the macro for free.

Credit for the idea belongs to @elichai.

Makes progress on: #352