### PR TITLE
Match against an optional single trailing colon

### DIFF
--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -1640,7 +1640,7 @@ mod tests {
 
     // Creates individual test functions to make it easier to find which check failed.
     macro_rules! check_format_non_negative {
-        ($denom:ident; $($test_name:ident, $val:expr, $format_string:expr, $expected:expr);* $(;)*) => {
+        ($denom:ident; $($test_name:ident, $val:expr, $format_string:expr, $expected:expr);* $(;)?) => {
             $(
                 #[test]
                 fn $test_name() {
@@ -1652,7 +1652,7 @@ mod tests {
     }
 
     macro_rules! check_format_non_negative_show_denom {
-        ($denom:ident, $denom_suffix:expr; $($test_name:ident, $val:expr, $format_string:expr, $expected:expr);* $(;)*) => {
+        ($denom:ident, $denom_suffix:expr; $($test_name:ident, $val:expr, $format_string:expr, $expected:expr);* $(;)?) => {
             $(
                 #[test]
                 fn $test_name() {


### PR DESCRIPTION
Currently we allow multiple trailing colons when matching within the
`check_format_non_negative` macro. We can be more restrictive with no
loss of usability.

Use `$(;)?` instead of `$(;)*` to match against 0 or 1 semi-colons
instead of 0 or more.

Done as part of the [edition 2018 checklist](https://github.com/rust-bitcoin/rust-bitcoin/issues/510).