### PR TITLE
Clean up bip158 module

### DIFF
--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -110,15 +110,15 @@ impl FilterHash {
 }
 
 impl BlockFilter {
+    /// Creates a new filter from pre-computed data.
+    pub fn new (content: &[u8]) -> BlockFilter {
+        BlockFilter { content: content.to_vec() }
+    }
+
     /// compute this filter's id in a chain of filters
     pub fn filter_header(&self, previous_filter_header: &FilterHeader) -> FilterHeader {
         let filter_hash = FilterHash::hash(self.content.as_slice());
         filter_hash.filter_header(previous_filter_header)
-    }
-
-    /// create a new filter from pre-computed data
-    pub fn new (content: &[u8]) -> BlockFilter {
-        BlockFilter { content: content.to_vec() }
     }
 
     /// Compute a SCRIPT_FILTER that contains spent and output scripts

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -542,16 +542,15 @@ impl<'a, W: io::Write> BitStreamWriter<'a, W> {
 
 #[cfg(test)]
 mod test {
-    use crate::hash_types::BlockHash;
-    use crate::hashes::hex::FromHex;
-
     use super::*;
 
-    extern crate serde_json;
-    use self::serde_json::Value;
+    use std::collections::HashMap;
+
+    use serde_json::Value;
 
     use crate::consensus::encode::deserialize;
-    use std::collections::HashMap;
+    use crate::hash_types::BlockHash;
+    use crate::hashes::hex::FromHex;
 
     #[test]
     fn test_blockfilters() {

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -86,13 +86,11 @@ impl std::error::Error for Error {
     }
 }
 
-
 impl From<io::Error> for Error {
     fn from(io: io::Error) -> Self {
         Error::Io(io)
     }
 }
-
 
 /// a computed or read block filter
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -208,7 +206,6 @@ impl<'a, W: io::Write> BlockFilterWriter<'a, W> {
     }
 }
 
-
 /// Reads and interpret a block filter
 pub struct BlockFilterReader {
     reader: GCSFilterReader
@@ -241,7 +238,6 @@ impl BlockFilterReader {
         self.reader.match_all(reader, query)
     }
 }
-
 
 /// Golomb-Rice encoded filter reader
 pub struct GCSFilterReader {

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -135,7 +135,9 @@ impl BlockFilter {
         Ok(BlockFilter { content: out })
     }
 
-    /// compute this filter's id in a chain of filters
+    /// Computes this filter's ID in a chain of filters (see [BIP 157]).
+    ///
+    /// [BIP 157]: <https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki#Filter_Headers>
     pub fn filter_header(&self, previous_filter_header: &FilterHeader) -> FilterHeader {
         let filter_hash = FilterHash::hash(self.content.as_slice());
         filter_hash.filter_header(previous_filter_header)

--- a/src/util/bip158.rs
+++ b/src/util/bip158.rs
@@ -5,14 +5,19 @@
 // on 11. June 2019 which is licensed under Apache, that file specifically
 // was written entirely by Tamas Blummer, who is re-licensing its contents here as CC0.
 
-//! BIP158 Compact Block Filters for light clients.
+//! BIP 158 Compact Block Filters for Light Clients.
 //!
 //! This module implements a structure for compact filters on block data, for
 //! use in the BIP 157 light client protocol. The filter construction proposed
 //! is an alternative to Bloom filters, as used in BIP 37, that minimizes filter
 //! size by using Golomb-Rice coding for compression.
 //!
-//! ## Example
+//! ### Relevant BIPS
+//!
+//! * [BIP 157 - Client Side Block Filtering](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki)
+//! * [BIP 158 - Compact Block Filters for Light Clients](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki)
+//!
+//! # Examples
 //!
 //! ```ignore
 //! fn get_script_for_coin(coin: &OutPoint) -> Result<Script, BlockFilterError> {


### PR DESCRIPTION
In attempt to resolve #1147 clean up the `bip158` module.

I was unable to resolve the `"confusing method names read and write that look like those from std:i:o::{trait}"`

I find the `bip158` data types and abstractions kind a funky but was unable to come up with any improvements.

Open question: Are all the public data types really meant to be public? Perhaps we should have an issue to write an example module that uses the bip158 module?