### PR TITLE
Refactor `serve_tcp` code

### DIFF
--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -207,7 +207,7 @@ mod test {
                 let mut ostream = ostream.unwrap();
 
                 for piece in pieces {
-                    ostream.write(&piece[..]).unwrap();
+                    ostream.write_all(&piece[..]).unwrap();
                     ostream.flush().unwrap();
                     thread::sleep(Duration::from_secs(1));
                 }

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -203,18 +203,15 @@ mod test {
         // 2. Spawning thread that will be writing our messages to the TCP Stream at the server side
         // in async mode
         let handle = thread::spawn(move || {
-            for ostream in listener.incoming() {
-                let mut ostream = ostream.unwrap();
-
-                for piece in pieces {
-                    ostream.write_all(&piece[..]).unwrap();
-                    ostream.flush().unwrap();
-                    thread::sleep(Duration::from_secs(1));
-                }
-
-                ostream.shutdown(Shutdown::Both).unwrap();
-                break;
+            // We only simulate a single connection.
+            let mut ostream = listener.incoming().next().unwrap().unwrap();
+            for piece in pieces {
+                ostream.write_all(&piece[..]).unwrap();
+                ostream.flush().unwrap();
+                thread::sleep(Duration::from_secs(1));
             }
+
+            ostream.shutdown(Shutdown::Both).unwrap();
         });
 
         // 3. Creating client side of the TCP socket connection

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -225,11 +225,10 @@ mod test {
     #[test]
     fn read_multipartmsg_test() {
         // Setting up TCP connection emulation
-        let (handle, istream) = serve_tcp(vec![
+        let (handle, stream) = serve_tcp(vec![
             // single message split in two parts to emulate real network conditions
             MSG_VERSION[..24].to_vec(), MSG_VERSION[24..].to_vec()
         ]);
-        let stream = istream;
         let mut reader = StreamReader::new(stream, None);
 
         // Reading and checking the whole message back
@@ -243,13 +242,12 @@ mod test {
     #[test]
     fn read_sequencemsg_test() {
         // Setting up TCP connection emulation
-        let (handle, istream) = serve_tcp(vec![
+        let (handle, stream) = serve_tcp(vec![
             // Real-world Bitcoin core communication case for /Satoshi:0.17.1/
             MSG_VERSION[..23].to_vec(), MSG_VERSION[23..].to_vec(),
             MSG_VERACK.to_vec(),
             MSG_ALERT[..24].to_vec(), MSG_ALERT[24..].to_vec()
         ]);
-        let stream = istream;
         let mut reader = StreamReader::new(stream, None);
 
         // Reading and checking the first message (Version)


### PR DESCRIPTION
Done while clearing clippy warnings, done as a separate PR because its not a simple glance to review like the others.

Remove 2 clippy warnings and remove unnecessary local variable.

