### PR TITLE
Remove deprecated method use for sighash conversion

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -356,7 +356,7 @@ impl Transaction {
             return Ok(())
         }
 
-        let (sighash, anyone_can_pay) = EcdsaSigHashType::from_u32_consensus(sighash_type).split_anyonecanpay_flag();
+        let (sighash, anyone_can_pay) = EcdsaSigHashType::from_consensus(sighash_type).split_anyonecanpay_flag();
 
         // Build tx to sign
         let mut tx = Transaction {


### PR DESCRIPTION
Post-merge #796 follow-up. Feel free to add other changes/nits which hadn't get into #796.