### PR TITLE
Remove extern crates

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -25,6 +25,7 @@ use crate::blockdata::transaction::Transaction;
 use crate::blockdata::constants::{max_target, WITNESS_SCALE_FACTOR};
 use crate::blockdata::script;
 use crate::VarInt;
+use crate::internal_macros::impl_consensus_encoding;
 
 /// Bitcoin block header.
 ///

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -21,6 +21,7 @@ use crate::blockdata::block::{Block, BlockHeader};
 use crate::blockdata::witness::Witness;
 use crate::network::constants::Network;
 use crate::util::uint::Uint256;
+use crate::internal_macros::{impl_array_newtype, impl_bytes_newtype};
 
 /// The maximum allowable sequence number
 pub const MAX_SEQUENCE: u32 = 0xFFFFFFFF;

--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -14,6 +14,7 @@
 #[cfg(feature = "serde")] use crate::prelude::*;
 
 use core::{fmt, convert::From};
+use crate::internal_macros::display_from_debug;
 
 // Note: I am deliberately not implementing PartialOrd or Ord on the
 //       opcode enum. If you want to check ranges of opcodes, etc.,

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -18,6 +18,7 @@ use crate::io;
 use core::convert::TryFrom;
 use core::{fmt, default::Default};
 use core::ops::Index;
+use crate::internal_macros::display_from_debug;
 
 #[cfg(feature = "serde")] use serde;
 
