### PR TITLE
Remove stale MSRV docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,9 +128,9 @@ PR authors may also find it useful to run the following script locally in order
 to check that each of the commits within the PR satisfies the requirements
 above, before submitting the PR to review:
 ```shell script
-BITCOIN_MSRV=1.29.0 ./contrib/test.sh
+RUSTUP_TOOLCHAIN=1.41.1 ./contrib/test.sh
 ```
-Please replace the value in `BITCOIN_MSRV=1.29.0` with the current MSRV from
+Please replace the value in `RUSTUP_TOOLCHAIN=1.41.1` with the current MSRV from
 [README.md].
 
 NB: Please keep in mind that the script above replaces `Cargo.lock` file, which

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,12 +183,6 @@ and [how it is planned to coordinate it with crate refactoring](https://github.c
 For the new code it is recommended to follow style of the existing codebase and
 avoid any end-line space characters.
 
-### MSRV
-
-The Minimal Supported Rust Version (MSRV) is 1.29; it is enforced by our CI.
-Later we plan to increase MSRV to support Rust 2018 and you are welcome to check
-the [tracking issue](https://github.com/rust-bitcoin/rust-bitcoin/issues/510).
-
 ### Naming conventions
 
 Naming of data structures/enums and their fields/variants must follow names used

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ please join us in
 [#bitcoin-rust](https://web.libera.chat/?channel=#bitcoin-rust) on
 [libera.chat](https://libera.chat).
 
+For more information please see `./CONTRIBUTING.md`.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This library should always compile with any combination of features (minus


### PR DESCRIPTION
We have stale docs referring to the old MSRV. We do not need MSRV docs
in `CONTRIBUTING` because we have them in the README already.

Fix stale docs by doing:
- Remove the MSRV docs from readme in favour of `CONTRIBUTING.md`.
- Add a sentence to the redame pointing readers towards `CONTRIBUTING.md`.
- Point readers towards `RUSTUP_TOOLCHAIN`