### PR TITLE
Use `listener.accept()`

### DIFF
--- a/src/network/stream_reader.rs
+++ b/src/network/stream_reader.rs
@@ -193,7 +193,7 @@ mod test {
         // in async mode
         let handle = thread::spawn(move || {
             // We only simulate a single connection.
-            let mut ostream = listener.incoming().next().unwrap().unwrap();
+            let (mut ostream, _) = listener.accept().unwrap();
             for piece in pieces {
                 ostream.write_all(&piece[..]).unwrap();
                 ostream.flush().unwrap();


### PR DESCRIPTION
During test network simulation we only accept a single connection, we can simplify the code by using `accept`.

Done as a follow up to review suggestion:

https://github.com/rust-bitcoin/rust-bitcoin/pull/1042#discussion_r898013799