### PR TITLE
Remove calls to debug_assert

### DIFF
--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -140,7 +140,7 @@ impl From<psbt::Error> for Error {
 pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
     let mut encoder = Vec::new();
     let len = data.consensus_encode(&mut encoder).expect("in-memory writers don't error");
-    debug_assert_eq!(len, encoder.len());
+    assert_eq!(len, encoder.len());
     encoder
 }
 

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -240,7 +240,7 @@ macro_rules! decoder_fn {
     ($name:ident, $val_type:ty, $readfn:ident, $byte_len: expr) => {
         #[inline]
         fn $name(&mut self) -> Result<$val_type, Error> {
-            debug_assert_eq!(::core::mem::size_of::<$val_type>(), $byte_len); // size_of isn't a constfn in 1.22
+            const_assert!(::core::mem::size_of::<$val_type>() == $byte_len);
             let mut val = [0; $byte_len];
             self.read_exact(&mut val[..]).map_err(Error::Io)?;
             Ok(endian::$readfn(&val))

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -564,3 +564,13 @@ macro_rules! user_enum {
         }
     );
 }
+
+/// Asserts a boolean expression at compile time.
+macro_rules! const_assert {
+    ($x:expr) => {
+        // Use `_UNUSED` and extra scope instead of `_` due to Rust 1.29
+        {
+            const _UNUSED: [(); 0 - !$x as usize] = [];
+        }
+    };
+}

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -78,7 +78,7 @@ impl Encodable for CommandString {
     fn consensus_encode<S: io::Write>(&self, s: S) -> Result<usize, io::Error> {
         let mut rawbytes = [0u8; 12];
         let strbytes = self.0.as_bytes();
-        debug_assert!(strbytes.len() <= 12);
+        assert!(strbytes.len() <= 12);
         rawbytes[..strbytes.len()].copy_from_slice(strbytes);
         rawbytes.consensus_encode(s)
     }

--- a/src/util/endian.rs
+++ b/src/util/endian.rs
@@ -28,7 +28,7 @@ macro_rules! define_be_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
         pub fn $name(val: $type) -> [u8; $byte_len] {
-            debug_assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            const_assert!(::core::mem::size_of::<$type>() == $byte_len);
             let mut res = [0; $byte_len];
             for i in 0..$byte_len {
                 res[i] = ((val >> ($byte_len - i - 1)*8) & 0xff) as u8;
@@ -41,7 +41,7 @@ macro_rules! define_le_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
         pub fn $name(val: $type) -> [u8; $byte_len] {
-            debug_assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            const_assert!(::core::mem::size_of::<$type>() == $byte_len);
             let mut res = [0; $byte_len];
             for i in 0..$byte_len {
                 res[i] = ((val >> i*8) & 0xff) as u8;

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -429,7 +429,7 @@ impl TaprootBuilder {
         }
         // Every iteration of the loop reduces the node_weights.len() by exactly 1
         // Therefore, the loop will eventually terminate with exactly 1 element
-        debug_assert_eq!(node_weights.len(), 1);
+        assert_eq!(node_weights.len(), 1);
         let node = node_weights.pop().expect("huffman tree algorithm is broken").1;
         Ok(TaprootBuilder{branch: vec![Some(node)]})
     }


### PR DESCRIPTION
Done after reading discussion on #853.

Audit the code for calls to the various `debug_assert` macros. Check if the call is likely to be add any performance costs and if not use the equivalent `assert` macro.

Done as separate patches so that each change can be fully described by the commit message.

With this PR applied there is one instance of `debug_assert!` left, the call checks against the result of `tweak_add_check`. I do not know if this call is fast or slow so I left it as it is.