### PR TITLE
Refactor `trait Decodable` (sketch)

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -23,6 +23,7 @@
 //! This module provides the structures and functions needed to support scripts.
 //!
 
+use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::prelude::*;
 
 use crate::io;
@@ -1076,8 +1077,13 @@ impl Encodable for Script {
 
 impl Decodable for Script {
     #[inline]
+    fn consensus_decode_from_finite_reader<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+        Ok(Script(Decodable::consensus_decode_from_finite_reader(d)?))
+    }
+
+    #[inline]
     fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        Ok(Script(Decodable::consensus_decode(d)?))
+        Self::consensus_decode_from_finite_reader(d.take(MAX_VEC_SIZE as u64))
     }
 }
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -621,10 +621,10 @@ impl Encodable for OutPoint {
     }
 }
 impl Decodable for OutPoint {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
         Ok(OutPoint {
-            txid: Decodable::consensus_decode(&mut d)?,
-            vout: Decodable::consensus_decode(d)?,
+            txid: Decodable::consensus_decode_from_finite_reader(&mut d)?,
+            vout: Decodable::consensus_decode_from_finite_reader(d)?,
         })
     }
 }
@@ -639,13 +639,17 @@ impl Encodable for TxIn {
     }
 }
 impl Decodable for TxIn {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
         Ok(TxIn {
-            previous_output: Decodable::consensus_decode(&mut d)?,
-            script_sig: Decodable::consensus_decode(&mut d)?,
-            sequence: Decodable::consensus_decode(d)?,
+            previous_output: Decodable::consensus_decode_from_finite_reader(&mut d)?,
+            script_sig: Decodable::consensus_decode_from_finite_reader(&mut d)?,
+            sequence: Decodable::consensus_decode_from_finite_reader(d)?,
             witness: Witness::default(),
         })
+    }
+
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+        Self::consensus_decode_from_finite_reader(d.take(MAX_VEC_SIZE as u64))
     }
 }
 
