### PR TITLE
Remove needless allocation from BIP-158 encoding

### DIFF
--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -364,9 +364,7 @@ impl<'a> GCSFilterWriter<'a> {
         mapped.sort_unstable();
 
         // write number of elements as varint
-        let mut encoder = Vec::new();
-        VarInt(mapped.len() as u64).consensus_encode(&mut encoder).expect("in-memory writers don't error");
-        let mut wrote = self.writer.write(encoder.as_slice())?;
+        let mut wrote = VarInt(mapped.len() as u64).consensus_encode(&mut self.writer)?;
 
         // write out deltas of sorted values into a Golonb-Rice coded bit stream
         let mut writer = BitStreamWriter::new(self.writer);


### PR DESCRIPTION
The BIP-158 finalize code was serializing value to `Vec` only to
serialize it to writer right away. Thus the intermediary `Vec` was not
needed.

Even more, the code used `write` which, while correct in case of `Vec`,
could trigger code analysis tools or reviewers.