### PR TITLE
Derive Hash trait for PSBT types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ bincode = "1.3.1"
 # We need to pin ryu (transitive dep from serde_json) to stay compatible with Rust 1.22.0
 ryu = "<1.0.5"
 
+[patch.crates-io]
+secp256k1 = { git = "https://github.com/LNP-BP/rust-secp256k1", branch = "derive/sig-hash" }
+
 [[example]]
 name = "bip32"
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -743,7 +743,7 @@ pub type SigHashType = EcdsaSigHashType;
 ///
 /// Fixed values so they can be cast as integer types for encoding (see also
 /// [`SchnorrSigHashType`]).
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub enum EcdsaSigHashType {
     /// 0x1: Sign all outputs.
     All		= 0x01,

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -25,7 +25,7 @@ use secp256k1;
 use EcdsaSigHashType;
 
 /// An ECDSA signature with the corresponding hash type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EcdsaSig {
     /// The underlying ECDSA Signature

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -79,7 +79,7 @@ const PSBT_IN_PROPRIETARY: u8 = 0xFC;
 
 /// A key-value map for an input of the corresponding index in the unsigned
 /// transaction.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Input {
     /// The non-witness transaction this input spends from. Should only be

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -47,7 +47,7 @@ const PSBT_OUT_PROPRIETARY: u8 = 0xFC;
 
 /// A key-value map for an output of the corresponding index in the unsigned
 /// transaction.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Output {
     /// The redeem script for this output.
@@ -80,7 +80,7 @@ pub struct Output {
 }
 
 /// Taproot Tree representing a finalized [`TaprootBuilder`] (a complete binary tree).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TapTree(pub(crate) TaprootBuilder);
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -47,7 +47,7 @@ use self::map::Map;
 use util::bip32::{ExtendedPubKey, KeySource};
 
 /// A Partially Signed Transaction.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PartiallySignedTransaction {
     /// The unsigned transaction, scriptSigs and witnesses for each input must be

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -214,7 +214,7 @@ impl From<TweakedKeyPair> for ::KeyPair {
 }
 
 /// A BIP340-341 serialized schnorr signature with the corresponding hash type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SchnorrSig {
     /// The underlying schnorr signature


### PR DESCRIPTION
This adds Hash derivation to PSBT types and signature-related types.

Depends on https://github.com/rust-bitcoin/rust-secp256k1/pull/433 which is pending MSRV bump