### PR TITLE
Remove feature gated enum variants

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -137,18 +137,17 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let str = match *self {
-            Error::NonMinimalPush => "non-minimal datapush",
-            Error::EarlyEndOfScript => "unexpected end of script",
-            Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
+        match *self {
+            Error::NonMinimalPush => write!(f, "non-minimal datapush"),
+            Error::EarlyEndOfScript => write!(f, "unexpected end of script"),
+            Error::NumericOverflow => write!(f, "numeric overflow (number on stack larger than 4 bytes)"),
             #[cfg(feature="bitcoinconsensus")]
-            Error::BitcoinConsensus(ref _n) => "bitcoinconsensus verification failed",
+            Error::BitcoinConsensus(ref _n) => write!(f, "bitcoinconsensus verification failed"),
             #[cfg(feature="bitcoinconsensus")]
-            Error::UnknownSpentOutput(ref _point) => "unknown spent output Transaction::verify()",
+            Error::UnknownSpentOutput(ref _point) => write!(f, "unknown spent output Transaction::verify()"),
             #[cfg(feature="bitcoinconsensus")]
-            Error::SerializationError => "can not serialize the spending transaction in Transaction::verify()",
-        };
-        f.write_str(str)
+            Error::SerializationError => write!(f, "can not serialize the spending transaction in Transaction::verify()"),
+        }
     }
 }
 

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -37,7 +37,7 @@ use hashes::{Hash, hex};
 use policy::DUST_RELAY_TX_FEE;
 #[cfg(feature="bitcoinconsensus")] use bitcoinconsensus;
 #[cfg(feature="bitcoinconsensus")] use core::convert::From;
-#[cfg(feature="bitcoinconsensus")] use OutPoint;
+use OutPoint;
 
 use util::key::PublicKey;
 use util::address::WitnessVersion;
@@ -122,17 +122,24 @@ pub enum Error {
     /// Tried to read an array off the stack as a number when it was more than 4 bytes
     NumericOverflow,
     /// Error validating the script with bitcoinconsensus library
-    #[cfg(feature = "bitcoinconsensus")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
-    BitcoinConsensus(bitcoinconsensus::Error),
+    BitcoinConsensus(BitcoinConsensusError),
     /// Can not find the spent output
-    #[cfg(feature = "bitcoinconsensus")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
     UnknownSpentOutput(OutPoint),
     /// Can not serialize the spending transaction
-    #[cfg(feature = "bitcoinconsensus")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
     SerializationError
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+enum Uninhabited {}
+
+#[cfg(feature = "bitcoinconsensus")]
+type BitcoinConsensusError = bitcoinconsensus::Error;
+
+/// Dummy error type used when `bitcoinconsensus` feature is not enabled.
+#[cfg(not(feature = "bitcoinconsensus"))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+pub struct BitcoinConsensusError {
+    _uninhabited: Uninhabited,
 }
 
 impl fmt::Display for Error {
@@ -141,11 +148,8 @@ impl fmt::Display for Error {
             Error::NonMinimalPush => write!(f, "non-minimal datapush"),
             Error::EarlyEndOfScript => write!(f, "unexpected end of script"),
             Error::NumericOverflow => write!(f, "numeric overflow (number on stack larger than 4 bytes)"),
-            #[cfg(feature="bitcoinconsensus")]
-            Error::BitcoinConsensus(ref _n) => write!(f, "bitcoinconsensus verification failed"),
-            #[cfg(feature="bitcoinconsensus")]
-            Error::UnknownSpentOutput(ref _point) => write!(f, "unknown spent output Transaction::verify()"),
-            #[cfg(feature="bitcoinconsensus")]
+            Error::BitcoinConsensus(ref err) => write!(f, "bitcoinconsensus verification failed: {:?}", err),
+            Error::UnknownSpentOutput(ref point) => write!(f, "unknown spent output Transaction::verify() for point: {}", point),
             Error::SerializationError => write!(f, "can not serialize the spending transaction in Transaction::verify()"),
         }
     }
@@ -171,13 +175,11 @@ impl From<UintError> for Error {
     }
 }
 
-#[cfg(feature="bitcoinconsensus")]
+#[cfg(feature = "bitcoinconsensus")]
 #[doc(hidden)]
 impl From<bitcoinconsensus::Error> for Error {
     fn from(err: bitcoinconsensus::Error) -> Error {
-        match err {
-            _ => Error::BitcoinConsensus(err)
-        }
+        Error::BitcoinConsensus(err)
     }
 }
 /// Helper to encode an integer in script format


### PR DESCRIPTION
Feature gating enum variants makes code that uses the library brittle while we do not have `non_exhaustive`, we should avoid doing so. Instead we can add a dummy type that is available when the feature is not turned on. Doing so enables the compiler to enforce that we do not create the error type that is feature gated when the feature is not enabled.

Remove the feature gating around `bitcoincensensus` featured error enum variants.

Patch 1 is a trivial preparatory change to the `Display` impl.

Closes: #645
