### PR TITLE
Add Serialize/Deserialize for TaprootSpendInfo

### DIFF
--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -40,6 +40,8 @@ pub type UntweakedPublicKey = ::XOnlyPublicKey;
 
 /// Tweaked BIP-340 X-coord-only public key
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct TweakedPublicKey(::XOnlyPublicKey);
 
 impl fmt::LowerHex for TweakedPublicKey {

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -173,6 +173,7 @@ type ScriptMerkleProofMap = BTreeMap<(Script, LeafVersion), BTreeSet<TaprootMerk
 ///
 /// Note: This library currently does not support [annex](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-5)
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TaprootSpendInfo {
     /// The BIP341 internal key.
     internal_key: UntweakedPublicKey,


### PR DESCRIPTION
I think this is missing -- unless there is a reason not to have it?
