### PR TITLE
Add taproot checks to `Address::from_script`

### DIFF
--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -1426,8 +1426,10 @@ mod tests {
     fn test_fail_address_from_script() {
         let bad_p2wpkh = hex_script!("0014dbc5b0a8f9d4353b4b54c3db48846bb15abfec");
         let bad_p2wsh = hex_script!("00202d4fa2eb233d008cc83206fa2f4f2e60199000f5b857a835e3172323385623");
+        let bad_p2tr = hex_script!("5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6");
 
         assert_eq!(Address::from_script(&bad_p2wpkh, Network::Bitcoin), None);
         assert_eq!(Address::from_script(&bad_p2wsh, Network::Bitcoin), None);
+        assert_eq!(Address::from_script(&bad_p2tr, Network::Bitcoin), None);
     }
 }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -671,6 +671,13 @@ impl Address {
     }
 
     /// Constructs an [`Address`] from an output script (`scriptPubkey`).
+    ///
+    /// # Returns
+    ///
+    /// The Bitcoin network allows well formed addresses that are unspendable, such as an address
+    /// created from an invalid script. We explicitly make an effort to protect users and do not
+    /// create such addresses, hence if `script` is a segwit script but is _invalid_ we do not
+    /// create an address and instead return `None`.
     pub fn from_script(script: &script::Script, network: Network) -> Option<Address> {
         if script.is_witness_program() {
             if script.witness_version() == Some(WitnessVersion::V0) && !(script.is_v0_p2wpkh() || script.is_v0_p2wsh()) {

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -672,6 +672,12 @@ impl Address {
 
     /// Constructs an [`Address`] from an output script (`scriptPubkey`).
     pub fn from_script(script: &script::Script, network: Network) -> Option<Address> {
+        if script.is_witness_program() {
+            if script.witness_version() == Some(WitnessVersion::V0) && !(script.is_v0_p2wpkh() || script.is_v0_p2wsh()) {
+                return None
+            }
+        }
+
         Some(Address {
             payload: Payload::from_script(script)?,
             network,
@@ -1397,5 +1403,14 @@ mod tests {
 
         let result = address.is_related_to_xonly_pubkey(&xonly_pubkey);
         assert!(result);
+    }
+
+    #[test]
+    fn test_fail_address_from_script() {
+        let bad_p2wpkh = hex_script!("0014dbc5b0a8f9d4353b4b54c3db48846bb15abfec");
+        let bad_p2wsh = hex_script!("00202d4fa2eb233d008cc83206fa2f4f2e60199000f5b857a835e3172323385623");
+
+        assert_eq!(Address::from_script(&bad_p2wpkh, Network::Bitcoin), None);
+        assert_eq!(Address::from_script(&bad_p2wsh, Network::Bitcoin), None);
     }
 }


### PR DESCRIPTION
Draft because includes https://github.com/rust-bitcoin/rust-bitcoin/pull/1021

#1021 adds segwit v0 checks to `Address::from_script`. This PR  adds taproot checks and documentation on _why_ we do the checks.

This was done while I was attempting to write a [decent issue](https://github.com/rust-bitcoin/rust-bitcoin/issues/1028). Is related to #1021 (obviously) and also to (#995).

cc @nlanson 