### PR TITLE
Run clippy from the test script

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ jobs:
           - rust: stable
             env:
               DO_COV: true
+              DO_LINT: true
               AS_DEPENDENCY: true
               DO_NO_STD: true
           - rust: beta
@@ -106,19 +107,3 @@ jobs:
           RUSTFLAGS: "-C link-arg=-Tlink.x"
           CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
         run: cd embedded && cargo run --target thumbv7m-none-eabi
-
-  Clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -31,6 +31,14 @@ if [ "$duplicate_dependencies" -ne 0 ]; then
     exit 1
 fi
 
+if [ "$DO_LINT" = true ]
+then
+    cargo clippy --all-features --all-targets -- -D warnings
+    cargo clippy --example bip32 -- -D warnings
+    cargo clippy --example handshake -- -D warnings
+    cargo clippy --example ecdsa-psbt --features=bitcoinconsensus -- -D warnings
+fi
+
 echo "********* Testing std *************"
 # Test without any features other than std first
 cargo test --verbose --no-default-features --features="std"

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -2033,10 +2033,10 @@ mod tests {
 
         let json = "{\"amt\": 21000000.00000001, \
                     \"samt\": -21000000.00000001}";
-        let t: T = serde_json::from_str(&json).unwrap();
+        let t: T = serde_json::from_str(json).unwrap();
         assert_eq!(t, orig);
 
-        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let value: serde_json::Value = serde_json::from_str(json).unwrap();
         assert_eq!(t, serde_json::from_value(value).unwrap());
 
         // errors

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -638,7 +638,7 @@ mod tests {
         ];
 
         let s = Secp256k1::new();
-        let sk = PrivateKey::from_str(&KEY_WIF).unwrap();
+        let sk = PrivateKey::from_str(KEY_WIF).unwrap();
         let pk = PublicKey::from_private_key(&s, &sk);
         let pk_u = PublicKey {
             inner: pk.inner,

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -331,7 +331,7 @@ mod tests {
         assert_eq!(signature.to_base64(), signature.to_string());
         let signature2 = super::MessageSignature::from_str(&signature.to_string()).unwrap();
         let pubkey = signature2.recover_pubkey(&secp, msg_hash).unwrap();
-        assert_eq!(pubkey.compressed, true);
+        assert!(pubkey.compressed);
         assert_eq!(pubkey.inner, secp256k1::PublicKey::from_secret_key(&secp, &privkey));
 
         let p2pkh = Address::p2pkh(&pubkey, Network::Bitcoin);

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -317,7 +317,7 @@ mod tests {
 
         let secp = secp256k1::Secp256k1::new();
         let message = "rust-bitcoin MessageSignature test";
-        let msg_hash = super::signed_msg_hash(&message);
+        let msg_hash = super::signed_msg_hash(message);
         let msg = secp256k1::Message::from(msg_hash);
 
 
@@ -357,7 +357,7 @@ mod tests {
 
         let secp = secp256k1::Secp256k1::new();
         let message = "a different message from what was signed";
-        let msg_hash = super::signed_msg_hash(&message);
+        let msg_hash = super::signed_msg_hash(message);
 
         // Signature of msg = "rust-bitcoin MessageSignature test"
         // Signed with pk "UuOGDsfLPr4HIMKQX0ipjJeRaj1geCq3yPUF2COP5ME="

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -543,7 +543,7 @@ mod tests {
                 let xpub: ExtendedPubKey =
                     "xpub661MyMwAqRbcGoRVtwfvzZsq2VBJR1LAHfQstHUoxqDorV89vRoMxUZ27kLrraAj6MPi\
                     QfrDb27gigC1VS1dBXi5jGpxmMeBXEkKkcXUTg4".parse().unwrap();
-                vec![(xpub, key_source.clone())].into_iter().collect()
+                vec![(xpub, key_source)].into_iter().collect()
             },
             unsigned_tx: {
                 let mut unsigned = tx.clone();
@@ -579,8 +579,8 @@ mod tests {
             }],
             outputs: vec![Output {
                 bip32_derivation: keypaths,
-                proprietary: proprietary.clone(),
-                unknown: unknown.clone(),
+                proprietary: proprietary,
+                unknown: unknown,
                 ..Default::default()
             }],
         };

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -579,8 +579,8 @@ mod tests {
             }],
             outputs: vec![Output {
                 bip32_derivation: keypaths,
-                proprietary: proprietary,
-                unknown: unknown,
+                proprietary,
+                unknown,
                 ..Default::default()
             }],
         };


### PR DESCRIPTION
Currently we run clippy in CI using a github action. The invocation has a couple of shortcomings

1. it does not lint the tests (this requires `--all-targets`)
2. it does not lint the examples

I could not find a way to lint the examples without explicitly linting each example by name.

**This PR does the following:**

- Fix clippy issues (patch 1-4)
- Move the clippy control to `test.sh`
- Add an env var `DO_LINT` to control it
- Remove the separate CI job
- Run the linter during the `Test` job using the stable toolchain.
- Run clippy with ` --all-features` AND `--all-targets` (only recently made possible).
- Run each example explicitly

Thanks to dunxen for noticing all the errors in my psbt example on review and prompting me to work out why clippy was not running :)

