### PR TITLE
Add needs-rebase bot

### DIFF
--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -1,0 +1,21 @@
+name: Needs rebase
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+    branches:
+      - master
+  pull_request_review_comment:
+    types: [created, deleted]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nokamoto/merge-conflict-action@v0.0.2
+        with:
+          owner: apoelstra
+          repo: rust-bitcoin
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: "Found merge conflicts with master branch, needs rebase."


### PR DESCRIPTION
Add a bot by way of github actions that checks for PRs that have merge conflicts with `master` branch i.e., need rebase.

Action runs on various occasions using `pull_request` and `pull_request_review_comment`.

I think we can iterate on the action after we see it in action (pun intended :)