### PR TITLE
Do not pin transitive ryu dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,6 @@ serde_json = "<1.0.45"
 serde_test = "1"
 secp256k1 = { version = "0.22.0", features = [ "recovery", "rand-std" ] }
 bincode = "1.3.1"
-# We need to pin ryu (transitive dep from serde_json) to stay compatible with Rust 1.22.0
-ryu = "<1.0.5"
 
 [[example]]
 name = "bip32"


### PR DESCRIPTION
We do not need to pin the `ryu` transitive dependency now that MSRV is not 1.29.