### PR TITLE
Add cargo crev reminder to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Supports (or should support)
 For JSONRPC interaction with Bitcoin Core, it is recommended to use
 [rust-bitcoincore-rpc](https://github.com/rust-bitcoin/rust-bitcoincore-rpc).
 
+It is recommended to always use [cargo-crev](https://github.com/crev-dev/cargo-crev)
+to verify the trustworthiness of each of your dependencies, including this one.
+
 ## Known limitations
 
 ### Consensus


### PR DESCRIPTION
As suggested by the `cargo-crev` project; add a comment to the readme reminding people to use `cargo-crev` to check their dependencies.

### Notes

Today I explored `cargo-crev`, it was new to me before today. I completed proofs for `bech32`, `rust-bitcoinconsenus`, `bitcoin_hashes`, `rust-secp256k1`, and `rust-bitcoin`. I published the proofs to https://github.com/tcharding/crev-proofs.

If I'm understanding correctly proofs are only useful if the author is connected to a web of trust. So far I only found @dpc within the active rust-bitcoin devs with a `crev-proofs` repo (that includes an ID). Since he wrote `cargo-crev` its not surprising he has one :) Two other devs have `crev-proofs` repos but they are both incomplete (no ID) so I was unable to climb onto their web, so to speak. I am not a particularly well know dev so I imagine it would be more useful if some of you more well know fellas publish proofs as well.

If we can get a web of trust between all the regular hackers here then we can start doing reviews/proofs of our dependencies and publishing them.