### PR TITLE
Remove extern crate core statement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,6 @@ extern crate alloc;
 #[cfg(feature = "no-std")]
 extern crate core2;
 
-#[cfg(any(feature = "std", test))]
-extern crate core; // for Rust 1.29 and no-std tests
-
 // Re-exported dependencies.
 #[macro_use] pub extern crate bitcoin_hashes as hashes;
 pub extern crate secp256k1;


### PR DESCRIPTION
Now that we have an MSRV of 1.41.1 we no longer need `extern crate core`, remove it.