### PR TITLE
Export the `hex_psbt!` macro

### DIFF
--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -12,8 +12,9 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+/// Helper macro to parse a hex string into a PSBT.
 #[cfg(any(feature = "std", test))]
-#[allow(unused_macros)]
+#[macro_export]
 macro_rules! hex_psbt {
     ($s:expr) => { $crate::consensus::deserialize::<$crate::psbt::Psbt>(&<Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()) };
 }

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -14,7 +14,7 @@
 
 #[allow(unused_macros)]
 macro_rules! hex_psbt {
-    ($s:expr) => { $crate::consensus::deserialize::<$crate::util::psbt::PartiallySignedTransaction>(&<$crate::prelude::Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()) };
+    ($s:expr) => { $crate::consensus::deserialize::<$crate::psbt::Psbt>(&<$crate::prelude::Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()) };
 }
 
 macro_rules! combine {

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -12,9 +12,10 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+#[cfg(any(feature = "std", test))]
 #[allow(unused_macros)]
 macro_rules! hex_psbt {
-    ($s:expr) => { $crate::consensus::deserialize::<$crate::psbt::Psbt>(&<$crate::prelude::Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()) };
+    ($s:expr) => { $crate::consensus::deserialize::<$crate::psbt::Psbt>(&<Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap()) };
 }
 
 macro_rules! combine {


### PR DESCRIPTION
The `hex_psbt` helper macro is useful for testing, examples, and in `rust-miniscript`. Export it for others to use.

The first two patches are preparatory cleanup, patch 3 does the work.