### PR TITLE
Use infallible conversions: `Hash` -> `secp256k1::Message`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bech32 = { version = "0.8.1", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { version = "0.24.0", default-features = false }
+secp256k1 = { version = "0.24.0", default-features = false, features = ["bitcoin_hashes"] }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -141,8 +141,7 @@ mod message_signing {
             secp_ctx: &secp256k1::Secp256k1<C>,
             msg_hash: sha256d::Hash
         ) -> Result<PublicKey, MessageSignatureError> {
-            let msg = secp256k1::Message::from_slice(&msg_hash[..])
-                .expect("cannot fail");
+            let msg = secp256k1::Message::from(msg_hash);
             let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
             Ok(PublicKey {
                 inner: pubkey,
@@ -319,7 +318,7 @@ mod tests {
         let secp = secp256k1::Secp256k1::new();
         let message = "rust-bitcoin MessageSignature test";
         let msg_hash = super::signed_msg_hash(&message);
-        let msg = secp256k1::Message::from_slice(&msg_hash).expect("message");
+        let msg = secp256k1::Message::from(msg_hash);
 
 
         let privkey = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -1148,7 +1148,7 @@ mod tests {
                 hash_ty
             ).unwrap();
 
-            let msg = secp256k1::Message::from_slice(&sighash).unwrap();
+            let msg = secp256k1::Message::from(sighash);
             let key_spend_sig = secp.sign_schnorr_with_aux_rand(&msg, &tweaked_keypair, &[0u8; 32]);
 
             assert_eq!(expected_internal_pk, internal_key);

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -62,6 +62,12 @@ sha256t_hash_newtype!(TapSighashHash, TapSighashTag, MIDSTATE_TAPSIGHASH, 64,
     doc="Taproot-tagged hash for the taproot signature hash", false
 );
 
+impl secp256k1::ThirtyTwoByteHash for TapSighashHash {
+        fn into_32(self) -> [u8; 32] {
+            self.into_inner()
+        }
+}
+
 impl TapTweakHash {
     /// Creates a new BIP341 [`TapTweakHash`] from key and tweak. Produces `H_taptweak(P||R)` where
     /// `P` is the internal key and `R` is the merkle root.


### PR DESCRIPTION
Replaces all instances of `secp256k1::Message::from_slice(_).expect(_)` with `secp256k1::Message::from(_)`. This also implements `ThirtyTwoByteHash` for `TapSighashHash`.

Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/824