### PR TITLE
Remove duplicate `must_use`

### DIFF
--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -647,7 +647,6 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
 
     /// Encodes the legacy signing data for any flag type into a given object implementing a
     /// [`std::io::Write`] trait. Internally calls [`Transaction::encode_signing_data_to`].
-    #[must_use]
     pub fn legacy_encode_signing_data_to<Write: io::Write, U: Into<u32>>(
         &self,
         mut writer: Write,


### PR DESCRIPTION
Clippy emits:

 warning: this function has an empty `#[must_use]` attribute, but
 returns a type already marked as `#[must_use]`

This is because the return type of the function
`legacy_encode_signing_data_to` is `EncodeSigningDataResult` which is
already marked as `must_use`. There is no need to have `must_use` on the
function also.

I'm guessing this got through to master because we only just added
clippy to CI.