### PR TITLE
Release 0.28.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 The previous release changed the behavior of `Display` for `ChildNumber`, assuming that any correct usage would not be
 affected. [Issue 608](https://github.com/rust-bitcoin/rust-bitcoin/issues/608) goes into the details of why this isn't
-the case and how we broke both `rust-miniscript` and BDK. 
+the case and how we broke both `rust-miniscript` and BDK.
 
 # 0.26.1 - 2021-06-06 (yanked, see explanation above)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.28.0-rc.1"
+version = "0.28.0-rc.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
This does not include a changelog because rc.1 did not have changelog.