### PR TITLE
Pin honggfuzz dependency in an attempt to fix fuzzing in ci

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ afl_fuzz = ["afl"]
 honggfuzz_fuzz = ["honggfuzz"]
 
 [dependencies]
-honggfuzz = { version = "0.5", optional = true }
+honggfuzz = { version = "=0.5.54", optional = true }
 afl = { version = "0.4", optional = true }
 bitcoin = { path = ".." }
 


### PR DESCRIPTION
Fuzzing is failing on CI with the following error:

 The version of the honggfuzz library dependency (0.5.55) and the version of the `cargo-hfuzz` executable (0.5.54) do not match.
  If updating both by running `cargo update` and `cargo install honggfuzz` does not work, you can either:
  - change the dependency in `Cargo.toml` to `honggfuzz = "=0.5.54"`
  - or run `cargo install honggfuzz --version 0.5.55`

Pint the honggfuzz dependency as suggested in the error message - I did
not investigate further or think very deeply about this.