### PR TITLE
Remove `MAX_SEQUENCE` constant

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -24,8 +24,6 @@ use crate::network::constants::Network;
 use crate::util::uint::Uint256;
 use crate::internal_macros::{impl_array_newtype, impl_bytes_newtype};
 
-/// The maximum allowable sequence number
-pub const MAX_SEQUENCE: u32 = 0xFFFFFFFF;
 /// How many satoshis are in "one bitcoin"
 pub const COIN_VALUE: u64 = 100_000_000;
 /// How many seconds between blocks we expect on average

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -22,7 +22,7 @@ use crate::hashes::{self, Hash, sha256d};
 use crate::hashes::hex::FromHex;
 
 use crate::util::endian;
-use crate::blockdata::constants::{WITNESS_SCALE_FACTOR, MAX_SEQUENCE};
+use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
 #[cfg(feature="bitcoinconsensus")] use crate::blockdata::script;
 use crate::blockdata::script::Script;
 use crate::blockdata::witness::Witness;
@@ -264,7 +264,7 @@ impl Sequence {
     /// The maximum allowable sequence number.
     ///
     /// This sequence number disables lock-time and replace-by-fee.
-    pub const MAX: Self = Sequence(MAX_SEQUENCE);
+    pub const MAX: Self = Sequence(0xFFFFFFFF);
     /// Zero value sequence.
     ///
     /// This sequence number enables replace-by-fee and lock-time.


### PR DESCRIPTION
This is follow up work to the recent addition of the `Sequence` type. We
do not need to keep a public integer const for `MAX_SEQUENCE` because we
offer the `Sequenc::MAX` associated type.

Use the all-bits-set u64 directly in the associated type `Sequence::MAX`.

cc nlanson 