### PR TITLE
Upgrade dev dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,10 +25,9 @@ jobs:
               AS_DEPENDENCY: true
               DO_NO_STD: true
               DO_DOCS: true
-          - rust: 1.29.0
+          - rust: 1.41.1
             env:
               AS_DEPENDENCY: true
-              PIN_VERSIONS: true
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,10 @@ serde = { version = "1", features = [ "derive" ], optional = true }
 hashbrown = { version = "0.8", optional = true }
 
 [dev-dependencies]
-serde_json = "<1.0.45"
+serde_json = "1"
 serde_test = "1"
 secp256k1 = { version = "0.22.0", features = [ "recovery", "rand-std" ] }
 bincode = "1.3.1"
-# We need to pin ryu (transitive dep from serde_json) to stay compatible with Rust 1.22.0
-ryu = "<1.0.5"
 
 [[example]]
 name = "bip32"

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -8,19 +8,6 @@ then
     alias cargo="cargo +$TOOLCHAIN"
 fi
 
-pin_common_verions() {
-    cargo generate-lockfile --verbose
-    cargo update -p cc --precise "1.0.41" --verbose
-    cargo update -p serde --precise "1.0.98" --verbose
-    cargo update -p serde_derive --precise "1.0.98" --verbose
-}
-
-# Pin `cc` for Rust 1.29
-if [ "$PIN_VERSIONS" = true ]; then
-    pin_common_verions
-    cargo update -p byteorder --precise "1.3.4"
-fi
-
 if [ "$DO_COV" = true ]
 then
     export RUSTFLAGS="-C link-dead-code"
@@ -94,11 +81,6 @@ then
     cargo new dep_test
     cd dep_test
     echo 'bitcoin = { path = "..", features = ["use-serde"] }' >> Cargo.toml
-
-    # Pin `cc` for Rust 1.29
-    if [ -n "$PIN_VERSIONS" ]; then
-        pin_common_verions
-    fi
 
     cargo test --verbose
 fi


### PR DESCRIPTION
Just the last patch, the first two are #964

Now we have removed Rust 1.29 from CI we can upgrade the `serde` dev dependency and remove the `ryu` dependency altogether.

Suggested during review of #964.