### PR TITLE
Update secp256k1 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }
 bitcoin_hashes = { version = "0.10.0", default-features = false }
-secp256k1 = { version = "0.21.2", default-features = false }
+secp256k1 = { version = "0.22.0", default-features = false }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64-compat = { version = "1.0.0", optional = true }
@@ -47,7 +47,7 @@ hashbrown = { version = "0.8", optional = true }
 [dev-dependencies]
 serde_json = "<1.0.45"
 serde_test = "1"
-secp256k1 = { version = "0.21.2", features = [ "recovery", "rand-std" ] }
+secp256k1 = { version = "0.22.0", features = [ "recovery", "rand-std" ] }
 bincode = "1.3.1"
 # We need to pin ryu (transitive dep from serde_json) to stay compatible with Rust 1.22.0
 ryu = "<1.0.5"

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -174,7 +174,7 @@ impl TweakedPublicKey {
     /// the y-coordinate is represented by only a single bit, as x determines
     /// it up to one bit.
     #[inline]
-    pub fn serialize(&self) -> [u8; constants::SCHNORRSIG_PUBLIC_KEY_SIZE] {
+    pub fn serialize(&self) -> [u8; constants::SCHNORR_PUBLIC_KEY_SIZE] {
         self.0.serialize()
     }
 }


### PR DESCRIPTION
Update our `rust-secp256k1` dependency to the latest released version.

Requires doing:

- Add a new variant to `Error` for the case where parity of the internal key is an invalid value (not 0 or 1).
- Use non-deprecated const

Please check the error change carefully, this error does relate _only_ to the parity of an internal key, right?