### PR TITLE
Temporarily disable fuzzing in CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,7 @@
 name: Fuzz
 
-on: [push, pull_request]
+# Temporarily disable job until someone works out how to fix honggfuzz.
+on: []
 
 jobs:
 


### PR DESCRIPTION
Honggfuzz is broken, I have no idea why but no PRs can merge while its broken.

(I tried a bunch of other things but could not debug this issue.)