### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -473,7 +473,7 @@ impl Script {
     /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
     #[inline]
     pub fn witness_version(&self) -> Option<WitnessVersion> {
-        self.0.get(0).and_then(|opcode| WitnessVersion::try_from(opcodes::All::from(*opcode)).ok())
+        self.0.first().and_then(|opcode| WitnessVersion::try_from(opcodes::All::from(*opcode)).ok())
     }
 
     /// Checks whether a script pubkey is a P2SH output.

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -847,7 +847,7 @@ impl Transaction {
         S: FnMut(&OutPoint) -> Option<TxOut>,
         F: Into<u32>
     {
-        let tx = encode::serialize(&*self);
+        let tx = encode::serialize(self);
         let flags: u32 = flags.into();
         for (idx, input) in self.input.iter().enumerate() {
             if let Some(output) = spent(&input.previous_output) {

--- a/src/util/bip152.rs
+++ b/src/util/bip152.rs
@@ -179,7 +179,7 @@ impl HeaderAndShortIds {
         let mut last_prefill = 0;
         for (idx, tx) in block.txdata.iter().enumerate() {
             // Check if we should prefill this tx.
-            let prefill_tx = if prefill.get(0) == Some(&idx) {
+            let prefill_tx = if prefill.first() == Some(&idx) {
                 prefill = &prefill[1..];
                 true
             } else {

--- a/src/util/psbt/raw.rs
+++ b/src/util/psbt/raw.rs
@@ -29,7 +29,7 @@ pub struct Key {
 }
 
 /// A PSBT key-value pair in its raw byte form.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Pair {

--- a/src/util/sighash.rs
+++ b/src/util/sighash.rs
@@ -905,7 +905,7 @@ impl<'a> Annex<'a> {
 
     /// Returns the Annex bytes data (including first byte `0x50`).
     pub fn as_bytes(&self) -> &[u8] {
-        &*self.0
+        self.0
     }
 }
 


### PR DESCRIPTION
We have a bunch of clippy warnings on master, at least one of them is from a patch dated from March, before we ran clippy on CI.

Fix clippy warnings

- warning: accessing first element with `self.0.get(0)`
- warning: deref on an immutable reference
- warning: you are deriving `PartialEq` and can implement `Eq`

All one patch because clippy has to run cleanly for each patch on CI now.

Please note the `Eq` change, adding this derive is an API change.
