### PR TITLE
Add PSBT alias

### DIFF
--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -46,6 +46,9 @@ use self::map::Map;
 
 use util::bip32::{ExtendedPubKey, KeySource};
 
+/// Partially signed transaction, commonly referred to as a PSBT.
+pub type Psbt = PartiallySignedTransaction;
+
 /// A Partially Signed Transaction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
Programmers are inherently lazy and for good reason. I'm yet to see
anyone write `PartiallySignedTransaction` in code that uses
`rust-bitcoin`, its too obvious to add a type alias for PSBTs, let's
just do it ourselves to save everyone else having to do so.

Add public type alias `Psbt` for `PartiallySignedTransaction`.