### PR TITLE
Disable Serde's default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64-compat = { version = "1.0.0", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
-serde = { version = "1", features = [ "derive" ], optional = true }
+serde = { version = "1", default-features = false, features = [ "derive", "alloc" ], optional = true }
 hashbrown = { version = "0.8", optional = true }
 
 [dev-dependencies]

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -1024,20 +1024,6 @@ impl<'de> serde::Deserialize<'de> for Script {
                     let v = Vec::from_hex(v).map_err(E::custom)?;
                     Ok(Script::from(v))
                 }
-
-                fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-                where
-                    E: serde::de::Error,
-                {
-                    self.visit_str(v)
-                }
-
-                fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-                where
-                    E: serde::de::Error,
-                {
-                    self.visit_str(&v)
-                }
             }
             deserializer.deserialize_str(Visitor)
         } else {

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -1042,6 +1042,13 @@ impl<'de> serde::Deserialize<'de> for Script {
                 {
                     Ok(Script::from(v.to_vec()))
                 }
+
+                fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(Script::from(v))
+                }
             }
             deserializer.deserialize_bytes(BytesVisitor)
         }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -152,20 +152,6 @@ macro_rules! serde_string_impl {
                     {
                         $name::from_str(v).map_err(E::custom)
                     }
-
-                    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-                    where
-                        E: $crate::serde::de::Error,
-                    {
-                        self.visit_str(v)
-                    }
-
-                    fn visit_string<E>(self, v: $crate::prelude::String) -> Result<Self::Value, E>
-                    where
-                        E: $crate::serde::de::Error,
-                    {
-                        self.visit_str(&v)
-                    }
                 }
 
                 deserializer.deserialize_str(Visitor)
@@ -215,19 +201,6 @@ macro_rules! serde_struct_human_string_impl {
                             $name::from_str(v).map_err(E::custom)
                         }
 
-                        fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-                        where
-                            E: $crate::serde::de::Error,
-                        {
-                            self.visit_str(v)
-                        }
-
-                        fn visit_string<E>(self, v: $crate::prelude::String) -> Result<Self::Value, E>
-                        where
-                            E: $crate::serde::de::Error,
-                        {
-                            self.visit_str(&v)
-                        }
                     }
 
                     deserializer.deserialize_str(Visitor)
@@ -573,21 +546,6 @@ macro_rules! user_enum {
                             Err(E::unknown_variant(v, FIELDS))
                         }
                     }
-
-                    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-                    where
-                        E: $crate::serde::de::Error,
-                    {
-                        self.visit_str(v)
-                    }
-
-                    fn visit_string<E>(self, v: $crate::prelude::String) -> Result<Self::Value, E>
-                    where
-                        E: $crate::serde::de::Error,
-                    {
-                        self.visit_str(&v)
-                    }
-
                 }
 
                 deserializer.deserialize_str(Visitor)


### PR DESCRIPTION
With this patch, existing users of the `use-serde` feature will no longer be
compiling with `serde/std` enabled, but this allows dependent projects
to import serde and enable `serde/alloc` as required by some no-std targets.