### PR TITLE
Improve ClassifyContext rustdocs

### DIFF
--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -661,8 +661,8 @@ impl fmt::Debug for All {
 
 /// Classification context for the opcode.
 ///
-/// Some opcodes like `OP_RESERVED` abort the script in [`ClassifyContext::Legacy`] context, but
-/// will act as `OP_SUCCESS` in tapscript.
+/// Some opcodes like [`all::OP_RESERVED`] abort the script in `ClassifyContext::Legacy` context,
+/// but will act as `OP_SUCCESSx` in `ClassifyContext::TapScript` (see BIP342 for full list).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ClassifyContext {
     /// Opcode used in tapscript context.


### PR DESCRIPTION
Improve the rustdocs on the `ClassifyContext` enum by doing:

- Use link for `OP_RESERVED`
- Use term `OP_SUCCESSx` is done in BIP342 (no code link, does not exist in code).
- Use enum::variant form for both variant mentions
- Direct readers to BIP342 for full list of opcode re-names