### PR TITLE
Add a merge-conflicts bot by way of GitHub Actions

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,0 +1,21 @@
+name: 'Merge Conflict Watcher'
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+    branches:
+      - master
+  pull_request_review_comment:
+    types: [created, deleted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "merge-conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a bot that labels PRs with the just-recently-created label "merge-conflicts".