### PR TITLE
DO NOT MERGE: Backport 'Fix `no_std` MSRV Fixes' to 0.28.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,10 @@ jobs:
             env:
               AS_DEPENDENCY: true
               PIN_VERSIONS: true
+          - rust: 1.47
+            env:
+              AS_DEPENDENCY: true
+              DO_NO_STD: true
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 Cargo.lock
+dep_test
 
 #fuzz
 fuzz/hfuzz_target

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ please join us in
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features on **Rust 1.29**.
+This library should always compile with any combination of features (minus
+`no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
 
 Because some dependencies have broken the build in minor/patch releases, to
 compile with 1.29.0 you will need to run the following version-pinning command:

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -74,7 +74,8 @@ impl fmt::Debug for ExtendedPrivKey {
             .field("parent_fingerprint", &self.parent_fingerprint)
             .field("child_number", &self.child_number)
             .field("chain_code", &self.chain_code)
-            .finish_non_exhaustive()
+            .field("private_key", &"[SecretKey]")
+            .finish()
     }
 }
 


### PR DESCRIPTION
Backport https://github.com/rust-bitcoin/rust-bitcoin/pull/690 onto the v0.28.0 tagged release.

I'm not sure exactly how the release will be done using this but for the record what I did was:
- Checked out the tagged 0.28.0 commit
- Applied the patch from #690 (fixing trivial conflicts)

The only conflict was that #690 removed `PIN_VERSIONS` (because `master` is already not using 1.29 anymore) where as the backport leaves pinning in place.

Please note; CI doesn't appear to run, I guess its because CI is configured to only run for merges into master, can we change the settings to run CI for the `0.28.x` base branch also?