### PR TITLE
Remove the Pay-to-Contract reference from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Supports (or should support)
 * Script de/serialization
 * Private keys and address creation, de/serialization and validation (including full BIP32 support)
 * PSBT v0 de/serialization and all but the Input Finalizer role. Use [rust-miniscript](https://docs.rs/miniscript/latest/miniscript/psbt/index.html) to finalize.
-* Pay-to-contract support as in Appendix A of the [Blockstream sidechains whitepaper](https://www.blockstream.com/sidechains.pdf)
 
 For JSONRPC interaction with Bitcoin Core, it is recommended to use
 [rust-bitcoincore-rpc](https://github.com/rust-bitcoin/rust-bitcoincore-rpc).


### PR DESCRIPTION
Removed in https://github.com/rust-bitcoin/rust-bitcoin/pull/871