### PR TITLE
Fix TapTree derserialization

### DIFF
--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -355,7 +355,7 @@ impl Deserialize for TapTree {
             builder = builder.add_leaf_with_ver(*depth, script, leaf_version)
                 .map_err(|_| encode::Error::ParseFailed("Tree not in DFS order"))?;
         }
-        if builder.is_finalized() || !builder.has_hidden_nodes() {
+        if builder.is_finalized() && !builder.has_hidden_nodes() {
             Ok(TapTree(builder))
         } else {
             Err(encode::Error::ParseFailed("Incomplete taproot Tree"))


### PR DESCRIPTION
Trees should only be serialized if both of the following conditions
hold:
1) Tree is complete binary tree(is_finalized)
2) Tree does not have any hidden nodes