### PR TITLE
[backport] Fix `no_std` MSRV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 Cargo.lock
+dep_test
 
 #fuzz
 fuzz/hfuzz_target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ please join us in
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features on **Rust 1.29**.
+This library should always compile with any combination of features (minus
+`no-std`) on **Rust 1.29** or **Rust 1.47** with `no-std`.
 
 Because some dependencies have broken the build in minor/patch releases, to
 compile with 1.29.0 you will need to run the following version-pinning command:

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -74,7 +74,8 @@ impl fmt::Debug for ExtendedPrivKey {
             .field("parent_fingerprint", &self.parent_fingerprint)
             .field("child_number", &self.child_number)
             .field("chain_code", &self.chain_code)
-            .finish_non_exhaustive()
+            .field("private_key", &"[SecretKey]")
+            .finish()
     }
 }
 


### PR DESCRIPTION
Backport of #690 to 0.28
