### PR TITLE
Use fragment-specifier literal

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -672,7 +672,7 @@ impl Script {
     pub fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
         // This has to be a macro because it needs to break the loop
         macro_rules! read_push_data_len {
-            ($iter:expr, $len:expr, $formatter:expr) => {
+            ($iter:expr, $len:literal, $formatter:expr) => {
                 match read_uint_iter($iter, $len) {
                     Ok(n) => {
                         n

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -536,7 +536,7 @@ impl Decodable for Cow<'static, str> {
 
 // Arrays
 macro_rules! impl_array {
-    ( $size:expr ) => {
+    ( $size:literal ) => {
         impl Encodable for [u8; $size] {
             #[inline]
             fn consensus_encode<S: WriteExt>(&self, mut s: S) -> Result<usize, io::Error> {

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -57,7 +57,7 @@ macro_rules! impl_consensus_encoding {
 
 /// Implements standard array methods for a given wrapper type
 macro_rules! impl_array_newtype {
-    ($thing:ident, $ty:ty, $len:expr) => {
+    ($thing:ident, $ty:ty, $len:literal) => {
         impl $thing {
             /// Converts the object to a raw pointer
             #[inline]
@@ -137,7 +137,7 @@ macro_rules! hex_hash (($h:ident, $s:expr) => ($h::from_slice(&<$crate::prelude:
 macro_rules! hex_decode (($h:ident, $s:expr) => (deserialize::<$h>(&<$crate::prelude::Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()).unwrap()));
 
 macro_rules! serde_string_impl {
-    ($name:ident, $expecting:expr) => {
+    ($name:ident, $expecting:literal) => {
         #[cfg(feature = "serde")]
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl<'de> $crate::serde::Deserialize<'de> for $name {
@@ -184,7 +184,7 @@ macro_rules! serde_string_impl {
 /// A combination macro where the human-readable serialization is done like
 /// serde_string_impl and the non-human-readable impl is done as a struct.
 macro_rules! serde_struct_human_string_impl {
-    ($name:ident, $expecting:expr, $($fe:ident),*) => (
+    ($name:ident, $expecting:literal, $($fe:ident),*) => (
         #[cfg(feature = "serde")]
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl<'de> $crate::serde::Deserialize<'de> for $name {
@@ -362,7 +362,7 @@ macro_rules! serde_struct_human_string_impl {
 /// - core::str::FromStr
 /// - hashes::hex::FromHex
 macro_rules! impl_bytes_newtype {
-    ($t:ident, $len:expr) => (
+    ($t:ident, $len:literal) => (
 
         impl ::core::fmt::LowerHex for $t {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -493,7 +493,7 @@ macro_rules! user_enum {
         $(#[$attr:meta])*
         pub enum $name:ident {
             $(#[$doc:meta]
-              $elem:ident <-> $txt:expr),*
+              $elem:ident <-> $txt:literal),*
         }
     ) => (
         $(#[$attr])*

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -946,11 +946,11 @@ mod tests {
 
     use super::*;
 
-    macro_rules! hex (($hex:expr) => (Vec::from_hex($hex).unwrap()));
-    macro_rules! hex_key (($hex:expr) => (PublicKey::from_slice(&hex!($hex)).unwrap()));
-    macro_rules! hex_script (($hex:expr) => (Script::from(hex!($hex))));
-    macro_rules! hex_pubkeyhash (($hex:expr) => (PubkeyHash::from_hex(&$hex).unwrap()));
-    macro_rules! hex_scripthash (($hex:expr) => (ScriptHash::from_hex($hex).unwrap()));
+    macro_rules! hex (($hex:literal) => (Vec::from_hex($hex).unwrap()));
+    macro_rules! hex_key (($hex:literal) => (PublicKey::from_slice(&hex!($hex)).unwrap()));
+    macro_rules! hex_script (($hex:literal) => (Script::from(hex!($hex))));
+    macro_rules! hex_pubkeyhash (($hex:literal) => (PubkeyHash::from_hex(&$hex).unwrap()));
+    macro_rules! hex_scripthash (($hex:literal) => (ScriptHash::from_hex($hex).unwrap()));
 
     fn roundtrips(addr: &Address) {
         assert_eq!(

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -1678,7 +1678,7 @@ mod tests {
 
     // Creates individual test functions to make it easier to find which check failed.
     macro_rules! check_format_non_negative {
-        ($denom:ident; $($test_name:ident, $val:expr, $format_string:expr, $expected:expr);* $(;)?) => {
+        ($denom:ident; $($test_name:ident, $val:literal, $format_string:literal, $expected:literal);* $(;)?) => {
             $(
                 #[test]
                 fn $test_name() {
@@ -1690,7 +1690,7 @@ mod tests {
     }
 
     macro_rules! check_format_non_negative_show_denom {
-        ($denom:ident, $denom_suffix:expr; $($test_name:ident, $val:expr, $format_string:expr, $expected:expr);* $(;)?) => {
+        ($denom:ident, $denom_suffix:literal; $($test_name:ident, $val:literal, $format_string:literal, $expected:literal);* $(;)?) => {
             $(
                 #[test]
                 fn $test_name() {

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -19,7 +19,7 @@
 //!
 
 macro_rules! construct_uint {
-    ($name:ident, $n_words:expr) => {
+    ($name:ident, $n_words:literal) => {
         /// Little-endian large integer type
         #[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
         pub struct $name(pub [u64; $n_words]);


### PR DESCRIPTION
Currently we are using the fragment-specifier `expr` in a bunch of
macros for captures that are only used for literals. If we use `literal`
instead it allows the compiler to give slightly more specific error
messages.

The benefits of this change are minor. Of note, this patch found one
unusual macro call site (removed unnecessary `&`).

The macros changed are all internal macros, this is not a breaking change.