### PR TITLE
Take Writer/Reader by `&mut` in consensus en/decoding

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -23,11 +23,9 @@
 //! This module provides the structures and functions needed to support scripts.
 //!
 
-use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::prelude::*;
 
 use crate::io;
-use io::Read as _;
 use core::{fmt, default::Default};
 use core::ops::Index;
 
@@ -1102,11 +1100,6 @@ impl Decodable for Script {
     #[inline]
     fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(Script(Decodable::consensus_decode_from_finite_reader(r)?))
-    }
-
-    #[inline]
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(r.take(MAX_VEC_SIZE as u64).by_ref())
     }
 }
 

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -1091,14 +1091,14 @@ impl serde::Serialize for Script {
 
 impl Encodable for Script {
     #[inline]
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         self.0.consensus_encode(w)
     }
 }
 
 impl Decodable for Script {
     #[inline]
-    fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(Script(Decodable::consensus_decode_from_finite_reader(r)?))
     }
 }

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -27,6 +27,7 @@ use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::prelude::*;
 
 use crate::io;
+use io::Read as _;
 use core::{fmt, default::Default};
 use core::ops::Index;
 
@@ -1092,20 +1093,20 @@ impl serde::Serialize for Script {
 
 impl Encodable for Script {
     #[inline]
-    fn consensus_encode<S: io::Write>(&self, s: S) -> Result<usize, io::Error> {
-        self.0.consensus_encode(s)
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
     }
 }
 
 impl Decodable for Script {
     #[inline]
-    fn consensus_decode_from_finite_reader<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        Ok(Script(Decodable::consensus_decode_from_finite_reader(d)?))
+    fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(Script(Decodable::consensus_decode_from_finite_reader(r)?))
     }
 
     #[inline]
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(d.take(MAX_VEC_SIZE as u64))
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        Self::consensus_decode_from_finite_reader(r.take(MAX_VEC_SIZE as u64).by_ref())
     }
 }
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -26,7 +26,6 @@
 use crate::prelude::*;
 
 use crate::io;
-use io::Read as _;
 use core::{fmt, str, default::Default};
 
 use crate::hashes::{self, Hash, sha256d};
@@ -38,7 +37,6 @@ use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
 use crate::blockdata::script::Script;
 use crate::blockdata::witness::Witness;
 use crate::consensus::{encode, Decodable, Encodable};
-use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::hash_types::{Sighash, Txid, Wtxid};
 use crate::VarInt;
 
@@ -687,11 +685,6 @@ impl Decodable for TxIn {
             witness: Witness::default(),
         })
     }
-
-    #[inline]
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(r.take(MAX_VEC_SIZE as u64).by_ref())
-    }
 }
 
 impl Encodable for Transaction {
@@ -762,10 +755,6 @@ impl Decodable for Transaction {
                 lock_time: Decodable::consensus_decode_from_finite_reader(r)?,
             })
         }
