### PR TITLE
Remove unused lifetimes

### DIFF
--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -171,7 +171,7 @@ macro_rules! serde_string_impl {
 
         #[cfg(feature = "serde")]
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-        impl<'de> $crate::serde::Serialize for $name {
+        impl $crate::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: $crate::serde::Serializer,
@@ -330,7 +330,7 @@ macro_rules! serde_struct_human_string_impl {
 
         #[cfg(feature = "serde")]
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-        impl<'de> $crate::serde::Serialize for $name {
+        impl $crate::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: $crate::serde::Serializer,


### PR DESCRIPTION
We somehow have two lifetimes that are unused and causing clippy warnings, remove them.

This fixes the red CI runs on a bunch of other open PRs. FTR I have no idea how these got past clippy onto master. 