### PR TITLE
Box value encoded in a variant to reduce enum stack space

### DIFF
--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -80,7 +80,7 @@ pub enum Error {
     },
     /// Conflicting data during combine procedure:
     /// global extended public key has inconsistent key sources
-    CombineInconsistentKeySources(ExtendedPubKey),
+    CombineInconsistentKeySources(Box<ExtendedPubKey>),
     /// Serialization error in bitcoin consensus-encoded structures
     ConsensusEncoding,
 }

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -194,7 +194,7 @@ impl PartiallySignedTransaction {
                         entry.insert((fingerprint1, derivation1));
                         continue
                     }
-                    return Err(Error::CombineInconsistentKeySources(xpub));
+                    return Err(Error::CombineInconsistentKeySources(Box::new(xpub)));
                 }
             }
         }


### PR DESCRIPTION
before

```
print-type-size type: `util::psbt::error::Error`: 120 bytes, alignment: 8 bytes
print-type-size     discriminant: 1 bytes
print-type-size     variant `CombineInconsistentKeySources`: 115 bytes
print-type-size         padding: 3 bytes
print-type-size         field `.0`: 112 bytes, alignment: 4 bytes
print-type-size     variant `InvalidKey`: 39 bytes
print-type-size         padding: 7 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
```

after
```
print-type-size type: `util::psbt::error::Error`: 40 bytes, alignment: 8 bytes
print-type-size     discriminant: 1 bytes
print-type-size     variant `InvalidKey`: 39 bytes
print-type-size         padding: 7 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `DuplicateKey`: 39 bytes
print-type-size         padding: 7 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
```

`util::psbt::error::Error` is wrapped also in `consensus::encode::Error` and stack savings are gained there also
