### PR TITLE
Future proof error types

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -25,7 +25,7 @@ use crate::blockdata::transaction::Transaction;
 use crate::blockdata::constants::{max_target, WITNESS_SCALE_FACTOR};
 use crate::blockdata::script;
 use crate::VarInt;
-use crate::internal_macros::impl_consensus_encoding;
+use crate::internal_macros::{impl_consensus_encoding, pub_error_type};
 
 /// Bitcoin block header.
 ///
@@ -346,7 +346,7 @@ impl Block {
 }
 
 /// An error when looking up a BIP34 block height.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Bip34Error {
     /// The block does not support BIP34 yet.
@@ -356,6 +356,7 @@ pub enum Bip34Error {
     /// The BIP34 push was larger than 8 bytes.
     UnexpectedPush(Vec<u8>),
 }
+pub_error_type!(Bip34Error);
 
 impl fmt::Display for Bip34Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/blockdata/locktime.rs
+++ b/src/blockdata/locktime.rs
@@ -27,7 +27,7 @@ use crate::parse;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::io::{self, Read, Write};
 use crate::prelude::*;
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 use crate::impl_parse_str_through_int;
 
 /// The Threshold for deciding whether a lock time value is a height or a time (see [Bitcoin Core]).
@@ -578,7 +578,7 @@ fn is_block_time(n: u32) -> bool {
 }
 
 /// Catchall type for errors that relate to time locks.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// An error occurred while converting a `u32` to a lock time variant.
@@ -588,6 +588,7 @@ pub enum Error {
     /// An error occurred while parsing a string into an `u32`.
     Parse(ParseIntError),
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -691,12 +692,13 @@ impl fmt::Display for LockTimeUnit {
 }
 
 /// Errors than occur when operating on lock times.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum OperationError {
     /// Cannot compare different lock time units (height vs time).
     InvalidComparison,
 }
+pub_error_type!(OperationError);
 
 impl fmt::Display for OperationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -18,7 +18,7 @@ use crate::io;
 use core::convert::TryFrom;
 use core::{fmt, default::Default};
 use core::ops::Index;
-use crate::internal_macros::display_from_debug;
+use crate::internal_macros::{display_from_debug, pub_error_type};
 
 #[cfg(feature = "serde")] use serde;
 
@@ -140,7 +140,7 @@ where
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
 /// would help you.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Something did a non-minimal push; for more information see
