### PR TITLE
Use `u8::try_from`

### DIFF
--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -604,9 +604,8 @@ impl ScriptLeaf {
     /// Returns the depth of this script leaf in the tap tree.
     #[inline]
     pub fn depth(&self) -> u8 {
-        // The depth is guaranteed to be < 127 by the TaprootBuilder type.
-        // TODO: Following MSRV bump implement via `try_into().expect("")`.
-        self.merkle_branch.0.len() as u8
+        // Depth is guarded by TAPROOT_CONTROL_MAX_NODE_COUNT.
+        u8::try_from(self.merkle_branch.0.len()).expect("depth is guaranteed to fit in a u8")
     }
 
     /// Computes a leaf hash for this [`ScriptLeaf`].


### PR DESCRIPTION
Currently we use a cast to get the `u8` depth, as suggested by the TODO in the code we can now use `TryFrom` since we bumped the MSRV.

Use `u8::try_from.expect("")` since depth (node count) is guarded by `TAPROOT_CONTROL_MAX_NODE_COUNT`.