### PR TITLE
Make PsbtSigHashType use the same formatting as other *SigHashTypes

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -758,7 +758,7 @@ impl str::FromStr for EcdsaSigHashType {
             "SIGHASH_ALL|SIGHASH_ANYONECANPAY" => Ok(EcdsaSigHashType::AllPlusAnyoneCanPay),
             "SIGHASH_NONE|SIGHASH_ANYONECANPAY" => Ok(EcdsaSigHashType::NonePlusAnyoneCanPay),
             "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY" => Ok(EcdsaSigHashType::SinglePlusAnyoneCanPay),
-            _ => Err(SigHashTypeParseError{ unrecognized: s.to_owned() }),
+            _ => Err(SigHashTypeParseError { unrecognized: s.to_owned() }),
         }
     }
 }

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -326,6 +326,7 @@ impl SchnorrSigHashType {
             0x81 => Ok(SchnorrSigHashType::AllPlusAnyoneCanPay),
             0x82 => Ok(SchnorrSigHashType::NonePlusAnyoneCanPay),
             0x83 => Ok(SchnorrSigHashType::SinglePlusAnyoneCanPay),
+            0xFF => Ok(SchnorrSigHashType::Reserved),
             x => Err(Error::InvalidSigHashType(x as u32)),
         }
     }


### PR DESCRIPTION
The newly introduced `PsbtSigHashType` uses very different serde formatting from previously used `EcdsaSigHashType`; for instance it does not output human-readable sighash. This is especially obvious when printing out PSBT as JSON/YAML object and is a breaking change from the `0.27`. Serde human-readable implementation requires `Display/FromStr`, which were also absent.