@@ -159,6 +159,7 @@ pub enum Error {
     /// Can not serialize the spending transaction
     SerializationError
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -31,7 +31,7 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::hash_types::{Sighash, Txid, Wtxid};
 use crate::VarInt;
 use crate::util::sighash::UINT256_ONE;
-use crate::internal_macros::{impl_consensus_encoding, serde_string_impl, serde_struct_human_string_impl, write_err};
+use crate::internal_macros::{impl_consensus_encoding, pub_error_type, serde_string_impl, serde_struct_human_string_impl, write_err};
 use crate::impl_parse_str_through_int;
 
 #[cfg(doc)]
@@ -102,7 +102,7 @@ impl fmt::Display for OutPoint {
 }
 
 /// An error in parsing an OutPoint.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum ParseOutPointError {
     /// Error in TXID part.
@@ -116,6 +116,7 @@ pub enum ParseOutPointError {
     /// Vout part is not strictly numeric without leading zeroes.
     VoutNotCanonical,
 }
+pub_error_type!(ParseOutPointError);
 
 impl fmt::Display for ParseOutPointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -252,13 +253,14 @@ impl Default for TxIn {
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Sequence(pub u32);
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 /// An error in creating relative lock-times.
 pub enum RelativeLockTimeError {
     /// The input was too large
     IntegerOverflow(u32)
 }
+pub_error_type!(RelativeLockTimeError);
 
 impl Sequence {
     /// The maximum allowable sequence number.

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -22,7 +22,7 @@ use core::{fmt, mem, u32, convert::From};
 
 use crate::hashes::{sha256d, Hash, sha256};
 use crate::hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};
-use crate::internal_macros::write_err;
+use crate::internal_macros::{write_err, pub_error_type};
 use crate::io::{self, Cursor, Read};
 
 use crate::util::endian;
@@ -73,6 +73,7 @@ pub enum Error {
     /// Unsupported Segwit flag
     UnsupportedSegwitFlag(u8),
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -604,3 +604,17 @@ macro_rules! const_assert {
     }};
 }
 pub(crate) use const_assert;
+
+/// Implemented by our error types to commit to `Send`/`Sync`.
+///
+/// In an attempt to guarantee forward compatibility for error types we only derive `Debug` and we
+/// use this trait to commit to `Send`/`Sync`.
+#[doc(hidden)]
+pub trait AssertSendSync: Send + Sync {}
+
+macro_rules! pub_error_type {
+    ($ty:ident) => {
+        impl $crate::internal_macros::AssertSendSync for $ty {}
+    }
+}
+pub(crate) use pub_error_type;

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -41,10 +41,10 @@ use crate::util::taproot::TapBranchHash;
 use crate::util::key::PublicKey;
 use crate::blockdata::script::Instruction;
 use crate::util::schnorr::{TapTweak, UntweakedPublicKey, TweakedPublicKey};
-use crate::internal_macros::{serde_string_impl, write_err};
+use crate::internal_macros::{pub_error_type, serde_string_impl, write_err};
 
 /// Address error.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error.
@@ -79,6 +79,7 @@ pub enum Error {
     /// Address type is either invalid or not supported in rust-bitcoin.
     UnknownAddressType(String),
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -11,6 +11,8 @@ use crate::prelude::*;
 use core::{ops, default, str::FromStr, cmp::Ordering};
 use core::fmt::{self, Write};
 
+use crate::internal_macros::pub_error_type;
+
 /// A set of denominations in which amounts can be expressed.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Denomination {
@@ -139,7 +141,7 @@ fn denomination_from_str(mut s: &str) -> Option<Denomination> {
 }
 
 /// An error during amount parsing.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum ParseAmountError {
     /// Amount is negative.
@@ -159,6 +161,7 @@ pub enum ParseAmountError {
     /// The denomination has multiple possible interpretations.
     PossiblyConfusingDenomination(String)
 }
+pub_error_type!(ParseAmountError);
 
 impl fmt::Display for ParseAmountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -15,10 +15,10 @@ use crate::hashes::{sha256d, Hash, hex};
 use secp256k1;
 
 use crate::util::{endian, key};
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 
 /// An error that might occur during base58 decoding
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Invalid character encountered
@@ -41,6 +41,7 @@ pub enum Error {
     // TODO: Remove this as part of crate-smashing, there should not be any key related errors in this module
     Hex(hex::Error)
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -49,7 +49,7 @@ use crate::blockdata::transaction::OutPoint;
 use crate::consensus::{Decodable, Encodable};
 use crate::consensus::encode::VarInt;
 use crate::util::endian;
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845
 const P: u8 = 19;
@@ -63,6 +63,7 @@ pub enum Error {
     /// some IO error reading or writing binary serialization of the filter
     Io(io::Error),
 }
+pub_error_type!(Error);
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -21,7 +21,7 @@ use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 use crate::network::constants::Network;
 use crate::util::{base58, endian, key};
 use crate::util::key::{PublicKey, PrivateKey, KeyPair};
-use crate::internal_macros::{impl_array_newtype, impl_bytes_newtype, serde_string_impl, write_err};
+use crate::internal_macros::{impl_array_newtype, impl_bytes_newtype, pub_error_type, serde_string_impl, write_err};
 
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -447,7 +447,7 @@ impl fmt::Debug for DerivationPath {
 pub type KeySource = (Fingerprint, DerivationPath);
 
 /// A BIP32 error
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// A pk->pk derivation was attempted on a hardened key
@@ -469,6 +469,7 @@ pub enum Error {
     /// Hexadecimal decoding error
     Hex(hex::Error)
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -12,7 +12,7 @@ use crate::hashes::hex::{self, FromHex};
 use crate::blockdata::transaction::NonStandardSighashType;
 use secp256k1;
 use crate::EcdsaSighashType;
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 
 /// An ECDSA signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -77,7 +77,7 @@ impl FromStr for EcdsaSig {
 }
 
 /// A key-related error.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum EcdsaSigError {
     /// Hex encoding error
@@ -89,6 +89,7 @@ pub enum EcdsaSigError {
     /// secp256k1-related error
     Secp256k1(secp256k1::Error),
 }
+pub_error_type!(EcdsaSigError);
 
 impl fmt::Display for EcdsaSigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/ecdsa.rs
+++ b/src/util/ecdsa.rs
@@ -90,7 +90,6 @@ pub enum EcdsaSigError {
     Secp256k1(secp256k1::Error),
 }
 
-
 impl fmt::Display for EcdsaSigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -18,10 +18,10 @@ use crate::network::constants::Network;
 use crate::hashes::{Hash, hash160, hex, hex::FromHex};
 use crate::hash_types::{PubkeyHash, WPubkeyHash};
 use crate::util::base58;
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 
 /// A key-related error.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error
@@ -33,6 +33,7 @@ pub enum Error {
     /// Hex decoding error
     Hex(hex::Error)
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/merkleblock.rs
+++ b/src/util/merkleblock.rs
@@ -51,10 +51,11 @@ use crate::blockdata::transaction::Transaction;
 use crate::blockdata::constants::{MAX_BLOCK_WEIGHT, MIN_TRANSACTION_WEIGHT};
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::util::merkleblock::MerkleBlockError::*;
+use crate::internal_macros::pub_error_type;
 use crate::{Block, BlockHeader};
 
 /// An error when verifying the merkle block
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Debug)]
 pub enum MerkleBlockError {
     /// When header merkle root don't match to the root calculated from the partial merkle tree
     MerkleRootMismatch,
@@ -65,6 +66,7 @@ pub enum MerkleBlockError {
     /// General format error
     BadFormat(String),
 }
+pub_error_type!(MerkleBlockError);
 
 /// Data structure that represents a partial merkle tree.
 ///

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -33,11 +33,11 @@ mod message_signing {
 
     use crate::util::key::PublicKey;
     use crate::util::address::{Address, AddressType};
-    use crate::internal_macros::write_err;
+    use crate::internal_macros::{pub_error_type, write_err};
 
     /// An error used for dealing with Bitcoin Signed Messages.
     #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum MessageSignatureError {
         /// Signature is expected to be 65 bytes.
@@ -49,6 +49,7 @@ mod message_signing {
         /// Unsupported Address Type
         UnsupportedAddressType(AddressType),
     }
+    pub_error_type!(MessageSignatureError);
 
     impl fmt::Display for MessageSignatureError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -31,7 +31,7 @@ use crate::io;
 use core::fmt;
 
 use crate::consensus::encode;
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 
 /// A trait which allows numbers to act as fixed-size bit arrays
 pub trait BitArray {
@@ -66,6 +66,7 @@ pub enum Error {
     /// The `target` field of a block header did not match the expected difficulty
     BlockBadTarget,
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/psbt/error.rs
+++ b/src/util/psbt/error.rs
@@ -10,7 +10,7 @@ use crate::util::psbt::raw;
 
 use crate::hashes;
 use crate::util::bip32::ExtendedPubKey;
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 
 /// Enum for marking psbt hash error.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -21,7 +21,7 @@ pub enum PsbtHash {
     Hash256,
 }
 /// Ways that a Partially Signed Transaction might fail.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Magic bytes for a PSBT must be the ASCII for "psbt" serialized in most
@@ -74,6 +74,7 @@ pub enum Error {
     /// Serialization error in bitcoin consensus-encoded structures
     ConsensusEncoding,
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -207,7 +207,7 @@ mod display_from_str {
     use core::str::FromStr;
     use crate::consensus::encode::{Error, self};
     use base64::display::Base64Display;
-    use crate::internal_macros::write_err;
+    use crate::internal_macros::{pub_error_type, write_err};
 
     /// Error encountered during PSBT decoding from Base64 string.
     #[derive(Debug)]
@@ -219,6 +219,7 @@ mod display_from_str {
         /// Error in PSBT Base64 encoding.
         Base64Encoding(::base64::DecodeError)
     }
+    pub_error_type!(PsbtParseError);
 
     impl Display for PsbtParseError {
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -14,7 +14,7 @@ use crate::prelude::*;
 use secp256k1::{self, Secp256k1, Verification, constants};
 use crate::util::taproot::{TapBranchHash, TapTweakHash};
 use crate::SchnorrSighashType;
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 
 /// Deprecated re-export of [`secp256k1::XOnlyPublicKey`]
 #[deprecated(since = "0.28.0", note = "Please use `util::key::XOnlyPublicKey` instead")]
@@ -255,7 +255,7 @@ impl SchnorrSig {
 }
 
 /// A schnorr sig related error.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum SchnorrSigError {
     /// Base58 encoding error
@@ -265,6 +265,7 @@ pub enum SchnorrSigError {
     /// Invalid schnorr signature size
     InvalidSchnorrSigSize(usize),
 }
+pub_error_type!(SchnorrSigError);
 
 impl fmt::Display for SchnorrSigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/util/schnorr.rs
+++ b/src/util/schnorr.rs
@@ -266,7 +266,6 @@ pub enum SchnorrSigError {
     InvalidSchnorrSigSize(usize),
 }
 
-
 impl fmt::Display for SchnorrSigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -22,7 +22,7 @@ use crate::io;
 use crate::util::taproot::{TapLeafHash, TAPROOT_ANNEX_PREFIX, TapSighashHash};
 use crate::Sighash;
 use crate::{Script, Transaction, TxOut};
-use crate::internal_macros::serde_string_impl;
+use crate::internal_macros::{pub_error_type, serde_string_impl};
 
 use super::taproot::LeafVersion;
 
@@ -159,7 +159,7 @@ impl str::FromStr for SchnorrSighashType {
 }
 
 /// Possible errors in computing the signature message.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Could happen only by using `*_encode_signing_*` methods with custom writers, engines writers
@@ -201,6 +201,7 @@ pub enum Error {
     /// Invalid Sighash type.
     InvalidSighashType(u32),
 }
+pub_error_type!(Error);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -17,7 +17,7 @@ use crate::hashes::{sha256, sha256t_hash_newtype, Hash, HashEngine};
 use crate::schnorr::{TweakedPublicKey, UntweakedPublicKey, TapTweak};
 use crate::util::key::XOnlyPublicKey;
 use crate::Script;
-use crate::internal_macros::write_err;
+use crate::internal_macros::{pub_error_type, write_err};
 use crate::consensus::Encodable;
 
 /// The SHA-256 midstate value for the TapLeaf hash.
@@ -1002,7 +1002,7 @@ impl<'de> serde::Deserialize<'de> for LeafVersion {
 }
 
 /// Detailed error type for taproot builder.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum TaprootBuilderError {
     /// Merkle tree depth must not be more than 128.
@@ -1018,6 +1018,8 @@ pub enum TaprootBuilderError {
     /// Called finalize on a empty tree.
     EmptyTree,
 }
+pub_error_type!(TaprootBuilderError);
+
 
 impl fmt::Display for TaprootBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1064,7 +1066,7 @@ impl std::error::Error for TaprootBuilderError {
 }
 
 /// Detailed error type for taproot utilities.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum TaprootError {
     /// Proof size must be a multiple of 32.
@@ -1082,6 +1084,7 @@ pub enum TaprootError {
     /// Empty tap tree.
     EmptyTree,
 }
+pub_error_type!(TaprootError);
 
 impl fmt::Display for TaprootError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
EDIT: Bother, I did not see https://github.com/rust-bitcoin/rust-bitcoin/issues/1143 before doing this work.

Done in an attempt to future proof our error types i.e., to prevent us
from inadvertently, or otherwise, making breaking API changes.

For all publicly exposed error types:

- Remove all the derives except `Debug`.
- Enforce `Send`/`Sync` using custom macro.

ref: https://github.com/rust-bitcoin/rust-bitcoin/pull/1127#discussion_r932115136