### PR TITLE
Introduce SPDX license identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,5 @@ See [CHANGELOG.md](CHANGELOG.md).
 ## Licensing
 
 The code in this project is licensed under the [Creative Commons CC0 1.0
-Universal license](LICENSE).
+Universal license](LICENSE). We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX
+IDs](https://spdx.dev/ids/).

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin blocks.
 //!

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Blockdata constants.
 //!

--- a/src/blockdata/mod.rs
+++ b/src/blockdata/mod.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin block data.
 //!

--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin script opcodes.
 //!

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin scripts.
 //!

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin transactions.
 //!

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Witness
 //!
 //! This module contains the [`Witness`] struct and related methods to operate on it

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin consensus-encodable types.
 //!

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin consensus.
 //!

--- a/src/consensus/params.rs
+++ b/src/consensus/params.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin consensus parameters.
 //!

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin hash types.
 //!

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Internal macros.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Rust Bitcoin Library
 //!

--- a/src/network/address.rs
+++ b/src/network/address.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network addresses.
 //!

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network constants.
 //!

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network messages.
 //!

--- a/src/network/message_blockdata.rs
+++ b/src/network/message_blockdata.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin blockdata network messages.
 //!

--- a/src/network/message_bloom.rs
+++ b/src/network/message_bloom.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Bitcoin Connection Bloom filtering network messages.
 //!
 //! This module describes BIP37 Connection Bloom filtering network messages.

--- a/src/network/message_filter.rs
+++ b/src/network/message_filter.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Bitcoin Client Side Block Filtering network messages.
 //!
 //! This module describes BIP157 Client Side Block Filtering network messages.

--- a/src/network/message_network.rs
+++ b/src/network/message_network.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network-related network messages.
 //!

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network support.
 //!

--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Stream reader.
 //!

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin policy.
 //!

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Bitcoin serde utilities.
 //!
 //! This module is for special serde serializations.

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin serde macros.
 //!

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -1,15 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin addresses.
 //!

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -1,12 +1,4 @@
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin amounts.
 //!

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Base58 encoder and decoder.
 //!

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -1,15 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2018 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! BIP143 implementation.
 //!

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2019 by
-//   The rust-bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 // This module was largely copied from https://github.com/rust-bitcoin/murmel/blob/master/src/blockfilter.rs
 // on 11. June 2019 which is licensed under Apache, that file specifically

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -1,15 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! BIP32 implementation.
 //!

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! ECDSA Bitcoin signatures.
 //!

--- a/src/util/endian.rs
+++ b/src/util/endian.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 macro_rules! define_slice_to_be {
     ($name: ident, $type: ty) => {
         #[inline]

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -1,15 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin hash functions.
 //!

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -1,15 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin keys.
 //!

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -1,22 +1,10 @@
-// Rust Bitcoin Library
-// Written by
-//   John L. Jegutanis
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written by John L. Jegutanis
+// SPDX-License-Identifier: CC0-1.0
 //
 // This code was translated from merkleblock.h, merkleblock.cpp and pmt_tests.cpp
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2018 The Bitcoin Core developers
-// Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// SPDX-License-Identifier: MIT
 
 //! Merkle Block and Partial Merkle Tree.
 //!

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Miscellaneous functions.
 //!

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Utility functions.
 //!

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::prelude::*;
 

--- a/src/util/psbt/macros.rs
+++ b/src/util/psbt/macros.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 #[allow(unused_macros)]
 macro_rules! hex_psbt {

--- a/src/util/psbt/map/global.rs
+++ b/src/util/psbt/map/global.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::prelude::*;
 

--- a/src/util/psbt/map/input.rs
+++ b/src/util/psbt/map/input.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::prelude::*;
 use crate::io;

--- a/src/util/psbt/map/mod.rs
+++ b/src/util/psbt/map/mod.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::prelude::*;
 

--- a/src/util/psbt/map/output.rs
+++ b/src/util/psbt/map/output.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::prelude::*;
 use core;

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Partially Signed Bitcoin Transactions.
 //!

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Raw PSBT key-value pairs.
 //!

--- a/src/util/psbt/serialize.rs
+++ b/src/util/psbt/serialize.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written by
-//   The Rust Bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! PSBT serialization.
 //!

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -1,15 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Schnorr Bitcoin keys.
 //!

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -1,16 +1,4 @@
-// Rust Bitcoin Library
-// Written in 2021 by
-//   The rust-bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Generalized, efficient, signature hash implementation.
 //!

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -1,15 +1,4 @@
-// Rust Bitcoin Library
-// Written in 2019 by
-//     The rust-bitcoin developers.
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin Taproot.
 //!

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -1,16 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2014 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Big unsigned integer types.
 //!


### PR DESCRIPTION
When `rust-bitcoin` was started in 2014 the SPDX license list and short identifiers where not a thing. Now that we have short identifiers and they are gaining popularity in other projects we can consider using them.

- Add links to the SPDX website in the readme
- Shorten the author section to a single line
- Remove all the licence information in each file and replace it with an
SPDX ID (see https://spdx.dev/ids/#how)

Of note:

- If the author of a file is explicitly listed, maintain this information
- If the 'author' is listed as the generic 'Rust Bitcoin developers' just remove the attribution, this is implicit. This does loose the date info but that can be seen at any time from the git index using

  `git log --follow --format=%ad --date default <FILE> | tail -1`

apoelstra, please confirm that I'm not treading on your toes here, especially, are you ok with the new 'written by' string format?

### Ref
- https://spdx.dev/ids/#how
- https://spdx.org/licenses/CC0-1.0.html
- https://spdx.dev/ids/