### PR TITLE
Remove MSRV todo comments

### DIFF
--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -651,7 +651,7 @@ impl fmt::Debug for All {
             all::OP_CHECKMULTISIGVERIFY => write!(f, "CHECKMULTISIGVERIFY"),
             all::OP_CLTV => write!(f, "CLTV"),
             all::OP_CSV => write!(f, "CSV"),
-            All {code: x} if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code => write!(f, "NOP{}", x - all::OP_NOP1.code + 1),
+            All {code: x} if (all::OP_NOP1.code..=all::OP_NOP10.code).contains(&x) => write!(f, "NOP{}", x - all::OP_NOP1.code + 1),
             all::OP_INVALIDOPCODE => write!(f, "INVALIDOPCODE"),
             all::OP_CHECKSIGADD => write!(f, "CHECKSIGADD"),
             All {code: x} => write!(f, "RETURN_{}", x),

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -1208,18 +1208,13 @@ mod tests {
     #[test]
     fn sighash_single_bug() {
         const SIGHASH_SINGLE: u32 = 3;
-        // We need a tx with more inputs than outputs.
-        let mut input = Vec::new();
-        input.push(TxIn::default());
-        input.push(TxIn::default());
-        let mut output = Vec::new();
-        output.push(TxOut::default());
 
+        // We need a tx with more inputs than outputs.
         let tx = Transaction {
             version: 1,
             lock_time: 0,
-            input: input,
-            output: output,   // TODO: Use Vec::from([TxOut]) once we bump MSRV.
+            input: vec![TxIn::default(), TxIn::default()],
+            output: vec![TxOut::default()],
         };
         let script = Script::new();
         let got = tx.signature_hash(1, &script, SIGHASH_SINGLE);

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -166,7 +166,6 @@ impl fmt::Display for PsbtSighashType {
     }
 }
 
-#[allow(deprecated)]  // TODO: Swap `trim_left_matches` for `trim_start_matches` once MSRV >= 1.30.
 impl FromStr for PsbtSighashType {
     type Err = SighashTypeParseError;
 
@@ -184,7 +183,7 @@ impl FromStr for PsbtSighashType {
         }
 
         // We accept non-standard sighash values.
-        if let Ok(inner) = u32::from_str_radix(s.trim_left_matches("0x"), 16) {
+        if let Ok(inner) = u32::from_str_radix(s.trim_start_matches("0x"), 16) {
             return Ok(PsbtSighashType { inner });
         }
 

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -683,13 +683,13 @@ impl TaprootMerkleBranch {
             Err(TaprootError::InvalidMerkleTreeDepth(sl.len() / TAPROOT_CONTROL_NODE_SIZE))
         } else {
             let inner = sl
-                // TODO: Use chunks_exact after MSRV changes to 1.31
-                .chunks(TAPROOT_CONTROL_NODE_SIZE)
+                .chunks_exact(TAPROOT_CONTROL_NODE_SIZE)
                 .map(|chunk| {
                     sha256::Hash::from_slice(chunk)
-                        .expect("chunk exact always returns the correct size")
+                        .expect("chunks_exact always returns the correct size")
                 })
                 .collect();
+
             Ok(TaprootMerkleBranch(inner))
         }
     }


### PR DESCRIPTION
Now that 0.28 is out we do not need to support Rust 1.29 on `master`.

Remove trivial MSRV `TODO`s from the code. (All these changes only rely on MSRV bumping to 1.31 so are easily within bounds.) 