### PR TITLE
Witness human-readable serde

### DIFF
--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -429,4 +429,18 @@ mod test {
         assert_eq!(new_witness_format, back);
     }
 
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_human() {
+        use serde_json;
+
+        let witness = Witness::from_vec(vec![vec![0u8, 123, 75], vec![2u8, 6, 3, 7, 8]]);
+
+        let json = serde_json::to_string(&witness).unwrap();
+
+        assert_eq!(json, r#"["007b4b","0206030708"]"#);
+
+        let back: Witness = serde_json::from_str(&json).unwrap();
+        assert_eq!(witness, back);
+    }
 }

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -377,18 +377,19 @@ mod test {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn test_serde() {
-        use serde_json;
+    fn test_serde_bincode() {
+        use bincode;
 
         let old_witness_format = vec![vec![0u8], vec![2]];
         let new_witness_format = Witness::from_vec(old_witness_format.clone());
 
-        let old = serde_json::to_string(&old_witness_format).unwrap();
-        let new = serde_json::to_string(&new_witness_format).unwrap();
+        let old = bincode::serialize(&old_witness_format).unwrap();
+        let new = bincode::serialize(&new_witness_format).unwrap();
 
         assert_eq!(old, new);
 
-        let back = serde_json::from_str(&new).unwrap();
+        let back: Witness = bincode::deserialize(&new).unwrap();
         assert_eq!(new_witness_format, back);
     }
+
 }


### PR DESCRIPTION
Previous implementations of Witness (and Vec<Vec<u8>>) serde serialization didn't support human-readable representations. This resulted in long unreadable JSON/YAML byte arrays, which were especially ugly when pretty-printed (a line per each byte).

<details>
    <summary>an example of that ugliness</summary>

    unsigned_tx:
      version: 2
      lock_time: 0
      input:
        - previous_output: "c96ec66b95ab23bbc287d698c5e63f141dcd75b7728d00f5a89e1f2d93a9424f:1"
          script_sig: ""
          sequence: 4294967295
          witness: []
      output:
        - value: 10000
          script_pubkey: 5120137b87fb9b00c8e09f1b91a9379c98eef1774a568f8ad8514079aaa3941666f3
        - value: 9666
          script_pubkey: 5120566b18c07d063d114a572735c4705f4aa007486b016463d4ffae278d225c3a91
    version: 0
    xpub:
      tpubDCLfi9JceW8Er2qcaK7gBudjXPrS31VCf7wiiPFLV2s9ptKLkaGxnQutTtdsJoqgbRxWhBDMHJEZ6XsGfC26QhMZEoRYfdCFS3qhaXskUeD:
        - 877c9433
        - "m/86'/1/0'"
      tpubDCLfi9JceW8FJEw6RpfrCtByfaKCHsS9VHdrvB97ZkfS2wKbxtygMxW4MraMuPV5avsDkvae5t36MMwtRuJ5btAfQh7NxKGpmNxzwSm15ZF:
        - 877c9433
        - "m/86'/1/10'"
    proprietary: []
    unknown: []
    inputs:
      - non_witness_utxo:
          version: 2
          lock_time: 2190833
          input:
            - previous_output: "8c7d5031f9e1e9ef691aacedd20a5a8e6dd79882b569581c331a38c0ba17491c:0"
              script_sig: ""
              sequence: 4294967294
              witness:
                - - 48
                  - 68
                  - 2
                  - 32
                  - 108
                  - 145
                  - 6
                  - 133
                  - 173
                  - 227
                  - 190
                  - 147
                  - 176
                  - 196
                  - 50
                  - 84
                  - 118
                  - 66
                  - 59
                  - 149
                  - 52
                  - 171
                  - 92
                  - 92
                  - 9
                  - 76
                  - 28
                  - 247
                  - 9
                  - 241
                  - 241
                  - 151
                  - 142
                  - 82
                  - 171
                  - 112
                  - 2
                  - 32
                  - 109
                  - 30
                  - 127
                  - 238
                  - 0
                  - 53
                  - 58
                  - 4
                  - 75
                  - 100
                  - 184
                  - 121
                  - 132
                  - 139
                  - 142
                  - 49
                  - 132
                  - 219
                  - 3
                  - 224
                  - 54
                  - 155
                  - 171
                  - 63
                  - 248
                  - 150
                  - 106
                  - 132
                  - 147
                  - 176
                  - 236
                  - 123
                  - 1
                - - 2
                  - 134
                  - 28
                  - 194
                  - 153
                  - 223
                  - 0
                  - 94
                  - 181
                  - 115
                  - 213
                  - 57
                  - 15
                  - 109
                  - 206
                  - 82
                  - 84
                  - 140
                  - 99
                  - 210
                  - 142
                  - 67
                  - 15
                  - 178
                  - 230
                  - 53
                  - 245
                  - 83
                  - 45
                  - 141
                  - 28
                  - 13
                  - 230
          output:
            - value: 464333
              script_pubkey: 0014862b51f53fa54235a0c5c5e1fb256d73dc90fffc
            - value: 20000
              script_pubkey: 5120f23d25a56919ba6c873a727a2699c8764fffaa2f5fb70df2f5febbec86b9fe8f
        witness_utxo: ~
        partial_sigs: {}
        sighash_type:
          inner: 1
        redeem_script: ~
        witness_script: ~
        bip32_derivation: []
        final_script_sig: ~
        final_script_witness: ~
        ripemd160_preimages: {}
        sha256_preimages: {}
        hash160_preimages: {}
        hash256_preimages: {}
        tap_key_sig:
          sig: 987a59ed7b7a57efa602b1ed86551f4bf4759f5198adc006b0043b045091813d870a253a45a0253c55acb77f71f3d3b90b05ea02a5989fdf7bb74535a8d0afb3
          hash_ty: All
        tap_script_sigs:
          - - - 6332fd4c53a053bccc53a1d82fa2e1e2276ce609c0200d3ced4cd74a22653388
              - 27686a1d5598f23ac8884676a4ffd6b742a9936abcc10fae26aecd09776af574
            - sig: 7e5e4521edccbe61bec1370b61fbd3d39ae8be4229af6f8c428faf7a02f1a4432b520ffefa6431482aa51b76e6dda8518a2aefa4ca90464b91f8ee1800ddff4d
              hash_ty: All
          - - - 6332fd4c53a053bccc53a1d82fa2e1e2276ce609c0200d3ced4cd74a22653388
              - 3b17906c53e5308858f3e5a78f1ca33ef014cb84096f608b35983822bc5867da
            - sig: 90f9f9651a0d6780a6ee2786868dbf546b99fef527fa0b1c3e92e7c36dc05f4006f22944bd0544724d55c0b43c091745d67a759cc015c4ec8b43ab2b8aea0d6f
              hash_ty: All
          - - - 6332fd4c53a053bccc53a1d82fa2e1e2276ce609c0200d3ced4cd74a22653388
              - d7cc5bca95baca4b690daa28d0efe18ae82fe4cc1ce44814ee2be098b7f1510b
            - sig: 7ad2b4fa33e8c9fe02e1e7db89068ca5171f1173bc876451d1d71f7519a1fbe8aedd4c5b93e202b2dafa8eb3ae17def57f4f9b0ec9c9a5c93caf4ab541d94b55
              hash_ty: All
        tap_scripts:
          - - leaf_version: 192
              output_key_parity: 1
              internal_key: d99571989a8fcd762e3bd5b3e864ee81727fbff82660c4a57b5de501b4ba8ed4
              merkle_branch:
                - 27686a1d5598f23ac8884676a4ffd6b742a9936abcc10fae26aecd09776af574
                - 3b17906c53e5308858f3e5a78f1ca33ef014cb84096f608b35983822bc5867da
            - - 206332fd4c53a053bccc53a1d82fa2e1e2276ce609c0200d3ced4cd74a22653388ac20cff309356e57796533f8c22ec6b9625e0b465498f123a8169b2a9d8e2c278255ba20dec28c52648655a6d711525503bbfebaa8c12a332e3c9ffd82064ff166af698cba529d5ab1
              - 192
          - - leaf_version: 192
              output_key_parity: 1
              internal_key: d99571989a8fcd762e3bd5b3e864ee81727fbff82660c4a57b5de501b4ba8ed4
              merkle_branch:
                - 9732abae6c1729c3bb135a2f52977265f290c8d8fba6377c7a0e0cc5eece5567
            - - 206332fd4c53a053bccc53a1d82fa2e1e2276ce609c0200d3ced4cd74a22653388ac20cff309356e57796533f8c22ec6b9625e0b465498f123a8169b2a9d8e2c278255ba20dec28c52648655a6d711525503bbfebaa8c12a332e3c9ffd82064ff166af698cba539c
              - 192
          - - leaf_version: 192
              output_key_parity: 1
              internal_key: d99571989a8fcd762e3bd5b3e864ee81727fbff82660c4a57b5de501b4ba8ed4
              merkle_branch:
                - d7cc5bca95baca4b690daa28d0efe18ae82fe4cc1ce44814ee2be098b7f1510b
                - 3b17906c53e5308858f3e5a78f1ca33ef014cb84096f608b35983822bc5867da
            - - 206332fd4c53a053bccc53a1d82fa2e1e2276ce609c0200d3ced4cd74a22653388ac20cff309356e57796533f8c22ec6b9625e0b465498f123a8169b2a9d8e2c278255ba20dec28c52648655a6d711525503bbfebaa8c12a332e3c9ffd82064ff166af698cba519d0164b1
              - 192
        tap_key_origins:
          - - 6332fd4c53a053bccc53a1d82fa2e1e2276ce609c0200d3ced4cd74a22653388
            - - - 27686a1d5598f23ac8884676a4ffd6b742a9936abcc10fae26aecd09776af574
                - 3b17906c53e5308858f3e5a78f1ca33ef014cb84096f608b35983822bc5867da
                - d7cc5bca95baca4b690daa28d0efe18ae82fe4cc1ce44814ee2be098b7f1510b
              - - fcedac08
                - m/0/0
          - - d99571989a8fcd762e3bd5b3e864ee81727fbff82660c4a57b5de501b4ba8ed4
            - - []
              - - 4d94875d
                - m/0/0
        tap_internal_key: d99571989a8fcd762e3bd5b3e864ee81727fbff82660c4a57b5de501b4ba8ed4
        tap_merkle_root: 94b1f8ca0e387b63d25fce87354e841f18d2a97c1027aaee7e3072fa40233b1e
        proprietary: []
        unknown: []
    outputs:
      - redeem_script: ~
        witness_script: ~
        bip32_derivation: []
        tap_internal_key: ~
        tap_tree: ~
        tap_key_origins: []
        proprietary: []
        unknown: []
      - redeem_script: ~
        witness_script: ~
        bip32_derivation: []
        tap_internal_key: 9342cfe214556af10e9b34549458af0d937603c68dd6e8b95f005095b26df7da
        tap_tree:
          branch:
            - hash: 2b15aae72ed4ac365785d21c56cf435a43633ba2af84e4ed3c0b4d26897bbcf2
              leaves:
                - script: 2071beef4035dca001a9ab71983b860d273b1a2c8173d00656b8bbaf497e6e444dac207339326d461857494b87bbe2cc9b3e31ccff1d7844a2bdfcb6c5c2e9727098aeba20ad21352f1ca6eef7db5fa23f6e573eb5c823da6c7755c61c652a45d3349d059aba519d0164b1
                  ver: 192
                  merkle_branch:
                    - 2409b7478a75b0350b4710b5eca54056fde8c22ba035eb209e9a1e4e659783f1
                    - 9653be7568281a9657d57478560cb2638acf80c98124f0318adaedb16d63b02c
                - script: 2071beef4035dca001a9ab71983b860d273b1a2c8173d00656b8bbaf497e6e444dac207339326d461857494b87bbe2cc9b3e31ccff1d7844a2bdfcb6c5c2e9727098aeba20ad21352f1ca6eef7db5fa23f6e573eb5c823da6c7755c61c652a45d3349d059aba529d5ab1
                  ver: 192
                  merkle_branch:
                    - 304ad4baaba8c42012939da18cd35fded9d15fb24e8af33e364cf02fb340a5ce
                    - 9653be7568281a9657d57478560cb2638acf80c98124f0318adaedb16d63b02c
                - script: 2071beef4035dca001a9ab71983b860d273b1a2c8173d00656b8bbaf497e6e444dac207339326d461857494b87bbe2cc9b3e31ccff1d7844a2bdfcb6c5c2e9727098aeba20ad21352f1ca6eef7db5fa23f6e573eb5c823da6c7755c61c652a45d3349d059aba539c
                  ver: 192
                  merkle_branch:
                    - ac035f11d4fdce47af56e62818ad3f11c7b6a2c5bcefc435787148f2c08318bf
        tap_key_origins: []
        proprietary: []
        unknown: []
</details>

This breaks backward compatibility for human-readable types, but I assume that previous representation was actually "non-human readable" and it was a bug, not a feature. Waiting for confirmation from @JeremyRubin who I know uses JSON serialization a lot.