### PR TITLE
Make `opcode::to_u8` a const function

### DIFF
--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -743,7 +743,7 @@ impl All {
 
     /// Encodes [`All`] as a byte.
     #[inline]
-    pub fn to_u8(self) -> u8 {
+    pub const fn to_u8(self) -> u8 {
         self.code
     }
 }


### PR DESCRIPTION
In general, if a function can be const, it should be, and this one
trivially can be, so it should be.