### PR TITLE
Implement std::error::Error for ParseAmount

### DIFF
--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -193,7 +193,22 @@ impl fmt::Display for ParseAmountError {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ParseAmountError {}
+impl std::error::Error for ParseAmountError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::ParseAmountError::*;
+
+        match *self {
+            Negative
+                | TooBig
+                | TooPrecise
+                | InvalidFormat
+                | InputTooLarge
+                | InvalidCharacter(_)
+                | UnknownDenomination(_)
+                | PossiblyConfusingDenomination(_) => None
+        }
+    }
+}
 
 fn is_too_precise(s: &str, precision: usize) -> bool {
     s.contains('.') || precision >= s.len() || s.chars().rev().take(precision).any(|d| d != '0')


### PR DESCRIPTION
The `ParseAmountError` does not implement `std::error::Error`, must have been missed when we did the rest.

Implement `std::error::Error` for `ParseAmount`.