-    }
-
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_VEC_SIZE as u64))
     }
 }
 

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -49,7 +49,7 @@ pub struct Iter<'a> {
 }
 
 impl Decodable for Witness {
-    fn consensus_decode<R: Read>(r: &mut R) -> Result<Self, Error> {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let witness_elements = VarInt::consensus_decode(r)?.0 as usize;
         if witness_elements == 0 {
             Ok(Witness::default())
@@ -116,7 +116,7 @@ fn resize_if_needed(vec: &mut Vec<u8>, required_len: usize) {
 }
 
 impl Encodable for Witness {
-    fn consensus_encode<W: Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let len = VarInt(self.witness_elements as u64);
         len.consensus_encode(w)?;
         w.emit_slice(&self.content[..])?;

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -49,8 +49,8 @@ pub struct Iter<'a> {
 }
 
 impl Decodable for Witness {
-    fn consensus_decode<D: Read>(mut d: D) -> Result<Self, Error> {
-        let witness_elements = VarInt::consensus_decode(&mut d)?.0 as usize;
+    fn consensus_decode<R: Read>(r: &mut R) -> Result<Self, Error> {
+        let witness_elements = VarInt::consensus_decode(r)?.0 as usize;
         if witness_elements == 0 {
             Ok(Witness::default())
         } else {
@@ -65,7 +65,7 @@ impl Decodable for Witness {
             for _ in 0..witness_elements {
                 second_to_last = last;
                 last = cursor;
-                let element_size_varint = VarInt::consensus_decode(&mut d)?;
+                let element_size_varint = VarInt::consensus_decode(r)?;
                 let element_size_varint_len = element_size_varint.len();
                 let element_size = element_size_varint.0 as usize;
                 let required_len = cursor
@@ -89,9 +89,9 @@ impl Decodable for Witness {
 
                 resize_if_needed(&mut content, required_len);
                 element_size_varint
-                    .consensus_encode(&mut content[cursor..cursor + element_size_varint_len])?;
+                    .consensus_encode(&mut &mut content[cursor..cursor + element_size_varint_len])?;
                 cursor += element_size_varint_len;
-                d.read_exact(&mut content[cursor..cursor + element_size])?;
+                r.read_exact(&mut content[cursor..cursor + element_size])?;
                 cursor += element_size;
             }
             content.truncate(cursor);
@@ -116,10 +116,10 @@ fn resize_if_needed(vec: &mut Vec<u8>, required_len: usize) {
 }
 
 impl Encodable for Witness {
-    fn consensus_encode<W: Write>(&self, mut writer: W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         let len = VarInt(self.witness_elements as u64);
-        len.consensus_encode(&mut writer)?;
-        writer.emit_slice(&self.content[..])?;
+        len.consensus_encode(w)?;
+        w.emit_slice(&self.content[..])?;
         Ok(self.content.len() + len.len())
     }
 }
@@ -148,7 +148,7 @@ impl Witness {
             last = cursor;
             let el_len_varint = VarInt(el.len() as u64);
             el_len_varint
-                .consensus_encode(&mut content[cursor..cursor + el_len_varint.len()])
+                .consensus_encode(&mut &mut content[cursor..cursor + el_len_varint.len()])
                 .expect("writers on vec don't errors, space granted by content_size");
             cursor += el_len_varint.len();
             content[cursor..cursor + el.len()].copy_from_slice(&el);
@@ -211,7 +211,7 @@ impl Witness {
             .resize(current_content_len + element_len_varint.len() + new_element.len(), 0);
         let end_varint = current_content_len + element_len_varint.len();
         element_len_varint
-            .consensus_encode(&mut self.content[current_content_len..end_varint])
+            .consensus_encode(&mut &mut self.content[current_content_len..end_varint])
             .expect("writers on vec don't error, space granted through previous resize");
         self.content[end_varint..].copy_from_slice(new_element);
     }
@@ -228,7 +228,7 @@ impl Witness {
 
 
     fn element_at(&self, index: usize) -> Option<&[u8]> {
-        let varint = VarInt::consensus_decode(&self.content[index..]).ok()?;
+        let varint = VarInt::consensus_decode(&mut &self.content[index..]).ok()?;
         let start = index + varint.len();
         Some(&self.content[start..start + varint.0 as usize])
     }
@@ -256,7 +256,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
-        let varint = VarInt::consensus_decode(self.inner.as_slice()).ok()?;
+        let varint = VarInt::consensus_decode(&mut self.inner.as_slice()).ok()?;
         self.inner.nth(varint.len() - 1)?; // VarInt::len returns at least 1
         let len = varint.0 as usize;
         let slice = &self.inner.as_slice()[..len];

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -25,13 +25,13 @@ use crate::hashes::{Hash, sha256, sha256d, hash160, hash_newtype};
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {
         impl $crate::consensus::Encodable for $hashtype {
-            fn consensus_encode<W: $crate::io::Write>(&self, w: &mut W) -> Result<usize, $crate::io::Error> {
+            fn consensus_encode<W: $crate::io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, $crate::io::Error> {
                 self.0.consensus_encode(w)
             }
         }
 
         impl $crate::consensus::Decodable for $hashtype {
-            fn consensus_decode<R: $crate::io::Read>(r: &mut R) -> Result<Self, $crate::consensus::encode::Error> {
+            fn consensus_decode<R: $crate::io::Read + ?Sized>(r: &mut R) -> Result<Self, $crate::consensus::encode::Error> {
                 use $crate::hashes::Hash;
                 Ok(Self::from_inner(<<$hashtype as $crate::hashes::Hash>::Inner>::consensus_decode(r)?))
             }

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -25,15 +25,15 @@ use crate::hashes::{Hash, sha256, sha256d, hash160, hash_newtype};
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {
         impl $crate::consensus::Encodable for $hashtype {
-            fn consensus_encode<S: $crate::io::Write>(&self, s: S) -> Result<usize, $crate::io::Error> {
-                self.0.consensus_encode(s)
+            fn consensus_encode<W: $crate::io::Write>(&self, w: &mut W) -> Result<usize, $crate::io::Error> {
+                self.0.consensus_encode(w)
             }
         }
 
         impl $crate::consensus::Decodable for $hashtype {
-            fn consensus_decode<D: $crate::io::Read>(d: D) -> Result<Self, $crate::consensus::encode::Error> {
+            fn consensus_decode<R: $crate::io::Read>(r: &mut R) -> Result<Self, $crate::consensus::encode::Error> {
                 use $crate::hashes::Hash;
-                Ok(Self::from_inner(<<$hashtype as $crate::hashes::Hash>::Inner>::consensus_decode(d)?))
+                Ok(Self::from_inner(<<$hashtype as $crate::hashes::Hash>::Inner>::consensus_decode(r)?))
             }
         }
     }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -21,12 +21,12 @@ macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl $crate::consensus::Encodable for $thing {
             #[inline]
-            fn consensus_encode<S: $crate::io::Write>(
+            fn consensus_encode<R: $crate::io::Write>(
                 &self,
-                mut s: S,
+                r: &mut R,
             ) -> Result<usize, $crate::io::Error> {
                 let mut len = 0;
-                $(len += self.$field.consensus_encode(&mut s)?;)+
+                $(len += self.$field.consensus_encode(r)?;)+
                 Ok(len)
             }
         }
@@ -34,21 +34,22 @@ macro_rules! impl_consensus_encoding {
         impl $crate::consensus::Decodable for $thing {
 
             #[inline]
-            fn consensus_decode_from_finite_reader<D: $crate::io::Read>(
-                mut d: D,
+            fn consensus_decode_from_finite_reader<R: $crate::io::Read>(
+                r: &mut R,
             ) -> Result<$thing, $crate::consensus::encode::Error> {
                 Ok($thing {
-                    $($field: $crate::consensus::Decodable::consensus_decode_from_finite_reader(&mut d)?),+
+                    $($field: $crate::consensus::Decodable::consensus_decode_from_finite_reader(r)?),+
                 })
             }
 
             #[inline]
-            fn consensus_decode<D: $crate::io::Read>(
-                d: D,
+            fn consensus_decode<R: $crate::io::Read>(
+                r: &mut R,
             ) -> Result<$thing, $crate::consensus::encode::Error> {
-                let mut d = d.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
+                use crate::io::Read as _;
+                let mut r = r.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
                 Ok($thing {
-                    $($field: $crate::consensus::Decodable::consensus_decode(&mut d)?),+
+                    $($field: $crate::consensus::Decodable::consensus_decode(r.by_ref())?),+
                 })
             }
         }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -21,7 +21,7 @@ macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl $crate::consensus::Encodable for $thing {
             #[inline]
-            fn consensus_encode<R: $crate::io::Write>(
+            fn consensus_encode<R: $crate::io::Write + ?Sized>(
                 &self,
                 r: &mut R,
             ) -> Result<usize, $crate::io::Error> {
@@ -34,7 +34,7 @@ macro_rules! impl_consensus_encoding {
         impl $crate::consensus::Decodable for $thing {
 
             #[inline]
-            fn consensus_decode_from_finite_reader<R: $crate::io::Read>(
+            fn consensus_decode_from_finite_reader<R: $crate::io::Read + ?Sized>(
                 r: &mut R,
             ) -> Result<$thing, $crate::consensus::encode::Error> {
                 Ok($thing {
@@ -43,7 +43,7 @@ macro_rules! impl_consensus_encoding {
             }
 
             #[inline]
-            fn consensus_decode<R: $crate::io::Read>(
+            fn consensus_decode<R: $crate::io::Read + ?Sized>(
                 r: &mut R,
             ) -> Result<$thing, $crate::consensus::encode::Error> {
                 use crate::io::Read as _;

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -69,15 +69,15 @@ impl Address {
 
 impl Encodable for Address {
     #[inline]
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
-        let mut len = self.services.consensus_encode(&mut s)?;
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.services.consensus_encode(w)?;
 
         for word in &self.address {
-            s.write_all(&word.to_be_bytes())?;
+            w.write_all(&word.to_be_bytes())?;
             len += 2;
         }
 
-        s.write_all(&self.port.to_be_bytes())?;
+        w.write_all(&self.port.to_be_bytes())?;
         len += 2;
 
         Ok(len)
@@ -86,22 +86,22 @@ impl Encodable for Address {
 
 impl Decodable for Address {
     #[inline]
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(Address {
-            services: Decodable::consensus_decode(&mut d)?,
-            address: read_be_address(&mut d)?,
-            port: u16::swap_bytes(Decodable::consensus_decode(d)?)
+            services: Decodable::consensus_decode(r)?,
+            address: read_be_address(r)?,
+            port: u16::swap_bytes(Decodable::consensus_decode(r)?)
         })
     }
 }
 
 /// Read a big-endian address from reader.
-fn read_be_address<R: io::Read>(mut r: R) -> Result<[u16; 8], encode::Error> {
+fn read_be_address<R: io::Read>(r: &mut R) -> Result<[u16; 8], encode::Error> {
     let mut address = [0u16; 8];
     let mut buf = [0u8; 2];
 
     for word in &mut address {
-        io::Read::read_exact(&mut r, &mut buf)?;
+        io::Read::read_exact(r, &mut buf)?;
         *word = u16::from_be_bytes(buf)
     }
     Ok(address)
@@ -147,12 +147,12 @@ pub enum AddrV2 {
 }
 
 impl Encodable for AddrV2 {
-    fn consensus_encode<W: io::Write>(&self, e: W) -> Result<usize, io::Error> {
-        fn encode_addr<W: io::Write>(mut e: W, network: u8, bytes: &[u8]) -> Result<usize, io::Error> {
-            let len = network.consensus_encode(&mut e)?
-                + VarInt(bytes.len() as u64).consensus_encode(&mut e)?
+    fn consensus_encode<W: io::Write>(&self, e: &mut W) -> Result<usize, io::Error> {
+        fn encode_addr<W: io::Write>(w: &mut W, network: u8, bytes: &[u8]) -> Result<usize, io::Error> {
+            let len = network.consensus_encode(w)?
+                + VarInt(bytes.len() as u64).consensus_encode(w)?
                 + bytes.len();
-            e.emit_slice(bytes)?;
+            w.emit_slice(bytes)?;
             Ok(len)
         }
         Ok(match *self {
@@ -168,9 +168,9 @@ impl Encodable for AddrV2 {
 }
 
 impl Decodable for AddrV2 {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        let network_id = u8::consensus_decode(&mut d)?;
-        let len = VarInt::consensus_decode(&mut d)?.0;
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let network_id = u8::consensus_decode(r)?;
+        let len = VarInt::consensus_decode(r)?.0;
         if len > 512 {
             return Err(encode::Error::ParseFailed("IP must be <= 512 bytes"));
         }
@@ -179,14 +179,14 @@ impl Decodable for AddrV2 {
                 if len != 4 {
                     return Err(encode::Error::ParseFailed("Invalid IPv4 address"));
                 }
-                let addr: [u8; 4] = Decodable::consensus_decode(&mut d)?;
+                let addr: [u8; 4] = Decodable::consensus_decode(r)?;
                 AddrV2::Ipv4(Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]))
             },
             2 => {
                 if len != 16 {
                     return Err(encode::Error::ParseFailed("Invalid IPv6 address"));
                 }
-                let addr: [u16; 8] = read_be_address(&mut d)?;
+                let addr: [u16; 8] = read_be_address(r)?;
                 if addr[0..3] == ONION {
                     return Err(encode::Error::ParseFailed("OnionCat address sent with IPv6 network id"));
                 }
@@ -199,28 +199,28 @@ impl Decodable for AddrV2 {
                 if len != 10 {
                     return Err(encode::Error::ParseFailed("Invalid TorV2 address"));
                 }
-                let id = Decodable::consensus_decode(&mut d)?;
+                let id = Decodable::consensus_decode(r)?;
                 AddrV2::TorV2(id)
             },
             4 => {
                 if len != 32 {
                     return Err(encode::Error::ParseFailed("Invalid TorV3 address"));
                 }
-                let pubkey = Decodable::consensus_decode(&mut d)?;
+                let pubkey = Decodable::consensus_decode(r)?;
                 AddrV2::TorV3(pubkey)
             },
             5 => {
                 if len != 32 {
                     return Err(encode::Error::ParseFailed("Invalid I2P address"));
                 }
-                let hash = Decodable::consensus_decode(&mut d)?;
+                let hash = Decodable::consensus_decode(r)?;
                 AddrV2::I2p(hash)
             },
             6 => {
                 if len != 16  {
                     return Err(encode::Error::ParseFailed("Invalid CJDNS address"));
                 }
-                let addr: [u16; 8] = read_be_address(&mut d)?;
+                let addr: [u16; 8] = read_be_address(r)?;
                 // check the first byte for the CJDNS marker
                 if addr[0] != u16::from_be_bytes([0xFC, 0x00]) {
                     return Err(encode::Error::ParseFailed("Invalid CJDNS address"));
@@ -230,7 +230,7 @@ impl Decodable for AddrV2 {
             _ => {
                 // len already checked above to be <= 512
                 let mut addr = vec![0u8; len as usize];
-                d.read_slice(&mut addr)?;
+                r.read_slice(&mut addr)?;
                 AddrV2::Unknown(network_id, addr)
             }
         })
@@ -264,26 +264,26 @@ impl AddrV2Message {
 }
 
 impl Encodable for AddrV2Message {
-    fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
-        len += self.time.consensus_encode(&mut e)?;
-        len += VarInt(self.services.to_u64()).consensus_encode(&mut e)?;
-        len += self.addr.consensus_encode(&mut e)?;
+        len += self.time.consensus_encode(w)?;
+        len += VarInt(self.services.to_u64()).consensus_encode(w)?;
+        len += self.addr.consensus_encode(w)?;
 
         // consensus_encode always encodes in LE, and we want to encode in BE.
-        //TODO `len += io::Write::write(&mut e, &self.port.to_be_bytes())?;` when MSRV >= 1.32
-        len += self.port.swap_bytes().consensus_encode(e)?;
+        //TODO `len += io::Write::write(w, &self.port.to_be_bytes())?;` when MSRV >= 1.32
+        len += self.port.swap_bytes().consensus_encode(w)?;
         Ok(len)
     }
 }
 
 impl Decodable for AddrV2Message {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(AddrV2Message {
-            time: Decodable::consensus_decode(&mut d)?,
-            services: ServiceFlags::from(VarInt::consensus_decode(&mut d)?.0),
-            addr: Decodable::consensus_decode(&mut d)?,
-            port: u16::swap_bytes(Decodable::consensus_decode(d)?),
+            time: Decodable::consensus_decode(r)?,
+            services: ServiceFlags::from(VarInt::consensus_decode(r)?.0),
+            addr: Decodable::consensus_decode(r)?,
+            port: u16::swap_bytes(Decodable::consensus_decode(r)?),
         })
     }
 }

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -69,7 +69,7 @@ impl Address {
 
 impl Encodable for Address {
     #[inline]
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = self.services.consensus_encode(w)?;
 
         for word in &self.address {
@@ -86,7 +86,7 @@ impl Encodable for Address {
 
 impl Decodable for Address {
     #[inline]
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(Address {
             services: Decodable::consensus_decode(r)?,
             address: read_be_address(r)?,
@@ -96,7 +96,7 @@ impl Decodable for Address {
 }
 
 /// Read a big-endian address from reader.
-fn read_be_address<R: io::Read>(r: &mut R) -> Result<[u16; 8], encode::Error> {
+fn read_be_address<R: io::Read + ?Sized>(r: &mut R) -> Result<[u16; 8], encode::Error> {
     let mut address = [0u16; 8];
     let mut buf = [0u8; 2];
 
@@ -147,8 +147,8 @@ pub enum AddrV2 {
 }
 
 impl Encodable for AddrV2 {
-    fn consensus_encode<W: io::Write>(&self, e: &mut W) -> Result<usize, io::Error> {
-        fn encode_addr<W: io::Write>(w: &mut W, network: u8, bytes: &[u8]) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, e: &mut W) -> Result<usize, io::Error> {
+        fn encode_addr<W: io::Write + ?Sized>(w: &mut W, network: u8, bytes: &[u8]) -> Result<usize, io::Error> {
             let len = network.consensus_encode(w)?
                 + VarInt(bytes.len() as u64).consensus_encode(w)?
                 + bytes.len();
@@ -168,7 +168,7 @@ impl Encodable for AddrV2 {
 }
 
 impl Decodable for AddrV2 {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let network_id = u8::consensus_decode(r)?;
         let len = VarInt::consensus_decode(r)?.0;
         if len > 512 {
@@ -264,7 +264,7 @@ impl AddrV2Message {
 }
 
 impl Encodable for AddrV2Message {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         len += self.time.consensus_encode(w)?;
         len += VarInt(self.services.to_u64()).consensus_encode(w)?;
@@ -278,7 +278,7 @@ impl Encodable for AddrV2Message {
 }
 
 impl Decodable for AddrV2Message {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(AddrV2Message {
             time: Decodable::consensus_decode(r)?,
             services: ServiceFlags::from(VarInt::consensus_decode(r)?.0),

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -280,15 +280,15 @@ impl ops::BitXorAssign for ServiceFlags {
 
 impl Encodable for ServiceFlags {
     #[inline]
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
-        self.0.consensus_encode(&mut s)
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
     }
 }
 
 impl Decodable for ServiceFlags {
     #[inline]
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        Ok(ServiceFlags(Decodable::consensus_decode(&mut d)?))
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(ServiceFlags(Decodable::consensus_decode(r)?))
     }
 }
 

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -280,14 +280,14 @@ impl ops::BitXorAssign for ServiceFlags {
 
 impl Encodable for ServiceFlags {
     #[inline]
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         self.0.consensus_encode(w)
     }
 }
 
 impl Decodable for ServiceFlags {
     #[inline]
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(ServiceFlags(Decodable::consensus_decode(r)?))
     }
 }

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -80,7 +80,7 @@ impl AsRef<str> for CommandString {
 
 impl Encodable for CommandString {
     #[inline]
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut rawbytes = [0u8; 12];
         let strbytes = self.0.as_bytes();
         debug_assert!(strbytes.len() <= 12);
@@ -91,7 +91,7 @@ impl Encodable for CommandString {
 
 impl Decodable for CommandString {
     #[inline]
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let rawbytes: [u8; 12] = Decodable::consensus_decode(r)?;
         let rv = iter::FromIterator::from_iter(
             rawbytes
@@ -287,7 +287,7 @@ struct HeaderSerializationWrapper<'a>(&'a Vec<block::BlockHeader>);
 
 impl<'a> Encodable for HeaderSerializationWrapper<'a> {
     #[inline]
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         len += VarInt(self.0.len() as u64).consensus_encode(w)?;
         for header in self.0.iter() {
@@ -299,7 +299,7 @@ impl<'a> Encodable for HeaderSerializationWrapper<'a> {
 }
 
 impl Encodable for RawNetworkMessage {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         len += self.magic.consensus_encode(w)?;
         len += self.command().consensus_encode(w)?;
@@ -346,7 +346,7 @@ struct HeaderDeserializationWrapper(Vec<block::BlockHeader>);
 
 impl Decodable for HeaderDeserializationWrapper {
     #[inline]
-    fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let len = VarInt::consensus_decode(r)?.0;
         // should be above usual number of items to avoid
         // allocation
@@ -361,13 +361,13 @@ impl Decodable for HeaderDeserializationWrapper {
     }
 
     #[inline]
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Self::consensus_decode_from_finite_reader(r.take(MAX_MSG_SIZE as u64).by_ref())
     }
 }
 
 impl Decodable for RawNetworkMessage {
-    fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let magic = Decodable::consensus_decode_from_finite_reader(r)?;
         let cmd = CommandString::consensus_decode_from_finite_reader(r)?;
         let raw_payload = CheckedData::consensus_decode_from_finite_reader(r)?.0;
@@ -420,7 +420,7 @@ impl Decodable for RawNetworkMessage {
     }
 
     #[inline]
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Self::consensus_decode_from_finite_reader(r.take(MAX_MSG_SIZE as u64).by_ref())
     }
 }

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -23,6 +23,7 @@ use crate::prelude::*;
 use core::{fmt, iter};
 
 use crate::io;
+use io::Read as _;
 use crate::blockdata::block;
 use crate::blockdata::transaction;
 use crate::network::address::{Address, AddrV2Message};
@@ -79,19 +80,19 @@ impl AsRef<str> for CommandString {
 
 impl Encodable for CommandString {
     #[inline]
-    fn consensus_encode<S: io::Write>(&self, s: S) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut rawbytes = [0u8; 12];
         let strbytes = self.0.as_bytes();
         debug_assert!(strbytes.len() <= 12);
         rawbytes[..strbytes.len()].copy_from_slice(strbytes);
-        rawbytes.consensus_encode(s)
+        rawbytes.consensus_encode(w)
     }
 }
 
 impl Decodable for CommandString {
     #[inline]
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        let rawbytes: [u8; 12] = Decodable::consensus_decode(d)?;
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let rawbytes: [u8; 12] = Decodable::consensus_decode(r)?;
         let rv = iter::FromIterator::from_iter(
             rawbytes
                 .iter()
@@ -286,22 +287,22 @@ struct HeaderSerializationWrapper<'a>(&'a Vec<block::BlockHeader>);
 
 impl<'a> Encodable for HeaderSerializationWrapper<'a> {
     #[inline]
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
-        len += VarInt(self.0.len() as u64).consensus_encode(&mut s)?;
+        len += VarInt(self.0.len() as u64).consensus_encode(w)?;
         for header in self.0.iter() {
-            len += header.consensus_encode(&mut s)?;
-            len += 0u8.consensus_encode(&mut s)?;
+            len += header.consensus_encode(w)?;
+            len += 0u8.consensus_encode(w)?;
         }
         Ok(len)
     }
 }
 
 impl Encodable for RawNetworkMessage {
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
-        len += self.magic.consensus_encode(&mut s)?;
-        len += self.command().consensus_encode(&mut s)?;
+        len += self.magic.consensus_encode(w)?;
+        len += self.command().consensus_encode(w)?;
         len += CheckedData(match self.payload {
             NetworkMessage::Version(ref dat) => serialize(dat),
             NetworkMessage::Addr(ref dat)    => serialize(dat),
@@ -336,7 +337,7 @@ impl Encodable for RawNetworkMessage {
             | NetworkMessage::FilterClear
             | NetworkMessage::SendAddrV2 => vec![],
             NetworkMessage::Unknown { payload: ref data, .. } => serialize(data),
-        }).consensus_encode(&mut s)?;
+        }).consensus_encode(w)?;
         Ok(len)
     }
 }
@@ -345,14 +346,14 @@ struct HeaderDeserializationWrapper(Vec<block::BlockHeader>);
 
 impl Decodable for HeaderDeserializationWrapper {
     #[inline]
-    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        let len = VarInt::consensus_decode(&mut d)?.0;
+    fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let len = VarInt::consensus_decode(r)?.0;
         // should be above usual number of items to avoid
         // allocation
         let mut ret = Vec::with_capacity(core::cmp::min(1024 * 16, len as usize));
         for _ in 0..len {
-            ret.push(Decodable::consensus_decode(&mut d)?);
-            if u8::consensus_decode(&mut d)? != 0u8 {
+            ret.push(Decodable::consensus_decode(r)?);
+            if u8::consensus_decode(r)? != 0u8 {
                 return Err(encode::Error::ParseFailed("Headers message should not contain transactions"));
             }
         }
@@ -360,16 +361,16 @@ impl Decodable for HeaderDeserializationWrapper {
     }
 
     #[inline]
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(d.take(MAX_MSG_SIZE as u64))
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        Self::consensus_decode_from_finite_reader(r.take(MAX_MSG_SIZE as u64).by_ref())
     }
 }
 
 impl Decodable for RawNetworkMessage {
-    fn consensus_decode_from_finite_reader<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        let magic = Decodable::consensus_decode_from_finite_reader(&mut d)?;
-        let cmd = CommandString::consensus_decode_from_finite_reader(&mut d)?;
-        let raw_payload = CheckedData::consensus_decode_from_finite_reader(&mut d)?.0;
+    fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let magic = Decodable::consensus_decode_from_finite_reader(r)?;
+        let cmd = CommandString::consensus_decode_from_finite_reader(r)?;
+        let raw_payload = CheckedData::consensus_decode_from_finite_reader(r)?.0;
 
         let mut mem_d = io::Cursor::new(raw_payload);
         let payload = match &cmd.0[..] {
@@ -419,8 +420,8 @@ impl Decodable for RawNetworkMessage {
     }
 
     #[inline]
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(d.take(MAX_MSG_SIZE as u64))
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        Self::consensus_decode_from_finite_reader(r.take(MAX_MSG_SIZE as u64).by_ref())
     }
 }
 

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -54,10 +54,10 @@ pub enum Inventory {
 
 impl Encodable for Inventory {
     #[inline]
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         macro_rules! encode_inv {
             ($code:expr, $item:expr) => {
-                u32::consensus_encode(&$code, &mut s)? + $item.consensus_encode(&mut s)?
+                u32::consensus_encode(&$code, w)? + $item.consensus_encode(w)?
             }
         }
         Ok(match *self {
@@ -74,18 +74,18 @@ impl Encodable for Inventory {
 
 impl Decodable for Inventory {
     #[inline]
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        let inv_type: u32 = Decodable::consensus_decode(&mut d)?;
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let inv_type: u32 = Decodable::consensus_decode(r)?;
         Ok(match inv_type {
             0 => Inventory::Error,
-            1 => Inventory::Transaction(Decodable::consensus_decode(&mut d)?),
-            2 => Inventory::Block(Decodable::consensus_decode(&mut d)?),
-            5 => Inventory::WTx(Decodable::consensus_decode(&mut d)?),
-            0x40000001 => Inventory::WitnessTransaction(Decodable::consensus_decode(&mut d)?),
-            0x40000002 => Inventory::WitnessBlock(Decodable::consensus_decode(&mut d)?),
+            1 => Inventory::Transaction(Decodable::consensus_decode(r)?),
+            2 => Inventory::Block(Decodable::consensus_decode(r)?),
+            5 => Inventory::WTx(Decodable::consensus_decode(r)?),
+            0x40000001 => Inventory::WitnessTransaction(Decodable::consensus_decode(r)?),
+            0x40000002 => Inventory::WitnessBlock(Decodable::consensus_decode(r)?),
             tp => Inventory::Unknown {
                 inv_type: tp,
-                hash: Decodable::consensus_decode(&mut d)?,
+                hash: Decodable::consensus_decode(r)?,
             }
         })
     }

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -54,7 +54,7 @@ pub enum Inventory {
 
 impl Encodable for Inventory {
     #[inline]
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         macro_rules! encode_inv {
             ($code:expr, $item:expr) => {
                 u32::consensus_encode(&$code, w)? + $item.consensus_encode(w)?
@@ -74,7 +74,7 @@ impl Encodable for Inventory {
 
 impl Decodable for Inventory {
     #[inline]
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let inv_type: u32 = Decodable::consensus_decode(r)?;
         Ok(match inv_type {
             0 => Inventory::Error,

--- a/src/network/message_bloom.rs
+++ b/src/network/message_bloom.rs
@@ -34,8 +34,8 @@ pub enum BloomFlags {
 }
 
 impl Encodable for BloomFlags {
-    fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, io::Error> {
-        e.write_all(&[match self {
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        w.write_all(&[match self {
             BloomFlags::None => 0,
             BloomFlags::All => 1,
             BloomFlags::PubkeyOnly => 2,
@@ -45,8 +45,8 @@ impl Encodable for BloomFlags {
 }
 
 impl Decodable for BloomFlags {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        Ok(match d.read_u8()? {
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(match r.read_u8()? {
             0 => BloomFlags::None,
             1 => BloomFlags::All,
             2 => BloomFlags::PubkeyOnly,

--- a/src/network/message_bloom.rs
+++ b/src/network/message_bloom.rs
@@ -34,7 +34,7 @@ pub enum BloomFlags {
 }
 
 impl Encodable for BloomFlags {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         w.write_all(&[match self {
             BloomFlags::None => 0,
             BloomFlags::All => 1,
@@ -45,7 +45,7 @@ impl Encodable for BloomFlags {
 }
 
 impl Decodable for BloomFlags {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(match r.read_u8()? {
             0 => BloomFlags::None,
             1 => BloomFlags::All,

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -106,15 +106,15 @@ pub enum RejectReason {
 }
 
 impl Encodable for RejectReason {
-    fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, io::Error> {
-        e.write_all(&[*self as u8])?;
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        w.write_all(&[*self as u8])?;
         Ok(1)
     }
 }
 
 impl Decodable for RejectReason {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        Ok(match d.read_u8()? {
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(match r.read_u8()? {
             0x01 => RejectReason::Malformed,
             0x10 => RejectReason::Invalid,
             0x11 => RejectReason::Obsolete,

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -106,14 +106,14 @@ pub enum RejectReason {
 }
 
 impl Encodable for RejectReason {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         w.write_all(&[*self as u8])?;
         Ok(1)
     }
 }
 
 impl Decodable for RejectReason {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(match r.read_u8()? {
             0x01 => RejectReason::Malformed,
             0x10 => RejectReason::Invalid,

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -355,23 +355,23 @@ impl PartialMerkleTree {
 }
 
 impl Encodable for PartialMerkleTree {
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
-        let ret = self.num_transactions.consensus_encode(&mut s)?
-            + self.hashes.consensus_encode(&mut s)?;
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let ret = self.num_transactions.consensus_encode(w)?
+            + self.hashes.consensus_encode(w)?;
         let mut bytes: Vec<u8> = vec![0; (self.bits.len() + 7) / 8];
         for p in 0..self.bits.len() {
             bytes[p / 8] |= (self.bits[p] as u8) << (p % 8) as u8;
         }
-        Ok(ret + bytes.consensus_encode(s)?)
+        Ok(ret + bytes.consensus_encode(w)?)
     }
 }
 
 impl Decodable for PartialMerkleTree {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        let num_transactions: u32 = Decodable::consensus_decode(&mut d)?;
-        let hashes: Vec<TxMerkleNode> = Decodable::consensus_decode(&mut d)?;
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let num_transactions: u32 = Decodable::consensus_decode(r)?;
+        let hashes: Vec<TxMerkleNode> = Decodable::consensus_decode(r)?;
 
-        let bytes: Vec<u8> = Decodable::consensus_decode(d)?;
+        let bytes: Vec<u8> = Decodable::consensus_decode(r)?;
         let mut bits: Vec<bool> = vec![false; bytes.len() * 8];
 
         for (p, bit) in bits.iter_mut().enumerate() {
@@ -506,18 +506,18 @@ impl MerkleBlock {
 }
 
 impl Encodable for MerkleBlock {
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
-        let len = self.header.consensus_encode(&mut s)?
-            + self.txn.consensus_encode(s)?;
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let len = self.header.consensus_encode(w)?
+            + self.txn.consensus_encode(w)?;
         Ok(len)
     }
 }
 
 impl Decodable for MerkleBlock {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(MerkleBlock {
-            header: Decodable::consensus_decode(&mut d)?,
-            txn: Decodable::consensus_decode(d)?,
+            header: Decodable::consensus_decode(r)?,
+            txn: Decodable::consensus_decode(r)?,
         })
     }
 }

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -355,7 +355,7 @@ impl PartialMerkleTree {
 }
 
 impl Encodable for PartialMerkleTree {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let ret = self.num_transactions.consensus_encode(w)?
             + self.hashes.consensus_encode(w)?;
         let mut bytes: Vec<u8> = vec![0; (self.bits.len() + 7) / 8];
@@ -367,7 +367,7 @@ impl Encodable for PartialMerkleTree {
 }
 
 impl Decodable for PartialMerkleTree {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let num_transactions: u32 = Decodable::consensus_decode(r)?;
         let hashes: Vec<TxMerkleNode> = Decodable::consensus_decode(r)?;
 
@@ -506,7 +506,7 @@ impl MerkleBlock {
 }
 
 impl Encodable for MerkleBlock {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let len = self.header.consensus_encode(w)?
             + self.txn.consensus_encode(w)?;
         Ok(len)
@@ -514,7 +514,7 @@ impl Encodable for MerkleBlock {
 }
 
 impl Decodable for MerkleBlock {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(MerkleBlock {
             header: Decodable::consensus_decode(r)?,
             txn: Decodable::consensus_decode(r)?,

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -55,11 +55,11 @@ macro_rules! impl_psbt_serialize {
 macro_rules! impl_psbtmap_consensus_encoding {
     ($thing:ty) => {
         impl $crate::consensus::Encodable for $thing {
-            fn consensus_encode<S: $crate::io::Write>(
+            fn consensus_encode<W: $crate::io::Write>(
                 &self,
-                s: S,
+                w: &mut W,
             ) -> Result<usize, $crate::io::Error> {
-                self.consensus_encode_map(s)
+                self.consensus_encode_map(w)
             }
         }
     };
@@ -68,13 +68,13 @@ macro_rules! impl_psbtmap_consensus_encoding {
 macro_rules! impl_psbtmap_consensus_decoding {
     ($thing:ty) => {
         impl $crate::consensus::Decodable for $thing {
-            fn consensus_decode<D: $crate::io::Read>(
-                mut d: D,
+            fn consensus_decode<R: $crate::io::Read>(
+                r: &mut R,
             ) -> Result<Self, $crate::consensus::encode::Error> {
                 let mut rv: Self = ::core::default::Default::default();
 
                 loop {
-                    match $crate::consensus::Decodable::consensus_decode(&mut d) {
+                    match $crate::consensus::Decodable::consensus_decode(r) {
                         Ok(pair) => rv.insert_pair(pair)?,
                         Err($crate::consensus::encode::Error::Psbt($crate::util::psbt::Error::NoMorePairs)) => return Ok(rv),
                         Err(e) => return Err(e),

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -55,7 +55,7 @@ macro_rules! impl_psbt_serialize {
 macro_rules! impl_psbtmap_consensus_encoding {
     ($thing:ty) => {
         impl $crate::consensus::Encodable for $thing {
-            fn consensus_encode<W: $crate::io::Write>(
+            fn consensus_encode<W: $crate::io::Write + ?Sized>(
                 &self,
                 w: &mut W,
             ) -> Result<usize, $crate::io::Error> {
@@ -68,7 +68,7 @@ macro_rules! impl_psbtmap_consensus_encoding {
 macro_rules! impl_psbtmap_consensus_decoding {
     ($thing:ty) => {
         impl $crate::consensus::Decodable for $thing {
-            fn consensus_decode<R: $crate::io::Read>(
+            fn consensus_decode<R: $crate::io::Read + ?Sized>(
                 r: &mut R,
             ) -> Result<Self, $crate::consensus::encode::Error> {
                 let mut rv: Self = ::core::default::Default::default();

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -100,7 +100,7 @@ impl Map for PartiallySignedTransaction {
 }
 
 impl PartiallySignedTransaction {
-    pub(crate) fn consensus_decode_global<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    pub(crate) fn consensus_decode_global<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let mut r = r.take(MAX_VEC_SIZE as u64);
         let mut tx: Option<Transaction> = None;
         let mut version: Option<u32> = None;

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -100,8 +100,8 @@ impl Map for PartiallySignedTransaction {
 }
 
 impl PartiallySignedTransaction {
-    pub(crate) fn consensus_decode_global<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        let mut d = d.take(MAX_VEC_SIZE as u64);
+    pub(crate) fn consensus_decode_global<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let mut r = r.take(MAX_VEC_SIZE as u64);
         let mut tx: Option<Transaction> = None;
         let mut version: Option<u32> = None;
         let mut unknowns: BTreeMap<raw::Key, Vec<u8>> = Default::default();
@@ -109,7 +109,7 @@ impl PartiallySignedTransaction {
         let mut proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>> = Default::default();
 
         loop {
-            match raw::Pair::consensus_decode(&mut d) {
+            match raw::Pair::consensus_decode(&mut r) {
                 Ok(pair) => {
                     match pair.key.type_value {
                         PSBT_GLOBAL_UNSIGNED_TX => {

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -32,7 +32,7 @@ pub(super) trait Map {
     fn get_pairs(&self) -> Result<Vec<raw::Pair>, io::Error>;
 
     /// Encodes map data with bitcoin consensus encoding.
-    fn consensus_encode_map<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode_map<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         for pair in Map::get_pairs(self)? {
             len += encode::Encodable::consensus_encode(&pair, w)?;

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -32,12 +32,12 @@ pub(super) trait Map {
     fn get_pairs(&self) -> Result<Vec<raw::Pair>, io::Error>;
 
     /// Encodes map data with bitcoin consensus encoding.
-    fn consensus_encode_map<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
+    fn consensus_encode_map<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         for pair in Map::get_pairs(self)? {
-            len += encode::Encodable::consensus_encode(&pair, &mut s)?;
+            len += encode::Encodable::consensus_encode(&pair, w)?;
         }
 
-        Ok(len + encode::Encodable::consensus_encode(&0x00_u8, s)?)
+        Ok(len + encode::Encodable::consensus_encode(&0x00_u8, w)?)
     }
 }

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -277,7 +277,7 @@ mod display_from_str {
 pub use self::display_from_str::PsbtParseError;
 
 impl Encodable for PartiallySignedTransaction {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         len += b"psbt".consensus_encode(w)?;
 
@@ -298,7 +298,7 @@ impl Encodable for PartiallySignedTransaction {
 }
 
 impl Decodable for PartiallySignedTransaction {
-    fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let magic: [u8; 4] = Decodable::consensus_decode(r)?;
 
         if *b"psbt" != magic {

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -23,13 +23,14 @@ use core::cmp;
 
 use crate::blockdata::script::Script;
 use crate::blockdata::transaction::{ TxOut, Transaction};
-use crate::consensus::{encode, Encodable, Decodable};
 use crate::consensus::encode::MAX_VEC_SIZE;
+use crate::consensus::{encode, Encodable, Decodable};
 pub use crate::util::sighash::Prevouts;
 
 use crate::prelude::*;
 
 use crate::io;
+use io::Read as _;
 mod error;
 pub use self::error::Error;
 
@@ -278,20 +279,20 @@ mod display_from_str {
 pub use self::display_from_str::PsbtParseError;
 
 impl Encodable for PartiallySignedTransaction {
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
-        len += b"psbt".consensus_encode(&mut s)?;
+        len += b"psbt".consensus_encode(w)?;
 
-        len += 0xff_u8.consensus_encode(&mut s)?;
+        len += 0xff_u8.consensus_encode(w)?;
 
-        len += self.consensus_encode_map(&mut s)?;
+        len += self.consensus_encode_map(w)?;
 
         for i in &self.inputs {
-            len += i.consensus_encode(&mut s)?;
+            len += i.consensus_encode(w)?;
         }
 
         for i in &self.outputs {
-            len += i.consensus_encode(&mut s)?;
+            len += i.consensus_encode(w)?;
         }
 
         Ok(len)
@@ -299,19 +300,18 @@ impl Encodable for PartiallySignedTransaction {
 }
 
 impl Decodable for PartiallySignedTransaction {
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        let mut d = d.take(MAX_VEC_SIZE as u64);
-        let magic: [u8; 4] = Decodable::consensus_decode(&mut d)?;
+    fn consensus_decode_from_finite_reader<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let magic: [u8; 4] = Decodable::consensus_decode(r)?;
 
         if *b"psbt" != magic {
             return Err(Error::InvalidMagic.into());
         }
 
-        if 0xff_u8 != u8::consensus_decode(&mut d)? {
+        if 0xff_u8 != u8::consensus_decode(r)? {
             return Err(Error::InvalidSeparator.into());
         }
 
-        let mut global = PartiallySignedTransaction::consensus_decode_global(&mut d)?;
+        let mut global = PartiallySignedTransaction::consensus_decode_global(r)?;
         global.unsigned_tx_checks()?;
 
         let inputs: Vec<Input> = {
@@ -320,7 +320,7 @@ impl Decodable for PartiallySignedTransaction {
             let mut inputs: Vec<Input> = Vec::with_capacity(inputs_len);
 
             for _ in 0..inputs_len {
-                inputs.push(Decodable::consensus_decode(&mut d)?);
+                inputs.push(Decodable::consensus_decode(r)?);
             }
 
             inputs
@@ -332,7 +332,7 @@ impl Decodable for PartiallySignedTransaction {
             let mut outputs: Vec<Output> = Vec::with_capacity(outputs_len);
 
             for _ in 0..outputs_len {
-                outputs.push(Decodable::consensus_decode(&mut d)?);
+                outputs.push(Decodable::consensus_decode(r)?);
             }
 
             outputs
@@ -341,6 +341,11 @@ impl Decodable for PartiallySignedTransaction {
         global.inputs = inputs;
         global.outputs = outputs;
         Ok(global)
+    }
+
+    #[inline]
+    fn consensus_decode<R: io::Read>(d: &mut R) -> Result<Self, encode::Error> {
+        Self::consensus_decode_from_finite_reader(d.take(MAX_VEC_SIZE as u64).by_ref())
     }
 }
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -23,14 +23,12 @@ use core::cmp;
 
 use crate::blockdata::script::Script;
 use crate::blockdata::transaction::{ TxOut, Transaction};
-use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::consensus::{encode, Encodable, Decodable};
 pub use crate::util::sighash::Prevouts;
 
 use crate::prelude::*;
 
 use crate::io;
-use io::Read as _;
 mod error;
 pub use self::error::Error;
 
@@ -341,11 +339,6 @@ impl Decodable for PartiallySignedTransaction {
         global.inputs = inputs;
         global.outputs = outputs;
         Ok(global)
-    }
-
-    #[inline]
-    fn consensus_decode<R: io::Read>(d: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(d.take(MAX_VEC_SIZE as u64).by_ref())
     }
 }
 

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -79,7 +79,7 @@ impl fmt::Display for Key {
 }
 
 impl Decodable for Key {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let VarInt(byte_size): VarInt = Decodable::consensus_decode(r)?;
 
         if byte_size == 0 {
@@ -107,7 +107,7 @@ impl Decodable for Key {
 }
 
 impl Encodable for Key {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         len += VarInt((self.key.len() + 1) as u64).consensus_encode(w)?;
 
@@ -122,14 +122,14 @@ impl Encodable for Key {
 }
 
 impl Encodable for Pair {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let len = self.key.consensus_encode(w)?;
         Ok(len + self.value.consensus_encode(w)?)
     }
 }
 
 impl Decodable for Pair {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(Pair {
             key: Decodable::consensus_decode(r)?,
             value: Decodable::consensus_decode(r)?,
@@ -138,7 +138,7 @@ impl Decodable for Pair {
 }
 
 impl<Subtype> Encodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u8> + Into<u8> {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = self.prefix.consensus_encode(w)? + 1;
         w.emit_u8(self.subtype.into())?;
         w.write_all(&self.key)?;
@@ -148,7 +148,7 @@ impl<Subtype> Encodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u
 }
 
 impl<Subtype> Decodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u8> + Into<u8> {
-    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let prefix = Vec::<u8>::consensus_decode(r)?;
         let subtype = Subtype::from(r.read_u8()?);
         let key = read_to_end(r)?;

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -79,8 +79,8 @@ impl fmt::Display for Key {
 }
 
 impl Decodable for Key {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        let VarInt(byte_size): VarInt = Decodable::consensus_decode(&mut d)?;
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let VarInt(byte_size): VarInt = Decodable::consensus_decode(r)?;
 
         if byte_size == 0 {
             return Err(Error::NoMorePairs.into());
@@ -95,11 +95,11 @@ impl Decodable for Key {
             })
         }
 
-        let type_value: u8 = Decodable::consensus_decode(&mut d)?;
+        let type_value: u8 = Decodable::consensus_decode(r)?;
 
         let mut key = Vec::with_capacity(key_byte_size as usize);
         for _ in 0..key_byte_size {
-            key.push(Decodable::consensus_decode(&mut d)?);
+            key.push(Decodable::consensus_decode(r)?);
         }
 
         Ok(Key { type_value, key })
@@ -107,14 +107,14 @@ impl Decodable for Key {
 }
 
 impl Encodable for Key {
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
-        len += VarInt((self.key.len() + 1) as u64).consensus_encode(&mut s)?;
+        len += VarInt((self.key.len() + 1) as u64).consensus_encode(w)?;
 
-        len += self.type_value.consensus_encode(&mut s)?;
+        len += self.type_value.consensus_encode(w)?;
 
         for key in &self.key {
-            len += key.consensus_encode(&mut s)?
+            len += key.consensus_encode(w)?
         }
 
         Ok(len)
@@ -122,36 +122,36 @@ impl Encodable for Key {
 }
 
 impl Encodable for Pair {
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, io::Error> {
-        let len = self.key.consensus_encode(&mut s)?;
-        Ok(len + self.value.consensus_encode(s)?)
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let len = self.key.consensus_encode(w)?;
+        Ok(len + self.value.consensus_encode(w)?)
     }
 }
 
 impl Decodable for Pair {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(Pair {
-            key: Decodable::consensus_decode(&mut d)?,
-            value: Decodable::consensus_decode(d)?,
+            key: Decodable::consensus_decode(r)?,
+            value: Decodable::consensus_decode(r)?,
         })
     }
 }
 
 impl<Subtype> Encodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u8> + Into<u8> {
-    fn consensus_encode<W: io::Write>(&self, mut e: W) -> Result<usize, io::Error> {
-        let mut len = self.prefix.consensus_encode(&mut e)? + 1;
-        e.emit_u8(self.subtype.into())?;
-        e.write_all(&self.key)?;
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = self.prefix.consensus_encode(w)? + 1;
+        w.emit_u8(self.subtype.into())?;
+        w.write_all(&self.key)?;
         len += self.key.len();
         Ok(len)
     }
 }
 
 impl<Subtype> Decodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u8> + Into<u8> {
-    fn consensus_decode<D: io::Read>(mut d: D) -> Result<Self, encode::Error> {
-        let prefix = Vec::<u8>::consensus_decode(&mut d)?;
-        let subtype = Subtype::from(d.read_u8()?);
-        let key = read_to_end(d)?;
+    fn consensus_decode<R: io::Read>(r: &mut R) -> Result<Self, encode::Error> {
+        let prefix = Vec::<u8>::consensus_decode(r)?;
+        let subtype = Subtype::from(r.read_u8()?);
+        let key = read_to_end(r)?;
 
         Ok(ProprietaryKey { prefix, subtype, key })
     }

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -794,8 +794,8 @@ impl<'a> Annex<'a> {
 }
 
 impl<'a> Encodable for Annex<'a> {
-    fn consensus_encode<W: io::Write>(&self, writer: W) -> Result<usize, io::Error> {
-        encode::consensus_encode_with_size(self.0, writer)
+    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+        encode::consensus_encode_with_size(self.0, w)
     }
 }
 

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -794,7 +794,7 @@ impl<'a> Annex<'a> {
 }
 
 impl<'a> Encodable for Annex<'a> {
-    fn consensus_encode<W: io::Write>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         encode::consensus_encode_with_size(self.0, w)
     }
 }

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -419,27 +419,27 @@ macro_rules! construct_uint {
 
         impl $crate::consensus::Encodable for $name {
             #[inline]
-            fn consensus_encode<S: $crate::io::Write>(
+            fn consensus_encode<W: $crate::io::Write>(
                 &self,
-                mut s: S,
+                w: &mut W,
             ) -> Result<usize, $crate::io::Error> {
                 let &$name(ref data) = self;
                 let mut len = 0;
                 for word in data.iter() {
-                    len += word.consensus_encode(&mut s)?;
+                    len += word.consensus_encode(w)?;
                 }
                 Ok(len)
             }
         }
 
         impl $crate::consensus::Decodable for $name {
-            fn consensus_decode<D: $crate::io::Read>(
-                mut d: D,
+            fn consensus_decode<R: $crate::io::Read>(
+                r: &mut R,
             ) -> Result<$name, $crate::consensus::encode::Error> {
                 use $crate::consensus::Decodable;
                 let mut ret: [u64; $n_words] = [0; $n_words];
                 for i in 0..$n_words {
-                    ret[i] = Decodable::consensus_decode(&mut d)?;
+                    ret[i] = Decodable::consensus_decode(r)?;
                 }
                 Ok($name(ret))
             }

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -419,7 +419,7 @@ macro_rules! construct_uint {
 
         impl $crate::consensus::Encodable for $name {
             #[inline]
-            fn consensus_encode<W: $crate::io::Write>(
+            fn consensus_encode<W: $crate::io::Write + ?Sized>(
                 &self,
                 w: &mut W,
             ) -> Result<usize, $crate::io::Error> {
@@ -433,7 +433,7 @@ macro_rules! construct_uint {
         }
 
         impl $crate::consensus::Decodable for $name {
-            fn consensus_decode<R: $crate::io::Read>(
+            fn consensus_decode<R: $crate::io::Read + ?Sized>(
                 r: &mut R,
             ) -> Result<$name, $crate::consensus::encode::Error> {
                 use $crate::consensus::Decodable;


### PR DESCRIPTION
Fix #1020 (see more relevant discussion there)

This definitely makes the amount of generics compiler
has to generate by avoding generating the same functions
for `R`, `&mut R`, `&mut &mut R` and so on.

old:

```
> ls -al target/release/deps/bitcoin-07a9dabf1f3e0266
-rwxrwxr-x 1 dpc dpc 9947832 Jun  2 22:42 target/release/deps/bitcoin-07a9dabf1f3e0266
> strip target/release/deps/bitcoin-07a9dabf1f3e0266
> ls -al target/release/deps/bitcoin-07a9dabf1f3e0266
-rwxrwxr-x 1 dpc dpc 4463024 Jun  2 22:46 target/release/deps/bitcoin-07a9dabf1f3e0266
```

new:

```

> ls -al target/release/deps/bitcoin-07a9dabf1f3e0266
-rwxrwxr-x 1 dpc dpc 9866800 Jun  2 22:44 target/release/deps/bitcoin-07a9dabf1f3e0266
> strip target/release/deps/bitcoin-07a9dabf1f3e0266
> ls -al target/release/deps/bitcoin-07a9dabf1f3e0266
-rwxrwxr-x 1 dpc dpc 4393392 Jun  2 22:45 target/release/deps/bitcoin-07a9dabf1f3e0266
```

In the unit-test binary itself, it saves ~100KB of data.

I did not expect much performance gains, but turn out I was wrong(*):

old:

```
test blockdata::block::benches::bench_block_deserialize                 ... bench:   1,072,710 ns/iter (+/- 21,871)
test blockdata::block::benches::bench_block_serialize                   ... bench:     191,223 ns/iter (+/- 5,833)
test blockdata::block::benches::bench_block_serialize_logic             ... bench:      37,543 ns/iter (+/- 732)
test blockdata::block::benches::bench_stream_reader                     ... bench:   1,872,455 ns/iter (+/- 149,519)
test blockdata::transaction::benches::bench_transaction_deserialize     ... bench:         136 ns/iter (+/- 3)
test blockdata::transaction::benches::bench_transaction_serialize       ... bench:          51 ns/iter (+/- 8)
test blockdata::transaction::benches::bench_transaction_serialize_logic ... bench:           5 ns/iter (+/- 0)
test blockdata::transaction::benches::bench_transaction_size            ... bench:           3 ns/iter (+/- 0)
```

new:

```
test blockdata::block::benches::bench_block_deserialize                 ... bench:   1,028,574 ns/iter (+/- 10,910)
test blockdata::block::benches::bench_block_serialize                   ... bench:     162,143 ns/iter (+/- 3,363)
test blockdata::block::benches::bench_block_serialize_logic             ... bench:      30,725 ns/iter (+/- 695)
test blockdata::block::benches::bench_stream_reader                     ... bench:   1,437,071 ns/iter (+/- 53,694)
test blockdata::transaction::benches::bench_transaction_deserialize     ... bench:          92 ns/iter (+/- 2)
test blockdata::transaction::benches::bench_transaction_serialize       ... bench:          17 ns/iter (+/- 0)
test blockdata::transaction::benches::bench_transaction_serialize_logic ... bench:           5 ns/iter (+/- 0)
test blockdata::transaction::benches::bench_transaction_size            ... bench:           4 ns/iter (+/- 0)
```

(*) - I'm benchmarking on a noisy laptop. Take this with a grain of salt. But I think
at least it doesn't make anything slower.

While doing all this manual labor that will probably generate conflicts,
I took a liberty of changing generic type names and variable names to
`r` and `R` (reader) and `w` and `W` for writer.