### PR TITLE
Impl std error using macro

### DIFF
--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -156,13 +156,7 @@ impl fmt::Display for CommandStringError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for CommandStringError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+crate::error::impl_std_error!(CommandStringError);
 
 /// A Network message
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -16,6 +16,7 @@ use crate::{io, Script, Transaction, TxIn, TxOut, Sequence, Sighash};
 use crate::blockdata::transaction::EncodeSigningDataResult;
 use crate::blockdata::witness::Witness;
 use crate::consensus::{encode, Encodable};
+use crate::error::impl_std_error;
 use crate::util::endian;
 use crate::hashes::{sha256, sha256d, Hash};
 use crate::internal_macros::serde_string_impl;
@@ -488,13 +489,7 @@ impl fmt::Display for NonStandardSighashType {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for NonStandardSighashType {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+impl_std_error!(NonStandardSighashType);
 
 /// Error returned for failure during parsing one of the sighash types.
 ///
@@ -511,13 +506,7 @@ impl fmt::Display for SighashTypeParseError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for SighashTypeParseError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+impl_std_error!(SighashTypeParseError);
 
 impl<R: Deref<Target = Transaction>> SighashCache<R> {
     /// Constructs a new `SighashCache` from an unsigned transaction.

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -521,13 +521,7 @@ impl core::fmt::Display for ParseLengthError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ParseLengthError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+crate::error::impl_std_error!(ParseLengthError);
 
 impl Uint256 {
     /// Decay to a uint128


### PR DESCRIPTION
There was a bunch of manual implemntations that can be converted to
macro call. This commit replaces them except for enums because those are
currently not supported by the macro and we want to protect against
forgetting to handle newly added variants.

Depends on #1129 and is **not** urgent for the next release.