### PR TITLE
Re-export blockdata modules

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -81,7 +81,7 @@ impl BlockHeader {
     /// [`Uint256`]: ../../util/uint/struct.Uint256.html
     ///
     /// ```
-    /// use bitcoin::blockdata::block::BlockHeader;
+    /// use bitcoin::block::BlockHeader;
     ///
     /// assert_eq!(0x1d00ffff,
     ///     BlockHeader::compact_target_from_u256(

--- a/src/blockdata/locktime.rs
+++ b/src/blockdata/locktime.rs
@@ -293,7 +293,7 @@ impl LockTime {
     ///
     /// # Examples
     /// ```no_run
-    /// # use bitcoin::blockdata::locktime::{LockTime, Height, Time};
+    /// # use bitcoin::locktime::{LockTime, Height, Time};
     /// // Can be implemented if block chain data is available.
     /// fn get_height() -> Height { todo!("return the current block height") }
     /// fn get_time() -> Time { todo!("return the current block time") }
@@ -420,7 +420,7 @@ impl Height {
     ///
     /// # Examples
     /// ```rust
-    /// use bitcoin::blockdata::locktime::Height;
+    /// use bitcoin::locktime::Height;
     ///
     /// let h: u32 = 741521;
     /// let height = Height::from_consensus(h).expect("invalid height value");
@@ -503,7 +503,7 @@ impl Time {
     ///
     /// # Examples
     /// ```rust
-    /// use bitcoin::blockdata::locktime::Time;
+    /// use bitcoin::locktime::Time;
     ///
     /// let t: u32 = 1653195600; // May 22nd, 5am UTC.
     /// let time = Time::from_consensus(t).expect("invalid time value");

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -72,7 +72,7 @@ impl OutPoint {
     /// # Examples
     ///
     /// ```rust
-    /// use bitcoin::blockdata::constants::genesis_block;
+    /// use bitcoin::constants::genesis_block;
     /// use bitcoin::network::constants::Network;
     ///
     /// let block = genesis_block(Network::Bitcoin);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,13 +94,14 @@ use std::io;
 use core2::io;
 
 pub use crate::address::{Address, AddressType};
-pub use crate::blockdata::block::{Block, BlockHeader};
+pub use crate::blockdata::block::{self, Block, BlockHeader};
 pub use crate::blockdata::locktime::{self, LockTime, PackedLockTime};
-pub use crate::blockdata::script::Script;
+pub use crate::blockdata::script::{self, Script};
 #[allow(deprecated)]
 pub use crate::blockdata::transaction::SigHashType;
-pub use crate::blockdata::transaction::{OutPoint, Sequence, Transaction, TxIn, TxOut};
-pub use crate::blockdata::witness::Witness;
+pub use crate::blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut};
+pub use crate::blockdata::witness::{self, Witness};
+pub use crate::blockdata::{constants, opcodes};
 pub use crate::consensus::encode::VarInt;
 pub use crate::hash_types::*;
 pub use crate::network::constants::Network;

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -78,8 +78,8 @@ impl<R: DerefMut<Target = Transaction>> SigHashCache<R> {
     /// panics if `input_index` is out of bounds with respect of the number of inputs
     ///
     /// ```
-    /// use bitcoin::util::bip143::SigHashCache;
     /// use bitcoin::{EcdsaSighashType, Script, Transaction, PackedLockTime};
+    /// use bitcoin::util::bip143::SigHashCache;
     ///
     /// let mut tx_to_sign = Transaction { version: 2, lock_time: PackedLockTime::ZERO, input: Vec::new(), output: Vec::new() };
     /// let input_count = tx_to_sign.input.len();

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -1035,9 +1035,7 @@ impl<R: DerefMut<Target=Transaction>> SighashCache<R> {
     ///
     /// This allows in-line signing such as
     /// ```
-    /// use bitcoin::blockdata::transaction::Transaction;
-    /// use bitcoin::util::sighash::{EcdsaSighashType, SighashCache};
-    /// use bitcoin::{PackedLockTime, Script};
+    /// use bitcoin::{EcdsaSighashType, PackedLockTime, Script, SighashCache, Transaction};
     ///
     /// let mut tx_to_sign = Transaction { version: 2, lock_time: PackedLockTime::ZERO, input: Vec::new(), output: Vec::new() };
     /// let input_count = tx_to_sign.input.len();


### PR DESCRIPTION
In an effort to make the library more ergonomic to use re-export modules from `blockdata` at the crate root level. This helps to decouple the internal code layout with the public API.