### PR TITLE
Upgrade `bitcoin_hashes` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }
-bitcoin_hashes = { version = "0.10.0", default-features = false }
+bitcoin_hashes = { version = "0.11.0", default-features = false }
 secp256k1 = { version = "0.23.0", default-features = false }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -254,7 +254,7 @@ impl Block {
         let hashes = self.txdata.iter().enumerate().map(|(i, t)| {
             if i == 0 {
                 // Replace the first hash with zeroes.
-                Wtxid::default().as_hash()
+                Wtxid::all_zeros().as_hash()
             } else {
                 t.wtxid().as_hash()
             }

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -13,7 +13,7 @@ use crate::prelude::*;
 use core::default::Default;
 
 use crate::hashes::hex::{self, HexIterator};
-use crate::hashes::sha256d;
+use crate::hashes::{Hash, sha256d};
 use crate::blockdata::opcodes;
 use crate::blockdata::script;
 use crate::blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn};
@@ -114,7 +114,7 @@ pub fn genesis_block(network: Network) -> Block {
             Block {
                 header: BlockHeader {
                     version: 1,
-                    prev_blockhash: Default::default(),
+                    prev_blockhash: Hash::all_zeros(),
                     merkle_root,
                     time: 1231006505,
                     bits: 0x1d00ffff,
@@ -127,7 +127,7 @@ pub fn genesis_block(network: Network) -> Block {
             Block {
                 header: BlockHeader {
                     version: 1,
-                    prev_blockhash: Default::default(),
+                    prev_blockhash: Hash::all_zeros(),
                     merkle_root,
                     time: 1296688602,
                     bits: 0x1d00ffff,
@@ -140,7 +140,7 @@ pub fn genesis_block(network: Network) -> Block {
             Block {
                 header: BlockHeader {
                     version: 1,
-                    prev_blockhash: Default::default(),
+                    prev_blockhash: Hash::all_zeros(),
                     merkle_root,
                     time: 1598918400,
                     bits: 0x1e0377ae,
@@ -153,7 +153,7 @@ pub fn genesis_block(network: Network) -> Block {
             Block {
                 header: BlockHeader {
                     version: 1,
-                    prev_blockhash: Default::default(),
+                    prev_blockhash: Hash::all_zeros(),
                     merkle_root,
                     time: 1296688602,
                     bits: 0x207fffff,
@@ -194,7 +194,6 @@ impl ChainHash {
 
 #[cfg(test)]
 mod test {
-    use core::default::Default;
     use super::*;
     use crate::hashes::hex::{ToHex, FromHex};
     use crate::network::constants::Network;
@@ -206,7 +205,7 @@ mod test {
 
         assert_eq!(gen.version, 1);
         assert_eq!(gen.input.len(), 1);
-        assert_eq!(gen.input[0].previous_output.txid, Default::default());
+        assert_eq!(gen.input[0].previous_output.txid, Hash::all_zeros());
         assert_eq!(gen.input[0].previous_output.vout, 0xFFFFFFFF);
         assert_eq!(serialize(&gen.input[0].script_sig),
                    Vec::from_hex("4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73").unwrap());
@@ -226,7 +225,7 @@ mod test {
         let gen = genesis_block(Network::Bitcoin);
 
         assert_eq!(gen.header.version, 1);
-        assert_eq!(gen.header.prev_blockhash, Default::default());
+        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
         assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 
         assert_eq!(gen.header.time, 1231006505);
@@ -239,7 +238,7 @@ mod test {
     fn testnet_genesis_full_block() {
         let gen = genesis_block(Network::Testnet);
         assert_eq!(gen.header.version, 1);
-        assert_eq!(gen.header.prev_blockhash, Default::default());
+        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
         assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
         assert_eq!(gen.header.time, 1296688602);
         assert_eq!(gen.header.bits, 0x1d00ffff);
@@ -251,7 +250,7 @@ mod test {
     fn signet_genesis_full_block() {
         let gen = genesis_block(Network::Signet);
         assert_eq!(gen.header.version, 1);
-        assert_eq!(gen.header.prev_blockhash, Default::default());
+        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
         assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
         assert_eq!(gen.header.time, 1598918400);
         assert_eq!(gen.header.bits, 0x1e0377ae);
@@ -262,7 +261,7 @@ mod test {
     // The *_chain_hash tests are sanity/regression tests, they verify that the const byte array
     // representing the genesis block is the same as that created by hashing the genesis block.
     fn chain_hash_and_genesis_block(network: Network) {
-        use hashes::{sha256, Hash};
+        use crate::hashes::sha256;
 
         // The genesis block hash is a double-sha256 and it is displayed backwards.
         let genesis_hash = genesis_block(network).block_hash();

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -60,7 +60,7 @@ impl OutPoint {
     #[inline]
     pub fn null() -> OutPoint {
         OutPoint {
-            txid: Default::default(),
+            txid: Hash::all_zeros(),
             vout: u32::max_value(),
         }
     }

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -9,7 +9,7 @@
 //! hash).
 //!
 
-use crate::hashes::{Hash, sha256, sha256d, hash160, hash_newtype};
+use bitcoin_hashes::{sha256, sha256d, hash160, hash_newtype};
 
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -11,7 +11,7 @@ use crate::prelude::*;
 
 use crate::io;
 
-use crate::hashes::sha256d;
+use crate::hashes::{Hash as _, sha256d};
 
 use crate::network::constants;
 use crate::consensus::encode::{self, Decodable, Encodable};
@@ -50,7 +50,7 @@ impl Encodable for Inventory {
             }
         }
         Ok(match *self {
-            Inventory::Error => encode_inv!(0, sha256d::Hash::default()),
+            Inventory::Error => encode_inv!(0, sha256d::Hash::all_zeros()),
             Inventory::Transaction(ref t) => encode_inv!(1, t),
             Inventory::Block(ref b) => encode_inv!(2, b),
             Inventory::WTx(w) => encode_inv!(5, w),
@@ -139,9 +139,8 @@ mod tests {
     use super::{Vec, GetHeadersMessage, GetBlocksMessage};
 
     use crate::hashes::hex::FromHex;
-
+    use crate::hashes::Hash;
     use crate::consensus::encode::{deserialize, serialize};
-    use core::default::Default;
 
     #[test]
     fn getblocks_message_test() {
@@ -154,7 +153,7 @@ mod tests {
         assert_eq!(real_decode.version, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
-        assert_eq!(real_decode.stop_hash, Default::default());
+        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
     }
@@ -170,7 +169,7 @@ mod tests {
         assert_eq!(real_decode.version, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
-        assert_eq!(real_decode.stop_hash, Default::default());
+        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
     }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -1339,8 +1339,8 @@ mod tests {
     #[test]
     fn test_valid_networks() {
         let legacy_payload = &[
-            Payload::PubkeyHash(PubkeyHash::default()),
-            Payload::ScriptHash(ScriptHash::default())
+            Payload::PubkeyHash(PubkeyHash::all_zeros()),
+            Payload::ScriptHash(ScriptHash::all_zeros())
         ];
         let segwit_payload = (0..=16).map(|version| {
             Payload::WitnessProgram {

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -114,7 +114,7 @@ mod tests {
 
         let hashes_iter = block.txdata.iter().map(|obj| obj.txid().as_hash());
 
-        let mut hashes_array: [sha256d::Hash; 15] = [Default::default(); 15];
+        let mut hashes_array: [sha256d::Hash; 15] = [Hash::all_zeros(); 15];
         for (i, hash) in hashes_iter.clone().enumerate() {
             hashes_array[i] = hash;
         }

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -584,7 +584,7 @@ mod tests {
 
                 // Check that it has the same merkle root as the original, and a valid one
                 assert_eq!(merkle_root_1, merkle_root_2);
-                assert_ne!(merkle_root_2, TxMerkleNode::default());
+                assert_ne!(merkle_root_2, TxMerkleNode::all_zeros());
 
                 // check that it contains the matched transactions (in the same order!)
                 assert_eq!(match_txid1, match_txid2);

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -382,7 +382,7 @@ mod tests {
     fn taptree_hidden() {
         let mut builder = compose_taproot_builder(0x51, &[2, 2, 2]);
         builder = builder.add_leaf_with_ver(3, Script::from_hex("b9").unwrap(), LeafVersion::from_consensus(0xC2).unwrap()).unwrap();
-        builder = builder.add_hidden_node(3, sha256::Hash::default()).unwrap();
+        builder = builder.add_hidden_node(3, sha256::Hash::all_zeros()).unwrap();
         assert!(TapTree::try_from(builder).is_err());
     }
 

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -567,7 +567,7 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
         value: u64,
         sighash_type: EcdsaSighashType,
     ) -> Result<(), Error> {
-        let zero_hash = sha256d::Hash::default();
+        let zero_hash = sha256d::Hash::all_zeros();
 
         let (sighash, anyone_can_pay) = sighash_type.split_anyonecanpay_flag();
 


### PR DESCRIPTION
We just released a new version of `bitcoin_hashes`, upgrade the dependency to v0.11.0