### PR TITLE
Add temporary warning about edition change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing to rust-bitcoin
 
+**Heads up about upcoming edition change**
+
+We're currently preparing to bump MSRV and **change the edition to 2018**.
+To minimize the churn we recommend you to submit your local WIP changes ASAP.
+There will be a lot of rebasing after the edition change.
+
 :+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
 The following is a set of guidelines for contributing to Rust Bitcoin

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
   </p>
 </div>
 
+**Heads up for contributors: upcoming edition change**
+
+We're currently preparing to bump MSRV and **change the edition to 2018**.
+To minimize the churn we recommend you to submit your local WIP changes ASAP.
+There will be a lot of rebasing after the edition change.
 
 [Documentation](https://docs.rs/bitcoin/)
 


### PR DESCRIPTION
This warns contributors about possible rebases. Changing CONTRIBUTING
should ensure that GitHub will display special warning. This will be
removed after migration is done.

See also https://github.com/rust-bitcoin/rust-bitcoin/discussions/945