### PR TITLE
Update bitcoinconsensus dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ secp256k1 = { version = "0.24.0", default-features = false, features = ["bitcoin
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }
-bitcoinconsensus = { version = "0.19.0-3", optional = true }
+bitcoinconsensus = { version = "0.20.2-0.5.0", optional = true }
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1", default-features = false, features = [ "derive", "alloc" ], optional = true }
 hashbrown = { version = "0.8", optional = true }


### PR DESCRIPTION
We recently released a couple of new versions of
`rust-bitcoinconsensus`, the first was mainly to move to git subtree,
included in this release was a bump of the patch version of bitcoin
core. The next release updated bitcoin core major version to 0.20.2

Update our bitcoinconsensus dependency to `0.20.2-0.5.0`.