### PR TITLE
Remove network::Error

### DIFF
--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -18,9 +18,6 @@
 //! of Bitcoin data and network messages.
 //!
 
-use crate::io;
-use core::fmt;
-
 pub mod constants;
 
 #[cfg(feature = "std")]
@@ -47,38 +44,3 @@ pub mod message_filter;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod stream_reader;
-
-/// Network error
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum Error {
-    /// And I/O error
-    Io(io::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Io(ref e) => write_err!(f, "IO error"; e),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use self::Error::*;
-
-        match self {
-            Io(e) => Some(e)
-        }
-    }
-}
-
-#[doc(hidden)]
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Error::Io(err)
-    }
-}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -40,7 +40,6 @@ use crate::prelude::*;
 use crate::io;
 use core::fmt;
 
-use crate::network;
 use crate::consensus::encode;
 
 /// A trait which allows numbers to act as fixed-size bit arrays
@@ -71,8 +70,6 @@ pub trait BitArray {
 pub enum Error {
     /// Encoding error
     Encode(encode::Error),
-    /// Network error
-    Network(network::Error),
     /// The header hash is not below the target
     BlockBadProofOfWork,
     /// The `target` field of a block header did not match the expected difficulty
@@ -83,7 +80,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Encode(ref e) => write_err!(f, "encoding error"; e),
-            Error::Network(ref e) => write_err!(f, "network error"; e),
             Error::BlockBadProofOfWork => f.write_str("block target correct but not attained"),
             Error::BlockBadTarget => f.write_str("block target incorrect"),
         }
@@ -98,9 +94,7 @@ impl std::error::Error for Error {
 
         match self {
             Encode(e) => Some(e),
-            Network(e) => Some(e),
-            BlockBadProofOfWork
-            | BlockBadTarget => None
+            BlockBadProofOfWork | BlockBadTarget => None
         }
     }
 }
@@ -109,13 +103,6 @@ impl std::error::Error for Error {
 impl From<encode::Error> for Error {
     fn from(e: encode::Error) -> Error {
         Error::Encode(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<network::Error> for Error {
-    fn from(e: network::Error) -> Error {
-        Error::Network(e)
     }
 }
 


### PR DESCRIPTION
The `network::Error` is not used, remove it.

(This description has been changed, the thumbs up emojis were put on the previous PR description.)