### PR TITLE
Make taproot LeafInfo public

### DIFF
--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -169,17 +169,16 @@ pub struct TapTreeIter<'tree> {
 }
 
 impl<'tree> Iterator for TapTreeIter<'tree> {
-    type Item = (u8, &'tree Script);
+    type Item = &'tree LeafInfo;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.leaf_iter.next().map(|leaf_info| {
-            (leaf_info.merkle_branch.as_inner().len() as u8, &leaf_info.script)
-        })
+        self.leaf_iter.next()
     }
 }
 
 impl<'tree> IntoIterator for &'tree TapTree {
-    type Item = (u8, &'tree Script);
+    type Item = &'tree LeafInfo;
     type IntoIter = TapTreeIter<'tree>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -158,7 +158,15 @@ impl TapTree {
     /// Returns [`TapTreeIter`] iterator for a taproot script tree, operating in DFS order over
     /// tree [`ScriptLeaf`]s.
     pub fn script_leaves(&self) -> TapTreeIter {
-        self.into_iter()
+        match (self.0.branch().len(), self.0.branch().last()) {
+            (1, Some(Some(root))) => {
+                TapTreeIter {
+                    leaf_iter: root.leaves.iter()
+                }
+            }
+            // This should be unreachable as we Taptree is already finalized
+            _ => unreachable!("non-finalized tree builder inside TapTree"),
+        }
     }
 }
 
@@ -174,23 +182,6 @@ impl<'tree> Iterator for TapTreeIter<'tree> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.leaf_iter.next()
-    }
-}
-
-impl<'tree> IntoIterator for &'tree TapTree {
-    type Item = &'tree ScriptLeaf;
-    type IntoIter = TapTreeIter<'tree>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        match (self.0.branch().len(), self.0.branch().last()) {
-            (1, Some(Some(root))) => {
-                TapTreeIter {
-                    leaf_iter: root.leaves.iter()
-                }
-            }
-            // This should be unreachable as we Taptree is already finalized
-            _ => unreachable!("non-finalized tree builder inside TapTree"),
-        }
     }
 }
 

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -155,9 +155,9 @@ impl TapTree {
         self.0
     }
 
-    /// Returns iterator for a taproot script tree, operating in DFS order over leaf depth and
-    /// leaf script pairs.
-    pub fn iter(&self) -> TapTreeIter {
+    /// Returns [`TapTreeIter`] iterator for a taproot script tree, operating in DFS order over
+    /// leaf depth and leaf script pairs.
+    pub fn script_leaves(&self) -> TapTreeIter {
         self.into_iter()
     }
 }

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -26,7 +26,7 @@ use util::psbt::map::Map;
 use util::psbt::raw;
 use util::psbt::Error;
 
-use util::taproot::{LeafInfo, TapLeafHash};
+use util::taproot::{ScriptLeaf, TapLeafHash};
 
 use util::taproot::{NodeInfo, TaprootBuilder};
 
@@ -156,7 +156,7 @@ impl TapTree {
     }
 
     /// Returns [`TapTreeIter`] iterator for a taproot script tree, operating in DFS order over
-    /// leaf depth and leaf script pairs.
+    /// tree [`ScriptLeaf`]s.
     pub fn script_leaves(&self) -> TapTreeIter {
         self.into_iter()
     }
