### PR TITLE
Fix broken_intra_doc_links lint warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 #![deny(unused_must_use)]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 #[cfg(not(any(feature = "std", feature = "no-std")))]
 compile_error!("at least one of the `std` or `no-std` features must be enabled");


### PR DESCRIPTION
Running `cargo test` shows a warning which conveniently includes the fix as well:

```shell
warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
  --> /home/dsaxton/git-repos/rust-bitcoin/src/lib.rs:60:9
   |
60 | #![deny(broken_intra_doc_links)]
   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default

warning: 1 warning emitted
```