### PR TITLE
WIP: Verify removal of Index trait bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bech32 = { version = "0.9.0", default-features = false }
-bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { version = "0.24.0", default-features = false, features = ["bitcoin_hashes"] }
+bitcoin_hashes = { git = "https://github.com/tcharding/bitcoin_hashes", branch = "08-09-rm-index-impls", default-features = false }
+# "dev-verify-rm-index" just depends on same version of bitcoin_hashes as above.
+secp256k1 = { git = "https://github.com/tcharding/rust-secp256k1", branch = "dev-verfiy-rm-index", default-features = false, features = ["bitcoin_hashes"] }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }
@@ -47,7 +48,8 @@ hashbrown = { version = "0.8", optional = true }
 [dev-dependencies]
 serde_json = "<1.0.45"
 serde_test = "1"
-secp256k1 = { version = "0.24.0", features = [ "recovery", "rand-std" ] }
+# "dev-verify-rm-index" just depends on same version of bitcoin_hashes as above.
+secp256k1 = { git = "https://github.com/tcharding/rust-secp256k1", branch = "dev-verfiy-rm-index", features = ["recovery", "rand-std"] }
 bincode = "1.3.1"
 
 [[example]]

--- a/examples/ecdsa-psbt.rs
+++ b/examples/ecdsa-psbt.rs
@@ -473,7 +473,7 @@ mod psbt_sign {
             cache.legacy_signature_hash(input_index, script_code, hash_ty.to_u32())?
         };
 
-        Ok((Message::from_slice(&sighash).expect("sighashes are 32 bytes"), hash_ty.into()))
+        Ok((Message::from_slice(sighash.as_ref()).expect("sighashes are 32 bytes"), hash_ty.into()))
     }
 
     /// Returns the prevouts for this PSBT.
@@ -545,7 +545,7 @@ mod psbt_sign {
             )?,
             None => cache.taproot_key_spend_signature_hash(input_index, &prevouts, hash_ty)?,
         };
