### PR TITLE
WIP: Add fuzz test for PrefilledTransaction

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,6 +33,10 @@ name = "deserialize_transaction"
 path = "fuzz_targets/deserialize_transaction.rs"
 
 [[bin]]
+name = "deserialize_prefilled_transaction"
+path = "fuzz_targets/deserialize_prefilled_transaction.rs"
+
+[[bin]]
 name = "deserialize_address"
 path = "fuzz_targets/deserialize_address.rs"
 

--- a/fuzz/fuzz_targets/deserialize_prefilled_transaction.rs
+++ b/fuzz/fuzz_targets/deserialize_prefilled_transaction.rs
@@ -1,0 +1,53 @@
+extern crate bitcoin;
+
+fn do_test(data: &[u8]) {
+    // We already fuzz Transactions in `./deserialize_transaction.rs`.
+    let _: Result<bitcoin::util::bip152::PrefilledTransaction, _>= bitcoin::consensus::encode::deserialize(data);
+}
+
+#[cfg(feature = "afl")]
+#[macro_use] extern crate afl;
+#[cfg(feature = "afl")]
+fn main() {
+    fuzz!(|data| {
+        do_test(&data);
+    });
+}
+
+#[cfg(feature = "honggfuzz")]
+#[macro_use] extern crate honggfuzz;
+#[cfg(feature = "honggfuzz")]
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("00000000", &mut a);
+        super::do_test(&a);
+    }
+}


### PR DESCRIPTION
Add a simple deserialization fuzz test for `PrefilledTransaction`.

I'm totally new to fuzzing. Is the thing being checked, (in for example `deser_net_msg.rs`) that there is no input data that will cause the deserialization to crash the process?

If that is the case then is the code in this PR what is meant by the issue: #460?

Do we want a fuzz file for each `pub struct` in `bip152.rs`?