### PR TITLE
Add newtype `TxAmount`

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -18,6 +18,7 @@ use crate::blockdata::opcodes;
 use crate::blockdata::script;
 use crate::blockdata::locktime::PackedLockTime;
 use crate::blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn, Sequence};
+use crate::blockdata::tx_amount::TxAmount;
 use crate::blockdata::block::{Block, BlockHeader};
 use crate::blockdata::witness::Witness;
 use crate::network::constants::Network;
@@ -100,7 +101,7 @@ fn bitcoin_genesis_tx() -> Transaction {
         .push_opcode(opcodes::all::OP_CHECKSIG)
         .into_script();
     ret.output.push(TxOut {
-        value: 50 * COIN_VALUE,
+        value: TxAmount::from_sat(50 * COIN_VALUE).expect("valid value"),
         script_pubkey: out_script
     });
 
@@ -219,7 +220,7 @@ mod test {
         assert_eq!(gen.output.len(), 1);
         assert_eq!(serialize(&gen.output[0].script_pubkey),
                    Vec::from_hex("434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac").unwrap());
-        assert_eq!(gen.output[0].value, 50 * COIN_VALUE);
+        assert_eq!(gen.output[0].value, TxAmount::from_sats(50 * COIN_VALUE).expect("valid value"));
         assert_eq!(gen.lock_time, PackedLockTime::ZERO);
 
         assert_eq!(gen.wtxid().to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");

--- a/src/blockdata/mod.rs
+++ b/src/blockdata/mod.rs
@@ -14,4 +14,3 @@ pub mod script;
 pub mod transaction;
 pub mod block;
 pub mod witness;
-

--- a/src/blockdata/mod.rs
+++ b/src/blockdata/mod.rs
@@ -14,3 +14,4 @@ pub mod script;
 pub mod transaction;
 pub mod block;
 pub mod witness;
+pub mod tx_amount;

--- a/src/blockdata/tx_amount.rs
+++ b/src/blockdata/tx_amount.rs
@@ -1,0 +1,349 @@
+// The Rust Bitcoin Library - Written by the rust-bitcoin developers.
+// SPDX-License-Identifier: CC0-1.0
+
+//! An amount that can represent the value of an unsigned transaction output (UTXO) or the total
+//! value of a transaction. This implies there is an upper limit for this value. We use 21 million
+//! as the upper bound because if a transaction gets included in the chain that spends more than
+//! this Bitcoin is dead - long live Bitcoin.
+//!
+
+use core::fmt;
+use core::convert::TryFrom;
+use core::str::FromStr;
+
+use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::internal_macros::write_err;
+use crate::io;
+use crate::parse::{self, ParseIntError};
+use crate::prelude::*;
+use crate::util::amount::Amount;
+
+/// Upper bound on maximum sats in a single transaction (21_000_000 * 100_000_000).
+const MAX_SATS: u64 = 2_100_000_000_000_000;
+
+/// TODO: Document this.
+const NULL_TX_OUT: u64 = 0xffffffffffffffff;
+
+/// The `TXAmount` type can be used to express Bitcoin transaction amounts, it only supports checked
+/// arithmetic because silently overflowing is never useful for bitcoin amounts.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TxAmount {
+    value: u64,
+    null: bool,
+}
+
+impl TxAmount {
+    /// The minimum value for a transaction amount.
+    ///
+    /// A transaction amount is always greater than, or equal to, zero i.e., [`TxAmount`] is a
+    /// signed integer type.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::Amount;
+    /// assert_eq!(TxAmount::MIN, TxAmount::from_sats(0).expect("valid value"););
+    /// assert_eq!(TXAmount::MIN, Amount::ZERO);
+    /// ```
+    pub const MIN: TxAmount = TxAmount { value: 0, null: false };
+    /// The maximum amount value for a transaction amount.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// assert_eq!(Amount::MAX, Amount::from_sats(21_000_000).expect("21 million is valid"));
+    /// ```
+    pub const MAX: TxAmount = TxAmount { value: MAX_SATS, null: false };
+    /// The zero amount.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// assert_eq!(TxAmount::ZERO, TxAmount::from_sats(0).expect("valid value"));
+    /// ```
+    pub const ZERO: TxAmount = TxAmount { value: 0, null: false };
+    /// Exactly one satoshi.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// assert_eq!(TxAmount::ONE_SAT, TxAmount::from_sats(1).expect("valid value"));
+    /// ```
+    pub const ONE_SAT: TxAmount = TxAmount { value: 1, null: false };
+    /// Exactly one bitcoin.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// assert_eq!(TxAmount::ONE_BTC, TxAmount::from_sats(100_000_000).expect("valid value"));
+    /// ```
+    pub const ONE_BTC: TxAmount = TxAmount { value: 100_000_000, null: false };
+
+    /// TODO: Document this with references from somewhere.
+    ///
+    /// The transaction amount with all bits set is used by consensus code to signal "null transaction".
+    pub const NULL_TX_OUT: TxAmount = TxAmount{ value: NULL_TX_OUT, null: true };
+
+    /// Returns the number of satoshis in `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin::Amount;
+    /// let value = TxAmount::from_sat(100_000).expect("valid value");
+    /// assert_eq!(value.to_sat(), 100_000);
+    /// ```
+    #[inline]
+    pub const fn to_sat(self) -> u64 {
+        self.value
+    }
+
+    /// Equivalent to [`TxAmount::to_sat`].
+    #[inline]
+    pub const fn to_sats(self) -> u64 {
+        self.to_sat()
+    }
+
+    /// Converts self to an [`Amount`].
+    ///
+    /// TODO: Write example.
+    #[inline]
+    pub fn to_amount(self) -> Amount {
+        if self.null {
+            Amount::from_sat(NULL_TX_OUT)
+        } else {
+            Amount::from_sat(self.value)
+        }
+    }
+
+    /// Creates a [`TxAmount`] from given number of satoshis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin::Amount;
+    /// let value = Amount::from_sat(100_000).expect("valid value");;
+    /// assert_eq!(value.to_sat(), 100_000);
+    /// ```
+    #[inline]
+    pub fn from_sat(sat: u64) -> Result<TxAmount, Error> {
+        if sat > MAX_SATS {
+            Err(Error::Overflow(sat as u64)) // Can't use `into` because its not `const`.
+        } else {
+            Ok(TxAmount{ value: sat, null: false })
+        }
+    }
+
+    /// Equivalent to [`TxAmount::from_sat`].
+    #[inline]
+    pub fn from_sats(sats: u64) -> Result<TxAmount, Error> {
+        TxAmount::from_sat(sats)
+    }
+
+    /// Creates a [`TxAmount`] from a number of satoshis as a string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin::Amount;
+    /// let value = Amount::from_sats(100_000).expect("valid value");;
+    /// assert_eq!(value.to_sat(), 100_000);
+    /// ```
+    #[inline]
+    pub fn from_sat_str(s: &str) -> Result<TxAmount, Error> {
+        let x = parse::int(s)?;
+        TxAmount::from_sats(x)
+    }
+
+    /// Checked integer addition. Computes `self + rhs`, returning `None` if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// let a = TxAmount::from_sats(10_000_000);
+    /// let b = TxAmount::from_sats(1_000_000);
+    /// assert_eq!(a.checked_add(b), Some(TxAmount::from_sats(11_000_000)));
+    /// assert_eq!(a.checked_add(TxAmount::MAX), None);
+    /// ```
+    #[inline]
+    pub fn checked_add(self, rhs: TxAmount) -> Option<TxAmount> {
+        let x = self.value + rhs.value;
+        TxAmount::from_sats(x).ok()
+    }
+
+    /// Checked integer subtraction. Computes `self - rhs`, returning `None` if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// let a = TxAmount::from_sats(10_000_000);
+    /// let b = TxAmount::from_sats(1_000_000);
+    /// assert_eq!(a.checked_sub(b), Some(TxAmount::from_sats(9_000_000)));
+    /// assert_eq!(TxAmount::MIN.checked_sub(TxAmount::ONE_SAT), None);
+    /// ```
+    #[inline]
+    pub fn checked_sub(self, rhs: TxAmount) -> Option<TxAmount> {
+        let x = self.value.checked_sub(rhs.value)?;
+        TxAmount::from_sats(x).ok()
+    }
+
+    /// Checked integer multiplication. Computes `self * rhs`, returning `None` if overflow occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// assert_eq!(TxAmount::ONE_SAT.checked_mul(1_000), Some(TxAmount::from_sats(1_000)));
+    /// assert_eq!(TxAmount::max_value().checked_mul(2), None);
+    /// ```
+    #[inline]
+    pub fn checked_mul(self, rhs: u64) -> Option<TxAmount> {
+        let x = self.value.checked_mul(rhs)?;
+        TxAmount::from_sats(x).ok()
+    }
+
+    /// Checked integer division. Computes `self / rhs`, returning `None` if `rhs == 0`.
+    ///
+    /// Be aware that integer division loses the remainder if no exact division
+    /// can be made (floor division).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// let a = TxAmount::from_sats(5);
+    /// assert_eq!(a.checked_div(2), Some(TxAmount::from_sats(2)));
+    /// assert_eq!(a.checked_div(0), None);
+    /// ```
+    #[inline]
+    pub fn checked_div(self, rhs: u64) -> Option<TxAmount> {
+        let x = self.value.checked_div(rhs)?;
+        TxAmount::from_sats(x).ok()
+    }
+
+    /// Checked integer remainder. Computes `self % rhs`, returning None if `rhs == 0`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin::TxAmount;
+    /// let a = TxAmount::from_sats(5);
+    /// assert_eq!(a.checked_rem(2), Some(TxAmount::from_sat(1)));
+    /// assert_eq!(a.checked_rem(0), None);
+    /// ```
+    #[inline]
+    pub fn checked_rem(self, rhs: u64) -> Option<TxAmount> {
+        let x = self.value.checked_rem(rhs)?;
+        TxAmount::from_sats(x).ok()
+    }
+}
+
+macro_rules! impl_try_from {
+    ($ty:ident) => {
+        impl TryFrom<$ty> for TxAmount {
+            type Error = Error;
+
+            #[inline]
+            fn try_from(x: $ty) -> Result<Self, Self::Error> {
+                TxAmount::from_sats(x.into())
+            }
+        }
+    }
+}
+impl_try_from!(u64);
+impl_try_from!(u32);
+impl_try_from!(u16);
+impl_try_from!(u8);
+
+impl FromStr for TxAmount {
+    type Err = Error;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let x = parse::int(s)?;
+        TxAmount::from_sats(x)
+    }
+}
+
+impl TryFrom<&str> for TxAmount {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let x = parse::int(s)?;
+        TxAmount::from_sats(x)
+    }
+}
+
+impl TryFrom<String> for TxAmount {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let x = parse::int(s)?;
+        TxAmount::from_sats(x)
+    }
+}
+
+impl Encodable for TxAmount {
+    #[inline]
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        if self.null {
+            NULL_TX_OUT.consensus_encode(w)
+        } else {
+            self.value.consensus_encode(w)
+        }
+    }
+}
+
+impl Decodable for TxAmount {
+    #[inline]
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let x = u64::consensus_decode(r)?;
+        if x == u64::max_value() {
+            Ok(TxAmount::NULL_TX_OUT)
+        } else {
+            TxAmount::from_sats(x).map_err(|_| encode::Error::ParseFailed("transaction amount is greater than 21 million"))
+        }
+    }
+}
+
+/// Errors encountered when working with [`TxAmount`].
+#[derive(Debug)]
+pub enum Error {
+    /// Value overflowed i.e., is greater than 21 million.
+    Overflow(u64),
+    /// String parse error.
+    Parse(ParseIntError),
+}
+
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+
+        match *self {
+            Overflow(ref x) => write!(f, "{} overflows tx amount (greater than 21 million)", x),
+            Parse(ref e) => write_err!(f, "error while attempting to parse a tx amount from string"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match *self {
+            Overflow(_) => None,
+            Parse(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(e: ParseIntError) -> Self {
+        Error::Parse(e)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ pub use crate::blockdata::transaction::SigHashType;
 pub use crate::blockdata::transaction::{
     EcdsaSighashType, OutPoint, Sequence, Transaction, TxIn, TxOut,
 };
+pub use crate::blockdata::tx_amount::TxAmount;
 pub use crate::blockdata::witness::Witness;
 pub use crate::consensus::encode::VarInt;
 pub use crate::hash_types::*;

--- a/src/util/bip152.rs
+++ b/src/util/bip152.rs
@@ -366,7 +366,7 @@ mod test {
     use crate::hashes::hex::FromHex;
     use crate::{
         Block, BlockHash, BlockHeader, OutPoint, Script, Sequence, Transaction, TxIn, TxMerkleNode,
-        TxOut, Txid, Witness, LockTime,
+        TxOut, Txid, Witness, LockTime, TxAmount,
     };
 
     fn dummy_tx(nonce: &[u8]) -> Transaction {
@@ -379,7 +379,7 @@ mod test {
                 sequence: Sequence(1),
                 witness: Witness::new(),
             }],
-            output: vec![TxOut { value: 1, script_pubkey: Script::new() }],
+            output: vec![TxOut { value: TxAmount::ONE_SAT, script_pubkey: Script::new() }],
         }
     }
 

--- a/src/util/psbt/mod.rs
+++ b/src/util/psbt/mod.rs
@@ -344,6 +344,7 @@ mod tests {
 
     use crate::blockdata::script::Script;
     use crate::blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint, Sequence};
+    use crate::blockdata::tx_amount::TxAmount;
     use crate::network::constants::Network::Bitcoin;
     use crate::consensus::encode::{deserialize, serialize, serialize_hex};
     use crate::util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, KeySource};
@@ -443,13 +444,13 @@ mod tests {
                 }],
                 output: vec![
                     TxOut {
-                        value: 99999699,
+                        value: TxAmount::from_sats(99999699).unwrap(),
                         script_pubkey: hex_script!(
                             "76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac"
                         ),
                     },
                     TxOut {
-                        value: 100000000,
+                        value: TxAmount::from_sats(100000000).unwrap(),
                         script_pubkey: hex_script!(
                             "a9143545e6e33b832c47050f24d3eeb93c9c03948bc787"
                         ),
@@ -514,7 +515,7 @@ mod tests {
             }],
             output: vec![
                 TxOut {
-                    value: 190303501938,
+                    value: TxAmount::from_sats(190303501938).unwrap(),
                     script_pubkey: hex_script!("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587"),
                 },
             ],
@@ -558,7 +559,7 @@ mod tests {
             inputs: vec![Input {
                 non_witness_utxo: Some(tx),
                 witness_utxo: Some(TxOut {
-                    value: 190303501938,
+                    value: TxAmount::from_sats(190303501938).unwrap(),
                     script_pubkey: hex_script!("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587"),
                 }),
                 sighash_type: Some("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY".parse::<EcdsaSighashType>().unwrap().into()),
@@ -599,6 +600,7 @@ mod tests {
 
         use crate::blockdata::script::Script;
         use crate::blockdata::transaction::{EcdsaSighashType, Transaction, TxIn, TxOut, OutPoint, Sequence};
+        use crate::blockdata::tx_amount::TxAmount;
         use crate::consensus::encode::serialize_hex;
         use crate::blockdata::locktime::PackedLockTime;
         use crate::util::psbt::map::{Map, Input, Output};
@@ -703,11 +705,11 @@ mod tests {
                     }],
                     output: vec![
                         TxOut {
-                            value: 99999699,
+                            value: TxAmount::from_sats(99999699).unwrap(),
                             script_pubkey: hex_script!("76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac"),
                         },
                         TxOut {
-                            value: 100000000,
+                            value: TxAmount::from_sats(100000000).unwrap(),
                             script_pubkey: hex_script!("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787"),
                         },
                     ],
@@ -751,11 +753,11 @@ mod tests {
                         }],
                         output: vec![
                             TxOut {
-                                value: 200000000,
+                                value: TxAmount::from_sats(200000000).unwrap(),
                                 script_pubkey: hex_script!("76a91485cff1097fd9e008bb34af709c62197b38978a4888ac"),
                             },
                             TxOut {
-                                value: 190303501938,
+                                value: TxAmount::from_sats(190303501938).unwrap(),
                                 script_pubkey: hex_script!("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587"),
                             },
                         ],
@@ -1015,11 +1017,11 @@ mod tests {
                 }],
                 output: vec![
                     TxOut {
-                        value: 99999699,
+                        value: TxAmount::from_sats(99999699).unwrap(),
                         script_pubkey: hex_script!("76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac"),
                     },
                     TxOut {
-                        value: 100000000,
+                        value: TxAmount::from_sats(100000000).unwrap(),
                         script_pubkey: hex_script!("a9143545e6e33b832c47050f24d3eeb93c9c03948bc787"),
                     },
                 ],
@@ -1063,11 +1065,11 @@ mod tests {
                     }],
                     output: vec![
                         TxOut {
-                            value: 200000000,
+                            value: TxAmount::from_sats(200000000).unwrap(),
                             script_pubkey: hex_script!("76a91485cff1097fd9e008bb34af709c62197b38978a4888ac"),
                         },
                         TxOut {
-                            value: 190303501938,
+                            value: TxAmount::from_sats(190303501938).unwrap(),
                             script_pubkey: hex_script!("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587"),
                         },
                     ],

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -824,7 +824,7 @@ mod tests {
     use crate::internal_macros::{hex_hash, hex_script, hex_decode};
     extern crate serde_json;
 
-    use crate::{Script, Transaction, TxIn, TxOut};
+    use crate::{Script, Transaction, TxIn, TxOut, TxAmount};
 
     #[test]
     fn test_tap_sighash_hash() {
@@ -1086,7 +1086,7 @@ mod tests {
         for utxo in key_path["given"]["utxosSpent"].as_array().unwrap() {
             let spk = hex_script!(utxo["scriptPubKey"].as_str().unwrap());
             let amt = utxo["amountSats"].as_u64().unwrap();
-            utxos.push(TxOut {value: amt, script_pubkey: spk });
+            utxos.push(TxOut {value: TxAmount::from_sat(amt).expect("valid amount"), script_pubkey: spk });
         }
 
         // Test intermediary


### PR DESCRIPTION
Draft for feedback on the idea, the code is pretty fully fleshed out since I've been working with integer types a lot this week. (also serde stuff is not fully done, expect some red in CI)

This type is used as the value field of `TxOut` and has an invariant that its value is never greater than 21 million.

There is one complexity: the `u64::MAX` (all bits on) value is apparently used to signal in consensus code "null txout". This is currently handled by having `TxAmount` be an enum - its a bit ugly though.

Done in an effort to resolve: https://github.com/rust-bitcoin/rust-bitcoin/issues/620
Related to: #599 #1158 #1162  phew!