-        let msg = Message::from_slice(&sighash).expect("sighashes are 32 bytes");
+        let msg = Message::from_slice(sighash.as_ref()).expect("sighashes are 32 bytes");
         Ok((msg, hash_ty.into()))
     }
 

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -341,7 +341,7 @@ impl Script {
         Builder::new()
             .push_opcode(opcodes::all::OP_DUP)
             .push_opcode(opcodes::all::OP_HASH160)
-            .push_slice(&pubkey_hash[..])
+            .push_slice(pubkey_hash.as_ref())
             .push_opcode(opcodes::all::OP_EQUALVERIFY)
             .push_opcode(opcodes::all::OP_CHECKSIG)
             .into_script()
@@ -351,7 +351,7 @@ impl Script {
     pub fn new_p2sh(script_hash: &ScriptHash) -> Script {
         Builder::new()
             .push_opcode(opcodes::all::OP_HASH160)
-            .push_slice(&script_hash[..])
+            .push_slice(script_hash.as_ref())
             .push_opcode(opcodes::all::OP_EQUAL)
             .into_script()
     }
@@ -364,7 +364,7 @@ impl Script {
 
     /// Generates P2WPKH-type of scriptPubkey.
     pub fn new_v0_p2wpkh(pubkey_hash: &WPubkeyHash) -> Script {
-        Script::new_witness_program(WitnessVersion::V0, &pubkey_hash[..])
+        Script::new_witness_program(WitnessVersion::V0, pubkey_hash.as_ref())
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
@@ -375,7 +375,7 @@ impl Script {
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
     pub fn new_v0_p2wsh(script_hash: &WScriptHash) -> Script {
-        Script::new_witness_program(WitnessVersion::V0, &script_hash[..])
+        Script::new_witness_program(WitnessVersion::V0, script_hash.as_ref())
     }
 
     /// Generates P2TR for script spending path using an internal public key and some optional

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -706,8 +706,11 @@ impl Decodable for Box<[u8]> {
 
 /// Do a double-SHA256 on some data and return the first 4 bytes
 fn sha2_checksum(data: &[u8]) -> [u8; 4] {
-    let checksum = <sha256d::Hash as Hash>::hash(data);
-    [checksum[0], checksum[1], checksum[2], checksum[3]]
+    let hash = <sha256d::Hash as Hash>::hash(data);
+
+    let mut checksum = [0u8; 4];
+    checksum.copy_from_slice(&hash.as_ref()[..4]);
+    checksum
 }
 
 // Checked data

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -543,7 +543,7 @@ mod test {
             NetworkMessage::MerkleBlock(merkle_block),
             NetworkMessage::FilterLoad(FilterLoad {filter: Vec::from_hex("03614e9b050000000000000001").unwrap(), hash_funcs: 1, tweak: 2, flags: BloomFlags::All}),
             NetworkMessage::FilterAdd(FilterAdd {data: script.as_bytes().to_vec()}),
-            NetworkMessage::FilterAdd(FilterAdd {data: hash([29u8; 32]).to_vec()}),
+            NetworkMessage::FilterAdd(FilterAdd {data: hash([29u8; 32]).as_ref().to_vec()}),
             NetworkMessage::FilterClear,
             NetworkMessage::GetCFilters(GetCFilters{filter_type: 2, start_height: 52, stop_hash: hash([42u8; 32]).into()}),
             NetworkMessage::CFilter(CFilter{filter_type: 7, block_hash: hash([25u8; 32]).into(), filter: vec![1,2,3]}),

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -511,7 +511,7 @@ impl Payload {
     pub fn p2wpkh(pk: &PublicKey) -> Result<Payload, Error> {
         Ok(Payload::WitnessProgram {
             version: WitnessVersion::V0,
-            program: pk.wpubkey_hash().ok_or(Error::UncompressedPubkey)?.to_vec(),
+            program: pk.wpubkey_hash().ok_or(Error::UncompressedPubkey)?.as_ref().to_vec(),
         })
     }
 
@@ -519,7 +519,7 @@ impl Payload {
     pub fn p2shwpkh(pk: &PublicKey) -> Result<Payload, Error> {
         let builder = script::Builder::new()
             .push_int(0)
-            .push_slice(&pk.wpubkey_hash().ok_or(Error::UncompressedPubkey)?);
+            .push_slice(pk.wpubkey_hash().ok_or(Error::UncompressedPubkey)?.as_ref());
 
         Ok(Payload::ScriptHash(builder.into_script().script_hash()))
     }
@@ -528,7 +528,7 @@ impl Payload {
     pub fn p2wsh(script: &script::Script) -> Payload {
         Payload::WitnessProgram {
             version: WitnessVersion::V0,
-            program: script.wscript_hash().to_vec(),
+            program: script.wscript_hash().as_ref().to_vec(),
         }
     }
 
@@ -536,7 +536,7 @@ impl Payload {
     pub fn p2shwsh(script: &script::Script) -> Payload {
         let ws = script::Builder::new()
             .push_int(0)
-            .push_slice(&script.wscript_hash())
+            .push_slice(script.wscript_hash().as_ref())
             .into_script();
 
         Payload::ScriptHash(ws.script_hash())
@@ -568,8 +568,8 @@ impl Payload {
     /// Returns a byte slice of the payload
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            Payload::ScriptHash(hash) => hash,
-            Payload::PubkeyHash(hash) => hash,
+            Payload::ScriptHash(hash) => hash.as_ref(),
+            Payload::PubkeyHash(hash) => hash.as_ref(),
             Payload::WitnessProgram { program, .. } => program,
         }
     }
@@ -594,13 +594,13 @@ impl<'a> fmt::Display for AddressEncoding<'a> {
             Payload::PubkeyHash(hash) => {
                 let mut prefixed = [0; 21];
                 prefixed[0] = self.p2pkh_prefix;
-                prefixed[1..].copy_from_slice(&hash[..]);
+                prefixed[1..].copy_from_slice(hash.as_ref());
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
             }
             Payload::ScriptHash(hash) => {
                 let mut prefixed = [0; 21];
                 prefixed[0] = self.p2sh_prefix;
-                prefixed[1..].copy_from_slice(&hash[..]);
+                prefixed[1..].copy_from_slice(hash.as_ref());
                 base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
             }
             Payload::WitnessProgram {
@@ -839,7 +839,7 @@ impl Address {
         let payload = self.payload.as_bytes();
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
 
-        (*pubkey_hash == *payload) || (xonly_pubkey.serialize() == *payload) || (*segwit_redeem_hash(&pubkey_hash) == *payload)
+        (pubkey_hash.as_ref() == payload) || (xonly_pubkey.serialize() == *payload) || (segwit_redeem_hash(pubkey_hash.as_ref()).as_ref() == payload)
     }
 
     /// Returns true if the supplied xonly public key can be used to derive the address.

--- a/src/util/base58.rs
+++ b/src/util/base58.rs
@@ -172,7 +172,7 @@ pub fn from_check(data: &str) -> Result<Vec<u8>, Error> {
         return Err(Error::TooShort(ret.len()));
     }
     let ck_start = ret.len() - 4;
-    let expected = endian::slice_to_u32_le(&sha256d::Hash::hash(&ret[..ck_start])[..4]);
+    let expected = endian::slice_to_u32_le(&sha256d::Hash::hash(&ret[..ck_start]).as_ref()[..4]);
     let actual = endian::slice_to_u32_le(&ret[ck_start..(ck_start + 4)]);
     if expected != actual {
         return Err(Error::BadChecksum(expected, actual));
@@ -245,7 +245,7 @@ pub fn check_encode_slice(data: &[u8]) -> String {
     encode_iter(
         data.iter()
             .cloned()
-            .chain(checksum[0..4].iter().cloned())
+            .chain(checksum.as_ref()[0..4].iter().cloned())
     )
 }
 
@@ -255,7 +255,7 @@ pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::
     let checksum = sha256d::Hash::hash(data);
     let iter = data.iter()
         .cloned()
-        .chain(checksum[0..4].iter().cloned());
+        .chain(checksum.as_ref()[0..4].iter().cloned());
     format_iter(fmt, iter)
 }
 

--- a/src/util/bip143.rs
+++ b/src/util/bip143.rs
@@ -113,7 +113,7 @@ mod tests {
         let tx: Transaction = deserialize(&Vec::<u8>::from_hex(tx).unwrap()[..]).unwrap();
         let script = Script::from(Vec::<u8>::from_hex(script).unwrap());
         let raw_expected = Sighash::from_hex(expected_result).unwrap();
-        let expected_result = Sighash::from_slice(&raw_expected[..]).unwrap();
+        let expected_result = Sighash::from_slice(raw_expected.as_ref()).unwrap();
         let mut cache = SighashCache::new(&tx);
         let sighash_type = EcdsaSighashType::from_u32_consensus(hash_type);
         let actual_result = cache.segwit_signature_hash(input_index, &script, value, sighash_type).unwrap();

--- a/src/util/bip152.rs
+++ b/src/util/bip152.rs
@@ -103,7 +103,7 @@ impl ShortId {
 
         // 2. Running SipHash-2-4 with the input being the transaction ID and the keys (k0/k1)
         // set to the first two little-endian 64-bit integers from the above hash, respectively.
-        (endian::slice_to_u64_le(&h[0..8]), endian::slice_to_u64_le(&h[8..16]))
+        (endian::slice_to_u64_le(&h.as_ref()[0..8]), endian::slice_to_u64_le(&h.as_ref()[8..16]))
     }
 
     /// Calculate the short ID with the given (w)txid and using the provided SipHash keys.
@@ -114,7 +114,7 @@ impl ShortId {
 
         // 3. Dropping the 2 most significant bytes from the SipHash output to make it 6 bytes.
         let mut id = ShortId([0; 6]);
-        id.0.copy_from_slice(&hash[0..6]);
+        id.0.copy_from_slice(&hash.as_ref()[0..6]);
         id
     }
 }

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -108,8 +108,8 @@ impl FilterHash {
     /// Computes the filter header from a filter hash and previous filter header.
     pub fn filter_header(&self, previous_filter_header: &FilterHeader) -> FilterHeader {
         let mut header_data = [0u8; 64];
-        header_data[0..32].copy_from_slice(&self[..]);
-        header_data[32..64].copy_from_slice(&previous_filter_header[..]);
+        header_data[0..32].copy_from_slice(self.as_ref());
+        header_data[32..64].copy_from_slice(previous_filter_header.as_ref());
         FilterHeader::hash(&header_data)
     }
 }

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -539,8 +539,8 @@ impl ExtendedPrivKey {
             depth: 0,
             parent_fingerprint: Default::default(),
             child_number: ChildNumber::from_normal_idx(0)?,
-            private_key: secp256k1::SecretKey::from_slice(&hmac_result[..32])?,
-            chain_code: ChainCode::from(&hmac_result[32..]),
+            private_key: secp256k1::SecretKey::from_slice(&hmac_result.as_ref()[..32])?,
+            chain_code: ChainCode::from(&hmac_result.as_ref()[32..]),
         })
     }
 
@@ -591,7 +591,7 @@ impl ExtendedPrivKey {
 
         hmac_engine.input(&endian::u32_to_array_be(u32::from(i)));
         let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
-        let sk = secp256k1::SecretKey::from_slice(&hmac_result[..32]).expect("statistically impossible to hit");
+        let sk = secp256k1::SecretKey::from_slice(&hmac_result.as_ref()[..32]).expect("statistically impossible to hit");
         let tweaked = sk.add_tweak(&self.private_key.into()).expect("statistically impossible to hit");
 
         Ok(ExtendedPrivKey {
@@ -600,7 +600,7 @@ impl ExtendedPrivKey {
             parent_fingerprint: self.fingerprint(secp),
             child_number: i,
             private_key: tweaked,
-            chain_code: ChainCode::from(&hmac_result[32..])
+            chain_code: ChainCode::from(&hmac_result.as_ref()[32..])
         })
     }
 
@@ -653,7 +653,7 @@ impl ExtendedPrivKey {
 
     /// Returns the first four bytes of the identifier
     pub fn fingerprint<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> Fingerprint {
-        Fingerprint::from(&self.identifier(secp)[0..4])
+        Fingerprint::from(&self.identifier(secp).as_ref()[0..4])
     }
 }
 
@@ -718,8 +718,8 @@ impl ExtendedPubKey {
 
                 let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
 
-                let private_key = secp256k1::SecretKey::from_slice(&hmac_result[..32])?;
-                let chain_code = ChainCode::from(&hmac_result[32..]);
+                let private_key = secp256k1::SecretKey::from_slice(&hmac_result.as_ref()[..32])?;
+                let chain_code = ChainCode::from(&hmac_result.as_ref()[32..]);
                 Ok((private_key, chain_code))
             }
         }
@@ -792,7 +792,7 @@ impl ExtendedPubKey {
 
     /// Returns the first four bytes of the identifier
     pub fn fingerprint(&self) -> Fingerprint {
-        Fingerprint::from(&self.identifier()[0..4])
+        Fingerprint::from(&self.identifier().as_ref()[0..4])
     }
 }
 

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -824,13 +824,13 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
             let common_cache = Self::common_cache_minimal_borrow(common_cache, tx);
             SegwitCache {
                 prevouts: sha256d::Hash::from_inner(
-                    sha256::Hash::hash(&common_cache.prevouts).into_inner(),
+                    sha256::Hash::hash(common_cache.prevouts.as_ref()).into_inner(),
                 ),
                 sequences: sha256d::Hash::from_inner(
-                    sha256::Hash::hash(&common_cache.sequences).into_inner(),
+                    sha256::Hash::hash(common_cache.sequences.as_ref()).into_inner(),
                 ),
                 outputs: sha256d::Hash::from_inner(
-                    sha256::Hash::hash(&common_cache.outputs).into_inner(),
+                    sha256::Hash::hash(common_cache.outputs.as_ref()).into_inner(),
                 ),
             }
         })

--- a/src/util/taproot.rs
+++ b/src/util/taproot.rs
@@ -79,7 +79,7 @@ impl TapTweakHash {
         // always hash the key
         eng.input(&internal_key.serialize());
         if let Some(h) = merkle_root {
-            eng.input(&h);
+            eng.input(h.as_ref());
         } else {
             // nothing to hash
         }
@@ -112,11 +112,11 @@ impl TapBranchHash {
     pub fn from_node_hashes(a: sha256::Hash, b: sha256::Hash) -> TapBranchHash {
         let mut eng = TapBranchHash::engine();
         if a < b {
-            eng.input(&a);
-            eng.input(&b);
+            eng.input(a.as_ref());
+            eng.input(b.as_ref());
         } else {
-            eng.input(&b);
-            eng.input(&a);
+            eng.input(b.as_ref());
+            eng.input(a.as_ref());
         };
         TapBranchHash::from_engine(eng)
     }
@@ -697,7 +697,7 @@ impl TaprootMerkleBranch {
     /// The number of bytes written to the writer.
     pub fn encode<Write: io::Write>(&self, mut writer: Write) -> io::Result<usize> {
         for hash in self.0.iter() {
-            writer.write_all(hash)?;
+            writer.write_all(hash.as_ref())?;
         }
         Ok(self.0.len() * sha256::Hash::LEN)
     }
@@ -1147,8 +1147,8 @@ mod test {
     fn tag_engine(tag_name: &str) -> sha256::HashEngine {
         let mut engine = sha256::Hash::engine();
         let tag_hash = sha256::Hash::hash(tag_name.as_bytes());
-        engine.input(&tag_hash[..]);
-        engine.input(&tag_hash[..]);
+        engine.input(tag_hash.as_ref());
+        engine.input(tag_hash.as_ref());
         engine
     }
 


### PR DESCRIPTION
This is not a merge candidate. The point of this PR is to verify https://github.com/rust-bitcoin/bitcoin_hashes/pull/168

Verify we can still build after `bitcoin_hashes` removes the `Index` trait bound and replaces it for `AsRef`.