### PR TITLE
 Edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "General purpose library for using and interoperating with Bitcoin
 keywords = [ "crypto", "bitcoin" ]
 readme = "README.md"
 exclude = ["./test_data"]
+edition = "2018"
 
 # Please don't forget to add relevant features to docs.rs below
 [features]

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -508,10 +508,10 @@ mod tests {
 #[cfg(all(test, feature = "unstable"))]
 mod benches {
     use super::Block;
-    use EmptyWrite;
-    use consensus::{deserialize, Encodable};
+    use crate::EmptyWrite;
+    use crate::consensus::{deserialize, Encodable};
     use test::{black_box, Bencher};
-    use network::stream_reader::StreamReader;
+    use crate::network::stream_reader::StreamReader;
 
     #[bench]
     #[allow(deprecated)]

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -20,22 +20,22 @@
 //! these blocks and the blockchain.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::fmt;
 
-use util;
-use util::Error::{BlockBadTarget, BlockBadProofOfWork};
-use util::hash::bitcoin_merkle_root;
-use hashes::{Hash, HashEngine};
-use hash_types::{Wtxid, BlockHash, TxMerkleNode, WitnessMerkleNode, WitnessCommitment};
-use util::uint::Uint256;
-use consensus::encode::Encodable;
-use network::constants::Network;
-use blockdata::transaction::Transaction;
-use blockdata::constants::{max_target, WITNESS_SCALE_FACTOR};
-use blockdata::script;
-use VarInt;
+use crate::util;
+use crate::util::Error::{BlockBadTarget, BlockBadProofOfWork};
+use crate::util::hash::bitcoin_merkle_root;
+use crate::hashes::{Hash, HashEngine};
+use crate::hash_types::{Wtxid, BlockHash, TxMerkleNode, WitnessMerkleNode, WitnessCommitment};
+use crate::util::uint::Uint256;
+use crate::consensus::encode::Encodable;
+use crate::network::constants::Network;
+use crate::blockdata::transaction::Transaction;
+use crate::blockdata::constants::{max_target, WITNESS_SCALE_FACTOR};
+use crate::blockdata::script;
+use crate::VarInt;
 
 /// A block header, which contains all the block's information except
 /// the actual transactions
@@ -359,13 +359,13 @@ impl ::std::error::Error for Bip34Error {}
 
 #[cfg(test)]
 mod tests {
-    use hashes::hex::FromHex;
+    use crate::hashes::hex::FromHex;
 
-    use blockdata::block::{Block, BlockHeader};
-    use consensus::encode::{deserialize, serialize};
-    use util::uint::Uint256;
-    use util::Error::{BlockBadTarget, BlockBadProofOfWork};
-    use network::constants::Network;
+    use crate::blockdata::block::{Block, BlockHeader};
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::util::uint::Uint256;
+    use crate::util::Error::{BlockBadTarget, BlockBadProofOfWork};
+    use crate::network::constants::Network;
 
     #[test]
     fn test_coinbase_and_bip34() {

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -19,19 +19,19 @@
 //! single transaction.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::default::Default;
 
-use hashes::hex::{self, HexIterator};
-use hashes::sha256d;
-use blockdata::opcodes;
-use blockdata::script;
-use blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn};
-use blockdata::block::{Block, BlockHeader};
-use blockdata::witness::Witness;
-use network::constants::Network;
-use util::uint::Uint256;
+use crate::hashes::hex::{self, HexIterator};
+use crate::hashes::sha256d;
+use crate::blockdata::opcodes;
+use crate::blockdata::script;
+use crate::blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn};
+use crate::blockdata::block::{Block, BlockHeader};
+use crate::blockdata::witness::Witness;
+use crate::network::constants::Network;
+use crate::util::uint::Uint256;
 
 /// The maximum allowable sequence number
 pub const MAX_SEQUENCE: u32 = 0xFFFFFFFF;
@@ -179,12 +179,12 @@ pub fn genesis_block(network: Network) -> Block {
 #[cfg(test)]
 mod test {
     use core::default::Default;
-    use hashes::hex::FromHex;
+    use crate::hashes::hex::FromHex;
 
-    use network::constants::Network;
-    use consensus::encode::serialize;
-    use blockdata::constants::{genesis_block, bitcoin_genesis_tx};
-    use blockdata::constants::{MAX_SEQUENCE, COIN_VALUE};
+    use crate::network::constants::Network;
+    use crate::consensus::encode::serialize;
+    use crate::blockdata::constants::{genesis_block, bitcoin_genesis_tx};
+    use crate::blockdata::constants::{MAX_SEQUENCE, COIN_VALUE};
 
     #[test]
     fn bitcoin_genesis_first_transaction() {

--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -22,7 +22,7 @@
 
 #[cfg(feature = "serde")] use serde;
 
-#[cfg(feature = "serde")] use prelude::*;
+#[cfg(feature = "serde")] use crate::prelude::*;
 
 use core::{fmt, convert::From};
 

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -23,28 +23,28 @@
 //! This module provides the structures and functions needed to support scripts.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 use core::{fmt, default::Default};
 use core::ops::Index;
 
 #[cfg(feature = "serde")] use serde;
 
-use hash_types::{PubkeyHash, WPubkeyHash, ScriptHash, WScriptHash};
-use blockdata::opcodes;
-use consensus::{encode, Decodable, Encodable};
-use hashes::{Hash, hex};
-use policy::DUST_RELAY_TX_FEE;
+use crate::hash_types::{PubkeyHash, WPubkeyHash, ScriptHash, WScriptHash};
+use crate::blockdata::opcodes;
+use crate::consensus::{encode, Decodable, Encodable};
+use crate::hashes::{Hash, hex};
+use crate::policy::DUST_RELAY_TX_FEE;
 #[cfg(feature="bitcoinconsensus")] use bitcoinconsensus;
 #[cfg(feature="bitcoinconsensus")] use core::convert::From;
-use OutPoint;
+use crate::OutPoint;
 
-use util::key::PublicKey;
-use util::address::WitnessVersion;
-use util::taproot::{LeafVersion, TapBranchHash, TapLeafHash};
+use crate::util::key::PublicKey;
+use crate::util::address::WitnessVersion;
+use crate::util::taproot::{LeafVersion, TapBranchHash, TapLeafHash};
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
-use schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
+use crate::schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
 
 /// A Bitcoin script.
 #[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -557,7 +557,7 @@ impl Script {
 
     /// Checks whether a script can be proven to have no satisfying input.
     pub fn is_provably_unspendable(&self) -> bool {
-        use blockdata::opcodes::Class::{ReturnOp, IllegalOp};
+        use crate::blockdata::opcodes::Class::{ReturnOp, IllegalOp};
 
         match self.0.first() {
             Some(b) => {
@@ -572,7 +572,7 @@ impl Script {
 
     /// Returns the minimum value an output with this script should have in order to be
     /// broadcastable on today's Bitcoin network.
-    pub fn dust_value(&self) -> ::Amount {
+    pub fn dust_value(&self) -> crate::Amount {
         // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
         // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
         let sats = DUST_RELAY_TX_FEE as u64 / 1000 * // The default dust relay fee is 3000 satoshi/kB (i.e. 3 sat/vByte)
@@ -588,7 +588,7 @@ impl Script {
             self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
         };
 
-        ::Amount::from_sat(sats)
+        crate::Amount::from_sat(sats)
     }
 
     /// Iterates over the script in the form of `Instruction`s, which are an enum covering opcodes,
@@ -1075,11 +1075,11 @@ mod test {
     use super::*;
     use super::build_scriptint;
 
-    use hashes::hex::{FromHex, ToHex};
-    use consensus::encode::{deserialize, serialize};
-    use blockdata::opcodes;
-    use util::key::PublicKey;
-    use util::psbt::serialize::Serialize;
+    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::blockdata::opcodes;
+    use crate::util::key::PublicKey;
+    use crate::util::psbt::serialize::Serialize;
 
     #[test]
     fn script() {
@@ -1449,7 +1449,7 @@ mod test {
         // well-known scriptPubKey types.
         let script_p2wpkh = Builder::new().push_int(0).push_slice(&[42; 20]).into_script();
         assert!(script_p2wpkh.is_v0_p2wpkh());
-        assert_eq!(script_p2wpkh.dust_value(), ::Amount::from_sat(294));
+        assert_eq!(script_p2wpkh.dust_value(), crate::Amount::from_sat(294));
 
         let script_p2pkh = Builder::new()
             .push_opcode(opcodes::all::OP_DUP)
@@ -1459,7 +1459,7 @@ mod test {
             .push_opcode(opcodes::all::OP_CHECKSIG)
             .into_script();
         assert!(script_p2pkh.is_p2pkh());
-        assert_eq!(script_p2pkh.dust_value(), ::Amount::from_sat(546));
+        assert_eq!(script_p2pkh.dust_value(), crate::Amount::from_sat(546));
     }
 
     #[test]

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -617,7 +617,7 @@ impl Script {
     /// Shorthand for [`Self::verify_with_flags`] with flag [bitcoinconsensus::VERIFY_ALL].
     #[cfg(feature="bitcoinconsensus")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
-    pub fn verify (&self, index: usize, amount: ::Amount, spending: &[u8]) -> Result<(), Error> {
+    pub fn verify (&self, index: usize, amount: crate::Amount, spending: &[u8]) -> Result<(), Error> {
         self.verify_with_flags(index, amount, spending, ::bitcoinconsensus::VERIFY_ALL)
     }
 
@@ -630,7 +630,7 @@ impl Script {
     ///  * `flags` - Verification flags, see [`bitcoinconsensus::VERIFY_ALL`] and similar.
     #[cfg(feature="bitcoinconsensus")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
-    pub fn verify_with_flags<F: Into<u32>>(&self, index: usize, amount: ::Amount, spending: &[u8], flags: F) -> Result<(), Error> {
+    pub fn verify_with_flags<F: Into<u32>>(&self, index: usize, amount: crate::Amount, spending: &[u8], flags: F) -> Result<(), Error> {
         Ok(bitcoinconsensus::verify_with_flags (&self.0[..], amount.as_sat(), spending, index, flags.into())?)
     }
 
@@ -1440,7 +1440,7 @@ mod test {
 		// a random segwit transaction from the blockchain using native segwit
 		let spent = Builder::from(Vec::from_hex("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d").unwrap()).into_script();
 		let spending = Vec::from_hex("010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000").unwrap();
-		spent.verify(0, ::Amount::from_sat(18393430), spending.as_slice()).unwrap();
+		spent.verify(0, crate::Amount::from_sat(18393430), spending.as_slice()).unwrap();
 	}
 
     #[test]

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -23,24 +23,24 @@
 //! This module provides the structures and functions needed to support transactions.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 use core::{fmt, str, default::Default};
 #[cfg(feature = "std")] use std::error;
 
-use hashes::{self, Hash, sha256d};
-use hashes::hex::FromHex;
+use crate::hashes::{self, Hash, sha256d};
+use crate::hashes::hex::FromHex;
 
-use util::endian;
-use blockdata::constants::WITNESS_SCALE_FACTOR;
+use crate::util::endian;
+use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
 #[cfg(feature="bitcoinconsensus")] use blockdata::script;
-use blockdata::script::Script;
-use blockdata::witness::Witness;
-use consensus::{encode, Decodable, Encodable};
-use consensus::encode::MAX_VEC_SIZE;
-use hash_types::{Sighash, Txid, Wtxid};
-use VarInt;
+use crate::blockdata::script::Script;
+use crate::blockdata::witness::Witness;
+use crate::consensus::{encode, Decodable, Encodable};
+use crate::consensus::encode::MAX_VEC_SIZE;
+use crate::hash_types::{Sighash, Txid, Wtxid};
+use crate::VarInt;
 
 #[cfg(doc)]
 use util::sighash::SchnorrSighashType;
@@ -895,17 +895,17 @@ mod tests {
     use super::*;
 
     use core::str::FromStr;
-    use blockdata::constants::WITNESS_SCALE_FACTOR;
-    use blockdata::script::Script;
-    use consensus::encode::serialize;
-    use consensus::encode::deserialize;
+    use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
+    use crate::blockdata::script::Script;
+    use crate::consensus::encode::serialize;
+    use crate::consensus::encode::deserialize;
 
-    use hashes::Hash;
-    use hashes::hex::FromHex;
+    use crate::hashes::Hash;
+    use crate::hashes::hex::FromHex;
 
-    use hash_types::*;
+    use crate::hash_types::*;
     use super::EcdsaSighashType;
-    use util::sighash::SighashCache;
+    use crate::util::sighash::SighashCache;
 
     #[test]
     fn test_outpoint() {
@@ -958,8 +958,8 @@ mod tests {
 
     #[test]
     fn test_is_coinbase () {
-        use network::constants::Network;
-        use blockdata::constants;
+        use crate::network::constants::Network;
+        use crate::blockdata::constants;
 
         let genesis = constants::genesis_block(Network::Bitcoin);
         assert! (genesis.txdata[0].is_coin_base());

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -34,7 +34,7 @@ use crate::hashes::hex::FromHex;
 
 use crate::util::endian;
 use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
-#[cfg(feature="bitcoinconsensus")] use blockdata::script;
+#[cfg(feature="bitcoinconsensus")] use crate::blockdata::script;
 use crate::blockdata::script::Script;
 use crate::blockdata::witness::Witness;
 use crate::consensus::{encode, Decodable, Encodable};
@@ -43,7 +43,7 @@ use crate::hash_types::{Sighash, Txid, Wtxid};
 use crate::VarInt;
 
 #[cfg(doc)]
-use util::sighash::SchnorrSighashType;
+use crate::util::sighash::SchnorrSighashType;
 
 /// Used for signature hash for invalid use of SIGHASH_SINGLE.
 const UINT256_ONE: [u8; 32] = [
@@ -590,7 +590,7 @@ impl Transaction {
         let flags: u32 = flags.into();
         for (idx, input) in self.input.iter().enumerate() {
             if let Some(output) = spent(&input.previous_output) {
-                output.script_pubkey.verify_with_flags(idx, ::Amount::from_sat(output.value), tx.as_slice(), flags)?;
+                output.script_pubkey.verify_with_flags(idx, crate::Amount::from_sat(output.value), tx.as_slice(), flags)?;
             } else {
                 return Err(script::Error::UnknownSpentOutput(input.previous_output.clone()));
             }
@@ -1541,10 +1541,10 @@ mod tests {
     #[test]
     #[cfg(feature="bitcoinconsensus")]
     fn test_transaction_verify () {
-        use hashes::hex::FromHex;
         use std::collections::HashMap;
-        use blockdata::script;
-        use blockdata::witness::Witness;
+        use crate::hashes::hex::FromHex;
+        use crate::blockdata::script;
+        use crate::blockdata::witness::Witness;
 
         // a random recent segwit transaction from blockchain using both old and segwit inputs
         let mut spending: Transaction = deserialize(Vec::from_hex("020000000001031cfbc8f54fbfa4a33a30068841371f80dbfe166211242213188428f437445c91000000006a47304402206fbcec8d2d2e740d824d3d36cc345b37d9f65d665a99f5bd5c9e8d42270a03a8022013959632492332200c2908459547bf8dbf97c65ab1a28dec377d6f1d41d3d63e012103d7279dfb90ce17fe139ba60a7c41ddf605b25e1c07a4ddcb9dfef4e7d6710f48feffffff476222484f5e35b3f0e43f65fc76e21d8be7818dd6a989c160b1e5039b7835fc00000000171600140914414d3c94af70ac7e25407b0689e0baa10c77feffffffa83d954a62568bbc99cc644c62eb7383d7c2a2563041a0aeb891a6a4055895570000000017160014795d04cc2d4f31480d9a3710993fbd80d04301dffeffffff06fef72f000000000017a91476fd7035cd26f1a32a5ab979e056713aac25796887a5000f00000000001976a914b8332d502a529571c6af4be66399cd33379071c588ac3fda0500000000001976a914fc1d692f8de10ae33295f090bea5fe49527d975c88ac522e1b00000000001976a914808406b54d1044c429ac54c0e189b0d8061667e088ac6eb68501000000001976a914dfab6085f3a8fb3e6710206a5a959313c5618f4d88acbba20000000000001976a914eb3026552d7e3f3073457d0bee5d4757de48160d88ac0002483045022100bee24b63212939d33d513e767bc79300051f7a0d433c3fcf1e0e3bf03b9eb1d70220588dc45a9ce3a939103b4459ce47500b64e23ab118dfc03c9caa7d6bfc32b9c601210354fd80328da0f9ae6eef2b3a81f74f9a6f66761fadf96f1d1d22b1fd6845876402483045022100e29c7e3a5efc10da6269e5fc20b6a1cb8beb92130cc52c67e46ef40aaa5cac5f0220644dd1b049727d991aece98a105563416e10a5ac4221abac7d16931842d5c322012103960b87412d6e169f30e12106bdf70122aabb9eb61f455518322a18b920a4dfa887d30700")
@@ -1601,9 +1601,9 @@ mod tests {
 #[cfg(all(test, feature = "unstable"))]
 mod benches {
     use super::Transaction;
-    use EmptyWrite;
-    use consensus::{deserialize, Encodable};
-    use hashes::hex::FromHex;
+    use crate::EmptyWrite;
+    use crate::consensus::{deserialize, Encodable};
+    use crate::hashes::hex::FromHex;
     use test::{black_box, Bencher};
 
     const SOME_TX: &'static str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -3,13 +3,13 @@
 //! This module contains the [`Witness`] struct and related methods to operate on it
 //!
 
-use blockdata::transaction::EcdsaSighashType;
-use consensus::encode::{Error, MAX_VEC_SIZE};
-use consensus::{Decodable, Encodable, WriteExt};
-use io::{self, Read, Write};
-use prelude::*;
+use crate::blockdata::transaction::EcdsaSighashType;
+use crate::consensus::encode::{Error, MAX_VEC_SIZE};
+use crate::consensus::{Decodable, Encodable, WriteExt};
+use crate::io::{self, Read, Write};
+use crate::prelude::*;
 use secp256k1::ecdsa;
-use VarInt;
+use crate::VarInt;
 
 #[cfg(feature = "serde")]
 use serde;
@@ -302,12 +302,12 @@ impl<'de> serde::Deserialize<'de> for Witness {
 
 #[cfg(test)]
 mod test {
-    use blockdata::transaction::EcdsaSighashType;
-    use blockdata::witness::Witness;
-    use consensus::{deserialize, serialize};
-    use hashes::hex::{FromHex, ToHex};
-    use Transaction;
-    use secp256k1::ecdsa;
+    use super::*;
+
+    use crate::consensus::{deserialize, serialize};
+    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::Transaction;
+    use crate::secp256k1::ecdsa;
 
     #[test]
     fn test_push() {

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -27,24 +27,24 @@
 //! typically big-endian decimals, etc.)
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::{fmt, mem, u32, convert::From};
 #[cfg(feature = "std")] use std::error;
 
-use hashes::{sha256d, Hash, sha256};
-use hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};
+use crate::hashes::{sha256d, Hash, sha256};
+use crate::hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};
 
-use io::{self, Cursor, Read};
+use crate::io::{self, Cursor, Read};
 
-use util::endian;
-use util::psbt;
-use util::taproot::TapLeafHash;
-use hashes::hex::ToHex;
+use crate::util::endian;
+use crate::util::psbt;
+use crate::util::taproot::TapLeafHash;
+use crate::hashes::hex::ToHex;
 
-use blockdata::transaction::{TxOut, Transaction, TxIn};
+use crate::blockdata::transaction::{TxOut, Transaction, TxIn};
 #[cfg(feature = "std")]
-use network::{message_blockdata::Inventory, address::{Address, AddrV2Message}};
+use crate::network::{message_blockdata::Inventory, address::{Address, AddrV2Message}};
 
 /// Encoding error
 #[derive(Debug)]
@@ -776,11 +776,11 @@ mod tests {
     use core::{mem::{self, discriminant}, fmt};
     use super::{deserialize, serialize, Error, CheckedData, VarInt};
     use super::{Transaction, BlockHash, FilterHash, TxMerkleNode, TxOut, TxIn};
-    use consensus::{Encodable, deserialize_partial, Decodable};
-    use util::endian::{u64_to_array_le, u32_to_array_le, u16_to_array_le};
+    use crate::consensus::{Encodable, deserialize_partial, Decodable};
+    use crate::util::endian::{u64_to_array_le, u32_to_array_le, u16_to_array_le};
     use secp256k1::rand::{thread_rng, Rng};
     #[cfg(feature = "std")]
-    use network::{Address, message_blockdata::Inventory};
+    use crate::network::{Address, message_blockdata::Inventory};
 
     #[test]
     fn serialize_int_test() {

--- a/src/consensus/params.rs
+++ b/src/consensus/params.rs
@@ -18,8 +18,8 @@
 //! chains (such as mainnet, testnet).
 //!
 
-use network::constants::Network;
-use util::uint::Uint256;
+use crate::network::constants::Network;
+use crate::util::uint::Uint256;
 
 /// Lowest possible difficulty for Mainnet. See comment on Params::pow_limit for more info.
 const MAX_BITS_BITCOIN: Uint256 = Uint256([

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -20,7 +20,7 @@
 //! hash).
 //!
 
-use hashes::{Hash, sha256, sha256d, hash160};
+use crate::hashes::{Hash, sha256, sha256d, hash160};
 
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -20,7 +20,7 @@
 //! hash).
 //!
 
-use crate::hashes::{Hash, sha256, sha256d, hash160};
+use crate::hashes::{Hash, sha256, sha256d, hash160, hash_newtype};
 
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -93,11 +93,11 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl<I> $crate::core::ops::Index<I> for $thing
+        impl<I> core::ops::Index<I> for $thing
         where
-            [$ty]: $crate::core::ops::Index<I>,
+            [$ty]: core::ops::Index<I>,
         {
-            type Output = <[$ty] as $crate::core::ops::Index<I>>::Output;
+            type Output = <[$ty] as core::ops::Index<I>>::Output;
 
             #[inline]
             fn index(&self, index: I) -> &Self::Output {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,33 +115,33 @@ pub mod consensus;
 pub mod hash_types;
 pub mod policy;
 
-pub use hash_types::*;
-pub use blockdata::block::Block;
-pub use blockdata::block::BlockHeader;
-pub use blockdata::script::Script;
-pub use blockdata::transaction::Transaction;
-pub use blockdata::transaction::TxIn;
-pub use blockdata::transaction::TxOut;
-pub use blockdata::transaction::OutPoint;
-pub use blockdata::transaction::EcdsaSighashType;
-pub use blockdata::witness::Witness;
-pub use consensus::encode::VarInt;
-pub use network::constants::Network;
-pub use util::Error;
-pub use util::address::Address;
-pub use util::address::AddressType;
-pub use util::amount::Amount;
-pub use util::amount::Denomination;
-pub use util::amount::SignedAmount;
-pub use util::merkleblock::MerkleBlock;
-pub use util::sighash::SchnorrSighashType;
+pub use crate::hash_types::*;
+pub use crate::blockdata::block::Block;
+pub use crate::blockdata::block::BlockHeader;
+pub use crate::blockdata::script::Script;
+pub use crate::blockdata::transaction::Transaction;
+pub use crate::blockdata::transaction::TxIn;
+pub use crate::blockdata::transaction::TxOut;
+pub use crate::blockdata::transaction::OutPoint;
+pub use crate::blockdata::transaction::EcdsaSighashType;
+pub use crate::blockdata::witness::Witness;
+pub use crate::consensus::encode::VarInt;
+pub use crate::network::constants::Network;
+pub use crate::util::Error;
+pub use crate::util::address::Address;
+pub use crate::util::address::AddressType;
+pub use crate::util::amount::Amount;
+pub use crate::util::amount::Denomination;
+pub use crate::util::amount::SignedAmount;
+pub use crate::util::merkleblock::MerkleBlock;
+pub use crate::util::sighash::SchnorrSighashType;
 
-pub use util::ecdsa::{self, EcdsaSig, EcdsaSigError};
-pub use util::schnorr::{self, SchnorrSig, SchnorrSigError};
-pub use util::key::{PrivateKey, PublicKey, XOnlyPublicKey, KeyPair};
-pub use util::psbt;
+pub use crate::util::ecdsa::{self, EcdsaSig, EcdsaSigError};
+pub use crate::util::schnorr::{self, SchnorrSig, SchnorrSigError};
+pub use crate::util::key::{PrivateKey, PublicKey, XOnlyPublicKey, KeyPair};
+pub use crate::util::psbt;
 #[allow(deprecated)]
-pub use blockdata::transaction::SigHashType;
+pub use crate::blockdata::transaction::SigHashType;
 
 #[cfg(feature = "std")]
 use std::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ mod prelude {
     pub use std::io::sink;
 
     #[cfg(not(feature = "std"))]
-    pub use io_extras::sink;
+    pub use crate::io_extras::sink;
 
     #[cfg(feature = "hashbrown")]
     pub use hashbrown::HashSet;
@@ -204,7 +204,7 @@ mod prelude {
 #[cfg(all(test, feature = "unstable"))]
 mod tests {
     use core::fmt::Arguments;
-    use io::{IoSlice, Result, Write};
+    use crate::io::{IoSlice, Result, Write};
 
     #[derive(Default, Clone, Debug, PartialEq, Eq)]
     pub struct EmptyWrite;

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -18,14 +18,14 @@
 //! network addresses in Bitcoin messages.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::{fmt, iter};
 use std::net::{SocketAddr, Ipv6Addr, SocketAddrV4, SocketAddrV6, Ipv4Addr, ToSocketAddrs};
 
-use io;
-use network::constants::ServiceFlags;
-use consensus::encode::{self, Decodable, Encodable, VarInt, ReadExt, WriteExt};
+use crate::io;
+use crate::network::constants::ServiceFlags;
+use crate::consensus::encode::{self, Decodable, Encodable, VarInt, ReadExt, WriteExt};
 
 /// A message which can be sent on the Bitcoin network
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -294,11 +294,11 @@ impl ToSocketAddrs for AddrV2Message {
 mod test {
     use core::str::FromStr;
     use super::{AddrV2Message, AddrV2, Address};
-    use network::constants::ServiceFlags;
+    use crate::network::constants::ServiceFlags;
     use std::net::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr};
-    use hashes::hex::FromHex;
+    use crate::hashes::hex::FromHex;
 
-    use consensus::encode::{deserialize, serialize};
+    use crate::consensus::encode::{deserialize, serialize};
 
     #[test]
     fn serialize_address_test() {

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -39,8 +39,8 @@
 
 use core::{fmt, ops, convert::From};
 
-use io;
-use consensus::encode::{self, Encodable, Decodable};
+use crate::io;
+use crate::consensus::encode::{self, Encodable, Decodable};
 
 /// Version of the protocol as appearing in network message headers
 /// This constant is used to signal to other peers which features you support.
@@ -289,7 +289,7 @@ impl Decodable for ServiceFlags {
 #[cfg(test)]
 mod tests {
     use super::{Network, ServiceFlags};
-    use consensus::encode::{deserialize, serialize};
+    use crate::consensus::encode::{deserialize, serialize};
 
     #[test]
     fn serialize_test() {

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -18,20 +18,20 @@
 //! are used for (de)serializing Bitcoin objects for transmission on the network.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::{mem, fmt, iter};
 
-use io;
-use blockdata::block;
-use blockdata::transaction;
-use network::address::{Address, AddrV2Message};
-use network::{message_network, message_bloom};
-use network::message_blockdata;
-use network::message_filter;
-use consensus::encode::{CheckedData, Decodable, Encodable, VarInt, MAX_VEC_SIZE};
-use consensus::{encode, serialize};
-use util::merkleblock::MerkleBlock;
+use crate::io;
+use crate::blockdata::block;
+use crate::blockdata::transaction;
+use crate::network::address::{Address, AddrV2Message};
+use crate::network::{message_network, message_bloom};
+use crate::network::message_blockdata;
+use crate::network::message_filter;
+use crate::consensus::encode::{CheckedData, Decodable, Encodable, VarInt, MAX_VEC_SIZE};
+use crate::consensus::{encode, serialize};
+use crate::util::merkleblock::MerkleBlock;
 
 /// The maximum number of [super::message_blockdata::Inventory] items in an `inv` message.
 ///
@@ -414,20 +414,20 @@ impl Decodable for RawNetworkMessage {
 mod test {
     use std::net::Ipv4Addr;
     use super::{RawNetworkMessage, NetworkMessage, CommandString};
-    use network::constants::ServiceFlags;
-    use consensus::encode::{deserialize, deserialize_partial, serialize};
-    use hashes::hex::FromHex;
-    use hashes::sha256d::Hash;
-    use hashes::Hash as HashTrait;
-    use network::address::{Address, AddrV2, AddrV2Message};
+    use crate::network::constants::ServiceFlags;
+    use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
+    use crate::hashes::hex::FromHex;
+    use crate::hashes::sha256d::Hash;
+    use crate::hashes::Hash as HashTrait;
+    use crate::network::address::{Address, AddrV2, AddrV2Message};
     use super::message_network::{Reject, RejectReason, VersionMessage};
-    use network::message_blockdata::{Inventory, GetBlocksMessage, GetHeadersMessage};
-    use blockdata::block::{Block, BlockHeader};
-    use network::message_filter::{GetCFilters, CFilter, GetCFHeaders, CFHeaders, GetCFCheckpt, CFCheckpt};
-    use blockdata::transaction::Transaction;
-    use blockdata::script::Script;
-    use network::message_bloom::{FilterAdd, FilterLoad, BloomFlags};
-    use MerkleBlock;
+    use crate::network::message_blockdata::{Inventory, GetBlocksMessage, GetHeadersMessage};
+    use crate::blockdata::block::{Block, BlockHeader};
+    use crate::network::message_filter::{GetCFilters, CFilter, GetCFHeaders, CFHeaders, GetCFCheckpt, CFCheckpt};
+    use crate::blockdata::transaction::Transaction;
+    use crate::blockdata::script::Script;
+    use crate::network::message_bloom::{FilterAdd, FilterLoad, BloomFlags};
+    use crate::MerkleBlock;
 
     fn hash(slice: [u8;32]) -> Hash {
         Hash::from_slice(&slice).unwrap()

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -18,15 +18,15 @@
 //! Bitcoin data (blocks and transactions) around.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 
-use hashes::sha256d;
+use crate::hashes::sha256d;
 
-use network::constants;
-use consensus::encode::{self, Decodable, Encodable};
-use hash_types::{BlockHash, Txid, Wtxid};
+use crate::network::constants;
+use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::hash_types::{BlockHash, Txid, Wtxid};
 
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]
@@ -149,9 +149,9 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 mod tests {
     use super::{Vec, GetHeadersMessage, GetBlocksMessage};
 
-    use hashes::hex::FromHex;
+    use crate::hashes::hex::FromHex;
 
-    use consensus::encode::{deserialize, serialize};
+    use crate::consensus::encode::{deserialize, serialize};
     use core::default::Default;
 
     #[test]

--- a/src/network/message_bloom.rs
+++ b/src/network/message_bloom.rs
@@ -3,8 +3,8 @@
 //! This module describes BIP37 Connection Bloom filtering network messages.
 //!
 
-use consensus::encode;
-use consensus::{Decodable, Encodable, ReadExt};
+use crate::consensus::encode;
+use crate::consensus::{Decodable, Encodable, ReadExt};
 use std::io;
 
 /// `filterload` message sets the current bloom filter

--- a/src/network/message_filter.rs
+++ b/src/network/message_filter.rs
@@ -3,7 +3,7 @@
 //! This module describes BIP157 Client Side Block Filtering network messages.
 //!
 
-use hash_types::{BlockHash, FilterHash, FilterHeader};
+use crate::hash_types::{BlockHash, FilterHash, FilterHeader};
 
 /// getcfilters message
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -18,15 +18,15 @@
 //! capabilities.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 
-use network::address::Address;
-use network::constants::{self, ServiceFlags};
-use consensus::{Encodable, Decodable, ReadExt};
-use consensus::encode;
-use hashes::sha256d;
+use crate::network::address::Address;
+use crate::network::constants::{self, ServiceFlags};
+use crate::consensus::{Encodable, Decodable, ReadExt};
+use crate::consensus::encode;
+use crate::hashes::sha256d;
 
 /// Some simple messages
 
@@ -149,11 +149,11 @@ mod tests {
     use super::Reject;
     use super::RejectReason;
 
-    use hashes::hex::FromHex;
-    use hashes::sha256d::Hash;
-    use network::constants::ServiceFlags;
+    use crate::hashes::hex::FromHex;
+    use crate::hashes::sha256d::Hash;
+    use crate::network::constants::ServiceFlags;
 
-    use consensus::encode::{deserialize, serialize};
+    use crate::consensus::encode::{deserialize, serialize};
 
     #[test]
     fn version_message_test() {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -18,7 +18,7 @@
 //! of Bitcoin data and network messages.
 //!
 
-use io;
+use crate::io;
 use core::fmt;
 #[cfg(feature = "std")] use std::error;
 

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -23,9 +23,9 @@
 //!
 
 use core::fmt;
-use io::{Read, BufReader};
+use crate::io::{Read, BufReader};
 
-use consensus::{encode, Decodable};
+use crate::consensus::{encode, Decodable};
 
 /// Struct used to configure stream reader function
 pub struct StreamReader<R: Read> {
@@ -60,13 +60,13 @@ impl<R: Read> StreamReader<R> {
 mod test {
     use std::thread;
     use std::time::Duration;
-    use io::{BufReader, Write};
+    use crate::io::{BufReader, Write};
     use std::net::{TcpListener, TcpStream, Shutdown};
     use std::thread::JoinHandle;
-    use network::constants::ServiceFlags;
+    use crate::network::constants::ServiceFlags;
 
     use super::StreamReader;
-    use network::message::{NetworkMessage, RawNetworkMessage};
+    use crate::network::message::{NetworkMessage, RawNetworkMessage};
 
     // First, let's define some byte arrays for sample messages - dumps are taken from live
     // Bitcoin Core node v0.17.1 with Wireshark
@@ -274,10 +274,10 @@ mod test {
 
     #[test]
     fn read_block_from_file_test() {
-        use io;
-        use consensus::serialize;
-        use hashes::hex::FromHex;
-        use Block;
+        use crate::io;
+        use crate::consensus::serialize;
+        use crate::hashes::hex::FromHex;
+        use crate::Block;
 
         let normal_data = Vec::from_hex("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac00000000").unwrap();
         let cutoff_data = Vec::from_hex("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").unwrap();

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -9,14 +9,14 @@ pub mod btreemap_byte_values {
 
     // NOTE: This module can be exactly copied to use with HashMap.
 
-    use prelude::*;
-    use hashes::hex::{FromHex, ToHex};
+    use crate::prelude::*;
+    use crate::hashes::hex::{FromHex, ToHex};
     use serde;
 
     pub fn serialize<S, T>(v: &BTreeMap<T, Vec<u8>>, s: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
-        T: serde::Serialize + ::core::hash::Hash + Eq + Ord,
+        T: serde::Serialize + core::hash::Hash + Eq + Ord,
     {
         use serde::ser::SerializeMap;
 
@@ -35,18 +35,18 @@ pub mod btreemap_byte_values {
     pub fn deserialize<'de, D, T>(d: D) -> Result<BTreeMap<T, Vec<u8>>, D::Error>
     where
         D: serde::Deserializer<'de>,
-        T: serde::Deserialize<'de> + ::core::hash::Hash + Eq + Ord,
+        T: serde::Deserialize<'de> + core::hash::Hash + Eq + Ord,
     {
-        use ::core::marker::PhantomData;
+        use core::marker::PhantomData;
 
         struct Visitor<T>(PhantomData<T>);
         impl<'de, T> serde::de::Visitor<'de> for Visitor<T>
         where
-            T: serde::Deserialize<'de> + ::core::hash::Hash + Eq + Ord,
+            T: serde::Deserialize<'de> + core::hash::Hash + Eq + Ord,
         {
             type Value = BTreeMap<T, Vec<u8>>;
 
-            fn expecting(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "a map with hexadecimal values")
             }
 
@@ -77,13 +77,13 @@ pub mod btreemap_as_seq {
 
     // NOTE: This module can be exactly copied to use with HashMap.
 
-    use prelude::*;
+    use crate::prelude::*;
     use serde;
 
     pub fn serialize<S, T, U>(v: &BTreeMap<T, U>, s: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
-        T: serde::Serialize + ::core::hash::Hash + Eq + Ord,
+        T: serde::Serialize + core::hash::Hash + Eq + Ord,
         U: serde::Serialize,
     {
         use serde::ser::SerializeSeq;
@@ -103,20 +103,20 @@ pub mod btreemap_as_seq {
     pub fn deserialize<'de, D, T, U>(d: D) -> Result<BTreeMap<T, U>, D::Error>
     where
         D: serde::Deserializer<'de>,
-        T: serde::Deserialize<'de> + ::core::hash::Hash + Eq + Ord,
+        T: serde::Deserialize<'de> + core::hash::Hash + Eq + Ord,
         U: serde::Deserialize<'de>,
     {
-        use ::core::marker::PhantomData;
+        use core::marker::PhantomData;
 
         struct Visitor<T, U>(PhantomData<(T, U)>);
         impl<'de, T, U> serde::de::Visitor<'de> for Visitor<T, U>
         where
-            T: serde::Deserialize<'de> + ::core::hash::Hash + Eq + Ord,
+            T: serde::Deserialize<'de> + core::hash::Hash + Eq + Ord,
             U: serde::Deserialize<'de>,
         {
             type Value = BTreeMap<T, U>;
 
-            fn expecting(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "a sequence of pairs")
             }
 
@@ -147,14 +147,14 @@ pub mod btreemap_as_seq_byte_values {
 
     // NOTE: This module can be exactly copied to use with HashMap.
 
-    use prelude::*;
+    use crate::prelude::*;
     use serde;
 
     /// A custom key-value pair type that serialized the bytes as hex.
     #[derive(Debug, Deserialize)]
     struct OwnedPair<T>(
         T,
-        #[serde(deserialize_with = "::serde_utils::hex_bytes::deserialize")]
+        #[serde(deserialize_with = "crate::serde_utils::hex_bytes::deserialize")]
         Vec<u8>,
     );
 
@@ -162,14 +162,14 @@ pub mod btreemap_as_seq_byte_values {
     #[derive(Debug, Serialize)]
     struct BorrowedPair<'a, T: 'static>(
         &'a T,
-        #[serde(serialize_with = "::serde_utils::hex_bytes::serialize")]
+        #[serde(serialize_with = "crate::serde_utils::hex_bytes::serialize")]
         &'a [u8],
     );
 
     pub fn serialize<S, T>(v: &BTreeMap<T, Vec<u8>>, s: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
-        T: serde::Serialize + ::core::hash::Hash + Eq + Ord + 'static,
+        T: serde::Serialize + core::hash::Hash + Eq + Ord + 'static,
     {
         use serde::ser::SerializeSeq;
 
@@ -188,18 +188,18 @@ pub mod btreemap_as_seq_byte_values {
     pub fn deserialize<'de, D, T>(d: D) -> Result<BTreeMap<T, Vec<u8>>, D::Error>
     where
         D: serde::Deserializer<'de>,
-        T: serde::Deserialize<'de> + ::core::hash::Hash + Eq + Ord,
+        T: serde::Deserialize<'de> + core::hash::Hash + Eq + Ord,
     {
-        use ::core::marker::PhantomData;
+        use core::marker::PhantomData;
 
         struct Visitor<T>(PhantomData<T>);
         impl<'de, T> serde::de::Visitor<'de> for Visitor<T>
         where
-            T: serde::Deserialize<'de> + ::core::hash::Hash + Eq + Ord,
+            T: serde::Deserialize<'de> + core::hash::Hash + Eq + Ord,
         {
             type Value = BTreeMap<T, Vec<u8>>;
 
-            fn expecting(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "a sequence of pairs")
             }
 
@@ -246,12 +246,12 @@ pub mod hex_bytes {
     where
         D: serde::Deserializer<'de>, B: serde::Deserialize<'de> + FromHex,
     {
-        struct Visitor<B>(::core::marker::PhantomData<B>);
+        struct Visitor<B>(core::marker::PhantomData<B>);
 
         impl<'de, B: FromHex> serde::de::Visitor<'de> for Visitor<B> {
             type Value = B;
 
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 formatter.write_str("an ASCII hex string")
             }
 
@@ -259,7 +259,7 @@ pub mod hex_bytes {
             where
                 E: serde::de::Error,
             {
-                if let Ok(hex) = ::core::str::from_utf8(v) {
+                if let Ok(hex) = core::str::from_utf8(v) {
                     FromHex::from_hex(hex).map_err(E::custom)
                 } else {
                     return Err(E::invalid_value(serde::de::Unexpected::Bytes(v), &self));
@@ -278,7 +278,7 @@ pub mod hex_bytes {
         if !d.is_human_readable() {
             serde::Deserialize::deserialize(d)
         } else {
-            d.deserialize_str(Visitor(::core::marker::PhantomData))
+            d.deserialize_str(Visitor(core::marker::PhantomData))
         }
     }
 }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -32,7 +32,7 @@
 //! let address = Address::p2pkh(&public_key, Network::Bitcoin);
 //! ```
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::fmt;
 use core::num::ParseIntError;
@@ -41,16 +41,16 @@ use core::str::FromStr;
 
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 use bech32;
-use hashes::{sha256, Hash, HashEngine};
-use hash_types::{PubkeyHash, ScriptHash};
-use blockdata::{script, opcodes};
-use blockdata::constants::{PUBKEY_ADDRESS_PREFIX_MAIN, SCRIPT_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST, SCRIPT_ADDRESS_PREFIX_TEST, MAX_SCRIPT_ELEMENT_SIZE};
-use network::constants::Network;
-use util::base58;
-use util::taproot::TapBranchHash;
-use util::key::PublicKey;
-use blockdata::script::Instruction;
-use util::schnorr::{TapTweak, UntweakedPublicKey, TweakedPublicKey};
+use crate::hashes::{sha256, Hash, HashEngine};
+use crate::hash_types::{PubkeyHash, ScriptHash};
+use crate::blockdata::{script, opcodes};
+use crate::blockdata::constants::{PUBKEY_ADDRESS_PREFIX_MAIN, SCRIPT_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST, SCRIPT_ADDRESS_PREFIX_TEST, MAX_SCRIPT_ELEMENT_SIZE};
+use crate::network::constants::Network;
+use crate::util::base58;
+use crate::util::taproot::TapBranchHash;
+use crate::util::key::PublicKey;
+use crate::blockdata::script::Instruction;
+use crate::util::schnorr::{TapTweak, UntweakedPublicKey, TweakedPublicKey};
 
 /// Address error.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -889,22 +889,22 @@ impl fmt::Debug for Address {
 }
 
 /// Convert a byte array of a pubkey hash into a segwit redeem hash
-fn segwit_redeem_hash(pubkey_hash: &[u8]) -> ::hashes::hash160::Hash {
+fn segwit_redeem_hash(pubkey_hash: &[u8]) -> crate::hashes::hash160::Hash {
     let mut sha_engine = sha256::Hash::engine();
     sha_engine.input(&[0, 20]);
     sha_engine.input(pubkey_hash);
-    ::hashes::hash160::Hash::from_engine(sha_engine)
+    crate::hashes::hash160::Hash::from_engine(sha_engine)
 }
 
 #[cfg(test)]
 mod tests {
     use core::str::FromStr;
 
-    use hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::{FromHex, ToHex};
 
-    use blockdata::script::Script;
-    use network::constants::Network::{Bitcoin, Testnet};
-    use util::key::PublicKey;
+    use crate::blockdata::script::Script;
+    use crate::network::constants::Network::{Bitcoin, Testnet};
+    use crate::util::key::PublicKey;
     use secp256k1::XOnlyPublicKey;
 
     use super::*;

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -1233,7 +1233,7 @@ pub mod serde {
     //! ```
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use util::amount::{Amount, Denomination, SignedAmount};
+    use crate::util::amount::{Amount, Denomination, SignedAmount};
 
     /// This trait is used only to avoid code duplication and naming collisions
     /// of the different serde serialization crates.
@@ -1322,7 +1322,7 @@ pub mod serde {
         //! Use with `#[serde(with = "amount::serde::as_sat")]`.
 
         use serde::{Deserializer, Serializer};
-        use util::amount::serde::SerdeAmount;
+        use crate::util::amount::serde::SerdeAmount;
 
         pub fn serialize<A: SerdeAmount, S: Serializer>(a: &A, s: S) -> Result<S::Ok, S::Error> {
             a.ser_sat(s)
@@ -1337,7 +1337,7 @@ pub mod serde {
             //! Use with `#[serde(default, with = "amount::serde::as_sat::opt")]`.
 
             use serde::{Deserializer, Serializer, de};
-            use util::amount::serde::SerdeAmountForOpt;
+            use crate::util::amount::serde::SerdeAmountForOpt;
             use core::fmt;
             use core::marker::PhantomData;
 
@@ -1386,7 +1386,7 @@ pub mod serde {
         //! Use with `#[serde(with = "amount::serde::as_btc")]`.
 
         use serde::{Deserializer, Serializer};
-        use util::amount::serde::SerdeAmount;
+        use crate::util::amount::serde::SerdeAmount;
 
         pub fn serialize<A: SerdeAmount, S: Serializer>(a: &A, s: S) -> Result<S::Ok, S::Error> {
             a.ser_btc(s)
@@ -1401,7 +1401,7 @@ pub mod serde {
             //! Use with `#[serde(default, with = "amount::serde::as_btc::opt")]`.
 
             use serde::{Deserializer, Serializer, de};
-            use util::amount::serde::SerdeAmountForOpt;
+            use crate::util::amount::serde::SerdeAmountForOpt;
             use core::fmt;
             use core::marker::PhantomData;
 
@@ -1941,9 +1941,9 @@ mod tests {
 
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
         struct T {
-            #[serde(with = "::util::amount::serde::as_sat")]
+            #[serde(with = "crate::util::amount::serde::as_sat")]
             pub amt: Amount,
-            #[serde(with = "::util::amount::serde::as_sat")]
+            #[serde(with = "crate::util::amount::serde::as_sat")]
             pub samt: SignedAmount,
         }
 
@@ -1970,9 +1970,9 @@ mod tests {
 
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
         struct T {
-            #[serde(with = "::util::amount::serde::as_btc")]
+            #[serde(with = "crate::util::amount::serde::as_btc")]
             pub amt: Amount,
-            #[serde(with = "::util::amount::serde::as_btc")]
+            #[serde(with = "crate::util::amount::serde::as_btc")]
             pub samt: SignedAmount,
         }
 
@@ -2004,9 +2004,9 @@ mod tests {
 
         #[derive(Serialize, Deserialize, PartialEq, Debug, Eq)]
         struct T {
-            #[serde(default, with = "::util::amount::serde::as_btc::opt")]
+            #[serde(default, with = "crate::util::amount::serde::as_btc::opt")]
             pub amt: Option<Amount>,
-            #[serde(default, with = "::util::amount::serde::as_btc::opt")]
+            #[serde(default, with = "crate::util::amount::serde::as_btc::opt")]
             pub samt: Option<SignedAmount>,
         }
 
@@ -2047,9 +2047,9 @@ mod tests {
 
         #[derive(Serialize, Deserialize, PartialEq, Debug, Eq)]
         struct T {
-            #[serde(default, with = "::util::amount::serde::as_sat::opt")]
+            #[serde(default, with = "crate::util::amount::serde::as_sat::opt")]
             pub amt: Option<Amount>,
-            #[serde(default, with = "::util::amount::serde::as_sat::opt")]
+            #[serde(default, with = "crate::util::amount::serde::as_sat::opt")]
             pub samt: Option<SignedAmount>,
         }
 

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -14,7 +14,7 @@
 //! We refer to the documentation on the types for more information.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::{ops, default, str::FromStr, cmp::Ordering};
 use core::fmt::{self, Write};
@@ -1201,7 +1201,7 @@ impl<T> CheckedSum<SignedAmount> for T where T: Iterator<Item=SignedAmount> {
 }
 
 mod private {
-    use ::{Amount, SignedAmount};
+    use crate::{Amount, SignedAmount};
 
     /// Used to seal the `CheckedSum` trait
     pub trait SumSeal<A> {}

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -18,14 +18,14 @@
 //! strings respectively.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::{fmt, str, iter, slice};
 
-use hashes::{sha256d, Hash, hex};
+use crate::hashes::{sha256d, Hash, hex};
 use secp256k1;
 
-use util::{endian, key};
+use crate::util::{endian, key};
 
 /// An error that might occur during base58 decoding
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
@@ -268,7 +268,7 @@ impl From<key::Error> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hashes::hex::FromHex;
+    use crate::hashes::hex::FromHex;
 
     #[test]
     fn test_base58_encode() {

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -19,16 +19,16 @@
 //! signatures, which are placed in the scriptSig.
 //!
 
-use hashes::Hash;
-use hash_types::Sighash;
-use blockdata::script::Script;
-use blockdata::witness::Witness;
-use blockdata::transaction::{Transaction, TxIn, EcdsaSighashType};
-use consensus::{encode, Encodable};
+use crate::hashes::Hash;
+use crate::hash_types::Sighash;
+use crate::blockdata::script::Script;
+use crate::blockdata::witness::Witness;
+use crate::blockdata::transaction::{Transaction, TxIn, EcdsaSighashType};
+use crate::consensus::{encode, Encodable};
 
-use io;
+use crate::io;
 use core::ops::{Deref, DerefMut};
-use util::sighash;
+use crate::util::sighash;
 
 /// Parts of a sighash which are common across inputs or signatures, and which are
 /// sufficient (in conjunction with a private key) to sign the transaction
@@ -188,14 +188,14 @@ impl<R: DerefMut<Target = Transaction>> SigHashCache<R> {
 #[allow(deprecated)]
 mod tests {
     use std::str::FromStr;
-    use hash_types::Sighash;
-    use blockdata::script::Script;
-    use blockdata::transaction::Transaction;
-    use consensus::encode::deserialize;
-    use network::constants::Network;
-    use util::address::Address;
-    use util::key::PublicKey;
-    use hashes::hex::FromHex;
+    use crate::hash_types::Sighash;
+    use crate::blockdata::script::Script;
+    use crate::blockdata::transaction::Transaction;
+    use crate::consensus::encode::deserialize;
+    use crate::network::constants::Network;
+    use crate::util::address::Address;
+    use crate::util::key::PublicKey;
+    use crate::hashes::hex::FromHex;
 
     use super::*;
 

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -45,21 +45,21 @@
 //!  ```
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-use io::{self, Cursor};
+use crate::io::{self, Cursor};
 use core::fmt::{self, Display, Formatter};
 use core::cmp::{self, Ordering};
 
-use hashes::{Hash, siphash24};
-use hash_types::{BlockHash, FilterHash, FilterHeader};
+use crate::hashes::{Hash, siphash24};
+use crate::hash_types::{BlockHash, FilterHash, FilterHeader};
 
-use blockdata::block::Block;
-use blockdata::script::Script;
-use blockdata::transaction::OutPoint;
-use consensus::{Decodable, Encodable};
-use consensus::encode::VarInt;
-use util::endian;
+use crate::blockdata::block::Block;
+use crate::blockdata::script::Script;
+use crate::blockdata::transaction::OutPoint;
+use crate::consensus::{Decodable, Encodable};
+use crate::consensus::encode::VarInt;
+use crate::util::endian;
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845
 const P: u8 = 19;
@@ -511,17 +511,17 @@ impl<'a> BitStreamWriter<'a> {
 
 #[cfg(test)]
 mod test {
-    use io::Cursor;
+    use crate::io::Cursor;
 
-    use hash_types::BlockHash;
-    use hashes::hex::FromHex;
+    use crate::hash_types::BlockHash;
+    use crate::hashes::hex::FromHex;
 
     use super::*;
 
     extern crate serde_json;
     use self::serde_json::Value;
 
-    use consensus::encode::deserialize;
+    use crate::consensus::encode::deserialize;
     use std::collections::HashMap;
 
     #[test]

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -17,21 +17,21 @@
 //! at <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-use io::Write;
+use crate::io::Write;
 use core::{fmt, str::FromStr, default::Default};
 use core::ops::Index;
 #[cfg(feature = "std")] use std::error;
 #[cfg(feature = "serde")] use serde;
 
-use hash_types::XpubIdentifier;
-use hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine, hex};
+use crate::hash_types::XpubIdentifier;
+use crate::hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine, hex};
 use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 
-use network::constants::Network;
-use util::{base58, endian, key};
-use util::key::{PublicKey, PrivateKey, KeyPair};
+use crate::network::constants::Network;
+use crate::util::{base58, endian, key};
+use crate::util::key::{PublicKey, PrivateKey, KeyPair};
 
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -846,9 +846,9 @@ mod tests {
     use core::str::FromStr;
 
     use secp256k1::{self, Secp256k1};
-    use hashes::hex::FromHex;
+    use crate::hashes::hex::FromHex;
 
-    use network::constants::Network::{self, Bitcoin};
+    use crate::network::constants::Network::{self, Bitcoin};
 
     #[test]
     fn test_parse_derivation_path() {

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -16,13 +16,13 @@
 //!
 //! This module provides ECDSA signatures used Bitcoin that can be roundtrip (de)serialized.
 
-use prelude::*;
+use crate::prelude::*;
 use core::str::FromStr;
 use core::{fmt, iter};
-use hashes::hex::{self, FromHex};
-use blockdata::transaction::NonStandardSighashType;
+use crate::hashes::hex::{self, FromHex};
+use crate::blockdata::transaction::NonStandardSighashType;
 use secp256k1;
-use EcdsaSighashType;
+use crate::EcdsaSighashType;
 
 /// An ECDSA signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -19,13 +19,13 @@
 
 use core::iter;
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 use core::cmp::min;
 
-use hashes::Hash;
-use consensus::encode::Encodable;
+use crate::hashes::Hash;
+use crate::consensus::encode::Encodable;
 
 /// Calculates the merkle root of a list of *hashes*, inline (in place) in `hashes`.
 ///
@@ -109,10 +109,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use consensus::encode::deserialize;
-    use hashes::sha256d;
+    use crate::consensus::encode::deserialize;
+    use crate::hashes::sha256d;
 
-    use blockdata::block::Block;
+    use crate::blockdata::block::Block;
     use super::*;
 
     #[test]

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -18,18 +18,18 @@
 
 pub use secp256k1::{XOnlyPublicKey, KeyPair};
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::{ops, str::FromStr};
 use core::fmt::{self, Write};
-use io;
+use crate::io;
 #[cfg(feature = "std")] use std::error;
 
 use secp256k1::{self, Secp256k1};
-use network::constants::Network;
-use hashes::{Hash, hash160, hex, hex::FromHex};
-use hash_types::{PubkeyHash, WPubkeyHash};
-use util::base58;
+use crate::network::constants::Network;
+use crate::hashes::{Hash, hash160, hex, hex::FromHex};
+use crate::hash_types::{PubkeyHash, WPubkeyHash};
+use crate::util::base58;
 
 /// A key-related error.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -482,14 +482,14 @@ impl<'de> ::serde::Deserialize<'de> for PublicKey {
 
 #[cfg(test)]
 mod tests {
-    use io;
+    use crate::io;
     use super::{PrivateKey, PublicKey};
     use secp256k1::Secp256k1;
     use std::str::FromStr;
-    use hashes::hex::ToHex;
-    use network::constants::Network::Testnet;
-    use network::constants::Network::Bitcoin;
-    use util::address::Address;
+    use crate::hashes::hex::ToHex;
+    use crate::network::constants::Network::Testnet;
+    use crate::network::constants::Network::Bitcoin;
+    use crate::util::address::Address;
 
     #[test]
     fn test_key_derivation() {

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -52,18 +52,18 @@
 //! assert_eq!(1, index[0]);
 //! ```
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 
-use hashes::Hash;
-use hash_types::{Txid, TxMerkleNode};
+use crate::hashes::Hash;
+use crate::hash_types::{Txid, TxMerkleNode};
 
-use blockdata::transaction::Transaction;
-use blockdata::constants::{MAX_BLOCK_WEIGHT, MIN_TRANSACTION_WEIGHT};
-use consensus::encode::{self, Decodable, Encodable};
-use util::merkleblock::MerkleBlockError::*;
-use {Block, BlockHeader};
+use crate::blockdata::transaction::Transaction;
+use crate::blockdata::constants::{MAX_BLOCK_WEIGHT, MIN_TRANSACTION_WEIGHT};
+use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::util::merkleblock::MerkleBlockError::*;
+use crate::{Block, BlockHeader};
 
 /// An error when verifying the merkle block
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -511,15 +511,15 @@ impl Decodable for MerkleBlock {
 mod tests {
     use core::cmp::min;
 
-    use hashes::Hash;
-    use hashes::hex::{FromHex, ToHex};
-    use hash_types::{Txid, TxMerkleNode};
+    use crate::hashes::Hash;
+    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hash_types::{Txid, TxMerkleNode};
     use secp256k1::rand::prelude::*;
 
-    use consensus::encode::{deserialize, serialize};
-    use util::hash::bitcoin_merkle_root;
-    use util::merkleblock::{MerkleBlock, PartialMerkleTree};
-    use Block;
+    use crate::consensus::encode::{deserialize, serialize};
+    use crate::util::hash::bitcoin_merkle_root;
+    use crate::util::merkleblock::{MerkleBlock, PartialMerkleTree};
+    use crate::Block;
 
     #[test]
     fn pmt_tests() {

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -34,7 +34,8 @@ pub const BITCOIN_SIGNED_MSG_PREFIX: &[u8] = b"\x18Bitcoin Signed Message:\n";
 
 #[cfg(feature = "secp-recovery")]
 mod message_signing {
-    #[cfg(feature = "base64")] use prelude::*;
+    #[cfg(feature = "base64")] use crate::prelude::*;
+
     use core::fmt;
     #[cfg(feature = "std")] use std::error;
 
@@ -321,7 +322,7 @@ mod tests {
     fn test_message_signature() {
         use core::str::FromStr;
         use secp256k1;
-        use ::AddressType;
+        use crate::{Address, Network, AddressType};
 
         let secp = secp256k1::Secp256k1::new();
         let message = "rust-bitcoin MessageSignature test";
@@ -342,14 +343,14 @@ mod tests {
         assert_eq!(pubkey.compressed, true);
         assert_eq!(pubkey.inner, secp256k1::PublicKey::from_secret_key(&secp, &privkey));
 
-        let p2pkh = ::Address::p2pkh(&pubkey, ::Network::Bitcoin);
+        let p2pkh = Address::p2pkh(&pubkey, Network::Bitcoin);
         assert_eq!(signature2.is_signed_by_address(&secp, &p2pkh, msg_hash), Ok(true));
-        let p2wpkh = ::Address::p2wpkh(&pubkey, ::Network::Bitcoin).unwrap();
+        let p2wpkh = Address::p2wpkh(&pubkey, Network::Bitcoin).unwrap();
         assert_eq!(
             signature2.is_signed_by_address(&secp, &p2wpkh, msg_hash),
             Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2wpkh))
         );
-        let p2shwpkh = ::Address::p2shwpkh(&pubkey, ::Network::Bitcoin).unwrap();
+        let p2shwpkh = Address::p2shwpkh(&pubkey, Network::Bitcoin).unwrap();
         assert_eq!(
             signature2.is_signed_by_address(&secp, &p2shwpkh, msg_hash),
             Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2sh))
@@ -360,7 +361,8 @@ mod tests {
     #[cfg(all(feature = "secp-recovery", feature = "base64"))]
     fn test_incorrect_message_signature() {
         use secp256k1;
-        use util::key::PublicKey;
+        use crate::util::key::PublicKey;
+        use crate::{Address, Network};
 
         let secp = secp256k1::Secp256k1::new();
         let message = "a different message from what was signed";
@@ -376,7 +378,7 @@ mod tests {
             &::base64::decode(&pubkey_base64).expect("base64 string")
         ).expect("pubkey slice");
 
-        let p2pkh = ::Address::p2pkh(&pubkey, ::Network::Bitcoin);
+        let p2pkh = Address::p2pkh(&pubkey, Network::Bitcoin);
         assert_eq!(signature.is_signed_by_address(&secp, &p2pkh, msg_hash), Ok(false));
     }
 }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -18,12 +18,12 @@
 //! recovery when library is used with the `secp-recovery` feature.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-use hashes::{sha256d, Hash, HashEngine};
+use crate::hashes::{sha256d, Hash, HashEngine};
 
-use blockdata::opcodes;
-use consensus::{encode, Encodable};
+use crate::blockdata::opcodes;
+use crate::consensus::{encode, Encodable};
 
 #[cfg(feature = "secp-recovery")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
@@ -38,12 +38,12 @@ mod message_signing {
     use core::fmt;
     #[cfg(feature = "std")] use std::error;
 
-    use hashes::sha256d;
+    use crate::hashes::sha256d;
     use secp256k1;
     use secp256k1::ecdsa::{RecoveryId, RecoverableSignature};
 
-    use util::key::PublicKey;
-    use util::address::{Address, AddressType};
+    use crate::util::key::PublicKey;
+    use crate::util::address::{Address, AddressType};
 
     /// An error used for dealing with Bitcoin Signed Messages.
     #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
@@ -267,7 +267,7 @@ pub fn signed_msg_hash(msg: &str) -> sha256d::Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hashes::hex::ToHex;
+    use crate::hashes::hex::ToHex;
     use super::script_find_and_remove;
     use super::signed_msg_hash;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -36,13 +36,13 @@ pub mod sighash;
 
 pub(crate) mod endian;
 
-use prelude::*;
-use io;
+use crate::prelude::*;
+use crate::io;
 use core::fmt;
 #[cfg(feature = "std")] use std::error;
 
-use network;
-use consensus::encode;
+use crate::network;
+use crate::consensus::encode;
 
 /// A trait which allows numbers to act as fixed-size bit arrays
 pub trait BitArray {

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -12,16 +12,16 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use prelude::*;
+use crate::prelude::*;
 
 use core::fmt;
 
-use blockdata::transaction::Transaction;
-use consensus::encode;
-use util::psbt::raw;
+use crate::blockdata::transaction::Transaction;
+use crate::consensus::encode;
+use crate::util::psbt::raw;
 
-use hashes;
-use util::bip32::ExtendedPubKey;
+use crate::hashes;
+use crate::util::bip32::ExtendedPubKey;
 
 /// Enum for marking psbt hash error.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -12,18 +12,18 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use prelude::*;
+use crate::prelude::*;
 
-use io::{self, Cursor, Read};
+use crate::io::{self, Cursor, Read};
 
-use blockdata::transaction::Transaction;
-use consensus::{encode, Encodable, Decodable};
-use consensus::encode::MAX_VEC_SIZE;
-use util::psbt::map::Map;
-use util::psbt::{raw, PartiallySignedTransaction};
-use util::psbt::Error;
-use util::endian::u32_to_array_le;
-use util::bip32::{ExtendedPubKey, Fingerprint, DerivationPath, ChildNumber};
+use crate::blockdata::transaction::Transaction;
+use crate::consensus::{encode, Encodable, Decodable};
+use crate::consensus::encode::MAX_VEC_SIZE;
+use crate::util::psbt::map::Map;
+use crate::util::psbt::{raw, PartiallySignedTransaction};
+use crate::util::psbt::Error;
+use crate::util::endian::u32_to_array_le;
+use crate::util::bip32::{ExtendedPubKey, Fingerprint, DerivationPath, ChildNumber};
 
 /// Type: Unsigned Transaction PSBT_GLOBAL_UNSIGNED_TX = 0x00
 const PSBT_GLOBAL_UNSIGNED_TX: u8 = 0x00;
@@ -205,7 +205,7 @@ impl PartiallySignedTransaction {
                         }
                     }
                 }
-                Err(::consensus::encode::Error::Psbt(::util::psbt::Error::NoMorePairs)) => break,
+                Err(crate::consensus::encode::Error::Psbt(crate::util::psbt::Error::NoMorePairs)) => break,
                 Err(e) => return Err(e),
             }
         }

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -102,7 +102,7 @@ pub struct Input {
     pub witness_script: Option<Script>,
     /// A map from public keys needed to sign this input to their corresponding
     /// master key fingerprints and derivation paths.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
     /// The finalized, fully-constructed scriptSig with signatures and any other
     /// scripts necessary for this input to pass validation.
@@ -112,37 +112,37 @@ pub struct Input {
     pub final_script_witness: Option<Witness>,
     /// TODO: Proof of reserves commitment
     /// RIPEMD160 hash to preimage map.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
     pub ripemd160_preimages: BTreeMap<ripemd160::Hash, Vec<u8>>,
     /// SHA256 hash to preimage map.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
     pub sha256_preimages: BTreeMap<sha256::Hash, Vec<u8>>,
     /// HSAH160 hash to preimage map.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
     pub hash160_preimages: BTreeMap<hash160::Hash, Vec<u8>>,
     /// HAS256 hash to preimage map.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
     pub hash256_preimages: BTreeMap<sha256d::Hash, Vec<u8>>,
     /// Serialized schnorr signature with sighash type for key spend.
     pub tap_key_sig: Option<SchnorrSig>,
     /// Map of <xonlypubkey>|<leafhash> with signature.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub tap_script_sigs: BTreeMap<(XOnlyPublicKey, TapLeafHash), SchnorrSig>,
     /// Map of Control blocks to Script version pair.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub tap_scripts: BTreeMap<ControlBlock, (Script, LeafVersion)>,
     /// Map of tap root x only keys to origin info and leaf hashes contained in it.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub tap_key_origins: BTreeMap<XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
     /// Taproot Internal key.
     pub tap_internal_key: Option<XOnlyPublicKey>,
     /// Taproot Merkle root.
     pub tap_merkle_root: Option<TapBranchHash>,
     /// Proprietary key-value pairs for this input.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
     /// Unknown key-value pairs for this input.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 }
 

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -12,29 +12,29 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use prelude::*;
-use io;
+use crate::prelude::*;
+use crate::io;
 use core::fmt;
 use core::str::FromStr;
 
 use secp256k1;
-use blockdata::script::Script;
-use blockdata::witness::Witness;
-use blockdata::transaction::{Transaction, TxOut, NonStandardSighashType, SighashTypeParseError};
-use consensus::encode;
-use hashes::{self, hash160, ripemd160, sha256, sha256d};
+use crate::blockdata::script::Script;
+use crate::blockdata::witness::Witness;
+use crate::blockdata::transaction::{Transaction, TxOut, NonStandardSighashType, SighashTypeParseError};
+use crate::consensus::encode;
+use crate::hashes::{self, hash160, ripemd160, sha256, sha256d};
 use secp256k1::XOnlyPublicKey;
-use util::bip32::KeySource;
-use util::psbt;
-use util::psbt::map::Map;
-use util::psbt::raw;
-use util::psbt::serialize::Deserialize;
-use util::psbt::{Error, error};
-use util::key::PublicKey;
+use crate::util::bip32::KeySource;
+use crate::util::psbt;
+use crate::util::psbt::map::Map;
+use crate::util::psbt::raw;
+use crate::util::psbt::serialize::Deserialize;
+use crate::util::psbt::{Error, error};
+use crate::util::key::PublicKey;
 
-use util::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapBranchHash};
-use util::sighash;
-use {EcdsaSighashType, SchnorrSighashType, EcdsaSig, SchnorrSig};
+use crate::util::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapBranchHash};
+use crate::util::sighash;
+use crate::{EcdsaSighashType, SchnorrSighashType, EcdsaSig, SchnorrSig};
 
 /// Type: Non-Witness UTXO PSBT_IN_NON_WITNESS_UTXO = 0x00
 const PSBT_IN_NON_WITNESS_UTXO: u8 = 0x00;
@@ -154,7 +154,7 @@ pub struct Input {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PsbtSighashType {
-    pub (in ::util::psbt) inner: u32,
+    pub (in crate::util::psbt) inner: u32,
 }
 
 impl fmt::Display for PsbtSighashType {

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -12,12 +12,12 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 
-use consensus::encode;
-use util::psbt::raw;
+use crate::consensus::encode;
+use crate::util::psbt::raw;
 
 mod global;
 mod input;

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -12,23 +12,23 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use prelude::*;
+use crate::prelude::*;
 use core;
 
-use io;
+use crate::io;
 
-use blockdata::script::Script;
-use consensus::encode;
+use crate::blockdata::script::Script;
+use crate::consensus::encode;
 use secp256k1::XOnlyPublicKey;
-use util::bip32::KeySource;
+use crate::util::bip32::KeySource;
 use secp256k1;
-use util::psbt::map::Map;
-use util::psbt::raw;
-use util::psbt::Error;
+use crate::util::psbt::map::Map;
+use crate::util::psbt::raw;
+use crate::util::psbt::Error;
 
-use util::taproot::{ScriptLeaf, TapLeafHash};
+use crate::util::taproot::{ScriptLeaf, TapLeafHash};
 
-use util::taproot::{NodeInfo, TaprootBuilder};
+use crate::util::taproot::{NodeInfo, TaprootBuilder};
 
 /// Type: Redeem Script PSBT_OUT_REDEEM_SCRIPT = 0x00
 const PSBT_OUT_REDEEM_SCRIPT: u8 = 0x00;

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -56,25 +56,25 @@ pub struct Output {
     pub witness_script: Option<Script>,
     /// A map from public keys needed to spend this output to their
     /// corresponding master key fingerprints and derivation paths.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
     /// The internal pubkey.
     pub tap_internal_key: Option<XOnlyPublicKey>,
     /// Taproot Output tree.
     pub tap_tree: Option<TapTree>,
     /// Map of tap root x only keys to origin info and leaf hashes contained in it.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub tap_key_origins: BTreeMap<XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
     /// Proprietary key-value pairs for this output.
     #[cfg_attr(
         feature = "serde",
-        serde(with = "::serde_utils::btreemap_as_seq_byte_values")
+        serde(with = "crate::serde_utils::btreemap_as_seq_byte_values")
     )]
     pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
     /// Unknown key-value pairs for this output.
     #[cfg_attr(
         feature = "serde",
-        serde(with = "::serde_utils::btreemap_as_seq_byte_values")
+        serde(with = "crate::serde_utils::btreemap_as_seq_byte_values")
     )]
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 }

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -21,15 +21,15 @@
 
 use core::cmp;
 
-use blockdata::script::Script;
-use blockdata::transaction::{ TxOut, Transaction};
-use consensus::{encode, Encodable, Decodable};
-use consensus::encode::MAX_VEC_SIZE;
-pub use util::sighash::Prevouts;
+use crate::blockdata::script::Script;
+use crate::blockdata::transaction::{ TxOut, Transaction};
+use crate::consensus::{encode, Encodable, Decodable};
+use crate::consensus::encode::MAX_VEC_SIZE;
+pub use crate::util::sighash::Prevouts;
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 mod error;
 pub use self::error::Error;
 
@@ -44,7 +44,7 @@ mod map;
 pub use self::map::{Input, Output, TapTree, PsbtSighashType, IncompleteTapTree};
 use self::map::Map;
 
-use util::bip32::{ExtendedPubKey, KeySource};
+use crate::util::bip32::{ExtendedPubKey, KeySource};
 
 /// Partially signed transaction, commonly referred to as a PSBT.
 pub type Psbt = PartiallySignedTransaction;
@@ -337,22 +337,22 @@ impl Decodable for PartiallySignedTransaction {
 mod tests {
     use super::*;
 
-    use hashes::hex::FromHex;
-    use hashes::{sha256, hash160, Hash, ripemd160};
-    use hash_types::Txid;
+    use crate::hashes::hex::FromHex;
+    use crate::hashes::{sha256, hash160, Hash, ripemd160};
+    use crate::hash_types::Txid;
 
     use secp256k1::{Secp256k1, self};
 
-    use blockdata::script::Script;
-    use blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint};
-    use network::constants::Network::Bitcoin;
-    use consensus::encode::{deserialize, serialize, serialize_hex};
-    use util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource};
-    use util::psbt::map::{Output, Input};
-    use util::psbt::raw;
+    use crate::blockdata::script::Script;
+    use crate::blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint};
+    use crate::network::constants::Network::Bitcoin;
+    use crate::consensus::encode::{deserialize, serialize, serialize_hex};
+    use crate::util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource};
+    use crate::util::psbt::map::{Output, Input};
+    use crate::util::psbt::raw;
 
     use std::collections::BTreeMap;
-    use blockdata::witness::Witness;
+    use crate::blockdata::witness::Witness;
 
     #[test]
     fn trivial_psbt() {
@@ -594,17 +594,17 @@ mod tests {
         #[cfg(feature = "base64")]
         use std::str::FromStr;
 
-        use hashes::hex::FromHex;
-        use hash_types::Txid;
+        use crate::hashes::hex::FromHex;
+        use crate::hash_types::Txid;
 
-        use blockdata::script::Script;
-        use blockdata::transaction::{EcdsaSighashType, Transaction, TxIn, TxOut, OutPoint};
-        use consensus::encode::serialize_hex;
-        use util::psbt::map::{Map, Input, Output};
-        use util::psbt::raw;
-        use util::psbt::{PartiallySignedTransaction, Error};
+        use crate::blockdata::script::Script;
+        use crate::blockdata::transaction::{EcdsaSighashType, Transaction, TxIn, TxOut, OutPoint};
+        use crate::consensus::encode::serialize_hex;
+        use crate::util::psbt::map::{Map, Input, Output};
+        use crate::util::psbt::raw;
+        use crate::util::psbt::{PartiallySignedTransaction, Error};
         use std::collections::BTreeMap;
-        use blockdata::witness::Witness;
+        use crate::blockdata::witness::Witness;
 
         #[test]
         #[should_panic(expected = "InvalidMagic")]

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -62,10 +62,10 @@ pub struct PartiallySignedTransaction {
     /// derivation path as defined by BIP 32
     pub xpub: BTreeMap<ExtendedPubKey, KeySource>,
     /// Global proprietary key-value pairs.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
     /// Unknown global key-value pairs.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::btreemap_as_seq_byte_values"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 
     /// The corresponding key-value map for each input in the unsigned
@@ -219,8 +219,8 @@ mod display_from_str {
     use super::PartiallySignedTransaction;
     use core::fmt::{Display, Formatter, self};
     use core::str::FromStr;
-    use consensus::encode::{Error, self};
-    use ::base64::display::Base64Display;
+    use crate::consensus::encode::{Error, self};
+    use base64::display::Base64Display;
 
     /// Error happening during PSBT decoding from Base64 string
     #[derive(Debug)]
@@ -496,8 +496,8 @@ mod tests {
     fn test_serde_psbt() {
         //! Create a full PSBT value with various fields filled and make sure it can be JSONized.
         use hashes::sha256d;
-        use util::psbt::map::Input;
-        use EcdsaSighashType;
+        use crate::util::psbt::map::Input;
+        use crate::EcdsaSighashType;
 
         // create some values to use in the PSBT
         let tx = Transaction {
@@ -632,7 +632,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "ConsensusEncoding")]
         fn invalid_vector_2_base64() {
-            use util::psbt::PsbtParseError;
+            use crate::util::psbt::PsbtParseError;
             PartiallySignedTransaction::from_str("cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAA==")
                 // This weird thing is necessary since rustc 0.29 prints out I/O error in a different format than later versions
                 .map_err(|err| match err {

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -18,14 +18,14 @@
 //! <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki>.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 use core::fmt;
 
-use io;
-use consensus::encode::{self, ReadExt, WriteExt, Decodable, Encodable, VarInt, serialize, deserialize, MAX_VEC_SIZE};
-use hashes::hex;
-use util::psbt::Error;
-use util::read_to_end;
+use crate::io;
+use crate::consensus::encode::{self, ReadExt, WriteExt, Decodable, Encodable, VarInt, serialize, deserialize, MAX_VEC_SIZE};
+use crate::hashes::hex;
+use crate::util::psbt::Error;
+use crate::util::read_to_end;
 
 /// A PSBT key in its raw byte form.
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -34,7 +34,7 @@ pub struct Key {
     /// The type of this PSBT key.
     pub type_value: u8,
     /// The key itself in raw byte form.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::hex_bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub key: Vec<u8>,
 }
 
@@ -45,7 +45,7 @@ pub struct Pair {
     /// The key of this key-value pair.
     pub key: Key,
     /// The value of this key-value pair in raw byte form.
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::hex_bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub value: Vec<u8>,
 }
 
@@ -59,12 +59,12 @@ pub type ProprietaryType = u8;
 pub struct ProprietaryKey<Subtype=ProprietaryType> where Subtype: Copy + From<u8> + Into<u8> {
     /// Proprietary type prefix used for grouping together keys under some
     /// application and avoid namespace collision
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::hex_bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub prefix: Vec<u8>,
     /// Custom proprietary subtype
     pub subtype: Subtype,
     /// Additional key bytes (like serialized public key data etc)
-    #[cfg_attr(feature = "serde", serde(with = "::serde_utils::hex_bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub key: Vec<u8>,
 }
 

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -18,26 +18,26 @@
 //! bytes from/as PSBT key-value pairs.
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-use io;
+use crate::io;
 
-use blockdata::script::Script;
-use blockdata::witness::Witness;
-use blockdata::transaction::{Transaction, TxOut};
-use consensus::encode::{self, serialize, Decodable, Encodable, deserialize_partial};
+use crate::blockdata::script::Script;
+use crate::blockdata::witness::Witness;
+use crate::blockdata::transaction::{Transaction, TxOut};
+use crate::consensus::encode::{self, serialize, Decodable, Encodable, deserialize_partial};
 use secp256k1::{self, XOnlyPublicKey};
-use util::bip32::{ChildNumber, Fingerprint, KeySource};
-use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
-use util::ecdsa::{EcdsaSig, EcdsaSigError};
-use util::psbt;
-use util::taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
-use schnorr;
-use util::key::PublicKey;
+use crate::util::bip32::{ChildNumber, Fingerprint, KeySource};
+use crate::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use crate::util::ecdsa::{EcdsaSig, EcdsaSigError};
+use crate::util::psbt;
+use crate::util::taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
+use crate::schnorr;
+use crate::util::key::PublicKey;
 
 use super::map::{TapTree, PsbtSighashType};
 
-use util::taproot::TaprootBuilder;
+use crate::util::taproot::TaprootBuilder;
 /// A trait for serializing a value as raw data for insertion into PSBT
 /// key-value pairs.
 pub trait Serialize {
@@ -370,7 +370,7 @@ fn key_source_len(key_source: &KeySource) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use hashes::hex::FromHex;
+    use crate::hashes::hex::FromHex;
     use super::*;
 
     // Composes tree matching a given depth map, filled with dumb script leafs,

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -18,12 +18,12 @@
 //!
 
 use core::fmt;
-use prelude::*;
+use crate::prelude::*;
 
 use secp256k1::{self, Secp256k1, Verification, constants};
-use hashes::Hash;
-use util::taproot::{TapBranchHash, TapTweakHash};
-use SchnorrSighashType;
+use crate::hashes::Hash;
+use crate::util::taproot::{TapBranchHash, TapTweakHash};
+use crate::SchnorrSighashType;
 
 /// Deprecated re-export of [`secp256k1::XOnlyPublicKey`]
 #[deprecated(since = "0.28.0", note = "Please use `util::key::XOnlyPublicKey` instead")]
@@ -34,13 +34,13 @@ pub type XOnlyPublicKey = secp256k1::XOnlyPublicKey;
 pub type KeyPair = secp256k1::KeyPair;
 
 /// Untweaked BIP-340 X-coord-only public key
-pub type UntweakedPublicKey = ::XOnlyPublicKey;
+pub type UntweakedPublicKey = crate::XOnlyPublicKey;
 
 /// Tweaked BIP-340 X-coord-only public key
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct TweakedPublicKey(::XOnlyPublicKey);
+pub struct TweakedPublicKey(crate::XOnlyPublicKey);
 
 impl fmt::LowerHex for TweakedPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -55,13 +55,13 @@ impl fmt::Display for TweakedPublicKey {
 }
 
 /// Untweaked BIP-340 key pair
-pub type UntweakedKeyPair = ::KeyPair;
+pub type UntweakedKeyPair = crate::KeyPair;
 
 /// Tweaked BIP-340 key pair
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct TweakedKeyPair(::KeyPair);
+pub struct TweakedKeyPair(crate::KeyPair);
 
 /// A trait for tweaking BIP340 key types (x-only public keys and key pairs).
 pub trait TapTweak {
@@ -138,7 +138,7 @@ impl TapTweak for UntweakedKeyPair {
     /// # Returns
     /// The tweaked key and its parity.
     fn tap_tweak<C: Verification>(mut self, secp: &Secp256k1<C>, merkle_root: Option<TapBranchHash>) -> TweakedKeyPair {
-        let pubkey = ::XOnlyPublicKey::from_keypair(&self);
+        let pubkey = crate::XOnlyPublicKey::from_keypair(&self);
         let tweak_value = TapTweakHash::from_key_and_tweak(pubkey, merkle_root).into_inner();
         self.tweak_add_assign(&secp, &tweak_value).expect("Tap tweak failed");
         TweakedKeyPair(self)
@@ -156,17 +156,17 @@ impl TweakedPublicKey {
     /// This method is dangerous and can lead to loss of funds if used incorrectly.
     /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
     #[inline]
-    pub fn dangerous_assume_tweaked(key: ::XOnlyPublicKey) -> TweakedPublicKey {
+    pub fn dangerous_assume_tweaked(key: crate::XOnlyPublicKey) -> TweakedPublicKey {
         TweakedPublicKey(key)
     }
 
     /// Returns the underlying public key.
-    pub fn to_inner(self) -> ::XOnlyPublicKey {
+    pub fn to_inner(self) -> crate::XOnlyPublicKey {
         self.0
     }
 
     /// Returns a reference to underlying public key.
-    pub fn as_inner(&self) -> &::XOnlyPublicKey {
+    pub fn as_inner(&self) -> &crate::XOnlyPublicKey {
         &self.0
     }
 
@@ -186,25 +186,25 @@ impl TweakedKeyPair {
     /// This method is dangerous and can lead to loss of funds if used incorrectly.
     /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
     #[inline]
-    pub fn dangerous_assume_tweaked(pair: ::KeyPair) -> TweakedKeyPair {
+    pub fn dangerous_assume_tweaked(pair: crate::KeyPair) -> TweakedKeyPair {
         TweakedKeyPair(pair)
     }
 
     /// Returns the underlying key pair
     #[inline]
-    pub fn into_inner(self) -> ::KeyPair {
+    pub fn into_inner(self) -> crate::KeyPair {
         self.0
     }
 }
 
-impl From<TweakedPublicKey> for ::XOnlyPublicKey {
+impl From<TweakedPublicKey> for crate::XOnlyPublicKey {
     #[inline]
     fn from(pair: TweakedPublicKey) -> Self {
         pair.0
     }
 }
 
-impl From<TweakedKeyPair> for ::KeyPair {
+impl From<TweakedKeyPair> for crate::KeyPair {
     #[inline]
     fn from(pair: TweakedKeyPair) -> Self {
         pair.0

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -20,19 +20,19 @@
 //! and legacy (before Bip143).
 //!
 
-use prelude::*;
+use crate::prelude::*;
 
-pub use blockdata::transaction::{EcdsaSighashType, SighashTypeParseError};
-use blockdata::witness::Witness;
-use consensus::{encode, Encodable};
+pub use crate::blockdata::transaction::{EcdsaSighashType, SighashTypeParseError};
+use crate::blockdata::witness::Witness;
+use crate::consensus::{encode, Encodable};
 use core::{str, fmt};
 use core::ops::{Deref, DerefMut};
 use core::borrow::Borrow;
-use hashes::{sha256, sha256d, Hash};
-use io;
-use util::taproot::{TapLeafHash, TAPROOT_ANNEX_PREFIX, TapSighashHash};
-use Sighash;
-use {Script, Transaction, TxOut};
+use crate::hashes::{sha256, sha256d, Hash};
+use crate::io;
+use crate::util::taproot::{TapLeafHash, TAPROOT_ANNEX_PREFIX, TapSighashHash};
+use crate::Sighash;
+use crate::{Script, Transaction, TxOut};
 
 use super::taproot::LeafVersion;
 
@@ -790,17 +790,17 @@ impl<'a> Encodable for Annex<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use consensus::deserialize;
-    use hashes::hex::FromHex;
-    use hashes::{Hash, HashEngine};
-    use util::sighash::{Annex, Error, Prevouts, ScriptPath, SighashCache};
+    use crate::consensus::deserialize;
+    use crate::hashes::hex::FromHex;
+    use crate::hashes::{Hash, HashEngine};
+    use crate::util::sighash::{Annex, Error, Prevouts, ScriptPath, SighashCache};
     use std::str::FromStr;
-    use hashes::hex::ToHex;
-    use util::taproot::{TapTweakHash, TapSighashHash, TapBranchHash, TapLeafHash};
+    use crate::hashes::hex::ToHex;
+    use crate::util::taproot::{TapTweakHash, TapSighashHash, TapBranchHash, TapLeafHash};
     use secp256k1::{self, SecretKey, XOnlyPublicKey};
     extern crate serde_json;
 
-    use {Script, Transaction, TxIn, TxOut};
+    use crate::{Script, Transaction, TxIn, TxOut};
 
     #[test]
     fn test_tap_sighash_hash() {

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -16,8 +16,8 @@
 //! This module provides support for taproot tagged hashes.
 //!
 
-use prelude::*;
-use io;
+use crate::prelude::*;
+use crate::io;
 use secp256k1::{self, Secp256k1};
 
 use core::fmt;
@@ -25,12 +25,12 @@ use core::cmp::Reverse;
 #[cfg(feature = "std")]
 use std::error;
 
-use hashes::{sha256, sha256t, Hash, HashEngine};
-use schnorr::{TweakedPublicKey, UntweakedPublicKey, TapTweak};
-use util::key::XOnlyPublicKey;
-use Script;
+use crate::hashes::{sha256, sha256t, Hash, HashEngine};
+use crate::schnorr::{TweakedPublicKey, UntweakedPublicKey, TapTweak};
+use crate::util::key::XOnlyPublicKey;
+use crate::Script;
 
-use consensus::Encodable;
+use crate::consensus::Encodable;
 
 /// The SHA-256 midstate value for the TapLeaf hash.
 const MIDSTATE_TAPLEAF: [u8; 32] = [
@@ -1096,13 +1096,13 @@ impl fmt::Display for TaprootError {
 impl error::Error for TaprootError {}
 #[cfg(test)]
 mod test {
-    use {Address, Network};
-    use schnorr::TapTweak;
+    use crate::{Address, Network};
+    use crate::schnorr::TapTweak;
 
     use super::*;
-    use hashes::hex::{FromHex, ToHex};
-    use hashes::sha256t::Tag;
-    use hashes::{sha256, Hash, HashEngine};
+    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::sha256t::Tag;
+    use crate::hashes::{sha256, Hash, HashEngine};
     use secp256k1::{VerifyOnly, XOnlyPublicKey};
     use core::str::FromStr;
     extern crate serde_json;

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -402,7 +402,7 @@ impl TaprootBuilder {
     /// If the script weight calculations overflow, a sub-optimal tree may be generated. This should
     /// not happen unless you are dealing with billions of branches with weights close to 2^32.
     ///
-    /// [`TapTree`]: ::util::psbt::TapTree
+    /// [`TapTree`]: crate::util::psbt::TapTree
     pub fn with_huffman_tree<I>(
         script_weights: I,
     ) -> Result<Self, TaprootBuilderError>
@@ -808,7 +808,7 @@ impl ControlBlock {
     /// Serializes the control block.
     ///
     /// This would be required when using [`ControlBlock`] as a witness element while spending an
-    /// output via script path. This serialization does not include the [`::VarInt`] prefix that would
+    /// output via script path. This serialization does not include the [`crate::VarInt`] prefix that would
     /// be applied when encoding this element as a witness.
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.size());

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -541,9 +541,9 @@ impl Uint256 {
 
 #[cfg(test)]
 mod tests {
-    use consensus::{deserialize, serialize};
-    use util::uint::{Uint256, Uint128};
-    use util::BitArray;
+    use crate::consensus::{deserialize, serialize};
+    use crate::util::uint::{Uint256, Uint128};
+    use crate::util::BitArray;
 
     #[test]
     pub fn uint256_bits_test() {


### PR DESCRIPTION
This PR supersedes #635 at the permission of @Kixunil in the thread of that PR.

Do a minimal set of changes to enable edition 2018.  Patch 1 is  the biggest change set, it is done with `cargo`, no other manual changes are included in patch 1.  It can verified by running `cargo fix --edition` on master and checking the diffs are the same.

Patch 2 enables 2018 and includes all the manual changes required to get the code to build (with _all_ the feature combinations :)