### PR TITLE
Implement TryFrom

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -27,6 +27,7 @@ use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::prelude::*;
 
 use crate::io;
+use core::convert::TryFrom;
 use core::{fmt, default::Default};
 use core::ops::Index;
 
@@ -498,7 +499,7 @@ impl Script {
     /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
     #[inline]
     pub fn witness_version(&self) -> Option<WitnessVersion> {
-        self.0.get(0).and_then(|opcode| WitnessVersion::from_opcode(opcodes::All::from(*opcode)).ok())
+        self.0.get(0).and_then(|opcode| WitnessVersion::try_from(opcodes::All::from(*opcode)).ok())
     }
 
     /// Checks whether a script pubkey is a P2SH output.
@@ -550,7 +551,7 @@ impl Script {
         }
         let ver_opcode = opcodes::All::from(self.0[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
         let push_opbyte = self.0[1]; // Second byte push opcode 2-40 bytes
-        WitnessVersion::from_opcode(ver_opcode).is_ok()
+        WitnessVersion::try_from(ver_opcode).is_ok()
             && push_opbyte >= opcodes::all::OP_PUSHBYTES_2.to_u8()
             && push_opbyte <= opcodes::all::OP_PUSHBYTES_40.to_u8()
             // Check that the rest of the script has the correct size

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -12,6 +12,8 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+use core::convert::TryFrom;
+
 use crate::prelude::*;
 
 use crate::io::{self, Cursor, Read};
@@ -191,7 +193,7 @@ impl PartiallySignedTransaction {
                                 return Err(Error::InvalidKey(pair.key).into())
                             }
                         }
-                        PSBT_GLOBAL_PROPRIETARY => match proprietary.entry(raw::ProprietaryKey::from_key(pair.key.clone())?) {
+                        PSBT_GLOBAL_PROPRIETARY => match proprietary.entry(raw::ProprietaryKey::try_from(pair.key.clone())?) {
                             btree_map::Entry::Vacant(empty_key) => {
                                 empty_key.insert(pair.value);
                             },

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -16,6 +16,7 @@ use crate::prelude::*;
 use crate::io;
 use core::fmt;
 use core::str::FromStr;
+use core::convert::TryFrom;
 
 use secp256k1;
 use crate::blockdata::script::Script;
@@ -356,7 +357,7 @@ impl Input {
                 }
             }
             PSBT_IN_PROPRIETARY => {
-                let key = raw::ProprietaryKey::from_key(raw_key.clone())?;
+                let key = raw::ProprietaryKey::try_from(raw_key.clone())?;
                 match self.proprietary.entry(key) {
                     btree_map::Entry::Vacant(empty_key) => {
                         empty_key.insert(raw_value);

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -216,7 +216,7 @@ impl PsbtSighashType {
         if self.inner > 0xffu32 {
             Err(sighash::Error::InvalidSighashType(self.inner))
         } else {
-            SchnorrSighashType::from_u8(self.inner as u8)
+            SchnorrSighashType::from_consensus_u8(self.inner as u8)
         }
     }
 

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -249,7 +249,7 @@ impl Output {
                 }
             }
             PSBT_OUT_PROPRIETARY => {
-                let key = raw::ProprietaryKey::from_key(raw_key.clone())?;
+                let key = raw::ProprietaryKey::try_from(raw_key.clone())?;
                 match self.proprietary.entry(key) {
                     btree_map::Entry::Vacant(empty_key) => {
                         empty_key.insert(raw_value);

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -14,6 +14,7 @@
 
 use crate::prelude::*;
 use core;
+use core::convert::TryFrom;
 
 use crate::io;
 
@@ -158,15 +159,11 @@ impl TapTree {
     /// # Returns
     /// A [`TapTree`] iff the `builder` is complete, otherwise return [`IncompleteTapTree`]
     /// error with the content of incomplete `builder` instance.
+    #[deprecated(since = "0.29.0", note = "use try_from instead")]
     pub fn from_builder(builder: TaprootBuilder) -> Result<Self, IncompleteTapTree> {
-        if !builder.is_finalized() {
-            Err(IncompleteTapTree::NotFinalized(builder))
-        } else if builder.has_hidden_nodes() {
-            Err(IncompleteTapTree::HiddenParts(builder))
-        } else {
-            Ok(TapTree(builder))
-        }
+        Self::try_from(builder)
     }
+
 
     /// Converts self into builder [`TaprootBuilder`]. The builder is guaranteed to be finalized.
     pub fn into_builder(self) -> TaprootBuilder {
@@ -190,6 +187,25 @@ impl TapTree {
             }
             // This should be unreachable as we Taptree is already finalized
             _ => unreachable!("non-finalized tree builder inside TapTree"),
+        }
+    }
+}
+
+impl TryFrom<TaprootBuilder> for TapTree {
+    type Error = IncompleteTapTree;
+
+    /// Constructs [`TapTree`] from a [`TaprootBuilder`] if it is complete binary tree.
+    ///
+    /// # Returns
+    /// A [`TapTree`] iff the `builder` is complete, otherwise return [`IncompleteTapTree`]
+    /// error with the content of incomplete `builder` instance.
+    fn try_from(builder: TaprootBuilder) -> Result<Self, Self::Error> {
+        if !builder.is_finalized() {
+            Err(IncompleteTapTree::NotFinalized(builder))
+        } else if builder.has_hidden_nodes() {
+            Err(IncompleteTapTree::HiddenParts(builder))
+        } else {
+            Ok(TapTree(builder))
         }
     }
 }

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -370,6 +370,8 @@ fn key_source_len(key_source: &KeySource) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use core::convert::TryFrom;
+
     use crate::hashes::hex::FromHex;
     use super::*;
 
@@ -393,14 +395,14 @@ mod tests {
         let mut builder = compose_taproot_builder(0x51, &[2, 2, 2]);
         builder = builder.add_leaf_with_ver(3, Script::from_hex("b9").unwrap(), LeafVersion::from_consensus(0xC2).unwrap()).unwrap();
         builder = builder.add_hidden_node(3, sha256::Hash::default()).unwrap();
-        assert!(TapTree::from_builder(builder).is_err());
+        assert!(TapTree::try_from(builder).is_err());
     }
 
     #[test]
     fn taptree_roundtrip() {
         let mut builder = compose_taproot_builder(0x51, &[2, 2, 2, 3]);
         builder = builder.add_leaf_with_ver(3, Script::from_hex("b9").unwrap(), LeafVersion::from_consensus(0xC2).unwrap()).unwrap();
-        let tree = TapTree::from_builder(builder).unwrap();
+        let tree = TapTree::try_from(builder).unwrap();
         let tree_prime = TapTree::deserialize(&tree.serialize()).unwrap();
         assert_eq!(tree, tree_prime);
     }

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -18,6 +18,7 @@
 //!
 
 use core::fmt;
+
 use crate::prelude::*;
 
 use secp256k1::{self, Secp256k1, Verification, constants};
@@ -238,7 +239,7 @@ impl SchnorrSig {
             },
             65 => {
                 let (hash_ty, sig) = sl.split_last().expect("Slice len checked == 65");
-                let hash_ty = SchnorrSighashType::from_u8(*hash_ty)
+                let hash_ty = SchnorrSighashType::from_consensus_u8(*hash_ty)
                     .map_err(|_| SchnorrSigError::InvalidSighashType(*hash_ty))?;
                 let sig = secp256k1::schnorr::Signature::from_slice(sig)
                     .map_err(SchnorrSigError::Secp256k1)?;

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -1113,7 +1113,7 @@ mod tests {
             } else {
                 Some(hex_hash!(TapBranchHash, inp["given"]["merkleRoot"].as_str().unwrap()))
             };
-            let hash_ty = SchnorrSighashType::from_u8(inp["given"]["hashType"].as_u64().unwrap() as u8).unwrap();
+            let hash_ty = SchnorrSighashType::try_from(inp["given"]["hashType"].as_u64().unwrap() as u8).unwrap();
 
             let expected_internal_pk = hex_hash!(XOnlyPublicKey, inp["intermediary"]["internalPubkey"].as_str().unwrap());
             let expected_tweak = hex_hash!(TapTweakHash, inp["intermediary"]["tweak"].as_str().unwrap());
@@ -1124,7 +1124,7 @@ mod tests {
             let (expected_key_spend_sig, expected_hash_ty) = if sig_str.len() == 128 {
                 (secp256k1::schnorr::Signature::from_str(sig_str).unwrap(), SchnorrSighashType::Default)
             } else {
-                let hash_ty = SchnorrSighashType::from_u8(Vec::<u8>::from_hex(&sig_str[128..]).unwrap()[0]).unwrap();
+                let hash_ty = SchnorrSighashType::try_from(Vec::<u8>::from_hex(&sig_str[128..]).unwrap()[0]).unwrap();
                 (secp256k1::schnorr::Signature::from_str(&sig_str[..128]).unwrap(), hash_ty)
             };
 


### PR DESCRIPTION
Audit the whole codebase checking for any method that is of the form `from_foo` where foo is not an interesting identifier (like 'consensus' and 'standard'). Implement `TryFrom` for any such methods, deprecating the original.

Done as separate patches so any can be easily dropped if not liked.