### PR TITLE
Add `serialized_len` method in `Encodable` trait

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -1072,6 +1072,7 @@ impl Encodable for Script {
     fn consensus_encode<S: io::Write>(&self, s: S) -> Result<usize, io::Error> {
         self.0.consensus_encode(s)
     }
+    fn serialized_len(&self) -> usize { self.0.serialized_len() }
 }
 
 impl Decodable for Script {

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -1686,6 +1686,30 @@ mod benches {
         });
     }
 
+
+    #[bench]
+    pub fn bench_transaction_serialize_realloc(bh: &mut Bencher) {
+        let raw_tx = Vec::from_hex(SOME_TX).unwrap();
+        let tx: Transaction = deserialize(&raw_tx).unwrap();
+
+        bh.iter(|| {
+            let mut vec = vec![];
+            let result = tx.consensus_encode(&mut vec).unwrap();
+            black_box(&result);
+        });
+    }
+
+    #[bench]
+    pub fn bench_transaction_serialized_len(bh: &mut Bencher) {
+        let raw_tx = Vec::from_hex(SOME_TX).unwrap();
+        let tx: Transaction = deserialize(&raw_tx).unwrap();
+
+        bh.iter(|| {
+            let result = tx.serialized_len();
+            black_box(&result);
+        });
+    }
+
     #[bench]
     pub fn bench_transaction_serialize_logic(bh: &mut Bencher) {
         let raw_tx = Vec::from_hex(SOME_TX).unwrap();

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -710,6 +710,9 @@ impl Encodable for Transaction {
         len += self.lock_time.serialized_len();
         len
      }
+     fn is_big_object(&self, max_iterations: usize) -> bool {
+        self.input.len().saturating_add(self.output.len()) > max_iterations
+    }
 }
 
 impl Decodable for Transaction {

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -119,6 +119,9 @@ impl Encodable for Witness {
         writer.emit_slice(&self.content[..])?;
         Ok(self.content.len() + len.len())
     }
+    fn serialized_len(&self) -> usize {
+        crate::consensus::encode::var_int_serialized_len(self.witness_elements as u64) + self.content.len()
+     }
 }
 
 impl Witness {
@@ -178,14 +181,6 @@ impl Witness {
     /// Returns the number of elements this witness holds
     pub fn len(&self) -> usize {
         self.witness_elements as usize
-    }
-
-    /// Returns the bytes required when this Witness is consensus encoded
-    pub fn serialized_len(&self) -> usize {
-        self.iter()
-            .map(|el| VarInt(el.len() as u64).len() + el.len())
-            .sum::<usize>()
-            + VarInt(self.witness_elements as u64).len()
     }
 
     /// Clear the witness

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -139,9 +139,11 @@ impl From<psbt::Error> for Error {
 
 /// Encode an object into a vector
 pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
-    let mut encoder = Vec::new();
+    let serialized_len = data.serialized_len();
+    let mut encoder = Vec::with_capacity(serialized_len);
     let len = data.consensus_encode(&mut encoder).expect("in-memory writers don't error");
     debug_assert_eq!(len, encoder.len());
+    debug_assert_eq!(serialized_len, encoder.len());
     encoder
 }
 

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -28,6 +28,7 @@ macro_rules! impl_hashencode {
             fn consensus_encode<S: $crate::io::Write>(&self, s: S) -> Result<usize, $crate::io::Error> {
                 self.0.consensus_encode(s)
             }
+            fn serialized_len(&self) -> usize { $hashtype::LEN }
         }
 
         impl $crate::consensus::Decodable for $hashtype {

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -29,6 +29,11 @@ macro_rules! impl_consensus_encoding {
                 $(len += self.$field.consensus_encode(&mut s)?;)+
                 Ok(len)
             }
+            fn serialized_len(&self) -> usize { 
+                let mut len = 0;
+                $(len += self.$field.serialized_len();)+
+                len
+             }
         }
 
         impl $crate::consensus::Decodable for $thing {

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -277,6 +277,7 @@ impl Encodable for ServiceFlags {
     fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
         self.0.consensus_encode(&mut s)
     }
+    fn serialized_len(&self) -> usize { self.0.serialized_len() }
 }
 
 impl Decodable for ServiceFlags {

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -70,6 +70,7 @@ impl Encodable for Inventory {
             Inventory::Unknown { inv_type: t, hash: ref d } => encode_inv!(t, d),
         })
     }
+    fn serialized_len(&self) -> usize { 36 }
 }
 
 impl Decodable for Inventory {

--- a/src/network/message_bloom.rs
+++ b/src/network/message_bloom.rs
@@ -42,6 +42,7 @@ impl Encodable for BloomFlags {
         }])?;
         Ok(1)
     }