@@ -680,20 +684,20 @@ impl Encodable for Transaction {
 }
 
 impl Decodable for Transaction {
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<D: io::Read>(d: D) -> Result<Self, encode::Error> {
         let mut d = d.take(MAX_VEC_SIZE as u64);
-        let version = i32::consensus_decode(&mut d)?;
-        let input = Vec::<TxIn>::consensus_decode(&mut d)?;
+        let version = i32::consensus_decode_from_finite_reader(&mut d)?;
+        let input = Vec::<TxIn>::consensus_decode_from_finite_reader(&mut d)?;
         // segwit
         if input.is_empty() {
-            let segwit_flag = u8::consensus_decode(&mut d)?;
+            let segwit_flag = u8::consensus_decode_from_finite_reader(&mut d)?;
             match segwit_flag {
                 // BIP144 input witnesses
                 1 => {
-                    let mut input = Vec::<TxIn>::consensus_decode(&mut d)?;
-                    let output = Vec::<TxOut>::consensus_decode(&mut d)?;
+                    let mut input = Vec::<TxIn>::consensus_decode_from_finite_reader(&mut d)?;
+                    let output = Vec::<TxOut>::consensus_decode_from_finite_reader(&mut d)?;
                     for txin in input.iter_mut() {
-                        txin.witness = Decodable::consensus_decode(&mut d)?;
+                        txin.witness = Decodable::consensus_decode_from_finite_reader(&mut d)?;
                     }
                     if !input.is_empty() && input.iter().all(|input| input.witness.is_empty()) {
                         Err(encode::Error::ParseFailed("witness flag set but no witnesses present"))
@@ -702,7 +706,7 @@ impl Decodable for Transaction {
                             version,
                             input,
                             output,
-                            lock_time: Decodable::consensus_decode(d)?,
+                            lock_time: Decodable::consensus_decode_from_finite_reader(d)?,
                         })
                     }
                 }
@@ -714,10 +718,14 @@ impl Decodable for Transaction {
             Ok(Transaction {
                 version,
                 input,
-                output: Decodable::consensus_decode(&mut d)?,
-                lock_time: Decodable::consensus_decode(d)?,
+                output: Decodable::consensus_decode_from_finite_reader(&mut d)?,
+                lock_time: Decodable::consensus_decode_from_finite_reader(d)?,
             })
         }
+    }
+
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+        Self::consensus_decode_from_finite_reader(d.take(MAX_VEC_SIZE as u64))
     }
 }
 

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -31,7 +31,7 @@ macro_rules! impl_hashencode {
         }
 
         impl $crate::consensus::Decodable for $hashtype {
-            fn consensus_decode<D: $crate::io::Read>(d: D) -> Result<Self, $crate::consensus::encode::Error> {
+            fn consensus_decode_from_finite_reader<D: $crate::io::Read>(d: D) -> Result<Self, $crate::consensus::encode::Error> {
                 use $crate::hashes::Hash;
                 Ok(Self::from_inner(<<$hashtype as $crate::hashes::Hash>::Inner>::consensus_decode(d)?))
             }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -33,13 +33,19 @@ macro_rules! impl_consensus_encoding {
 
         impl $crate::consensus::Decodable for $thing {
             #[inline]
+            fn consensus_decode_from_finite_reader<D: $crate::io::Read>(
+                mut d: D,
+            ) -> Result<$thing, $crate::consensus::encode::Error> {
+                Ok($thing {
+                    $($field: $crate::consensus::Decodable::consensus_decode_from_finite_reader(&mut d)?),+
+                })
+            }
+
+            #[inline]
             fn consensus_decode<D: $crate::io::Read>(
                 d: D,
             ) -> Result<$thing, $crate::consensus::encode::Error> {
-                let mut d = d.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
-                Ok($thing {
-                    $($field: $crate::consensus::Decodable::consensus_decode(&mut d)?),+
-                })
+                Self::consensus_decode_from_finite_reader(d.take($crate::consensus::encode::MAX_VEC_SIZE as u64))
             }
         }
     );

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -86,11 +86,11 @@ impl Encodable for Address {
 
 impl Decodable for Address {
     #[inline]
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
         Ok(Address {
-            services: Decodable::consensus_decode(&mut d)?,
+            services: Decodable::consensus_decode_from_finite_reader(&mut d)?,
             address: read_be_address(&mut d)?,
-            port: u16::swap_bytes(Decodable::consensus_decode(d)?)
+            port: u16::swap_bytes(Decodable::consensus_decode_from_finite_reader(d)?)
         })
     }
 }
@@ -168,7 +168,7 @@ impl Encodable for AddrV2 {
 }
 
 impl Decodable for AddrV2 {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
         let network_id = u8::consensus_decode(&mut d)?;
         let len = VarInt::consensus_decode(&mut d)?.0;
         if len > 512 {
@@ -278,7 +278,7 @@ impl Encodable for AddrV2Message {
 }
 
 impl Decodable for AddrV2Message {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
         Ok(AddrV2Message {
             time: Decodable::consensus_decode(&mut d)?,
             services: ServiceFlags::from(VarInt::consensus_decode(&mut d)?.0),

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -281,8 +281,8 @@ impl Encodable for ServiceFlags {
 
 impl Decodable for ServiceFlags {
     #[inline]
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        Ok(ServiceFlags(Decodable::consensus_decode(&mut d)?))
+    fn consensus_decode_from_finite_reader<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+        Ok(ServiceFlags(Decodable::consensus_decode_from_finite_reader(d)?))
     }
 }
 

--- a/src/network/message_bloom.rs
+++ b/src/network/message_bloom.rs
@@ -45,7 +45,7 @@ impl Encodable for BloomFlags {
 }
 
 impl Decodable for BloomFlags {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
         Ok(match d.read_u8()? {
             0 => BloomFlags::None,
             1 => BloomFlags::All,

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -113,7 +113,7 @@ impl Encodable for RejectReason {
 }
 
 impl Decodable for RejectReason {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
         Ok(match d.read_u8()? {
             0x01 => RejectReason::Malformed,
             0x10 => RejectReason::Invalid,

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -68,18 +68,23 @@ macro_rules! impl_psbtmap_consensus_encoding {
 macro_rules! impl_psbtmap_consensus_decoding {
     ($thing:ty) => {
         impl $crate::consensus::Decodable for $thing {
-            fn consensus_decode<D: $crate::io::Read>(
+            fn consensus_decode_from_finite_reader<D: $crate::io::Read>(
                 mut d: D,
             ) -> Result<Self, $crate::consensus::encode::Error> {
                 let mut rv: Self = ::core::default::Default::default();
 
                 loop {
-                    match $crate::consensus::Decodable::consensus_decode(&mut d) {
+                    match $crate::consensus::Decodable::consensus_decode_from_finite_reader(&mut d) {
                         Ok(pair) => rv.insert_pair(pair)?,
                         Err($crate::consensus::encode::Error::Psbt($crate::util::psbt::Error::NoMorePairs)) => return Ok(rv),
                         Err(e) => return Err(e),
                     }
                 }
+            }
+            fn consensus_decode<D: $crate::io::Read>(
+                d: D,
+            ) -> Result<Self, $crate::consensus::encode::Error> {
+                Self::consensus_decode_from_finite_reader(d.take($crate::consensus::encode::MAX_VEC_SIZE as u64))
             }
         }
     };

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -433,15 +433,21 @@ macro_rules! construct_uint {
         }
 
         impl $crate::consensus::Decodable for $name {
-            fn consensus_decode<D: $crate::io::Read>(
+            fn consensus_decode_from_finite_reader<D: $crate::io::Read>(
                 mut d: D,
             ) -> Result<$name, $crate::consensus::encode::Error> {
                 use $crate::consensus::Decodable;
                 let mut ret: [u64; $n_words] = [0; $n_words];
                 for i in 0..$n_words {
-                    ret[i] = Decodable::consensus_decode(&mut d)?;
+                    ret[i] = Decodable::consensus_decode_from_finite_reader(&mut d)?;
                 }
                 Ok($name(ret))
+            }
+
+            fn consensus_decode<D: $crate::io::Read>(
+                d: D,
+            ) -> Result<$name, $crate::consensus::encode::Error> {
+                Self::consensus_decode_from_finite_reader(d.take($crate::consensus::encode::MAX_VEC_SIZE as u64))
             }
         }
 


### PR DESCRIPTION
Adjust code afterwards. This is to address #997.

**Edit**: Eh, this is backwards. :facepalm:  I started with details somewhat different, then reverted that idea and didn't realize the implications until i woke up today.


`consensus_decode_from_finite_reader` should just forward to `consensus_decode` because in the general case decoding without finite-len requirement is more general than with it.

Most of the type won't care, because they are finite and non-recursive. Only vecs and some other containers will overwrite `consensus_decode_from_finite_reader` +  `consensus_decode` .

Yeah. I'll redo later today if I find time.