### PR TITLE
Improve amounts and use `Amount` in `TxOut`

### DIFF
--- a/examples/ecdsa-psbt.rs
+++ b/examples/ecdsa-psbt.rs
@@ -218,9 +218,9 @@ impl WatchOnly {
                 witness: Witness::default(),
             }],
             output: vec![
-                TxOut { value: to_amount.to_sat(), script_pubkey: to_address.script_pubkey() },
+                TxOut { value: to_amount, script_pubkey: to_address.script_pubkey() },
                 TxOut {
-                    value: change_amount.to_sat(),
+                    value: change_amount,
                     script_pubkey: change_address.script_pubkey(),
                 },
             ],
@@ -310,7 +310,7 @@ fn previous_output() -> TxOut {
         .expect("failed to parse input utxo scriptPubkey");
     let amount = Amount::from_str(INPUT_UTXO_VALUE).expect("failed to parse input utxo value");
 
-    TxOut { value: amount.to_sat(), script_pubkey }
+    TxOut { value: amount, script_pubkey }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -458,11 +458,11 @@ mod psbt_sign {
                     Script::p2wpkh_script_code(input.redeem_script.as_ref().expect("checked above"))
                         .ok_or(SighashError::NotWpkh)?
                 };
-                cache.segwit_signature_hash(input_index, &script_code, utxo.value, hash_ty)?
+                cache.segwit_signature_hash(input_index, &script_code, utxo.value.to_sat(), hash_ty)?
             } else {
                 let script_code =
                     input.witness_script.as_ref().ok_or(SighashError::MissingWitnessScript)?;
-                cache.segwit_signature_hash(input_index, script_code, utxo.value, hash_ty)?
+                cache.segwit_signature_hash(input_index, script_code, utxo.value.to_sat(), hash_ty)?
             }
         } else {
             let script_code = if script.is_p2sh() {

--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -21,6 +21,7 @@ use crate::blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn, Sequence
 use crate::blockdata::block::{Block, BlockHeader};
 use crate::blockdata::witness::Witness;
 use crate::network::constants::Network;
+use crate::amount::Amount;
 use crate::util::uint::Uint256;
 use crate::internal_macros::{impl_array_newtype, impl_bytes_newtype};
 
@@ -100,7 +101,7 @@ fn bitcoin_genesis_tx() -> Transaction {
         .push_opcode(opcodes::all::OP_CHECKSIG)
         .into_script();
     ret.output.push(TxOut {
-        value: 50 * COIN_VALUE,
+        value: Amount::from_btc(50.0).expect("50.0 is a valid value"),
         script_pubkey: out_script
     });
 
@@ -219,7 +220,7 @@ mod test {
         assert_eq!(gen.output.len(), 1);
         assert_eq!(serialize(&gen.output[0].script_pubkey),
                    Vec::from_hex("434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac").unwrap());
-        assert_eq!(gen.output[0].value, 50 * COIN_VALUE);
+        assert_eq!(gen.output[0].value, Amount::from_btc(50.0).expect("50.0 is a valid value"));
         assert_eq!(gen.lock_time, PackedLockTime::ZERO);
 
         assert_eq!(gen.wtxid().to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub use crate::consensus::encode::VarInt;
 pub use crate::hash_types::*;
 pub use crate::network::constants::Network;
 pub use crate::util::address::{Address, AddressType};
-pub use crate::util::amount::{Amount, Denomination, SignedAmount};
+pub use crate::util::amount::{self, Amount, Denomination, SignedAmount};
 pub use crate::util::ecdsa::{self, EcdsaSig, EcdsaSigError};
 pub use crate::util::key::{KeyPair, PrivateKey, PublicKey, XOnlyPublicKey};
 pub use crate::util::merkleblock::MerkleBlock;

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -456,23 +456,18 @@ fn fmt_satoshi_in(
     Ok(())
 }
 
-/// Amount
+/// The `Amount` type can be used to express unsigned Bitcoin amounts, it supports arithmetic and
+/// conversion to various denominations.
 ///
-/// The [Amount] type can be used to express Bitcoin amounts that supports
-/// arithmetic and conversion to various denominations.
+/// This type implements several arithmetic operations from [`core::ops`]. To prevent errors due to
+/// overflow when using these operations, it is advised to instead use the checked arithmetic
+/// methods whose names start with `checked_`.
 ///
+/// # Panics
 ///
-/// Warning!
-///
-/// This type implements several arithmetic operations from [core::ops].
-/// To prevent errors due to overflow or underflow when using these operations,
-/// it is advised to instead use the checked arithmetic methods whose names
-/// start with `checked_`.  The operations from [core::ops] that [Amount]
-/// implements will panic when overflow or underflow occurs.  Also note that
-/// since the internal representation of amounts is unsigned, subtracting below
-/// zero is considered an underflow and will cause a panic if you're not using
-/// the checked arithmetic methods.
-///
+/// The operations from [`core::ops`] that `Amount` implements will panic when overflow occurs. Also
+/// note that since the internal representation of `Amount` is unsigned, subtracting below zero is
+/// considered an overflow and will cause a panic if you're not using the checked arithmetic methods.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Amount(u64);
 
@@ -842,20 +837,16 @@ enum DisplayStyle {
     DynamicDenomination,
 }
 
-/// SignedAmount
+/// The `SignedAmount` type can be used to express signed Bitcoin amounts, it supports arithmetic
+/// and conversion to various denominations.
 ///
-/// The [SignedAmount] type can be used to express Bitcoin amounts that supports
-/// arithmetic and conversion to various denominations.
+/// This type implements several arithmetic operations from [`core::ops`]. To prevent errors due to
+/// overflow when using these operations, it is advised to instead use the checked arithmetic
+/// methods whose names start with `checked_`.
 ///
+/// # Panics
 ///
-/// Warning!
-///
-/// This type implements several arithmetic operations from [core::ops].
-/// To prevent errors due to overflow or underflow when using these operations,
-/// it is advised to instead use the checked arithmetic methods whose names
-/// start with `checked_`.  The operations from [core::ops] that [Amount]
-/// implements will panic when overflow or underflow occurs.
-///
+/// The operations from [`core::ops`] that `SignedAmount` implements will panic when overflow occurs.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SignedAmount(i64);
 

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -6,10 +6,12 @@
 //! We refer to the documentation on the types for more information.
 //!
 
-use crate::prelude::*;
-
 use core::{ops, default, str::FromStr, cmp::Ordering};
 use core::fmt::{self, Write};
+
+use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::io;
+use crate::prelude::*;
 
 /// A set of denominations in which amounts can be expressed.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -956,6 +958,20 @@ impl core::iter::Sum for Amount {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         let sats: u64 = iter.map(|amt| amt.0).sum();
         Amount::from_sat(sats)
+    }
+}
+
+impl Encodable for Amount {
+    #[inline]
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
+    }
+}
+
+impl Decodable for Amount {
+    #[inline]
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        u64::consensus_decode(r).map(Amount)
     }
 }
 

--- a/src/util/bip152.rs
+++ b/src/util/bip152.rs
@@ -365,8 +365,8 @@ mod test {
     use crate::consensus::encode::{deserialize, serialize};
     use crate::hashes::hex::FromHex;
     use crate::{
-        Block, BlockHash, BlockHeader, OutPoint, Script, Sequence, Transaction, TxIn, TxMerkleNode,
-        TxOut, Txid, Witness, LockTime,
+        Amount, Block, BlockHash, BlockHeader, OutPoint, Script, Sequence, Transaction, TxIn,
+        TxMerkleNode, TxOut, Txid, Witness, LockTime,
     };
 
     fn dummy_tx(nonce: &[u8]) -> Transaction {
@@ -379,7 +379,7 @@ mod test {
                 sequence: Sequence(1),
                 witness: Witness::new(),
             }],
-            output: vec![TxOut { value: 1, script_pubkey: Script::new() }],
+            output: vec![TxOut { value: Amount::from_sat(1), script_pubkey: Script::new() }],
         }
     }
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -342,6 +342,7 @@ mod tests {
 
     use secp256k1::{Secp256k1, self};
 
+    use crate::amount::Amount;
     use crate::blockdata::script::Script;
     use crate::blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint, Sequence};
     use crate::network::constants::Network::Bitcoin;
