### PR TITLE
Add cfg nightly

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -539,7 +539,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(all(nightly, test, feature = "unstable"))]
 mod benches {
     use super::Block;
     use crate::EmptyWrite;

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -1735,7 +1735,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(all(nightly, test, feature = "unstable"))]
 mod benches {
     use super::Transaction;
     use crate::EmptyWrite;

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -439,7 +439,7 @@ mod test {
 }
 
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(all(nightly, test, feature = "unstable"))]
 mod benches {
     use test::{Bencher, black_box};
     use super::Witness;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 // Experimental features we need
-#![cfg_attr(all(test, feature = "unstable"), feature(test))]
+#![cfg_attr(all(nightly, test, feature = "unstable"), feature(test))]
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -93,7 +93,7 @@ pub extern crate base64;
 #[cfg(all(test, feature = "serde"))] extern crate serde_json;
 #[cfg(all(test, feature = "serde"))] extern crate serde_test;
 #[cfg(all(test, feature = "serde"))] extern crate bincode;
-#[cfg(all(test, feature = "unstable"))] extern crate test;
+#[cfg(all(nightly, test, feature = "unstable"))] extern crate test;
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("rust-bitcoin cannot be used on 16-bit architectures");
@@ -198,7 +198,8 @@ mod prelude {
     pub use std::collections::HashSet;
 }
 
-#[cfg(all(test, feature = "unstable"))] use tests::EmptyWrite;
+#[cfg(all(nightly, test, feature = "unstable"))]
+use tests::EmptyWrite;
 
 #[cfg(all(test, feature = "unstable"))]
 mod tests {


### PR DESCRIPTION
Currently we use `#![cfg_attr(all(test, feature = "unstable"), feature(test))]` in `lib.rs` to enable unstable test features. This works but has the unfortunate side effect that we can not use `cargo test --all-features`because this command enables `"unstable"` and `test` but uses the stable toolchain. The problem is further compounded by the fact that we cannot use `cargo clippy --all-features` so we cannot lint the test code.

There is a `nightly` feature that can be used with `cfg` to get around this, since enabling the `"unstable"` feature implies that we are using a nightly toolchain this has no ill-effects.

Add `nightly` to the compiler attribute when guarding on the `"unstable"` feature. E.g., `#[cfg(all(nightly, test, feature = "unstable"))]`