### PR TITLE
Use `to_hex` when available

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -207,7 +207,7 @@ impl ChainHash {
 mod test {
     use core::default::Default;
     use super::*;
-    use crate::hashes::hex::FromHex;
+    use crate::hashes::hex::{ToHex, FromHex};
     use crate::network::constants::Network;
     use crate::consensus::encode::serialize;
 
@@ -229,8 +229,7 @@ mod test {
         assert_eq!(gen.output[0].value, 50 * COIN_VALUE);
         assert_eq!(gen.lock_time, 0);
 
-        assert_eq!(format!("{:x}", gen.wtxid()),
-                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string());
+        assert_eq!(gen.wtxid().to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
     }
 
     #[test]
@@ -239,13 +238,12 @@ mod test {
 
         assert_eq!(gen.header.version, 1);
         assert_eq!(gen.header.prev_blockhash, Default::default());
-        assert_eq!(format!("{:x}", gen.header.merkle_root),
-                   "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string());
+        assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+
         assert_eq!(gen.header.time, 1231006505);
         assert_eq!(gen.header.bits, 0x1d00ffff);
         assert_eq!(gen.header.nonce, 2083236893);
-        assert_eq!(format!("{:x}", gen.header.block_hash()),
-                   "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f".to_string());
+        assert_eq!(gen.header.block_hash().to_hex(), "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
     }
 
     #[test]
@@ -253,13 +251,11 @@ mod test {
         let gen = genesis_block(Network::Testnet);
         assert_eq!(gen.header.version, 1);
         assert_eq!(gen.header.prev_blockhash, Default::default());
-        assert_eq!(format!("{:x}", gen.header.merkle_root),
-                  "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string());
+        assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
         assert_eq!(gen.header.time, 1296688602);
         assert_eq!(gen.header.bits, 0x1d00ffff);
         assert_eq!(gen.header.nonce, 414098458);
-        assert_eq!(format!("{:x}", gen.header.block_hash()),
-                   "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943".to_string());
+        assert_eq!(gen.header.block_hash().to_hex(), "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
     }
 
     #[test]
@@ -267,13 +263,11 @@ mod test {
         let gen = genesis_block(Network::Signet);
         assert_eq!(gen.header.version, 1);
         assert_eq!(gen.header.prev_blockhash, Default::default());
-        assert_eq!(format!("{:x}", gen.header.merkle_root),
-                  "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b".to_string());
+        assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
         assert_eq!(gen.header.time, 1598918400);
         assert_eq!(gen.header.bits, 0x1e0377ae);
         assert_eq!(gen.header.nonce, 52613770);
-        assert_eq!(format!("{:x}", gen.header.block_hash()),
-                   "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6".to_string());
+        assert_eq!(gen.header.block_hash().to_hex(), "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6");
     }
 
     // The *_chain_hash tests are sanity/regression tests, they verify that the const byte array
@@ -315,7 +309,7 @@ mod test {
     // Test vector taken from: https://github.com/lightning/bolts/blob/master/00-introduction.md
     #[test]
     fn mainnet_chain_hash_test_vector() {
-        let got = format!("{:x}", ChainHash::using_genesis_block(Network::Bitcoin));
+        let got = ChainHash::using_genesis_block(Network::Bitcoin).to_hex();
         let want = "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000";
         assert_eq!(got, want);
     }

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -1067,8 +1067,10 @@ impl serde::Serialize for Script {
     where
         S: serde::Serializer,
     {
+        use crate::hashes::hex::ToHex;
+
         if serializer.is_human_readable() {
-            serializer.serialize_str(&format!("{:x}", self))
+            serializer.serialize_str(&self.to_hex())
         } else {
             serializer.serialize_bytes(self.as_bytes())
         }
@@ -1158,7 +1160,7 @@ mod test {
                                    .push_opcode(opcodes::all::OP_EQUALVERIFY)
                                    .push_opcode(opcodes::all::OP_CHECKSIG)
                                    .into_script();
-        assert_eq!(&format!("{:x}", script), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
+        assert_eq!(script.to_hex(), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
     }
 
     #[test]
@@ -1198,71 +1200,71 @@ mod test {
         let simple = Builder::new()
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", simple), "69");
+        assert_eq!(simple.to_hex(), "69");
         let simple2 = Builder::from(vec![])
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", simple2), "69");
+        assert_eq!(simple2.to_hex(), "69");
 
         let nonverify = Builder::new()
             .push_verify()
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", nonverify), "6969");
+        assert_eq!(nonverify.to_hex(), "6969");
         let nonverify2 = Builder::from(vec![0x69])
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", nonverify2), "6969");
+        assert_eq!(nonverify2.to_hex(), "6969");
 
         let equal = Builder::new()
             .push_opcode(opcodes::all::OP_EQUAL)
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", equal), "88");
+        assert_eq!(equal.to_hex(), "88");
         let equal2 = Builder::from(vec![0x87])
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", equal2), "88");
+        assert_eq!(equal2.to_hex(), "88");
 
         let numequal = Builder::new()
             .push_opcode(opcodes::all::OP_NUMEQUAL)
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", numequal), "9d");
+        assert_eq!(numequal.to_hex(), "9d");
         let numequal2 = Builder::from(vec![0x9c])
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", numequal2), "9d");
+        assert_eq!(numequal2.to_hex(), "9d");
 
         let checksig = Builder::new()
             .push_opcode(opcodes::all::OP_CHECKSIG)
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", checksig), "ad");
+        assert_eq!(checksig.to_hex(), "ad");
         let checksig2 = Builder::from(vec![0xac])
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", checksig2), "ad");
+        assert_eq!(checksig2.to_hex(), "ad");
 
         let checkmultisig = Builder::new()
             .push_opcode(opcodes::all::OP_CHECKMULTISIG)
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", checkmultisig), "af");
+        assert_eq!(checkmultisig.to_hex(), "af");
         let checkmultisig2 = Builder::from(vec![0xae])
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", checkmultisig2), "af");
+        assert_eq!(checkmultisig2.to_hex(), "af");
 
         let trick_slice = Builder::new()
             .push_slice(&[0xae]) // OP_CHECKMULTISIG
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", trick_slice), "01ae69");
+        assert_eq!(trick_slice.to_hex(), "01ae69");
         let trick_slice2 = Builder::from(vec![0x01, 0xae])
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", trick_slice2), "01ae69");
+        assert_eq!(trick_slice2.to_hex(), "01ae69");
    }
 
     #[test]


### PR DESCRIPTION
We have a bunch of calls to `format!("{:x}", foo)` for types that implement `ToHex`. The code is terser with no loss of clarity if we use the trait method and call `to_hex()`.