### PR TITLE
Depend on secp256k1 upcoming release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { version = "0.23.0", default-features = false }
+secp256k1 = { git = "https://github.com/tcharding/rust-secp256k1", branch = "07-19-bump-version-0.24.0", default-features = false }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }
@@ -47,7 +47,7 @@ hashbrown = { version = "0.8", optional = true }
 [dev-dependencies]
 serde_json = "<1.0.45"
 serde_test = "1"
-secp256k1 = { version = "0.23.0", features = [ "recovery", "rand-std" ] }
+secp256k1 = {  git = "https://github.com/tcharding/rust-secp256k1", branch = "07-19-bump-version-0.24.0", features = [ "recovery", "rand-std" ] }
 bincode = "1.3.1"
 
 [[example]]


### PR DESCRIPTION
**This is not a merge candidate.**

Depend on the branch of `secp256k1` that bumps version to v0.24.0, this PR is just to get a green CI run using the secp release branch as a dependency.

We messed up and upgraded the `bitcoin_hashes` dependency without first doing it in `rust-secp256k1`. 

Found by @arturomf94 https://github.com/rust-bitcoin/rust-bitcoin/issues/824#issuecomment-1188259382