### PR TITLE
Implement human-readable serde for `Witness`

### DIFF
--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -423,20 +423,21 @@ mod test {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn test_serde() {
-        use serde_json;
+    fn test_serde_bincode() {
+        use bincode;
 
         let old_witness_format = vec![vec![0u8], vec![2]];
         let new_witness_format = Witness::from_vec(old_witness_format.clone());
 
-        let old = serde_json::to_string(&old_witness_format).unwrap();
-        let new = serde_json::to_string(&new_witness_format).unwrap();
+        let old = bincode::serialize(&old_witness_format).unwrap();
+        let new = bincode::serialize(&new_witness_format).unwrap();
 
         assert_eq!(old, new);
 
-        let back = serde_json::from_str(&new).unwrap();
+        let back: Witness = bincode::deserialize(&new).unwrap();
         assert_eq!(new_witness_format, back);
     }
+
 }
 
 

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -3,12 +3,13 @@
 //! This module contains the [`Witness`] struct and related methods to operate on it
 //!
 
+use secp256k1::ecdsa;
+
 use crate::blockdata::transaction::EcdsaSighashType;
 use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::io::{self, Read, Write};
 use crate::prelude::*;
-use secp256k1::ecdsa;
 use crate::VarInt;
 
 /// The Witness is the data used to unlock bitcoins since the [segwit upgrade](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki)

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -489,6 +489,20 @@ mod test {
         assert_eq!(new_witness_format, back);
     }
 
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_human() {
+        use serde_json;
+
+        let witness = Witness::from_vec(vec![vec![0u8, 123, 75], vec![2u8, 6, 3, 7, 8]]);
+
+        let json = serde_json::to_string(&witness).unwrap();
+
+        assert_eq!(json, r#"["007b4b","0206030708"]"#);
+
+        let back: Witness = serde_json::from_str(&json).unwrap();
+        assert_eq!(witness, back);
+    }
 }
 
 

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -122,7 +122,6 @@ impl Encodable for Witness {
 }
 
 impl Witness {
-
     /// Create a new empty [`Witness`]
     pub fn new() -> Self {
         Witness::default()

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -290,6 +290,7 @@ impl serde::Serialize for Witness {
         seq.end()
     }
 }
+
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Witness {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>


### PR DESCRIPTION
This is dr-orlovsky's [PR](https://github.com/rust-bitcoin/rust-bitcoin/pull/899) picked up at his permission in the discussion thread.

I went through the review comments and implemented everything except the perf optimisations. Also includes a patch at the front of the PR that adds a unit test that can be run to see the "before and after", not sure if we want it in, perhaps it should be removed before merge.

This PR implicitly fixes 942.

To test this PR works as advertised run `cargo test display_transaction --features=serde -- --nocapture` after creating a unit test as follows: 
```rust

    // Used to verify that parts of a transaction pretty print.
    // `cargo test display_transaction --features=serde -- --nocapture`
    #[cfg(feature = "serde")]
    #[test]
    fn serde_display_transaction() {
        let tx_bytes = Vec::from_hex(
            "02000000000101595895ea20179de87052b4046dfe6fd515860505d6511a9004cf12a1f93cac7c01000000\
            00ffffffff01deb807000000000017a9140f3444e271620c736808aa7b33e370bd87cb5a078702483045022\
            100fb60dad8df4af2841adc0346638c16d0b8035f5e3f3753b88db122e70c79f9370220756e6633b17fd271\
            0e626347d28d60b0a2d6cbb41de51740644b9fb3ba7751040121028fa937ca8cba2197a37c007176ed89410\
            55d3bcb8627d085e94553e62f057dcc00000000"
        ).unwrap();
        let tx: Transaction = deserialize(&tx_bytes).unwrap();
        let ser = serde_json::to_string_pretty(&tx).unwrap();
        println!("{}", ser);
    }
```

Fixes: #942 