### PR TITLE
Add non_exhaustive compiler directive to `AddressType`

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -139,6 +139,7 @@ impl From<bech32::Error> for Error {
 
 /// The different types of addresses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum AddressType {
     /// Pay to pubkey hash.
     P2pkh,


### PR DESCRIPTION
Add non_exhaustive compiler directive to AddressType

Currently adding variants to enums is a breaking change. In an effort to
reduce the upgrade burden on users we can use the `non_exhaustive`
compiler directive so that adding a new variant does not cause
downstream code to break.

Add `non_exhaustive` to the `AddressType` since it may be extended in
the future.