### PR TITLE
Add ensure_no_std crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,3 +107,20 @@ jobs:
           RUSTFLAGS: "-C link-arg=-Tlink.x"
           CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
         run: cd embedded && cargo run --target thumbv7m-none-eabi
+
+  NoStd:
+    name: no std
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v2
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Building ensure_no_std
+        run: cd ensure_no_std && cargo rustc -- -C link-arg=-nostartfiles

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ensure_no_std"
+version = "0.1.0"
+authors = ["The rust-bitcoin developers"]
+license = "CC0-1.0"
+description = "Helper crate to ensure our dependencies can be built in a no-std environment"
+readme = "README.md"
+edition = "2018"
+
+[dependencies]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/ensure_no_std/src/main.rs
+++ b/ensure_no_std/src/main.rs
@@ -1,0 +1,26 @@
+//! Test for no-std comparability in dependant crates.
+//!
+//! Idea taken from: https://blog.dbrgn.ch/2019/12/24/testing-for-no-std-compatibility/
+//! Build with: `cargo rustc -- -C link-arg=-nostartfiles`.
+//!
+//! To verify a crate, add it as a dependency and add (using bech32 as an example):
+//! 
+//!    #[allow(unused_imports)]
+//!    use bech32;
+//!
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+/// This function is called on panic.
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    loop {}
+}


### PR DESCRIPTION
Draft for feedback on the approach. I got the idea from [this blogpost](https://blog.dbrgn.ch/2019/12/24/testing-for-no-std-compatibility/)

Adds zero dependencies, so currently proves nothing. We will want to eventually add all our dependencies to this crate (incl. `rust-bitcoin`).