### PR TITLE
Remove 1.29 checks from CI pipeline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,10 +25,9 @@ jobs:
               AS_DEPENDENCY: true
               DO_NO_STD: true
               DO_DOCS: true
-          - rust: 1.29.0
+          - rust: 1.41.1
             env:
               AS_DEPENDENCY: true
-              PIN_VERSIONS: true
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -8,19 +8,6 @@ then
     alias cargo="cargo +$TOOLCHAIN"
 fi
 
-pin_common_verions() {
-    cargo generate-lockfile --verbose
-    cargo update -p cc --precise "1.0.41" --verbose
-    cargo update -p serde --precise "1.0.98" --verbose
-    cargo update -p serde_derive --precise "1.0.98" --verbose
-}
-
-# Pin `cc` for Rust 1.29
-if [ "$PIN_VERSIONS" = true ]; then
-    pin_common_verions
-    cargo update -p byteorder --precise "1.3.4"
-fi
-
 if [ "$DO_COV" = true ]
 then
     export RUSTFLAGS="-C link-dead-code"
@@ -94,11 +81,6 @@ then
     cargo new dep_test
     cd dep_test
     echo 'bitcoin = { path = "..", features = ["use-serde"] }' >> Cargo.toml
-
-    # Pin `cc` for Rust 1.29
-    if [ -n "$PIN_VERSIONS" ]; then
-        pin_common_verions
-    fi
 
     cargo test --verbose
 fi


### PR DESCRIPTION
We no longer need to test against Rust 1.29 now that v0.28 is out. In order to allow minor changes to be merged (i.e., not the _big_ MSRV patchset) that rely on MSRV being 1.41.1 update the CI pipeline.

Remove the pinning stuff from `contrib/test.sh` while we are at it.