### PR TITLE
Derive Hash on a bunch of types

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -852,7 +852,7 @@ pub type SigHashType = EcdsaSighashType;
 ///
 /// Fixed values so they can be cast as integer types for encoding (see also
 /// [`SchnorrSighashType`]).
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub enum EcdsaSighashType {
     /// 0x1: Sign all outputs.
     All		= 0x01,

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -14,7 +14,7 @@ use secp256k1;
 use crate::EcdsaSighashType;
 
 /// An ECDSA signature with the corresponding hash type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct EcdsaSig {

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -68,7 +68,7 @@ const PSBT_IN_PROPRIETARY: u8 = 0xFC;
 
 /// A key-value map for an input of the corresponding index in the unsigned
 /// transaction.
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Input {

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -36,7 +36,7 @@ const PSBT_OUT_PROPRIETARY: u8 = 0xFC;
 
 /// A key-value map for an output of the corresponding index in the unsigned
 /// transaction.
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Output {
@@ -120,6 +120,12 @@ pub struct TapTree(pub(crate) TaprootBuilder);
 impl PartialEq for TapTree {
     fn eq(&self, other: &Self) -> bool {
         self.node_info().hash.eq(&other.node_info().hash)
+    }
+}
+
+impl core::hash::Hash for TapTree {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.node_info().hash(state)
     }
 }
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -37,7 +37,7 @@ use crate::util::bip32::{ExtendedPubKey, KeySource};
 pub type Psbt = PartiallySignedTransaction;
 
 /// A Partially Signed Transaction.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct PartiallySignedTransaction {

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -205,7 +205,7 @@ impl From<TweakedKeyPair> for crate::KeyPair {
 }
 
 /// A BIP340-341 serialized schnorr signature with the corresponding hash type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct SchnorrSig {


### PR DESCRIPTION
In preparation for being able to derive `Hash` on all types in `miniscript`, derive `Hash` on all of the required types.

This PR includes all the changes in https://github.com/rust-bitcoin/rust-bitcoin/pull/933/files and hence supersedes it.

ref: https://github.com/rust-bitcoin/rust-miniscript/issues/226