### PR TITLE
Upgrade to secp v0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { version = "0.23.0", default-features = false }
+secp256k1 = { version = "0.24.0", default-features = false }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }
@@ -47,7 +47,7 @@ hashbrown = { version = "0.8", optional = true }
 [dev-dependencies]
 serde_json = "<1.0.45"
 serde_test = "1"
-secp256k1 = { version = "0.23.0", features = [ "recovery", "rand-std" ] }
+secp256k1 = { version = "0.24.0", features = [ "recovery", "rand-std" ] }
 bincode = "1.3.1"
 
 [[example]]


### PR DESCRIPTION
We just released a new version of `rust-secp256k1`, lets use it.

This also fixes a bug where we upgraded our `bitcoin_hashes` dependency
before secp had done theirs.