### PR TITLE
Add chain hash type using consts

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -179,12 +179,10 @@ pub fn genesis_block(network: Network) -> Block {
 #[cfg(test)]
 mod test {
     use core::default::Default;
+    use super::*;
     use crate::hashes::hex::FromHex;
-
     use crate::network::constants::Network;
     use crate::consensus::encode::serialize;
-    use crate::blockdata::constants::{genesis_block, bitcoin_genesis_tx};
-    use crate::blockdata::constants::{MAX_SEQUENCE, COIN_VALUE};
 
     #[test]
     fn bitcoin_genesis_first_transaction() {

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -84,7 +84,7 @@ macro_rules! impl_array_newtype {
             pub fn into_bytes(self) -> [$ty; $len] { self.0 }
         }
 
-        impl<'a> ::core::convert::From<&'a [$ty]> for $thing {
+        impl<'a> core::convert::From<&'a [$ty]> for $thing {
             fn from(data: &'a [$ty]) -> $thing {
                 assert_eq!(data.len(), $len);
                 let mut ret = [0; $len];
@@ -109,7 +109,7 @@ macro_rules! impl_array_newtype {
 
 macro_rules! display_from_debug {
     ($thing:ident) => {
-        impl ::core::fmt::Display for $thing {
+        impl core::fmt::Display for $thing {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
                 ::core::fmt::Debug::fmt(self, f)
             }
@@ -365,13 +365,13 @@ macro_rules! impl_bytes_newtype {
 
         impl ::core::fmt::Display for $t {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                fmt::LowerHex::fmt(self, f)
+                ::core::fmt::LowerHex::fmt(self, f)
             }
         }
 
         impl ::core::fmt::Debug for $t {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                fmt::LowerHex::fmt(self, f)
+                ::core::fmt::LowerHex::fmt(self, f)
             }
         }
 


### PR DESCRIPTION
The Lightning network defines a type called 'chain hash' that is used to uniquely represent the various Bitcoin networks as a 32 byte hash value. Chain hash is now being used by the DLC folks, as such it is useful to have it implemented in rust-bitcoin.

One method of calculating a chain hash is by hashing the genesis block for the respective network.

Add a `ChainHash` type that can be used to get the unique identifier of each of the 4 Bitcoin networks we support. Add a method that calculates the chain hash for a network using the double sha256 of the genesis block. Do so using hard coded consts and add unit tests (regression/sanity) that show these hard coded byte arrays match the hash of the data we return for the genesis block for the respective network.

The chain hash for the main Bitcoin network can be verified from LN docs (BOLT 0), add a link to this document.

Closes: #481 