### PR TITLE
Add a test to check `bitcoin_hashes` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ hashbrown = { version = "0.8", optional = true }
 [dev-dependencies]
 serde_json = "<1.0.45"
 serde_test = "1"
-secp256k1 = { version = "0.23.0", features = [ "recovery", "rand-std" ] }
+secp256k1 = { version = "0.23.0", features = [ "recovery", "rand-std", "bitcoin_hashes" ] }
 bincode = "1.3.1"
 
 [[example]]

--- a/tests/dependencies.rs
+++ b/tests/dependencies.rs
@@ -1,0 +1,9 @@
+//! This file does arbitrary comparisons of various types to ensure all the dependency versions
+//! are equal. It exists to catch our mistakes when upgrading crates in the stack.
+
+#[test]
+fn bitcoin_hashes() {
+    let our_dep = bitcoin_hashes::hex::Error::InvalidChar(0_u8);
+    let secp_dep = secp256k1::hashes::hex::Error::InvalidChar(0_u8);
+    assert_eq!(our_dep, secp_dep)
+}


### PR DESCRIPTION
Recently we updated the `bitcoin_hashes` dependency without first doing
so in `secp256k1`. Since `bitcoin_hashes` is an optional dependency of
secp this did not show up in our CI run and was reported by a user.

To prevent this from happening again we can add a test that creates two
arbitrary objects, one from the `rust-bitcoin` `bitcoin_hashes`
dependency and one from the `rust-secp256k1` `bitcoin_hashes` dependency
then assert that they are comparable. If different versions of
`bitcoin_hashes` are being used then the compiler will complain.

This will not be mergable until we release secp256 v0.24.0