### PR TITLE
Add chain hash type

### DIFF
--- a/src/chain_hash.rs
+++ b/src/chain_hash.rs
@@ -1,0 +1,38 @@
+//! Provides the chain hash type.
+//!
+//! ref: https://github.com/lightning/bolts/blob/ffeece3dab1c52efdb9b53ae476539320fa44938/00-introduction.md#chain_hash
+//!
+
+use Network;
+use blockdata::constants;
+use hashes::Hash;
+
+/// The uniquely identifying hash of the target blockchain.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ChainHash([u8; 32]);
+impl_array_newtype!(ChainHash, u8, 32);
+impl_bytes_newtype!(ChainHash, 32);
+
+impl ChainHash {
+    /// Returns the chain hash for `network`.
+    pub fn for_network(network: Network) -> Self {
+        let genesis = constants::genesis_block(network);
+        ChainHash(genesis.block_hash().into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mainnet_chain_hash() {
+        let mainnet = ChainHash::for_network(Network::Bitcoin);
+
+        // Taken from BOLT 0 (linked above).
+        let want = "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000";
+        let got = format!("{:x}", mainnet);
+
+        assert_eq!(got, want);
+    }
+}

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -434,13 +434,13 @@ macro_rules! impl_bytes_newtype {
 
         impl ::core::fmt::Display for $t {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                fmt::LowerHex::fmt(self, f)
+                ::core::fmt::LowerHex::fmt(self, f)
             }
         }
 
         impl ::core::fmt::Debug for $t {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                fmt::LowerHex::fmt(self, f)
+                ::core::fmt::LowerHex::fmt(self, f)
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub mod util;
 pub mod consensus;
 pub mod hash_types;
 pub mod policy;
+pub mod chain_hash;
 
 pub use hash_types::*;
 pub use blockdata::block::Block;


### PR DESCRIPTION
The Lightning network defines a type called 'chain hash' that is used to uniquely represent the various Bitcoin networks as a 32 byte hash value. It is calculated by hashing the genesis block for the respective network. Chain hash is now being used by the DLC folks, as such it is useful to have it implemented in `rust-bitcoin`.

Add a `ChainHash` type that can be used to get the unique identifier of each of the 4 Bitcoin networks we support.

Question: Are new files required to include a copyright notice like many of the other files?

Closes: #481 