### PR TITLE
Add docs re Rust 1.51.1

### DIFF
--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -336,7 +336,7 @@ fn dec_width(mut num: u64) -> usize {
     width
 }
 
-// NIH due to MSRV, impl copied from `core`
+// NIH due to MSRV, impl copied from `core::i8::unsigned_abs` (introduced in Rust 1.51.1).
 fn unsigned_abs(x: i8) -> u8 {
     x.wrapping_abs() as u8
 }


### PR DESCRIPTION
After auditing the code base for 'msrv' the only remaining mention (excl. md files) is on `unsigned_abs`.

Add docs to save the next guy looking up what version of Rust introduced `unsigned_abs`. (I also added an item to the [msrv tracking issue](https://github.com/rust-bitcoin/rust-bitcoin/issues/1060).)