### PR TITLE
Introduce new canonical license blurb

### DIFF
--- a/src/blockdata/locktime.rs
+++ b/src/blockdata/locktime.rs
@@ -1,15 +1,5 @@
-// Rust Bitcoin Library
-// Written in 2022 by
-//     Tobin C. Harding <me@tobin.cc>
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Rust Bitcoin Library - Written by the rust-bitcoin developers.
+// SPDX-License-Identifier: CC0-1.0
 
 //! Provides type [`LockTime`] that implements the logic around nLockTime/OP_CHECKLOCKTIMEVERIFY.
 //!


### PR DESCRIPTION
Recently we introduced SPDX license ids but there was some confusion
about the use, form, and purpose of lines before (library name, author).

It was pointed out to me by Andrew that if/when folks cut'n'paste our
code they often will keep the whole blurb. Design it with that in
mind. FTR, Andrew also indicated that he did not mind his name being
removed in favour of "The rust-bitcoin developers".

At first I thought the term "The rust-bitcoin developers" was a bit
wishy-washy but yesterday I realised that I am proud to be part of that
crew, striving to deliver code to the highest possible standard.

Introduce a canonical format for the licences blurb.

- Use the name of the library
- Use "The rust-bitcoin developers"
- Use the SPDX ID