### PR TITLE
Add non_exhaustive to all error enums

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -333,6 +333,7 @@ impl Block {
 
 /// An error when looking up a BIP34 block height.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Bip34Error {
     /// The block does not support BIP34 yet.
     Unsupported,

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -137,6 +137,7 @@ where
 /// much as it could be; patches welcome if more detailed errors
 /// would help you.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum Error {
     /// Something did a non-minimal push; for more information see
     /// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -114,6 +114,7 @@ impl fmt::Display for OutPoint {
 
 /// An error in parsing an OutPoint.
 #[derive(Clone, PartialEq, Eq, Debug)]
+#[non_exhaustive]
 pub enum ParseOutPointError {
     /// Error in TXID part.
     Txid(hashes::hex::Error),

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -47,6 +47,7 @@ use crate::network::{message_blockdata::Inventory, address::{Address, AddrV2Mess
 
 /// Encoding error
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// And I/O error
     Io(io::Error),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -50,6 +50,7 @@ pub mod stream_reader;
 
 /// Network error
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// And I/O error
     Io(io::Error),

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -53,6 +53,7 @@ use crate::util::schnorr::{TapTweak, UntweakedPublicKey, TweakedPublicKey};
 
 /// Address error.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error.
     Base58(base58::Error),

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -148,6 +148,7 @@ fn denomination_from_str(mut s: &str) -> Option<Denomination> {
 
 /// An error during amount parsing.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ParseAmountError {
     /// Amount is negative.
     Negative,

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -29,6 +29,7 @@ use crate::util::{endian, key};
 
 /// An error that might occur during base58 decoding
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[non_exhaustive]
 pub enum Error {
     /// Invalid character encountered
     BadByte(u8),

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -457,6 +457,7 @@ pub type KeySource = (Fingerprint, DerivationPath);
 
 /// A BIP32 error
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// A pk->pk derivation was attempted on a hardened key
     CannotDeriveFromHardenedKey,

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -87,6 +87,7 @@ impl FromStr for EcdsaSig {
 
 /// A key-related error.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
 pub enum EcdsaSigError {
     /// Hex encoding error
     HexEncoding(hex::Error),

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -31,6 +31,7 @@ use crate::util::base58;
 
 /// A key-related error.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error
     Base58(base58::Error),

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -48,6 +48,7 @@ mod message_signing {
     /// An error used for dealing with Bitcoin Signed Messages.
     #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
     #[derive(Debug, PartialEq, Eq)]
+    #[non_exhaustive]
     pub enum MessageSignatureError {
         /// Signature is expected to be 65 bytes.
         InvalidLength,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -67,6 +67,7 @@ pub trait BitArray {
 /// A general error code, other errors should implement conversions to/from this
 /// if appropriate.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Encoding error
     Encode(encode::Error),

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -33,6 +33,7 @@ pub enum PsbtHash {
 }
 /// Ways that a Partially Signed Transaction might fail.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Magic bytes for a PSBT must be the ASCII for "psbt" serialized in most
     /// significant byte order.

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -82,6 +82,7 @@ pub struct Output {
 /// Error happening when [`TapTree`] is constructed from a [`TaprootBuilder`]
 /// having hidden branches or not being finalized.
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum IncompleteTapTree {
     /// Indicates an attempt to construct a tap tree from a builder containing incomplete branches.
     NotFinalized(TaprootBuilder),

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -223,6 +223,7 @@ mod display_from_str {
     /// Error encountered during PSBT decoding from Base64 string.
     #[derive(Debug)]
     #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
+    #[non_exhaustive]
     pub enum PsbtParseError {
         /// Error in internal PSBT data structure.
         PsbtEncoding(Error),

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -261,6 +261,7 @@ impl SchnorrSig {
 
 /// A schnorr sig related error.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
 pub enum SchnorrSigError {
     /// Base58 encoding error
     InvalidSighashType(u8),

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -167,6 +167,7 @@ impl str::FromStr for SchnorrSighashType {
 
 /// Possible errors in computing the signature message.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Could happen only by using `*_encode_signing_*` methods with custom writers, engines writers
     /// like the ones used in methods `*_signature_hash` do not error.

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -969,6 +969,7 @@ impl<'de> ::serde::Deserialize<'de> for LeafVersion {
 
 /// Detailed error type for taproot builder.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum TaprootBuilderError {
     /// Merkle tree depth must not be more than 128.
     InvalidMerkleTreeDepth(usize),
@@ -1030,6 +1031,7 @@ impl std::error::Error for TaprootBuilderError {
 
 /// Detailed error type for taproot utilities.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum TaprootError {
     /// Proof size must be a multiple of 32.
     InvalidMerkleBranchSize(usize),


### PR DESCRIPTION
Adding an error variant to a public enum is an API breaking change, this means making, what could be, small refactorings or improvements harder. If we use `non_exhaustive` for error types then we mitigate this cost.

There is a tradeoff however, downstream users who explicitly match on our public error types must include a wildcard pattern.