@@ -165,11 +165,11 @@ impl TapTree {
 /// Iterator for a taproot script tree, operating in DFS order over leaf depth and
 /// leaf script pairs.
 pub struct TapTreeIter<'tree> {
-    leaf_iter: core::slice::Iter<'tree, LeafInfo>,
+    leaf_iter: core::slice::Iter<'tree, ScriptLeaf>,
 }
 
 impl<'tree> Iterator for TapTreeIter<'tree> {
-    type Item = &'tree LeafInfo;
+    type Item = &'tree ScriptLeaf;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -178,7 +178,7 @@ impl<'tree> Iterator for TapTreeIter<'tree> {
 }
 
 impl<'tree> IntoIterator for &'tree TapTree {
-    type Item = &'tree LeafInfo;
+    type Item = &'tree ScriptLeaf;
     type IntoIter = TapTreeIter<'tree>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -327,9 +327,9 @@ impl Serialize for TapTree {
                     //
                     // TaprootMerkleBranch can only have len atmost 128(TAPROOT_CONTROL_MAX_NODE_COUNT).
                     // safe to cast from usize to u8
-                    buf.push(leaf_info.merkle_branch.as_inner().len() as u8);
-                    buf.push(leaf_info.ver.to_consensus());
-                    leaf_info.script.consensus_encode(&mut buf).expect("Vecs dont err");
+                    buf.push(leaf_info.merkle_branch().as_inner().len() as u8);
+                    buf.push(leaf_info.leaf_version().to_consensus());
+                    leaf_info.script().consensus_encode(&mut buf).expect("Vecs dont err");
                 }
                 buf
             }

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -608,7 +608,7 @@ impl NodeInfo {
 /// Store information about taproot leaf node.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub(crate) struct LeafInfo {
+pub struct LeafInfo {
     /// The underlying script.
     pub(crate) script: Script,
     /// The leaf version.

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -560,7 +560,7 @@ pub struct NodeInfo {
     /// Merkle hash for this node.
     pub(crate) hash: sha256::Hash,
     /// Information about leaves inside this node.
-    pub(crate) leaves: Vec<LeafInfo>,
+    pub(crate) leaves: Vec<ScriptLeaf>,
     /// Tracks information on hidden nodes below this node.
     pub(crate) has_hidden_nodes: bool,
 }
@@ -577,7 +577,7 @@ impl NodeInfo {
 
     /// Creates a new leaf [`NodeInfo`] with given [`Script`] and [`LeafVersion`].
     pub fn new_leaf_with_ver(script: Script, ver: LeafVersion) -> Self {
-        let leaf = LeafInfo::new(script, ver);
+        let leaf = ScriptLeaf::new(script, ver);
         Self {
             hash: sha256::Hash::from_inner(leaf.leaf_hash().into_inner()),
             leaves: vec![leaf],
@@ -608,7 +608,7 @@ impl NodeInfo {
 /// Store information about taproot leaf node.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LeafInfo {
+pub struct ScriptLeaf {
     /// The underlying script.
     script: Script,
     /// The leaf version.
@@ -617,8 +617,8 @@ pub struct LeafInfo {
     merkle_branch: TaprootMerkleBranch,
 }
 
-impl LeafInfo {
-    /// Creates an new [`LeafInfo`] from `script` and `ver` and no merkle branch.
+impl ScriptLeaf {
+    /// Creates an new [`ScriptLeaf`] from `script` and `ver` and no merkle branch.
     fn new(script: Script, ver: LeafVersion) -> Self {
         Self {
             script: script,
@@ -635,7 +635,7 @@ impl LeafInfo {
         self.merkle_branch.0.len() as u8
     }
 
-    /// Computes a leaf hash for this [`LeafInfo`].
+    /// Computes a leaf hash for this [`ScriptLeaf`].
     #[inline]
     pub fn leaf_hash(&self) -> TapLeafHash {
         TapLeafHash::from_script(&self.script, self.ver)

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -610,11 +610,11 @@ impl NodeInfo {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LeafInfo {
     /// The underlying script.
-    pub(crate) script: Script,
+    script: Script,
     /// The leaf version.
-    pub(crate) ver: LeafVersion,
+    ver: LeafVersion,
     /// The merkle proof (hashing partners) to get this node.
-    pub(crate) merkle_branch: TaprootMerkleBranch,
+    merkle_branch: TaprootMerkleBranch,
 }
 
 impl LeafInfo {

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -627,6 +627,14 @@ impl LeafInfo {
         }
     }
 
+    /// Returns the depth of this script leaf in the tap tree.
+    #[inline]
+    pub fn depth(&self) -> u8 {
+        // The depth is guaranteed to be < 127 by the TaprootBuilder type.
+        // TODO: Following MSRV bump implement via `try_into().expect("")`.
+        self.merkle_branch.0.len() as u8
+    }
+
     /// Computes a leaf hash for this [`LeafInfo`].
     #[inline]
     pub fn leaf_hash(&self) -> TapLeafHash {

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -632,6 +632,25 @@ impl LeafInfo {
     pub fn leaf_hash(&self) -> TapLeafHash {
         TapLeafHash::from_script(&self.script, self.ver)
     }
+
+    /// Returns reference to the leaf script.
+    #[inline]
+    pub fn script(&self) -> &Script {
+        &self.script
+    }
+
+    /// Returns leaf version of the script.
+    #[inline]
+    pub fn leaf_version(&self) -> LeafVersion {
+        self.ver
+    }
+
+    /// Returns reference to the merkle proof (hashing partners) to get this
+    /// node in form of [`TaprootMerkleBranch`].
+    #[inline]
+    pub fn merkle_branch(&self) -> &TaprootMerkleBranch {
+        &self.merkle_branch
+    }
 }
 
 /// The merkle proof for inclusion of a tree in a taptree hash.

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -579,7 +579,7 @@ impl NodeInfo {
     pub fn new_leaf_with_ver(script: Script, ver: LeafVersion) -> Self {
         let leaf = LeafInfo::new(script, ver);
         Self {
-            hash: leaf.hash(),
+            hash: sha256::Hash::from_inner(leaf.leaf_hash().into_inner()),
             leaves: vec![leaf],
             has_hidden_nodes: false,
         }
@@ -628,9 +628,9 @@ impl LeafInfo {
     }
 
     /// Computes a leaf hash for this [`LeafInfo`].
-    fn hash(&self) -> sha256::Hash {
-        let leaf_hash = TapLeafHash::from_script(&self.script, self.ver);
-        sha256::Hash::from_inner(leaf_hash.into_inner())
+    #[inline]
+    pub fn leaf_hash(&self) -> TapLeafHash {
+        TapLeafHash::from_script(&self.script, self.ver)
     }
 }
 


### PR DESCRIPTION
LeafInfo structure is a useful form of representing leaf script information (script, leaf version, and merkle proof).

Same as #924, but rebased.