### PR TITLE
Upgrade bech32 to version 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ features = [ "std", "secp-recovery", "base64", "rand", "serde", "bitcoinconsensu
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-bech32 = { version = "0.8.1", default-features = false }
+bech32 = { version = "0.9.0", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }
 secp256k1 = { version = "0.24.0", default-features = false, features = ["bitcoin_hashes"] }
 core2 = { version = "0.3.0", optional = true, default-features = false }


### PR DESCRIPTION
Recently `rust-bech32` v0.9.0 was released, this release included
updating the MSRV to 1.41.1.