@@ -443,13 +444,13 @@ mod tests {
                 }],
                 output: vec![
                     TxOut {
-                        value: 99999699,
+                        value: Amount::from_sat(99999699),
                         script_pubkey: hex_script!(
                             "76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac"
                         ),
                     },
                     TxOut {
-                        value: 100000000,
+                        value: Amount::from_sat(100000000),
                         script_pubkey: hex_script!(
                             "a9143545e6e33b832c47050f24d3eeb93c9c03948bc787"
                         ),
@@ -514,7 +515,7 @@ mod tests {
             }],
             output: vec![
                 TxOut {
-                    value: 190303501938,
+                    value: Amount::from_sat(190303501938),
                     script_pubkey: hex_script!("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587"),
                 },
             ],
@@ -558,7 +559,7 @@ mod tests {
             inputs: vec![Input {
                 non_witness_utxo: Some(tx),
                 witness_utxo: Some(TxOut {
-                    value: 190303501938,
+                    value: Amount::from_sat(190303501938),
                     script_pubkey: hex_script!("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587"),
                 }),
                 sighash_type: Some("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY".parse::<EcdsaSighashType>().unwrap().into()),
@@ -596,7 +597,7 @@ mod tests {
 
         use crate::hashes::hex::FromHex;
         use crate::hash_types::Txid;
-
+        use crate::amount::Amount;
         use crate::blockdata::script::Script;
         use crate::blockdata::transaction::{EcdsaSighashType, Transaction, TxIn, TxOut, OutPoint, Sequence};
         use crate::consensus::encode::serialize_hex;
@@ -703,11 +704,11 @@ mod tests {
                     }],
                     output: vec![
                         TxOut {
-                            value: 99999699,
+                            value: Amount::from_sat(99999699),
                             script_pubkey: hex_script!("76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac"),
                         },
                         TxOut {
-                            value: 100000000,
+                            value: Amount::from_sat(100000000),
                             script_pubkey: hex_script!("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787"),
                         },
                     ],
@@ -751,11 +752,11 @@ mod tests {
                         }],
                         output: vec![
                             TxOut {
-                                value: 200000000,
+                                value: Amount::from_sat(200000000),
                                 script_pubkey: hex_script!("76a91485cff1097fd9e008bb34af709c62197b38978a4888ac"),
                             },
                             TxOut {
-                                value: 190303501938,
+                                value: Amount::from_sat(190303501938),
                                 script_pubkey: hex_script!("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587"),
                             },
                         ],
@@ -1015,11 +1016,11 @@ mod tests {
                 }],
                 output: vec![
                     TxOut {
-                        value: 99999699,
+                        value: Amount::from_sat(99999699),
                         script_pubkey: hex_script!("76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac"),
                     },
                     TxOut {
-                        value: 100000000,
+                        value: Amount::from_sat(100000000),
                         script_pubkey: hex_script!("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787"),
                     },
                 ],
@@ -1063,11 +1064,11 @@ mod tests {
                     }],
                     output: vec![
                         TxOut {
-                            value: 200000000,
+                            value: Amount::from_sat(200000000),
                             script_pubkey: hex_script!("76a91485cff1097fd9e008bb34af709c62197b38978a4888ac"),
                         },
                         TxOut {
-                            value: 190303501938,
+                            value: Amount::from_sat(190303501938),
                             script_pubkey: hex_script!("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587"),
                         },
                     ],

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -824,7 +824,7 @@ mod tests {
     use crate::internal_macros::{hex_hash, hex_script, hex_decode};
     extern crate serde_json;
 
-    use crate::{Script, Transaction, TxIn, TxOut};
+    use crate::{Amount, Script, Transaction, TxIn, TxOut};
 
     #[test]
     fn test_tap_sighash_hash() {
@@ -1086,7 +1086,7 @@ mod tests {
         for utxo in key_path["given"]["utxosSpent"].as_array().unwrap() {
             let spk = hex_script!(utxo["scriptPubKey"].as_str().unwrap());
             let amt = utxo["amountSats"].as_u64().unwrap();
-            utxos.push(TxOut {value: amt, script_pubkey: spk });
+            utxos.push(TxOut {value: Amount::from_sat(amt), script_pubkey: spk });
         }
 
         // Test intermediary


### PR DESCRIPTION
What started as a little clean up of `Amount` docs turned in to an epic docs PR for `Amount` and `SignedAmount` (first two patches). Next we deprecate `min_value` and `max_value` in favour of associated consts `MIN`/`MAX` respectively (patch 3). Finally we use `Amount` in `TxOut`.

Fix: #1158 

(This is a re-birthing of #599.)

This demonstrates adding examples to every method of a type, something I'm going to work towards doing. If you see anything that I'm doing that could be done better please air the opinion to save me coming back in a months time and fixing 500 instances of it. One thing I noticed is we tend to say `Returns the foo for this [Type]` where as I noticed in stdlib they tend to say `Returns the foo for self`, if you have an opinion please share it.

Please note, this PR does not attempt to limit `Amount` to a sane amount for bitcoin (21 mil * 100 mil), see https://github.com/rust-bitcoin/rust-bitcoin/issues/620 for discussion on that topic.