### PR TITLE
Document PSBT roles and limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Supports (or should support)
 * De/serialization of blocks and transactions
 * Script de/serialization
 * Private keys and address creation, de/serialization and validation (including full BIP32 support)
-* PSBT creation, manipulation, merging and finalization
+* PSBT v0 de/serialization and all but the Input Finalizer role. Use [rust-miniscript](https://docs.rs/miniscript/latest/miniscript/psbt/index.html) to finalize.
 * Pay-to-contract support as in Appendix A of the [Blockstream sidechains whitepaper](https://www.blockstream.com/sidechains.pdf)
 
 For JSONRPC interaction with Bitcoin Core, it is recommended to use


### PR DESCRIPTION
The READEME claims rust-bitcoin supports PSBT finalization, but really needs rust-miniscript for that. I think we should make this clear in this crate's PSBT examples as well.

> > Understanding scripts and witnesses doesn't scream rust-miniscript to me. Miniscript crate is not the first place I'd look, since it's additional.
> 
> We should probably add it to the README here or something. If I needed to deal with scripts or witnesses in any way beyond reserializing them or hashing scriptpubkeys into addresses, I'd immediately turn to Miniscript. You basically can't work on scripts without it, unless you are doing something very specific.
> 
> >Anywhere there's PSBT code I expect a finalizer, even if it had documented limitations.
> 
> Not to be too glib, but suppose we had a finalizer that just always returned an error, and was documented not to finalize any transactions. Would that meet your expectations? It is hard to do much more without Miniscript.
> 

_Originally posted by apoelstra in https://github.com/rust-bitcoin/rust-bitcoin/issues/630#issuecomment-1175316689_