### PR TITLE
Feature `use-serde` renamed to `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = [ "std", "secp-recovery" ]
 base64 = [ "base64-compat" ]
 unstable = []
 rand = ["secp256k1/rand-std"]
-use-serde = ["serde", "bitcoin_hashes/serde", "secp256k1/serde"]
+serde = ["actual-serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 
@@ -31,7 +31,7 @@ std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std"]
 no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
 
 [package.metadata.docs.rs]
-features = [ "std", "secp-recovery", "base64", "rand", "use-serde", "bitcoinconsensus" ]
+features = [ "std", "secp-recovery", "base64", "rand", "serde", "bitcoinconsensus" ]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
@@ -42,7 +42,8 @@ core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64-compat = { version = "1.0.0", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
-serde = { version = "1", default-features = false, features = [ "derive", "alloc" ], optional = true }
+# Do NOT use this as a feature! Use the `serde` feature instead.
+actual-serde = { package = "serde", version = "1", default-features = false, features = [ "derive", "alloc" ], optional = true }
 hashbrown = { version = "0.8", optional = true }
 
 [dev-dependencies]

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-FEATURES="base64 bitcoinconsensus use-serde rand secp-recovery"
+FEATURES="base64 bitcoinconsensus serde rand secp-recovery"
 
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]
@@ -80,7 +80,7 @@ if [ "$AS_DEPENDENCY" = true ]
 then
     cargo new dep_test
     cd dep_test
-    echo 'bitcoin = { path = "..", features = ["use-serde"] }' >> Cargo.toml
+    echo 'bitcoin = { path = "..", features = ["serde"] }' >> Cargo.toml
 
     cargo test --verbose
 fi

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -41,6 +41,7 @@ use crate::VarInt;
 /// the actual transactions
 #[derive(Copy, PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct BlockHeader {
     /// The protocol version. Should always be 1.
     pub version: i32,
@@ -159,6 +160,7 @@ impl BlockHeader {
 /// proof of work.
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Block {
     /// The block header
     pub header: BlockHeader,

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -190,6 +190,7 @@ impl ::core::str::FromStr for OutPoint {
 /// A transaction input, which defines old coins to be consumed
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct TxIn {
     /// The reference to the previous output that is being used an an input.
     pub previous_output: OutPoint,
@@ -223,6 +224,7 @@ impl Default for TxIn {
 /// A transaction output, which defines new coins to be created from old ones.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct TxOut {
     /// The value of the output, in satoshis.
     pub value: u64,
@@ -269,6 +271,7 @@ impl Default for TxOut {
 /// for 0-input transactions, which results in unambiguously parseable transactions.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Transaction {
     /// The protocol version, is currently expected to be 1 or 2 (BIP 68).
     pub version: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! * `base64` - (dependency), enables encoding of PSBTs and message signatures.
 //! * `unstable` - enables unstable features for testing.
 //! * `rand` - (dependency), makes it more convenient to generate random values.
-//! * `use-serde` - (dependency), implements `serde`-based serialization and
+//! * `serde` - (dependency), implements `serde`-based serialization and
 //!                 deserialization.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
 //! * `no-std` - enables additional features required for this crate to be usable
@@ -90,7 +90,7 @@ extern crate hashbrown;
 pub extern crate base64;
 
 #[cfg(feature="bitcoinconsensus")] extern crate bitcoinconsensus;
-#[cfg(feature = "serde")] #[macro_use] extern crate serde;
+#[cfg(feature = "serde")] #[macro_use] extern crate actual_serde as serde;
 #[cfg(all(test, feature = "serde"))] extern crate serde_json;
 #[cfg(all(test, feature = "serde"))] extern crate serde_test;
 #[cfg(all(test, feature = "serde"))] extern crate bincode;

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -152,6 +152,7 @@ pub mod btreemap_as_seq_byte_values {
 
     /// A custom key-value pair type that serialized the bytes as hex.
     #[derive(Debug, Deserialize)]
+    #[serde(crate = "actual_serde")]
     struct OwnedPair<T>(
         T,
         #[serde(deserialize_with = "crate::serde_utils::hex_bytes::deserialize")]
@@ -160,6 +161,7 @@ pub mod btreemap_as_seq_byte_values {
 
     /// A custom key-value pair type that serialized the bytes as hex.
     #[derive(Debug, Serialize)]
+    #[serde(crate = "actual_serde")]
     struct BorrowedPair<'a, T: 'static>(
         &'a T,
         #[serde(serialize_with = "crate::serde_utils::hex_bytes::serialize")]

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -1226,6 +1226,7 @@ pub mod serde {
     //! use bitcoin::Amount;
     //!
     //! #[derive(Serialize, Deserialize)]
+    //! # #[serde(crate = "actual_serde")]
     //! pub struct HasAmount {
     //!     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     //!     pub amount: Amount,
@@ -1940,6 +1941,7 @@ mod tests {
     fn serde_as_sat() {
 
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        #[serde(crate = "actual_serde")]
         struct T {
             #[serde(with = "crate::util::amount::serde::as_sat")]
             pub amt: Amount,
@@ -1969,6 +1971,7 @@ mod tests {
         use serde_json;
 
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        #[serde(crate = "actual_serde")]
         struct T {
             #[serde(with = "crate::util::amount::serde::as_btc")]
             pub amt: Amount,
@@ -2003,6 +2006,7 @@ mod tests {
         use serde_json;
 
         #[derive(Serialize, Deserialize, PartialEq, Debug, Eq)]
+        #[serde(crate = "actual_serde")]
         struct T {
             #[serde(default, with = "crate::util::amount::serde::as_btc::opt")]
             pub amt: Option<Amount>,
@@ -2046,6 +2050,7 @@ mod tests {
         use serde_json;
 
         #[derive(Serialize, Deserialize, PartialEq, Debug, Eq)]
+        #[serde(crate = "actual_serde")]
         struct T {
             #[serde(default, with = "crate::util::amount::serde::as_sat::opt")]
             pub amt: Option<Amount>,

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -27,6 +27,7 @@ use crate::EcdsaSighashType;
 /// An ECDSA signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct EcdsaSig {
     /// The underlying ECDSA Signature
     pub sig: secp256k1::ecdsa::Signature,

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -81,6 +81,7 @@ const PSBT_IN_PROPRIETARY: u8 = 0xFC;
 /// transaction.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Input {
     /// The non-witness transaction this input spends from. Should only be
     /// [std::option::Option::Some] for inputs which spend non-segwit outputs or
@@ -153,6 +154,7 @@ pub struct Input {
 /// for converting to/from [`PsbtSighashType`] from/to the desired signature hash type they need.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct PsbtSighashType {
     pub (in crate::util::psbt) inner: u32,
 }

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -49,6 +49,7 @@ const PSBT_OUT_PROPRIETARY: u8 = 0xFC;
 /// transaction.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Output {
     /// The redeem script for this output.
     pub redeem_script: Option<Script>,
@@ -123,6 +124,7 @@ impl std::error::Error for IncompleteTapTree {
 /// Taproot Tree representing a finalized [`TaprootBuilder`] (a complete binary tree).
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct TapTree(pub(crate) TaprootBuilder);
 
 impl PartialEq for TapTree {

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -52,6 +52,7 @@ pub type Psbt = PartiallySignedTransaction;
 /// A Partially Signed Transaction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct PartiallySignedTransaction {
     /// The unsigned transaction, scriptSigs and witnesses for each input must be empty.
     pub unsigned_tx: Transaction,

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -30,6 +30,7 @@ use crate::util::read_to_end;
 /// A PSBT key in its raw byte form.
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Key {
     /// The type of this PSBT key.
     pub type_value: u8,
@@ -41,6 +42,7 @@ pub struct Key {
 /// A PSBT key-value pair in its raw byte form.
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Pair {
     /// The key of this key-value pair.
     pub key: Key,
@@ -56,6 +58,7 @@ pub type ProprietaryType = u8;
 /// structure according to BIP 174.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct ProprietaryKey<Subtype=ProprietaryType> where Subtype: Copy + From<u8> + Into<u8> {
     /// Proprietary type prefix used for grouping together keys under some
     /// application and avoid namespace collision

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -39,6 +39,7 @@ pub type UntweakedPublicKey = crate::XOnlyPublicKey;
 /// Tweaked BIP-340 X-coord-only public key
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct TweakedPublicKey(crate::XOnlyPublicKey);
 
@@ -60,6 +61,7 @@ pub type UntweakedKeyPair = crate::KeyPair;
 /// Tweaked BIP-340 key pair
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct TweakedKeyPair(crate::KeyPair);
 
@@ -214,6 +216,7 @@ impl From<TweakedKeyPair> for crate::KeyPair {
 /// A BIP340-341 serialized schnorr signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct SchnorrSig {
     /// The underlying schnorr signature
     pub sig: secp256k1::schnorr::Signature,

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -166,6 +166,7 @@ type ScriptMerkleProofMap = BTreeMap<(Script, LeafVersion), BTreeSet<TaprootMerk
 /// [annex](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-5).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct TaprootSpendInfo {
     /// The BIP341 internal key.
     internal_key: UntweakedPublicKey,
@@ -314,6 +315,7 @@ impl TaprootSpendInfo {
 // Similar to Taproot Builder in bitcoin core.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct TaprootBuilder {
     // The following doc-comment is from bitcoin core, but modified for Rust. It describes the
     // current state of the builder for a given tree.
@@ -531,6 +533,7 @@ impl TaprootBuilder {
 /// root [`NodeInfo`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct NodeInfo {
     /// Merkle hash for this node.
     pub(crate) hash: sha256::Hash,
@@ -583,6 +586,7 @@ impl NodeInfo {
 /// Store information about taproot leaf node.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct ScriptLeaf {
     /// The underlying script.
     script: Script,
@@ -641,6 +645,7 @@ impl ScriptLeaf {
 // `TapLeafHash`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct TaprootMerkleBranch(Vec<sha256::Hash>);
 
 impl TaprootMerkleBranch {
@@ -717,6 +722,7 @@ impl TaprootMerkleBranch {
 /// Control block data structure used in Tapscript satisfaction.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct ControlBlock {
     /// The tapleaf version.
     pub leaf_version: LeafVersion,


### PR DESCRIPTION
Features activating external crates are supposed to have same name as
those crates. However we depend on same feature in other crates so we
need a separate feature. After MSRV bump it is possible to rename the
crates and features so we can now fix this inconsistency.

Sadly, derive can't see that the crate was renamed so all derives must
be told to use the other one.

Replaces #373 