@@ -1092,6 +1093,7 @@ mod test {
     use crate::blockdata::opcodes;
     use crate::util::key::PublicKey;
     use crate::util::psbt::serialize::Serialize;
+    use crate::internal_macros::hex_script;
 
     #[test]
     fn script() {

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -998,7 +998,7 @@ impl<'de> serde::Deserialize<'de> for Script {
         D: serde::Deserializer<'de>,
     {
         use core::fmt::Formatter;
-        use hashes::hex::FromHex;
+        use crate::hashes::hex::FromHex;
 
         if deserializer.is_human_readable() {
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -30,6 +30,7 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::hash_types::{Sighash, Txid, Wtxid};
 use crate::VarInt;
 use crate::util::sighash::UINT256_ONE;
+use crate::internal_macros::{impl_consensus_encoding, serde_string_impl, serde_struct_human_string_impl, write_err};
 
 #[cfg(doc)]
 use crate::util::sighash::SchnorrSighashType;

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -281,7 +281,7 @@ impl serde::Serialize for Witness {
     where
         S: serde::Serializer,
     {
-        use hashes::hex::ToHex;
+        use crate::hashes::hex::ToHex;
         use serde::ser::SerializeSeq;
 
         let human_readable = serializer.is_human_readable();
@@ -315,8 +315,8 @@ impl<'de> serde::Deserialize<'de> for Witness {
 
             fn visit_seq<A: serde::de::SeqAccess<'de>>(self, mut a: A) -> Result<Self::Value, A::Error>
             {
-                use hashes::hex::FromHex;
-                use hashes::hex::Error::*;
+                use crate::hashes::hex::FromHex;
+                use crate::hashes::hex::Error::*;
                 use serde::de::{self, Unexpected};
 
                 let mut ret = match a.size_hint() {

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -22,7 +22,7 @@ use core::{fmt, mem, u32, convert::From};
 
 use crate::hashes::{sha256d, Hash, sha256};
 use crate::hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};
-
+use crate::internal_macros::write_err;
 use crate::io::{self, Cursor, Read};
 
 use crate::util::endian;
@@ -231,7 +231,7 @@ macro_rules! decoder_fn {
     ($name:ident, $val_type:ty, $readfn:ident, $byte_len: expr) => {
         #[inline]
         fn $name(&mut self) -> Result<$val_type, Error> {
-            const_assert!(::core::mem::size_of::<$val_type>() == $byte_len);
+            $crate::internal_macros::const_assert!(::core::mem::size_of::<$val_type>() == $byte_len);
             let mut val = [0; $byte_len];
             self.read_exact(&mut val[..]).map_err(Error::Io)?;
             Ok(endian::$readfn(&val))

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -44,6 +44,7 @@ macro_rules! impl_consensus_encoding {
         }
     );
 }
+pub(crate) use impl_consensus_encoding;
 
 /// Implements standard array methods for a given wrapper type
 macro_rules! impl_array_newtype {
@@ -104,6 +105,7 @@ macro_rules! impl_array_newtype {
         }
     };
 }
+pub(crate) use impl_array_newtype;
 
 macro_rules! display_from_debug {
     ($thing:ident) => {
@@ -114,15 +116,22 @@ macro_rules! display_from_debug {
         }
     };
 }
+pub(crate) use display_from_debug;
 
 #[cfg(test)]
 macro_rules! hex_script (($s:expr) => (<$crate::Script as core::str::FromStr>::from_str($s).unwrap()));
+#[cfg(test)]
+pub(crate) use hex_script;
 
 #[cfg(test)]
 macro_rules! hex_hash (($h:ident, $s:expr) => ($h::from_slice(&<$crate::prelude::Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()).unwrap()));
+#[cfg(test)]
+pub(crate) use hex_hash;
 
 #[cfg(test)]
 macro_rules! hex_decode (($h:ident, $s:expr) => (deserialize::<$h>(&<$crate::prelude::Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()).unwrap()));
+#[cfg(test)]
+pub(crate) use hex_decode;
 
 macro_rules! serde_string_impl {
     ($name:ident, $expecting:literal) => {
@@ -168,6 +177,7 @@ macro_rules! serde_string_impl {
         }
     };
 }
+pub(crate) use serde_string_impl;
 
 /// A combination macro where the human-readable serialization is done like
 /// serde_string_impl and the non-human-readable impl is done as a struct.
@@ -342,6 +352,7 @@ macro_rules! serde_struct_human_string_impl {
         }
     )
 }
+pub(crate) use serde_struct_human_string_impl;
 
 /// Implements several traits for byte-based newtypes.
 /// Implements:
@@ -476,6 +487,7 @@ macro_rules! impl_bytes_newtype {
         }
     };
 }
+pub(crate) use impl_bytes_newtype;
 
 macro_rules! user_enum {
     (
@@ -563,6 +575,7 @@ macro_rules! user_enum {
         }
     );
 }
+pub(crate) use user_enum;
 
 /// Formats error. If `std` feature is OFF appends error source (delimited by `: `). We do this
 /// because `e.source()` is only available in std builds, without this macro the error source is
@@ -582,6 +595,7 @@ macro_rules! write_err {
         }
     }
 }
+pub(crate) use write_err;
 
 /// Asserts a boolean expression at compile time.
 macro_rules! const_assert {
@@ -589,3 +603,4 @@ macro_rules! const_assert {
         const _: [(); 0 - !$x as usize] = [];
     }};
 }
+pub(crate) use const_assert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,7 @@ extern crate alloc;
 extern crate core2;
 
 // Re-exported dependencies.
-#[macro_use]
-pub extern crate bitcoin_hashes as hashes;
+pub use bitcoin_hashes as hashes;
 pub extern crate bech32;
 pub extern crate secp256k1;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,32 +59,18 @@ extern crate test;
 #[cfg(feature = "no-std")]
 #[macro_use]
 extern crate alloc;
-#[cfg(feature = "no-std")]
-extern crate core2;
 
-// Re-exported dependencies.
+// Re-export dependencies we control.
 pub use bitcoin_hashes as hashes;
-pub extern crate bech32;
-pub extern crate secp256k1;
+pub use secp256k1;
+pub use bech32;
+#[cfg(feature="bitcoinconsensus")]
+pub use bitcoinconsensus;
 
-#[cfg(feature = "no-std")]
-extern crate hashbrown;
-
-#[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
-pub extern crate base64;
-
-#[cfg(feature = "bitcoinconsensus")]
-extern crate bitcoinconsensus;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate actual_serde as serde;
-#[cfg(all(test, feature = "serde"))]
-extern crate bincode;
-#[cfg(all(test, feature = "serde"))]
-extern crate serde_json;
-#[cfg(all(test, feature = "serde"))]
-extern crate serde_test;
+
 
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,6 @@ extern crate bincode;
 extern crate serde_json;
 #[cfg(all(test, feature = "serde"))]
 extern crate serde_test;
-#[cfg(all(test, feature = "unstable"))]
-extern crate test;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@ extern crate actual_serde as serde;
 #[cfg(test)]
 #[macro_use]
 mod test_macros;
-#[macro_use]
 mod internal_macros;
 #[cfg(feature = "serde")]
 mod serde_utils;

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -30,6 +30,7 @@ use core::{fmt, ops, convert::From};
 
 use crate::io;
 use crate::consensus::encode::{self, Encodable, Decodable};
+use crate::internal_macros::user_enum;
 
 /// Version of the protocol as appearing in network message headers
 /// This constant is used to signal to other peers which features you support.

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -16,6 +16,7 @@ use crate::hashes::{Hash as _, sha256d};
 use crate::network::constants;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::hash_types::{BlockHash, Txid, Wtxid};
+use crate::internal_macros::impl_consensus_encoding;
 
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]

--- a/src/network/message_bloom.rs
+++ b/src/network/message_bloom.rs
@@ -7,6 +7,7 @@
 
 use crate::consensus::encode;
 use crate::consensus::{Decodable, Encodable, ReadExt};
+use crate::internal_macros::impl_consensus_encoding;
 use std::io;
 
 /// `filterload` message sets the current bloom filter

--- a/src/network/message_filter.rs
+++ b/src/network/message_filter.rs
@@ -6,6 +6,7 @@
 //!
 
 use crate::hash_types::{BlockHash, FilterHash, FilterHeader};
+use crate::internal_macros::impl_consensus_encoding;
 
 /// getcfilters message
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -16,6 +16,7 @@ use crate::network::constants::{self, ServiceFlags};
 use crate::consensus::{Encodable, Decodable, ReadExt};
 use crate::consensus::encode;
 use crate::hashes::sha256d;
+use crate::internal_macros::impl_consensus_encoding;
 
 /// Some simple messages
 

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -235,7 +235,7 @@ pub mod hex_bytes {
     //! Module for serialization of byte arrays as hex strings.
     #![allow(missing_docs)]
 
-    use hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::{FromHex, ToHex};
     use serde;
 
     pub fn serialize<T, S>(bytes: &T, s: S) -> Result<S::Ok, S::Error>

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -41,6 +41,7 @@ use crate::util::taproot::TapBranchHash;
 use crate::util::key::PublicKey;
 use crate::blockdata::script::Instruction;
 use crate::util::schnorr::{TapTweak, UntweakedPublicKey, TweakedPublicKey};
+use crate::internal_macros::{serde_string_impl, write_err};
 
 /// Address error.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -15,6 +15,7 @@ use crate::hashes::{sha256d, Hash, hex};
 use secp256k1;
 
 use crate::util::{endian, key};
+use crate::internal_macros::write_err;
 
 /// An error that might occur during base58 decoding
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -186,6 +186,7 @@ mod tests {
     use crate::util::address::Address;
     use crate::util::key::PublicKey;
     use crate::hashes::hex::FromHex;
+    use crate::internal_macros::{hex_hash, hex_script};
 
     use super::*;
 

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -49,6 +49,7 @@ use crate::blockdata::transaction::OutPoint;
 use crate::consensus::{Decodable, Encodable};
 use crate::consensus::encode::VarInt;
 use crate::util::endian;
+use crate::internal_macros::write_err;
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845
 const P: u8 = 19;

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -21,6 +21,7 @@ use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 use crate::network::constants::Network;
 use crate::util::{base58, endian, key};
 use crate::util::key::{PublicKey, PrivateKey, KeyPair};
+use crate::internal_macros::{impl_array_newtype, impl_bytes_newtype, serde_string_impl, write_err};
 
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -12,6 +12,7 @@ use crate::hashes::hex::{self, FromHex};
 use crate::blockdata::transaction::NonStandardSighashType;
 use secp256k1;
 use crate::EcdsaSighashType;
+use crate::internal_macros::write_err;
 
 /// An ECDSA signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/util/endian.rs
+++ b/src/util/endian.rs
@@ -30,7 +30,7 @@ macro_rules! define_be_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
         pub fn $name(val: $type) -> [u8; $byte_len] {
-            const_assert!(::core::mem::size_of::<$type>() == $byte_len);
+            $crate::internal_macros::const_assert!(::core::mem::size_of::<$type>() == $byte_len);
             let mut res = [0; $byte_len];
             for i in 0..$byte_len {
                 res[i] = ((val >> ($byte_len - i - 1)*8) & 0xff) as u8;
@@ -43,7 +43,7 @@ macro_rules! define_le_to_array {
     ($name: ident, $type: ty, $byte_len: expr) => {
         #[inline]
         pub fn $name(val: $type) -> [u8; $byte_len] {
-            const_assert!(::core::mem::size_of::<$type>() == $byte_len);
+            $crate::internal_macros::const_assert!(::core::mem::size_of::<$type>() == $byte_len);
             let mut res = [0; $byte_len];
             for i in 0..$byte_len {
                 res[i] = ((val >> i*8) & 0xff) as u8;

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -18,6 +18,7 @@ use crate::network::constants::Network;
 use crate::hashes::{Hash, hash160, hex, hex::FromHex};
 use crate::hash_types::{PubkeyHash, WPubkeyHash};
 use crate::util::base58;
+use crate::internal_macros::write_err;
 
 /// A key-related error.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -33,6 +33,7 @@ mod message_signing {
 
     use crate::util::key::PublicKey;
     use crate::util::address::{Address, AddressType};
+    use crate::internal_macros::write_err;
 
     /// An error used for dealing with Bitcoin Signed Messages.
     #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -30,6 +30,7 @@ use crate::io;
 use core::fmt;
 
 use crate::consensus::encode;
+use crate::internal_macros::write_err;
 
 /// A trait which allows numbers to act as fixed-size bit arrays
 pub trait BitArray {

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -10,6 +10,7 @@ use crate::util::psbt::raw;
 
 use crate::hashes;
 use crate::util::bip32::ExtendedPubKey;
+use crate::internal_macros::write_err;
 
 /// Enum for marking psbt hash error.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -207,6 +207,7 @@ mod display_from_str {
     use core::str::FromStr;
     use crate::consensus::encode::{Error, self};
     use base64::display::Base64Display;
+    use crate::internal_macros::write_err;
 
     /// Error encountered during PSBT decoding from Base64 string.
     #[derive(Debug)]
@@ -347,6 +348,7 @@ mod tests {
     use crate::util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, KeySource};
     use crate::util::psbt::map::{Output, Input};
     use crate::util::psbt::raw;
+    use crate::internal_macros::hex_script;
 
     use std::collections::BTreeMap;
     use crate::blockdata::witness::Witness;
@@ -602,6 +604,7 @@ mod tests {
         use crate::util::psbt::{PartiallySignedTransaction, Error};
         use std::collections::BTreeMap;
         use crate::blockdata::witness::Witness;
+        use crate::internal_macros::hex_script;
 
         #[test]
         #[should_panic(expected = "InvalidMagic")]

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn test_serde_psbt() {
         //! Create a full PSBT value with various fields filled and make sure it can be JSONized.
-        use hashes::sha256d;
+        use crate::hashes::sha256d;
         use crate::util::psbt::map::Input;
         use crate::EcdsaSighashType;
 

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -14,6 +14,7 @@ use crate::prelude::*;
 use secp256k1::{self, Secp256k1, Verification, constants};
 use crate::util::taproot::{TapBranchHash, TapTweakHash};
 use crate::SchnorrSighashType;
+use crate::internal_macros::write_err;
 
 /// Deprecated re-export of [`secp256k1::XOnlyPublicKey`]
 #[deprecated(since = "0.28.0", note = "Please use `util::key::XOnlyPublicKey` instead")]

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -22,6 +22,7 @@ use crate::io;
 use crate::util::taproot::{TapLeafHash, TAPROOT_ANNEX_PREFIX, TapSighashHash};
 use crate::Sighash;
 use crate::{Script, Transaction, TxOut};
+use crate::internal_macros::serde_string_impl;
 
 use super::taproot::LeafVersion;
 
@@ -819,6 +820,7 @@ mod tests {
     use crate::hashes::hex::ToHex;
     use crate::util::taproot::{TapTweakHash, TapSighashHash, TapBranchHash, TapLeafHash};
     use secp256k1::{self, SecretKey, XOnlyPublicKey};
+    use crate::internal_macros::{hex_hash, hex_script, hex_decode};
     extern crate serde_json;
 
     use crate::{Script, Transaction, TxIn, TxOut};

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -13,7 +13,7 @@ use core::convert::TryFrom;
 use core::fmt;
 use core::cmp::Reverse;
 
-use crate::hashes::{sha256, Hash, HashEngine};
+use crate::hashes::{sha256, sha256t_hash_newtype, Hash, HashEngine};
 use crate::schnorr::{TweakedPublicKey, UntweakedPublicKey, TapTweak};
 use crate::util::key::XOnlyPublicKey;
 use crate::Script;
@@ -49,16 +49,16 @@ const MIDSTATE_TAPSIGHASH: [u8; 32] = [
 // f504a425d7f8783b1363868ae3e556586eee945dbc7888dd02a6e2c31873fe9f
 
 // Taproot test vectors from BIP-341 state the hashes without any reversing
-hashes::sha256t_hash_newtype!(TapLeafHash, TapLeafTag, MIDSTATE_TAPLEAF, 64,
+sha256t_hash_newtype!(TapLeafHash, TapLeafTag, MIDSTATE_TAPLEAF, 64,
     doc="Taproot-tagged hash for tapscript Merkle tree leafs", false
 );
-hashes::sha256t_hash_newtype!(TapBranchHash, TapBranchTag, MIDSTATE_TAPBRANCH, 64,
+sha256t_hash_newtype!(TapBranchHash, TapBranchTag, MIDSTATE_TAPBRANCH, 64,
     doc="Taproot-tagged hash for tapscript Merkle tree branches", false
 );
-hashes::sha256t_hash_newtype!(TapTweakHash, TapTweakTag, MIDSTATE_TAPTWEAK, 64,
+sha256t_hash_newtype!(TapTweakHash, TapTweakTag, MIDSTATE_TAPTWEAK, 64,
     doc="Taproot-tagged hash for public key tweaks", false
 );
-hashes::sha256t_hash_newtype!(TapSighashHash, TapSighashTag, MIDSTATE_TAPSIGHASH, 64,
+sha256t_hash_newtype!(TapSighashHash, TapSighashTag, MIDSTATE_TAPSIGHASH, 64,
     doc="Taproot-tagged hash for the taproot signature hash", false
 );
 

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -17,7 +17,7 @@ use crate::hashes::{sha256, sha256t_hash_newtype, Hash, HashEngine};
 use crate::schnorr::{TweakedPublicKey, UntweakedPublicKey, TapTweak};
 use crate::util::key::XOnlyPublicKey;
 use crate::Script;
-
+use crate::internal_macros::write_err;
 use crate::consensus::Encodable;
 
 /// The SHA-256 midstate value for the TapLeaf hash.

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -12,7 +12,7 @@ macro_rules! construct_uint {
         /// Little-endian large integer type
         #[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
         pub struct $name(pub [u64; $n_words]);
-        impl_array_newtype!($name, u64, $n_words);
+        $crate::internal_macros::impl_array_newtype!($name, u64, $n_words);
 
         impl $name {
             /// Conversion to u32
@@ -404,7 +404,7 @@ macro_rules! construct_uint {
             }
         }
 
-        display_from_debug!($name);
+        $crate::internal_macros::display_from_debug!($name);
 
         impl $crate::consensus::Encodable for $name {
             #[inline]


### PR DESCRIPTION
Do some clean up of `extern crate` statements now we have edition 2018.

4 separate but very similar patches, separated to ease review.