### PR TITLE
Expose PartialMerkleTree fields

### DIFF
--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -114,11 +114,11 @@ pub enum MerkleBlockError {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct PartialMerkleTree {
     /// The total number of transactions in the block
-    num_transactions: u32,
+    pub num_transactions: u32,
     /// node-is-parent-of-matched-txid bits
-    bits: Vec<bool>,
+    pub bits: Vec<bool>,
     /// Transaction ids and internal hashes
-    hashes: Vec<TxMerkleNode>,
+    pub hashes: Vec<TxMerkleNode>,
 }
 
 impl PartialMerkleTree {


### PR DESCRIPTION
Would be nice to have a way of accessing the the fields of [`PartialMerkleTree`](https://docs.rs/bitcoin/0.27.1/bitcoin/util/merkleblock/struct.PartialMerkleTree.html) when, e.g., receiving a [`MerkleBlock`](https://docs.rs/bitcoin/0.27.1/bitcoin/util/merkleblock/struct.MerkleBlock.html) over the network. 