### PR TITLE
Implemented unsized `Script`

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -20,6 +20,7 @@ serde = ["actual-serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
+rust_v_1_53 = []
 
 # At least one of std, no-std must be enabled.
 #

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -42,7 +42,7 @@ use bitcoin::locktime::absolute;
 use bitcoin::psbt::{self, Input, Psbt, PsbtSighashType};
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};
 use bitcoin::{
-    Address, Amount, Network, OutPoint, PublicKey, Script, Sequence, Transaction, TxIn, TxOut,
+    Address, Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
     Txid, Witness,
 };
 
@@ -191,7 +191,7 @@ impl WatchOnly {
                     txid: Txid::from_hex(INPUT_UTXO_TXID)?,
                     vout: INPUT_UTXO_VOUT,
                 },
-                script_sig: Script::new(),
+                script_sig: ScriptBuf::new(),
                 sequence: Sequence::MAX, // Disable LockTime and RBF.
                 witness: Witness::default(),
             }],
@@ -216,7 +216,7 @@ impl WatchOnly {
         let pk = self.input_xpub.to_pub();
         let wpkh = pk.wpubkey_hash().expect("a compressed pubkey");
 
-        let redeem_script = Script::new_v0_p2wpkh(&wpkh);
+        let redeem_script = ScriptBuf::new_v0_p2wpkh(&wpkh);
         input.redeem_script = Some(redeem_script);
 
         let fingerprint = self.master_fingerprint;
@@ -284,7 +284,7 @@ fn input_derivation_path() -> Result<DerivationPath> {
 }
 
 fn previous_output() -> TxOut {
-    let script_pubkey = Script::from_hex(INPUT_UTXO_SCRIPT_PUBKEY)
+    let script_pubkey = ScriptBuf::from_hex(INPUT_UTXO_SCRIPT_PUBKEY)
         .expect("failed to parse input utxo scriptPubkey");
     let amount = Amount::from_str(INPUT_UTXO_VALUE).expect("failed to parse input utxo value");
 

--- a/bitcoin/fuzz/fuzz_targets/deserialize_script.rs
+++ b/bitcoin/fuzz/fuzz_targets/deserialize_script.rs
@@ -6,7 +6,7 @@ use bitcoin::blockdata::script;
 use bitcoin::consensus::encode;
 
 fn do_test(data: &[u8]) {
-    let s: Result<script::Script, _> = encode::deserialize(data);
+    let s: Result<script::ScriptBuf, _> = encode::deserialize(data);
     if let Ok(script) = s {
         let _: Result<Vec<script::Instruction>, script::Error> = script.instructions().collect();
 

--- a/bitcoin/fuzz/fuzz_targets/script_bytes_to_asm_fmt.rs
+++ b/bitcoin/fuzz/fuzz_targets/script_bytes_to_asm_fmt.rs
@@ -17,7 +17,7 @@ impl fmt::Write for NullWriter {
 
 fn do_test(data: &[u8]) {
     let mut writer = NullWriter;
-    bitcoin::Script::bytes_to_asm_fmt(data, &mut writer);
+    bitcoin::Script::from_bytes(data).fmt_asm(&mut writer);
 }
 
 #[cfg(feature = "afl")]

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -377,7 +377,7 @@ mod test {
     use crate::consensus::encode::{deserialize, serialize};
     use crate::hashes::hex::FromHex;
     use crate::{
-        CompactTarget, OutPoint, Script, Sequence, Transaction, TxIn, TxMerkleNode, TxOut, Txid,
+        CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxMerkleNode, TxOut, Txid,
         Witness,
     };
 
@@ -387,11 +387,11 @@ mod test {
             lock_time: absolute::LockTime::from_consensus(2),
             input: vec![TxIn {
                 previous_output: OutPoint::new(Txid::hash(nonce), 0),
-                script_sig: Script::new(),
+                script_sig: ScriptBuf::new(),
                 sequence: Sequence(1),
                 witness: Witness::new(),
             }],
-            output: vec![TxOut { value: 1, script_pubkey: Script::new() }],
+            output: vec![TxOut { value: 1, script_pubkey: ScriptBuf::new() }],
         }
     }
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -240,7 +240,7 @@ impl Block {
 
         // Commitment is in the last output that starts with magic bytes.
         if let Some(pos) = coinbase.output.iter()
-            .rposition(|o| o.script_pubkey.len () >= 38 && o.script_pubkey[0..6] ==  MAGIC)
+            .rposition(|o| o.script_pubkey.len () >= 38 && o.script_pubkey.as_bytes()[0..6] ==  MAGIC)
         {
             let commitment = WitnessCommitment::from_slice(&coinbase.output[pos].script_pubkey.as_bytes()[6..38]).unwrap();
             // Witness reserved value is in coinbase input witness.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -26,7 +26,7 @@ use crate::hashes::hex::FromHex;
 
 use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
 #[cfg(feature="bitcoinconsensus")] use crate::blockdata::script;
-use crate::blockdata::script::Script;
+use crate::blockdata::script::{ScriptBuf, Script};
 use crate::blockdata::witness::Witness;
 use crate::blockdata::locktime::absolute::{self, Height, Time};
 use crate::blockdata::locktime::relative;
@@ -198,7 +198,7 @@ pub struct TxIn {
     pub previous_output: OutPoint,
     /// The script which pushes values on the stack which will cause
     /// the referenced output's script to be accepted.
-    pub script_sig: Script,
+    pub script_sig: ScriptBuf,
     /// The sequence number, which suggests to miners which of two
     /// conflicting transactions should be preferred, or 0xFFFFFFFF
     /// to ignore this feature. This is generally never used since
@@ -231,7 +231,7 @@ impl Default for TxIn {
     fn default() -> TxIn {
         TxIn {
             previous_output: OutPoint::default(),
-            script_sig: Script::new(),
+            script_sig: ScriptBuf::new(),
             sequence: Sequence::MAX,
             witness: Witness::default(),
         }
@@ -466,13 +466,13 @@ pub struct TxOut {
     /// The value of the output, in satoshis.
     pub value: u64,
     /// The script which must be satisfied for the output to be spent.
-    pub script_pubkey: Script
+    pub script_pubkey: ScriptBuf
 }
 
 // This is used as a "null txout" in consensus signing code.
 impl Default for TxOut {
     fn default() -> TxOut {
-        TxOut { value: 0xffffffffffffffff, script_pubkey: Script::new() }
+        TxOut { value: 0xffffffffffffffff, script_pubkey: ScriptBuf::new() }
     }
 }
 
@@ -505,7 +505,7 @@ impl<E> EncodeSigningDataResult<E> {
     /// # use bitcoin_hashes::{Hash, hex::FromHex};
     /// # let mut writer = Sighash::engine();
     /// # let input_index = 0;
-    /// # let script_pubkey = bitcoin::Script::new();
+    /// # let script_pubkey = bitcoin::ScriptBuf::new();
     /// # let sighash_u32 = 0u32;
     /// # const SOME_TX: &'static str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
     /// # let raw_tx = Vec::from_hex(SOME_TX).unwrap();
@@ -622,7 +622,7 @@ impl Transaction {
         let cloned_tx = Transaction {
             version: self.version,
             lock_time: self.lock_time,
-            input: self.input.iter().map(|txin| TxIn { script_sig: Script::new(), witness: Witness::default(), .. *txin }).collect(),
+            input: self.input.iter().map(|txin| TxIn { script_sig: ScriptBuf::new(), witness: Witness::default(), .. *txin }).collect(),
             output: self.output.clone(),
         };
         cloned_tx.txid().into()
@@ -1073,7 +1073,7 @@ mod tests {
     use core::str::FromStr;
 
     use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
-    use crate::blockdata::script::Script;
+    use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::locktime::absolute;
     use crate::consensus::encode::serialize;
     use crate::consensus::encode::deserialize;
@@ -1139,7 +1139,7 @@ mod tests {
     fn test_txin_default() {
         let txin = TxIn::default();
         assert_eq!(txin.previous_output, OutPoint::default());
-        assert_eq!(txin.script_sig, Script::new());
+        assert_eq!(txin.script_sig, ScriptBuf::new());
         assert_eq!(txin.sequence, Sequence::from_consensus(0xFFFFFFFF));
         assert_eq!(txin.previous_output, OutPoint::default());
         assert_eq!(txin.witness.len(), 0);
@@ -1288,10 +1288,10 @@ mod tests {
         let old_ntxid = tx.ntxid();
         assert_eq!(format!("{:x}", old_ntxid), "c3573dbea28ce24425c59a189391937e00d255150fa973d59d61caf3a06b601d");
         // changing sigs does not affect it
-        tx.input[0].script_sig = Script::new();
+        tx.input[0].script_sig = ScriptBuf::new();
         assert_eq!(old_ntxid, tx.ntxid());
         // changing pks does
-        tx.output[0].script_pubkey = Script::new();
+        tx.output[0].script_pubkey = ScriptBuf::new();
         assert!(old_ntxid != tx.ntxid());
     }
 

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -88,7 +88,7 @@ mod test_macros {
     pub(crate) use hex_into;
 
     // Script is commonly used in places where inference may fail
-    macro_rules! hex_script (($hex:expr) => ($crate::internal_macros::hex_into!($crate::Script, $hex)));
+    macro_rules! hex_script (($hex:expr) => ($crate::internal_macros::hex_into!($crate::ScriptBuf, $hex)));
     pub(crate) use hex_script;
 
     // For types that can't use TestFromHex due to coherence rules or reversed hex

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -59,7 +59,6 @@ compile_error!(
 #[cfg(bench)]
 extern crate test;
 
-#[cfg(feature = "no-std")]
 #[macro_use]
 extern crate alloc;
 
@@ -128,7 +127,7 @@ pub use crate::address::{Address, AddressType};
 pub use crate::amount::{Amount, Denomination, SignedAmount};
 pub use crate::blockdata::block::{self, Block};
 pub use crate::blockdata::locktime::{self, absolute, relative};
-pub use crate::blockdata::script::{self, Script};
+pub use crate::blockdata::script::{self, Script, ScriptBuf};
 pub use crate::blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut};
 pub use crate::blockdata::witness::{self, Witness};
 pub use crate::blockdata::{constants, opcodes};

--- a/bitcoin/src/network/message.rs
+++ b/bitcoin/src/network/message.rs
@@ -516,7 +516,7 @@ mod test {
     use super::{CommandString, NetworkMessage, RawNetworkMessage, *};
     use crate::bip152::BlockTransactionsRequest;
     use crate::blockdata::block::{self, Block};
-    use crate::blockdata::script::Script;
+    use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::Transaction;
     use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
     use crate::hashes::hex::FromHex;
@@ -540,7 +540,7 @@ mod test {
         let tx: Transaction = deserialize(&Vec::from_hex("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap()).unwrap();
         let block: Block = deserialize(&include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw")[..]).unwrap();
         let header: block::Header = deserialize(&Vec::from_hex("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b").unwrap()).unwrap();
-        let script: Script = deserialize(
+        let script: ScriptBuf = deserialize(
             &Vec::from_hex("1976a91431a420903c05a0a7de2de40c9f02ebedbacdc17288ac").unwrap(),
         )
         .unwrap();

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -9,7 +9,7 @@ use core::convert::TryFrom;
 
 use secp256k1::XOnlyPublicKey;
 
-use crate::blockdata::script::Script;
+use crate::blockdata::script::ScriptBuf;
 use crate::blockdata::witness::Witness;
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::consensus::encode;
@@ -85,16 +85,16 @@ pub struct Input {
     /// must use the sighash type.
     pub sighash_type: Option<PsbtSighashType>,
     /// The redeem script for this input.
-    pub redeem_script: Option<Script>,
+    pub redeem_script: Option<ScriptBuf>,
     /// The witness script for this input.
-    pub witness_script: Option<Script>,
+    pub witness_script: Option<ScriptBuf>,
     /// A map from public keys needed to sign this input to their corresponding
     /// master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
     /// The finalized, fully-constructed scriptSig with signatures and any other
     /// scripts necessary for this input to pass validation.
-    pub final_script_sig: Option<Script>,
+    pub final_script_sig: Option<ScriptBuf>,
     /// The finalized, fully-constructed scriptWitness with signatures and any
     /// other scripts necessary for this input to pass validation.
     pub final_script_witness: Option<Witness>,
@@ -118,7 +118,7 @@ pub struct Input {
     pub tap_script_sigs: BTreeMap<(XOnlyPublicKey, TapLeafHash), schnorr::Signature>,
     /// Map of Control blocks to Script version pair.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
-    pub tap_scripts: BTreeMap<ControlBlock, (Script, LeafVersion)>,
+    pub tap_scripts: BTreeMap<ControlBlock, (ScriptBuf, LeafVersion)>,
     /// Map of tap root x only keys to origin info and leaf hashes contained in it.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
     pub tap_key_origins: BTreeMap<XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)>,
@@ -277,12 +277,12 @@ impl Input {
             }
             PSBT_IN_REDEEM_SCRIPT => {
                 impl_psbt_insert_pair! {
-                    self.redeem_script <= <raw_key: _>|<raw_value: Script>
+                    self.redeem_script <= <raw_key: _>|<raw_value: ScriptBuf>
                 }
             }
             PSBT_IN_WITNESS_SCRIPT => {
                 impl_psbt_insert_pair! {
-                    self.witness_script <= <raw_key: _>|<raw_value: Script>
+                    self.witness_script <= <raw_key: _>|<raw_value: ScriptBuf>
                 }
             }
             PSBT_IN_BIP32_DERIVATION => {
@@ -292,7 +292,7 @@ impl Input {
             }
             PSBT_IN_FINAL_SCRIPTSIG => {
                 impl_psbt_insert_pair! {
-                    self.final_script_sig <= <raw_key: _>|<raw_value: Script>
+                    self.final_script_sig <= <raw_key: _>|<raw_value: ScriptBuf>
                 }
             }
             PSBT_IN_FINAL_SCRIPTWITNESS => {
@@ -324,7 +324,7 @@ impl Input {
             }
             PSBT_IN_TAP_LEAF_SCRIPT => {
                 impl_psbt_insert_pair! {
-                    self.tap_scripts <= <raw_key: ControlBlock>|< raw_value: (Script, LeafVersion)>
+                    self.tap_scripts <= <raw_key: ControlBlock>|< raw_value: (ScriptBuf, LeafVersion)>
                 }
             }
             PSBT_IN_TAP_BIP32_DERIVATION => {

--- a/bitcoin/src/psbt/map/output.rs
+++ b/bitcoin/src/psbt/map/output.rs
@@ -6,7 +6,7 @@ use core::convert::TryFrom;
 
 use crate::io;
 
-use crate::blockdata::script::Script;
+use crate::blockdata::script::ScriptBuf;
 use crate::consensus::encode;
 use secp256k1::XOnlyPublicKey;
 use crate::bip32::KeySource;
@@ -17,9 +17,9 @@ use crate::psbt::Error;
 
 use crate::taproot::{ScriptLeaf, TapLeafHash, NodeInfo, TaprootBuilder};
 
-/// Type: Redeem Script PSBT_OUT_REDEEM_SCRIPT = 0x00
+/// Type: Redeem ScriptBuf PSBT_OUT_REDEEM_SCRIPT = 0x00
 const PSBT_OUT_REDEEM_SCRIPT: u8 = 0x00;
-/// Type: Witness Script PSBT_OUT_WITNESS_SCRIPT = 0x01
+/// Type: Witness ScriptBuf PSBT_OUT_WITNESS_SCRIPT = 0x01
 const PSBT_OUT_WITNESS_SCRIPT: u8 = 0x01;
 /// Type: BIP 32 Derivation Path PSBT_OUT_BIP32_DERIVATION = 0x02
 const PSBT_OUT_BIP32_DERIVATION: u8 = 0x02;
@@ -39,9 +39,9 @@ const PSBT_OUT_PROPRIETARY: u8 = 0xFC;
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Output {
     /// The redeem script for this output.
-    pub redeem_script: Option<Script>,
+    pub redeem_script: Option<ScriptBuf>,
     /// The witness script for this output.
-    pub witness_script: Option<Script>,
+    pub witness_script: Option<ScriptBuf>,
     /// A map from public keys needed to spend this output to their
     /// corresponding master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
@@ -216,12 +216,12 @@ impl Output {
         match raw_key.type_value {
             PSBT_OUT_REDEEM_SCRIPT => {
                 impl_psbt_insert_pair! {
-                    self.redeem_script <= <raw_key: _>|<raw_value: Script>
+                    self.redeem_script <= <raw_key: _>|<raw_value: ScriptBuf>
                 }
             }
             PSBT_OUT_WITNESS_SCRIPT => {
                 impl_psbt_insert_pair! {
-                    self.witness_script <= <raw_key: _>|<raw_value: Script>
+                    self.witness_script <= <raw_key: _>|<raw_value: ScriptBuf>
                 }
             }
             PSBT_OUT_BIP32_DERIVATION => {

--- a/bitcoin/tests/psbt.rs
+++ b/bitcoin/tests/psbt.rs
@@ -12,7 +12,7 @@ use bitcoin::hashes::hex::FromHex;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::secp256k1::{self, Secp256k1};
 use bitcoin::{
-    absolute, Amount, Denomination, Network, OutPoint, PrivateKey, PublicKey, Script, Sequence,
+    absolute, Amount, Denomination, Network, OutPoint, PrivateKey, PublicKey, ScriptBuf, Sequence,
     Transaction, TxIn, TxOut, Txid, Witness,
 };
 
@@ -20,7 +20,7 @@ const NETWORK: Network = Network::Testnet;
 
 macro_rules! hex_script {
     ($s:expr) => {
-        <Script as FromStr>::from_str($s).unwrap()
+        <ScriptBuf as FromStr>::from_str($s).unwrap()
     };
 }
 
@@ -169,7 +169,7 @@ fn create_transaction() -> Transaction {
                     txid: Txid::from_hex(input_0.txid).expect("failed to parse txid"),
                     vout: input_0.index,
                 },
-                script_sig: Script::new(),
+                script_sig: ScriptBuf::new(),
                 sequence: Sequence::MAX, // Disable nSequence.
                 witness: Witness::default(),
             },
@@ -178,7 +178,7 @@ fn create_transaction() -> Transaction {
                     txid: Txid::from_hex(input_1.txid).expect("failed to parse txid"),
                     vout: input_1.index,
                 },
-                script_sig: Script::new(),
+                script_sig: ScriptBuf::new(),
                 sequence: Sequence::MAX,
                 witness: Witness::default(),
             },
@@ -188,14 +188,14 @@ fn create_transaction() -> Transaction {
                 value: Amount::from_str_in(output_0.amount, Denomination::Bitcoin)
                     .expect("failed to parse amount")
                     .to_sat(),
-                script_pubkey: Script::from_str(output_0.script_pubkey)
+                script_pubkey: ScriptBuf::from_str(output_0.script_pubkey)
                     .expect("failed to parse script"),
             },
             TxOut {
                 value: Amount::from_str_in(output_1.amount, Denomination::Bitcoin)
                     .expect("failed to parse amount")
                     .to_sat(),
-                script_pubkey: Script::from_str(output_1.script_pubkey)
+                script_pubkey: ScriptBuf::from_str(output_1.script_pubkey)
                     .expect("failed to parse script"),
             },
         ],

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -15,7 +15,7 @@
 //
 //  use std::fs::File;
 //  use std::io::Write;
-//  let script = Script::from(vec![0u8, 1u8, 2u8]);
+//  let script = ScriptBuf::from(vec![0u8, 1u8, 2u8]);
 //  let got = serialize(&script).unwrap();
 //  let mut file = File::create("/tmp/script_bincode").unwrap();
 //  file.write_all(&got).unwrap();
@@ -38,7 +38,7 @@ use bitcoin::schnorr::{self, UntweakedPublicKey};
 use bitcoin::sighash::{EcdsaSighashType, SchnorrSighashType};
 use bitcoin::taproot::{ControlBlock, LeafVersion, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::{
-    ecdsa, Address, Block, Network, OutPoint, PrivateKey, PublicKey, Script, Sequence, Target,
+    ecdsa, Address, Block, Network, OutPoint, PrivateKey, PublicKey, ScriptBuf, Sequence, Target,
     Transaction, TxIn, TxOut, Txid, Work,
 };
 use secp256k1::Secp256k1;
@@ -95,7 +95,7 @@ fn serde_regression_relative_lock_time_time() {
 
 #[test]
 fn serde_regression_script() {
-    let script = Script::from(vec![0u8, 1u8, 2u8]);
+    let script = ScriptBuf::from(vec![0u8, 1u8, 2u8]);
     let got = serialize(&script).unwrap();
     let want = include_bytes!("data/serde/script_bincode") as &[_];
     assert_eq!(got, want)
@@ -114,7 +114,7 @@ fn serde_regression_txin() {
 #[test]
 fn serde_regression_txout() {
     let txout =
-        TxOut { value: 0xDEADBEEFCAFEBABE, script_pubkey: Script::from(vec![0u8, 1u8, 2u8]) };
+        TxOut { value: 0xDEADBEEFCAFEBABE, script_pubkey: ScriptBuf::from(vec![0u8, 1u8, 2u8]) };
     let got = serialize(&txout).unwrap();
     let want = include_bytes!("data/serde/txout_bincode") as &[_];
     assert_eq!(got, want)
@@ -232,7 +232,7 @@ fn serde_regression_psbt() {
                 .unwrap(),
                 vout: 1,
             },
-            script_sig: Script::from_str("160014be18d152a9b012039daf3da7de4f53349eecb985").unwrap(),
+            script_sig: ScriptBuf::from_str("160014be18d152a9b012039daf3da7de4f53349eecb985").unwrap(),
             sequence: Sequence::from_consensus(4294967295),
             witness: Witness::from_slice(&[Vec::from_hex(
                 "03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105",
@@ -241,7 +241,7 @@ fn serde_regression_psbt() {
         }],
         output: vec![TxOut {
             value: 190303501938,
-            script_pubkey: Script::from_str("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587")
+            script_pubkey: ScriptBuf::from_str("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587")
                 .unwrap(),
         }],
     };
@@ -275,7 +275,7 @@ fn serde_regression_psbt() {
         },
         unsigned_tx: {
             let mut unsigned = tx.clone();
-            unsigned.input[0].script_sig = Script::new();
+            unsigned.input[0].script_sig = ScriptBuf::new();
             unsigned.input[0].witness = Witness::default();
             unsigned
         },
@@ -286,7 +286,7 @@ fn serde_regression_psbt() {
             non_witness_utxo: Some(tx),
             witness_utxo: Some(TxOut {
                 value: 190303501938,
-                script_pubkey: Script::from_str("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587").unwrap(),
+                script_pubkey: ScriptBuf::from_str("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587").unwrap(),
             }),
             sighash_type: Some(PsbtSighashType::from(EcdsaSighashType::from_str("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY").unwrap())),
             redeem_script: Some(vec![0x51].into()),
@@ -357,7 +357,7 @@ fn serde_regression_schnorr_sig() {
 #[test]
 fn serde_regression_taproot_builder() {
     let ver = LeafVersion::from_consensus(0).unwrap();
-    let script = Script::from(vec![0u8, 1u8, 2u8]);
+    let script = ScriptBuf::from(vec![0u8, 1u8, 2u8]);
     let builder = TaprootBuilder::new().add_leaf_with_ver(1, script, ver).unwrap();
 
     let got = serialize(&builder).unwrap();
@@ -374,11 +374,11 @@ fn serde_regression_taproot_spend_info() {
     .unwrap();
 
     let script_weights = vec![
-        (10, Script::from_hex("51").unwrap()), // semantics of script don't matter for this test
-        (20, Script::from_hex("52").unwrap()),
-        (20, Script::from_hex("53").unwrap()),
-        (30, Script::from_hex("54").unwrap()),
-        (19, Script::from_hex("55").unwrap()),
+        (10, ScriptBuf::from_hex("51").unwrap()), // semantics of script don't matter for this test
+        (20, ScriptBuf::from_hex("52").unwrap()),
+        (20, ScriptBuf::from_hex("53").unwrap()),
+        (30, ScriptBuf::from_hex("54").unwrap()),
+        (19, ScriptBuf::from_hex("55").unwrap()),
     ];
     let tree_info =
         TaprootSpendInfo::with_huffman_tree(&secp, internal_key, script_weights).unwrap();


### PR DESCRIPTION
This renames `Script` to `ScriptBuf` and adds unsized `Script` modeled
after `PathBuf`/`Path`. The change cleans up the API a bit, especially
all functions that previously accepted `&Script` now accept truly
borrowed version. Some functions that perviously accepted `&[u8]` can
now accept `&Script` because constructing it is no loger costly.

This is a more idiomatic alternative to #884 with two unavoidable lines of `unsafe` copied from `std`.

Closes #522 
Closes #949 

(For 949, we allow users to use whichever they like but still use `ScriptBuf` in `Transaction`.)