### PR TITLE
Clear clippy warnings from `--all-targets`

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -521,7 +521,7 @@ mod tests {
         }
 
         // test with modified header
-        let mut invalid_header: BlockHeader = some_header.clone();
+        let mut invalid_header: BlockHeader = some_header;
         invalid_header.version += 1;
         match invalid_header.validate_pow(&invalid_header.target()) {
             Err(BlockBadProofOfWork) => (),

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -517,7 +517,7 @@ mod tests {
         // test with zero target
         match some_header.validate_pow(&Uint256::default()) {
             Err(BlockBadTarget) => (),
-            _ => assert!(false)
+            _ => panic!("unexpected result from validate_pow"),
         }
 
         // test with modified header
@@ -525,7 +525,7 @@ mod tests {
         invalid_header.version = invalid_header.version + 1;
         match invalid_header.validate_pow(&invalid_header.target()) {
             Err(BlockBadProofOfWork) => (),
-            _ => assert!(false)
+            _ => panic!("unexpected result from validate_pow"),
         }
     }
 

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -522,7 +522,7 @@ mod tests {
 
         // test with modified header
         let mut invalid_header: BlockHeader = some_header.clone();
-        invalid_header.version = invalid_header.version + 1;
+        invalid_header.version += 1;
         match invalid_header.validate_pow(&invalid_header.target()) {
             Err(BlockBadProofOfWork) => (),
             _ => panic!("unexpected result from validate_pow"),

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -1329,18 +1329,18 @@ mod test {
     #[test]
     fn provably_unspendable_test() {
         // p2pk
-        assert_eq!(hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").is_provably_unspendable(), false);
-        assert_eq!(hex_script!("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").is_provably_unspendable(), false);
+        assert!(!hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").is_provably_unspendable());
+        assert!(!hex_script!("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").is_provably_unspendable());
         // p2pkhash
-        assert_eq!(hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_provably_unspendable(), false);
-        assert_eq!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_provably_unspendable(), true);
+        assert!(!hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_provably_unspendable());
+        assert!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_provably_unspendable());
     }
 
     #[test]
     fn op_return_test() {
-        assert_eq!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_op_return(), true);
-        assert_eq!(hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_op_return(), false);
-        assert_eq!(hex_script!("").is_op_return(), false);
+        assert!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_op_return());
+        assert!(!hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_op_return());
+        assert!(!hex_script!("").is_op_return());
     }
 
     #[test]

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -1092,7 +1092,7 @@ mod tests {
         let expected_strippedsize = (EXPECTED_WEIGHT - tx_bytes.len()) / (WITNESS_SCALE_FACTOR - 1);
         assert_eq!(realtx.strippedsize(), expected_strippedsize);
         // Construct a transaction without the witness data.
-        let mut tx_without_witness = realtx.clone();
+        let mut tx_without_witness = realtx;
         tx_without_witness.input.iter_mut().for_each(|input| input.witness.clear());
         assert_eq!(tx_without_witness.weight(), expected_strippedsize*WITNESS_SCALE_FACTOR);
         assert_eq!(tx_without_witness.size(), expected_strippedsize);

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -1009,7 +1009,7 @@ mod tests {
         assert_eq!(txin.script_sig, Script::new());
         assert_eq!(txin.sequence, 0xFFFFFFFF);
         assert_eq!(txin.previous_output, OutPoint::default());
-        assert_eq!(txin.witness.len(), 0 as usize);
+        assert_eq!(txin.witness.len(), 0);
     }
 
     #[test]

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -597,7 +597,7 @@ mod test {
             assert_eq!(version_msg.nonce, 13952548347456104954);
             assert_eq!(version_msg.user_agent, "/Satoshi:0.17.1/");
             assert_eq!(version_msg.start_height, 560275);
-            assert_eq!(version_msg.relay, true);
+            assert!(version_msg.relay);
         } else {
             panic!("Wrong message type");
         }
@@ -634,7 +634,7 @@ mod test {
             assert_eq!(version_msg.nonce, 13952548347456104954);
             assert_eq!(version_msg.user_agent, "/Satoshi:0.17.1/");
             assert_eq!(version_msg.start_height, 560275);
-            assert_eq!(version_msg.relay, true);
+            assert!(version_msg.relay);
         } else {
             panic!("Wrong message type");
         }

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(real_decode.nonce, 16735069437859780935);
         assert_eq!(real_decode.user_agent, "/Satoshi:0.9.99/".to_string());
         assert_eq!(real_decode.start_height, 302892);
-        assert_eq!(real_decode.relay, true);
+        assert!(real_decode.relay);
 
         assert_eq!(serialize(&real_decode), from_sat);
     }

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -139,7 +139,7 @@ mod test {
             assert_eq!(version_msg.nonce, 13952548347456104954);
             assert_eq!(version_msg.user_agent, "/Satoshi:0.17.1/");
             assert_eq!(version_msg.start_height, 560275);
-            assert_eq!(version_msg.relay, true);
+            assert!(version_msg.relay);
         } else {
             panic!("Wrong message type: expected VersionMessage");
         }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -1086,7 +1086,7 @@ mod tests {
         let addr = Address {
             payload: Payload::WitnessProgram {
                 version: WitnessVersion::V13,
-                program: program,
+                program,
             },
             network: Network::Bitcoin,
         };

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -988,7 +988,7 @@ mod tests {
         let addr = Address::p2pkh(&key, Bitcoin);
         assert_eq!(&addr.to_string(), "1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY");
 
-        let key = hex_key!(&"03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f");
+        let key = hex_key!("03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f");
         let addr = Address::p2pkh(&key, Testnet);
         assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
         assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
@@ -1108,7 +1108,7 @@ mod tests {
             ("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", None),
         ];
         for (address, expected_type) in &addresses {
-            let addr = Address::from_str(&address).unwrap();
+            let addr = Address::from_str(address).unwrap();
             assert_eq!(&addr.address_type(), expected_type);
         }
     }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -693,10 +693,10 @@ impl Address {
 
     /// Constructs an [`Address`] from an output script (`scriptPubkey`).
     pub fn from_script(script: &script::Script, network: Network) -> Option<Address> {
-        if script.is_witness_program() {
-            if script.witness_version() == Some(WitnessVersion::V0) && !(script.is_v0_p2wpkh() || script.is_v0_p2wsh()) {
+        if script.is_witness_program()
+            && script.witness_version() == Some(WitnessVersion::V0)
+            && !(script.is_v0_p2wpkh() || script.is_v0_p2wsh()) {
                 return None
-            }
         }
 
         Some(Address {

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -1292,11 +1292,10 @@ mod tests {
 
         fn test_addr_type(payloads: &[Payload], equivalence_classes: &[&[Network]]) {
             for pl in payloads {
-                for addr_net in equivalence_classes.iter().map(|ec| ec.iter()).flatten() {
+                for addr_net in equivalence_classes.iter().flat_map(|ec| ec.iter()) {
                     for valid_net in equivalence_classes.iter()
                         .filter(|ec| ec.contains(addr_net))
-                        .map(|ec| ec.iter())
-                        .flatten()
+                        .flat_map(|ec| ec.iter())
                     {
                         let addr = Address {
                             payload: pl.clone(),
@@ -1307,8 +1306,7 @@ mod tests {
 
                     for invalid_net in equivalence_classes.iter()
                         .filter(|ec| !ec.contains(addr_net))
-                        .map(|ec| ec.iter())
-                        .flatten()
+                        .flat_map(|ec| ec.iter())
                     {
                         let addr = Address {
                             payload: pl.clone(),

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -1599,6 +1599,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
     fn parsing() {
         use super::ParseAmountError as E;
         let btc = Denomination::Bitcoin;
@@ -1868,6 +1869,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
     fn from_str() {
         use super::ParseAmountError as E;
         let p = Amount::from_str;
@@ -1906,6 +1908,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
     fn to_from_string_in() {
         use super::Denomination as D;
         let ua_str = Amount::from_str_in;

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(&encode_slice(&[0, 0, 0, 0, 13, 36][..]), "1111211");
 
         // Long input (>100 bytes => has to use heap)
-        let res = encode_slice(&"BitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBit\
+        let res = encode_slice("BitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBit\
         coinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoin".as_bytes());
         let exp = "ZqC5ZdfpZRi7fjA8hbhX5pEE96MdH9hEaC1YouxscPtbJF16qVWksHWR4wwvx7MotFcs2ChbJqK8KJ9X\
         wZznwWn1JFDhhTmGo9v6GjAVikzCsBWZehu7bm22xL8b5zBR5AsBygYRwbFJsNwNkjpyFuDKwmsUTKvkULCvucPJrN5\

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -201,8 +201,7 @@ mod tests {
 
     fn p2pkh_hex(pk: &str) -> Script {
         let pk: PublicKey = PublicKey::from_str(pk).unwrap();
-        let witness_script = Address::p2pkh(&pk, Network::Bitcoin).script_pubkey();
-        witness_script
+        Address::p2pkh(&pk, Network::Bitcoin).script_pubkey()
     }
 
     fn run_test_sighash_bip143(tx: &str, script: &str, input_index: usize, value: u64, hash_type: u32, expected_result: &str) {

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -573,7 +573,7 @@ mod test {
             assert!(filter.match_all(block_hash, &mut txmap.iter()
                 .filter_map(|(_, s)| if !s.is_empty() { Some(s.as_bytes()) } else { None })).unwrap());
 
-            for (_, script) in &txmap {
+            for script in txmap.values() {
                 let query = vec![script];
                 if !script.is_empty () {
                     assert!(filter.match_any(block_hash, &mut query.iter()

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -618,19 +618,13 @@ mod test {
         let bytes = out;
 
         {
-            let mut query = Vec::new();
-            query.push(Vec::from_hex("abcdef").unwrap());
-            query.push(Vec::from_hex("eeeeee").unwrap());
-
+            let query = vec![Vec::from_hex("abcdef").unwrap(), Vec::from_hex("eeeeee").unwrap()];
             let reader = GCSFilterReader::new(0, 0, M, P);
             let mut input = Cursor::new(bytes.clone());
             assert!(reader.match_any(&mut input, &mut query.iter().map(|v| v.as_slice())).unwrap());
         }
         {
-            let mut query = Vec::new();
-            query.push(Vec::from_hex("abcdef").unwrap());
-            query.push(Vec::from_hex("123456").unwrap());
-
+            let query = vec![Vec::from_hex("abcdef").unwrap(), Vec::from_hex("123456").unwrap()];
             let reader = GCSFilterReader::new(0, 0, M, P);
             let mut input = Cursor::new(bytes.clone());
             assert!(!reader.match_any(&mut input, &mut query.iter().map(|v| v.as_slice())).unwrap());

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -554,7 +554,7 @@ mod test {
             let mut si = scripts.iter();
             for tx in block.txdata.iter().skip(1) {
                 for input in tx.input.iter() {
-                    txmap.insert(input.previous_output.clone(), Script::from(Vec::from_hex(si.next().unwrap().as_str().unwrap()).unwrap()));
+                    txmap.insert(input.previous_output, Script::from(Vec::from_hex(si.next().unwrap().as_str().unwrap()).unwrap()));
                 }
             }
 
@@ -562,7 +562,7 @@ mod test {
                                         |o| if let Some(s) = txmap.get(o) {
                                             Ok(s.clone())
                                         } else {
-                                            Err(Error::UtxoMissing(o.clone()))
+                                            Err(Error::UtxoMissing(*o))
                                         }).unwrap();
 
             let test_filter = BlockFilter::new(filter_content.as_slice());

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -651,7 +651,7 @@ mod test {
                 query.push(p.clone());
             }
             query.push(Vec::from_hex("abcdef").unwrap());
-            let mut input = Cursor::new(bytes.clone());
+            let mut input = Cursor::new(bytes);
             assert!(!reader.match_all(&mut input, &mut query.iter().map(|v| v.as_slice())).unwrap());
         }
     }

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -542,13 +542,13 @@ mod test {
 
         let testdata = serde_json::from_str::<Value>(data).unwrap().as_array().unwrap().clone();
         for t in testdata.iter().skip(1) {
-            let block_hash = BlockHash::from_hex(&t.get(1).unwrap().as_str().unwrap()).unwrap();
-            let block: Block = deserialize(&Vec::from_hex(&t.get(2).unwrap().as_str().unwrap()).unwrap()).unwrap();
+            let block_hash = BlockHash::from_hex(t.get(1).unwrap().as_str().unwrap()).unwrap();
+            let block: Block = deserialize(&Vec::from_hex(t.get(2).unwrap().as_str().unwrap()).unwrap()).unwrap();
             assert_eq!(block.block_hash(), block_hash);
             let scripts = t.get(3).unwrap().as_array().unwrap();
-            let previous_filter_header = FilterHeader::from_hex(&t.get(4).unwrap().as_str().unwrap()).unwrap();
-            let filter_content = Vec::from_hex(&t.get(5).unwrap().as_str().unwrap()).unwrap();
-            let filter_header = FilterHeader::from_hex(&t.get(6).unwrap().as_str().unwrap()).unwrap();
+            let previous_filter_header = FilterHeader::from_hex(t.get(4).unwrap().as_str().unwrap()).unwrap();
+            let filter_content = Vec::from_hex(t.get(5).unwrap().as_str().unwrap()).unwrap();
+            let filter_header = FilterHeader::from_hex(t.get(6).unwrap().as_str().unwrap()).unwrap();
 
             let mut txmap = HashMap::new();
             let mut si = scripts.iter();
@@ -576,7 +576,7 @@ mod test {
             for (_, script) in &txmap {
                 let query = vec![script];
                 if !script.is_empty () {
-                    assert!(filter.match_any(&block_hash, &mut query.iter()
+                    assert!(filter.match_any(block_hash, &mut query.iter()
                         .map(|s| s.as_bytes())).unwrap());
                 }
             }

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -497,7 +497,7 @@ mod tests {
         // testnet compressed
         let sk = PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
         assert_eq!(sk.network, Testnet);
-        assert_eq!(sk.compressed, true);
+        assert!(sk.compressed);
         assert_eq!(&sk.to_wif(), "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy");
 
         let secp = Secp256k1::new();
@@ -513,12 +513,12 @@ mod tests {
         // mainnet uncompressed
         let sk = PrivateKey::from_wif("5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3").unwrap();
         assert_eq!(sk.network, Bitcoin);
-        assert_eq!(sk.compressed, false);
+        assert!(!sk.compressed);
         assert_eq!(&sk.to_wif(), "5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3");
 
         let secp = Secp256k1::new();
         let mut pk = sk.public_key(&secp);
-        assert_eq!(pk.compressed, false);
+        assert!(!pk.compressed);
         assert_eq!(&pk.to_string(), "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133");
         assert_eq!(pk, PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap());
         let addr = Address::p2pkh(&pk, sk.network);

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -178,9 +178,8 @@ impl FromStr for PsbtSighashType {
         // NB: some of Schnorr sighash types are non-standard for pre-taproot
         // inputs. We also do not support SIGHASH_RESERVED in verbatim form
         // ("0xFF" string should be used instead).
-        match SchnorrSighashType::from_str(s) {
-            Ok(ty) => return Ok(ty.into()),
-            Err(_) => {}
+        if let Ok(ty) = SchnorrSighashType::from_str(s) {
+            return Ok(ty.into());
         }
 
         // We accept non-standard sighash values.

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -860,7 +860,7 @@ mod tests {
             assert_eq!(redeem_script.to_p2sh(), expected_out);
 
             for output in psbt.outputs {
-                assert!(output.get_pairs().unwrap().len() > 0)
+                assert!(!output.get_pairs().unwrap().is_empty())
             }
         }
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -358,7 +358,7 @@ mod tests {
     use crate::blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint};
     use crate::network::constants::Network::Bitcoin;
     use crate::consensus::encode::{deserialize, serialize, serialize_hex};
-    use crate::util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource};
+    use crate::util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, KeySource};
     use crate::util::psbt::map::{Output, Input};
     use crate::util::psbt::raw;
 
@@ -404,7 +404,7 @@ mod tests {
 
         let mut sk: ExtendedPrivKey = ExtendedPrivKey::new_master(Bitcoin, &seed).unwrap();
 
-        let fprint: Fingerprint = sk.fingerprint(&secp);
+        let fprint = sk.fingerprint(secp);
 
         let dpath: Vec<ChildNumber> = vec![
             ChildNumber::from_normal_idx(0).unwrap(),
@@ -419,7 +419,7 @@ mod tests {
 
         sk = sk.derive_priv(secp, &dpath).unwrap();
 
-        let pk: ExtendedPubKey = ExtendedPubKey::from_priv(&secp, &sk);
+        let pk = ExtendedPubKey::from_priv(secp, &sk);
 
         hd_keypaths.insert(pk.public_key, (fprint, dpath.into()));
 
@@ -803,7 +803,7 @@ mod tests {
 
             assert!(&psbt.inputs[0].final_script_sig.is_some());
 
-            let redeem_script: &Script = &psbt.inputs[1].redeem_script.as_ref().unwrap();
+            let redeem_script = psbt.inputs[1].redeem_script.as_ref().unwrap();
             let expected_out = hex_script!("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787");
 
             assert!(redeem_script.is_v0_p2wpkh());
@@ -849,7 +849,7 @@ mod tests {
             assert!(&psbt.inputs[0].final_script_sig.is_none());
             assert!(&psbt.inputs[1].final_script_sig.is_none());
 
-            let redeem_script: &Script = &psbt.inputs[1].redeem_script.as_ref().unwrap();
+            let redeem_script = psbt.inputs[1].redeem_script.as_ref().unwrap();
             let expected_out = hex_script!("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787");
 
             assert!(redeem_script.is_v0_p2wpkh());
@@ -873,7 +873,7 @@ mod tests {
 
             assert!(&psbt.inputs[0].final_script_sig.is_none());
 
-            let redeem_script: &Script = &psbt.inputs[0].redeem_script.as_ref().unwrap();
+            let redeem_script = psbt.inputs[0].redeem_script.as_ref().unwrap();
             let expected_out = hex_script!("a9146345200f68d189e1adc0df1c4d16ea8f14c0dbeb87");
 
             assert!(redeem_script.is_v0_p2wsh());

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -393,7 +393,7 @@ mod tests {
         let mut builder = compose_taproot_builder(0x51, &[2, 2, 2]);
         builder = builder.add_leaf_with_ver(3, Script::from_hex("b9").unwrap(), LeafVersion::from_consensus(0xC2).unwrap()).unwrap();
         builder = builder.add_hidden_node(3, sha256::Hash::default()).unwrap();
-        assert!(TapTree::from_builder(builder.clone()).is_err());
+        assert!(TapTree::from_builder(builder).is_err());
     }
 
     #[test]

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -1007,6 +1007,7 @@ mod tests {
         assert_eq!(Annex::new(&[0x51, 0x50]), Err(Error::WrongAnnex));
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn test_taproot_sighash(
         tx_hex: &str,
         prevout_hex: &str,

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -1002,9 +1002,9 @@ mod tests {
 
     #[test]
     fn test_annex_errors() {
-        assert_eq!(Annex::new(&vec![]), Err(Error::WrongAnnex));
-        assert_eq!(Annex::new(&vec![0x51]), Err(Error::WrongAnnex));
-        assert_eq!(Annex::new(&vec![0x51, 0x50]), Err(Error::WrongAnnex));
+        assert_eq!(Annex::new(&[]), Err(Error::WrongAnnex));
+        assert_eq!(Annex::new(&[0x51]), Err(Error::WrongAnnex));
+        assert_eq!(Annex::new(&[0x51, 0x50]), Err(Error::WrongAnnex));
     }
 
     fn test_taproot_sighash(

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -1115,11 +1115,11 @@ mod tests {
             };
 
             // tests
-            let keypair = secp256k1::KeyPair::from_secret_key(&secp, internal_priv_key);
+            let keypair = secp256k1::KeyPair::from_secret_key(secp, internal_priv_key);
             let internal_key = XOnlyPublicKey::from_keypair(&keypair);
             let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
             let mut tweaked_keypair = keypair;
-            tweaked_keypair.tweak_add_assign(&secp, &tweak).unwrap();
+            tweaked_keypair.tweak_add_assign(secp, &tweak).unwrap();
             let mut sig_msg = Vec::new();
             cache.taproot_encode_signing_data_to(
                 &mut sig_msg,

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -1262,9 +1262,9 @@ mod test {
          *   3            55 51
          */
 
-        for (script, length) in vec![("51", 3), ("52", 2), ("53", 2), ("54", 2), ("55", 3)] {
+        for (script, length) in [("51", 3), ("52", 2), ("53", 2), ("54", 2), ("55", 3)].iter() {
             assert_eq!(
-                length,
+                *length,
                 tree_info
                     .script_map
                     .get(&(Script::from_hex(script).unwrap(), LeafVersion::TapScript))

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -1361,12 +1361,12 @@ mod test {
             if script_tree.is_null() {
                 assert!(arr["intermediary"]["merkleRoot"].is_null());
             } else {
-                merkle_root = Some(TapBranchHash::from_str(&arr["intermediary"]["merkleRoot"].as_str().unwrap()).unwrap());
+                merkle_root = Some(TapBranchHash::from_str(arr["intermediary"]["merkleRoot"].as_str().unwrap()).unwrap());
                 let leaf_hashes = arr["intermediary"]["leafHashes"].as_array().unwrap();
                 let ctrl_blks = arr["expected"]["scriptPathControlBlocks"].as_array().unwrap();
                 let mut builder = TaprootBuilder::new();
                 let mut leaves = vec![];
-                builder = process_script_trees(&script_tree, builder, &mut leaves, 0);
+                builder = process_script_trees(script_tree, builder, &mut leaves, 0);
                 let spend_info = builder.finalize(secp, internal_key).unwrap();
                 for (i, script_ver) in leaves.iter().enumerate() {
                     let expected_leaf_hash = leaf_hashes[i].as_str().unwrap();
@@ -1384,8 +1384,8 @@ mod test {
             let expected_addr = Address::from_str(arr["expected"]["bip350Address"].as_str().unwrap()).unwrap();
 
             let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
-            let (output_key, _parity) = internal_key.tap_tweak(&secp, merkle_root);
-            let addr = Address::p2tr(&secp, internal_key, merkle_root, Network::Bitcoin);
+            let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
+            let addr = Address::p2tr(secp, internal_key, merkle_root, Network::Bitcoin);
             let spk = addr.script_pubkey();
 
             assert_eq!(expected_output_key, output_key.to_inner());


### PR DESCRIPTION
Clear all the clippy warnings (excl. #1042) that are returned by running `cargo clippy --all-targets`. 

I apologize in advance for the review burden :) 
