### PR TITLE
Remove unnecessary `Write as _fmtWrite`

### DIFF
--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -21,7 +21,7 @@ pub use secp256k1::{XOnlyPublicKey, KeyPair};
 use prelude::*;
 
 use core::{ops, str::FromStr};
-use core::fmt::{self, Write as _fmtWrite};
+use core::fmt::{self, Write};
 use io;
 #[cfg(feature = "std")] use std::error;
 


### PR DESCRIPTION
We can bring the `Write` trait into scope, no need to underscore it.

Done as part of the MSRV checklist.