### PR TITLE
Trival docs fixes

### DIFF
--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -35,7 +35,7 @@ pub struct EcdsaSig {
 }
 
 impl EcdsaSig {
-    /// Constructs ECDSA bitcoin signature for [`EcdsaSighashType::All`]
+    /// Constructs an ECDSA bitcoin signature for [`EcdsaSighashType::All`].
     pub fn sighash_all(sig: secp256k1::ecdsa::Signature) -> EcdsaSig {
         EcdsaSig {
             sig,
@@ -43,7 +43,7 @@ impl EcdsaSig {
         }
     }
 
-    /// Deserialize from slice following the standardness rules for [`EcdsaSighashType`]
+    /// Deserializes from slice following the standardness rules for [`EcdsaSighashType`].
     pub fn from_slice(sl: &[u8]) -> Result<Self, EcdsaSigError> {
         let (hash_ty, sig) = sl.split_last()
             .ok_or(EcdsaSigError::EmptySignature)?;
@@ -54,7 +54,7 @@ impl EcdsaSig {
         Ok(EcdsaSig { sig, hash_ty })
     }
 
-    /// Serialize EcdsaSig
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format).
     pub fn to_vec(&self) -> Vec<u8> {
         // TODO: add support to serialize to a writer to SerializedSig
         self.sig.serialize_der()

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -168,7 +168,7 @@ impl TapTree {
         self.0.clone()
     }
 
-    /// Returns [`TapTreeIter`] iterator for a taproot script tree, operating in DFS order over
+    /// Returns [`TapTreeIter<'_>`] iterator for a taproot script tree, operating in DFS order over
     /// tree [`ScriptLeaf`]s.
     pub fn script_leaves(&self) -> TapTreeIter {
         match (self.0.branch().len(), self.0.branch().last()) {


### PR DESCRIPTION
Do a couple of trivial docs fixes, done during other work.

- Patch 1 improves docs on the `EcdsaSig` struct
- Patch 2 clears a clippy warning during docs build - no sure if the solution is the best available though