+    fn serialized_len(&self) -> usize { 1 }
 }
 
 impl Decodable for BloomFlags {

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -110,6 +110,7 @@ impl Encodable for RejectReason {
         e.write_all(&[*self as u8])?;
         Ok(1)
     }
+    fn serialized_len(&self) -> usize { 1 }
 }
 
 impl Decodable for RejectReason {

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -349,6 +349,11 @@ impl Encodable for PartialMerkleTree {
         }
         Ok(ret + bytes.consensus_encode(s)?)
     }
+    fn serialized_len(&self) -> usize { 
+        let bytes_len = (self.bits.len() + 7) / 8;
+        4 + self.hashes.serialized_len() + encode::var_int_serialized_len(bytes_len as u64) + bytes_len 
+    }
+
 }
 
 impl Decodable for PartialMerkleTree {
@@ -496,6 +501,8 @@ impl Encodable for MerkleBlock {
             + self.txn.consensus_encode(s)?;
         Ok(len)
     }
+    fn serialized_len(&self) -> usize { self.header.serialized_len() + self.txn.serialized_len() }
+
 }
 
 impl Decodable for MerkleBlock {

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -61,6 +61,8 @@ macro_rules! impl_psbtmap_consensus_encoding {
             ) -> Result<usize, $crate::io::Error> {
                 self.consensus_encode_map(s)
             }
+
+            fn serialized_len(&self) -> usize { 0 /* TODO */ }
         }
     };
 }

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -292,6 +292,7 @@ impl Encodable for PartiallySignedTransaction {
 
         Ok(len)
     }
+    fn serialized_len(&self) -> usize { 0 /* TODO */ }
 }
 
 impl Decodable for PartiallySignedTransaction {

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -116,6 +116,7 @@ impl Encodable for Key {
 
         Ok(len)
     }
+    fn serialized_len(&self) -> usize { encode::var_int_serialized_len((self.key.len() + 1) as u64) + 1 + self.key.len() }
 }
 
 impl Encodable for Pair {
@@ -123,6 +124,8 @@ impl Encodable for Pair {
         let len = self.key.consensus_encode(&mut s)?;
         Ok(len + self.value.consensus_encode(s)?)
     }
+
+    fn serialized_len(&self) -> usize { self.key.serialized_len() + self.value.serialized_len() }
 }
 
 impl Decodable for Pair {
@@ -142,6 +145,8 @@ impl<Subtype> Encodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u
         len += self.key.len();
         Ok(len)
     }
+
+    fn serialized_len(&self) -> usize { self.prefix.serialized_len() + 1 + self.key.len() }
 }
 
 impl<Subtype> Decodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u8> + Into<u8> {

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -803,6 +803,7 @@ impl<'a> Encodable for Annex<'a> {
     fn consensus_encode<W: io::Write>(&self, writer: W) -> Result<usize, io::Error> {
         encode::consensus_encode_with_size(self.0, writer)
     }
+    fn serialized_len(&self) -> usize { encode::bytes_serialized_len(self.0) }
 }
 
 #[cfg(test)]

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -430,6 +430,14 @@ macro_rules! construct_uint {
                 }
                 Ok(len)
             }
+            fn serialized_len(&self) -> usize {
+                let &$name(ref data) = self;
+                let mut len = 0;
+                for word in data.iter() {
+                    len += word.serialized_len();
+                }
+                len
+            }
         }
 
         impl $crate::consensus::Decodable for $name {


### PR DESCRIPTION
It's nice to know ahead of time how much space an encodable object will take once serialized, this allows to allocate the capacity of a vector before using it for storing serialized information, avoiding vector re-allocations.

Used in the `serialize` method here https://github.com/rust-bitcoin/rust-bitcoin/blob/99ae48ab010fa6773687ca96deff46ab63fadc12/src/consensus/encode.rs#L142 as done in the second commit, improve serialize performance a lot for object sized hundreds of bytes where the weight of re-allocations in comparison of the serialization work is bigger. 

```
# before                                                                        
                                                                                
test blockdata::transaction::benches::bench_transaction_serialize               ... bench:         550 ns/iter (+/- 31)
                                                                                
# after                                                                         
                                                                                
test blockdata::transaction::benches::bench_transaction_serialize               ... bench:         144 ns/iter (+/- 4)
```
(Note I renamed current benchmark to `bench_transaction_serialize_with_capacity` because it was using a pre-created workhorse collection to store serialization data and created a new one `bench_transaction_serialize` which use `serialize()`)

Still a draft cause I have to re-check everything but I will do after https://github.com/rust-bitcoin/rust-bitcoin/pull/988 is merged so that I don't have to bother to implement `serialized_len` in psbt methods .