### PR TITLE
Upstream bdk sighash calculation code

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -427,6 +427,23 @@ impl Script {
         Script::new_p2sh(&self.script_hash())
     }
 
+    /// Returns the script code used for spending a P2WPKH output if this script is a script pubkey
+    /// for a P2WPKH output.
+    pub fn p2wpkh_script_code(&self) -> Option<Script> {
+        if !self.is_v0_p2wpkh() {
+            return None
+        }
+        let script = Builder::new()
+            .push_opcode(opcodes::all::OP_DUP)
+            .push_opcode(opcodes::all::OP_HASH160)
+            .push_slice(&self[2..]) // The `self` script is 0x00, 0x14, <pubkey_hash>
+            .push_opcode(opcodes::all::OP_EQUALVERIFY)
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+
+        Some(script)
+    }
+
     /// Computes the P2WSH output corresponding to this witnessScript (aka the "witness redeem
     /// script").
     pub fn to_v0_p2wsh(&self) -> Script {


### PR DESCRIPTION
bitcoindevkit's [bdk](github.com/bitcoindevkit/bdk) has some code in it for computing the sighash of PSBT inputs during signing (and some nice signing code too). I first came across this code a few years back and wondered why it was not upstream. This last week @DanGould and myself have been working on some PSBT examples/tests and for them I shamelessly stole the code out of `bdk` for signing.

This PR is an exploration to see if we want this code in `rust-bitcoin`. I'm no where near fully understanding what goes where in PSBTs, or sighashes even, so this will need a fair bit of review.

I have added a `TODO` to add attribution and/or the bdk license, not sure if this is enough code to warrant that. @RCasatta can you speak for bdk on this matter?

So far this is just the sighash code, I rekon we could use the PSBT signing code as well possibly but I'll wait to see how this is received.

Thanks