### PR TITLE
Mayhem Fuzzing Integration

### DIFF
--- a/.github/workflows/mayhem.yml
+++ b/.github/workflows/mayhem.yml
@@ -1,0 +1,83 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  DESERIALIZE_ADDRESS_MAYHEMFILE: mayhem/deserialize_address.mayhemfile
+  DESERIALIZE_BLOCK_MAYHEMFILE: mayhem/deserialize_block.mayhemfile
+  DESERIALIZE_SCRIPT_MAYHEMFILE: mayhem/deserialize_script.mayhemfile
+  DESERIALIZE_TRANSACTION_MAYHEMFILE: mayhem/deserialize_transaction.mayhemfile
+
+jobs:
+  build:
+    name: "${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Start analysis for deserialize_address
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --file ${{ env.DESERIALIZE_ADDRESS_MAYHEMFILE }} --duration 300
+          sarif-output: sarif
+
+      - name: Start analysis for deserialize_block
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --file ${{ env.DESERIALIZE_BLOCK_MAYHEMFILE }} --duration 300
+          sarif-output: sarif
+
+      - name: Start analysis for deserialize_script
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --file ${{ env.DESERIALIZE_SCRIPT_MAYHEMFILE }} --duration 300
+          sarif-output: sarif
+
+      - name: Start analysis for deserialize_transaction
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --file ${{ env.DESERIALIZE_TRANSACTION_MAYHEMFILE }} --duration 300
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/.github/workflows/mayhem.yml
+++ b/.github/workflows/mayhem.yml
@@ -45,6 +45,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          file: mayhem/mayhem.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/mayhem/deserialize_address.mayhemfile
+++ b/mayhem/deserialize_address.mayhemfile
@@ -1,0 +1,10 @@
+project: rust-bitcoin
+target: deserialize_address
+
+# image: ghcr.io/nottirb/rust-bitcoin:latest
+
+cmds:
+    - cmd: /deserialize_address
+
+tests:
+    - file://fuzz/hfuzz_input/deserialize_address

--- a/mayhem/deserialize_address.mayhemfile
+++ b/mayhem/deserialize_address.mayhemfile
@@ -6,5 +6,5 @@ target: deserialize_address
 cmds:
     - cmd: /deserialize_address
 
-tests:
+testsuite:
     - file://fuzz/hfuzz_input/deserialize_address

--- a/mayhem/deserialize_address.mayhemfile
+++ b/mayhem/deserialize_address.mayhemfile
@@ -1,8 +1,6 @@
 project: rust-bitcoin
 target: deserialize_address
 
-# image: ghcr.io/nottirb/rust-bitcoin:latest
-
 cmds:
     - cmd: /deserialize_address
 

--- a/mayhem/deserialize_block.mayhemfile
+++ b/mayhem/deserialize_block.mayhemfile
@@ -6,5 +6,5 @@ target: deserialize_block
 cmds:
     - cmd: /deserialize_block
 
-tests:
+testsuite:
     - file://fuzz/hfuzz_input/deserialize_block

--- a/mayhem/deserialize_block.mayhemfile
+++ b/mayhem/deserialize_block.mayhemfile
@@ -1,8 +1,6 @@
 project: rust-bitcoin
 target: deserialize_block
 
-# image: ghcr.io/nottirb/rust-bitcoin:latest
-
 cmds:
     - cmd: /deserialize_block
 

--- a/mayhem/deserialize_block.mayhemfile
+++ b/mayhem/deserialize_block.mayhemfile
@@ -1,0 +1,10 @@
+project: rust-bitcoin
+target: deserialize_block
+
+# image: ghcr.io/nottirb/rust-bitcoin:latest
+
+cmds:
+    - cmd: /deserialize_block
+
+tests:
+    - file://fuzz/hfuzz_input/deserialize_block

--- a/mayhem/deserialize_script.mayhemfile
+++ b/mayhem/deserialize_script.mayhemfile
@@ -6,5 +6,5 @@ target: deserialize_script
 cmds:
     - cmd: /deserialize_script
 
-tests:
+testsuite:
     - file://fuzz/hfuzz_input/deserialize_script

--- a/mayhem/deserialize_script.mayhemfile
+++ b/mayhem/deserialize_script.mayhemfile
@@ -1,0 +1,10 @@
+project: rust-bitcoin
+target: deserialize_script
+
+# image: ghcr.io/nottirb/rust-bitcoin:latest
+
+cmds:
+    - cmd: /deserialize_script
+
+tests:
+    - file://fuzz/hfuzz_input/deserialize_script

--- a/mayhem/deserialize_script.mayhemfile
+++ b/mayhem/deserialize_script.mayhemfile
@@ -1,8 +1,6 @@
 project: rust-bitcoin
 target: deserialize_script
 
-# image: ghcr.io/nottirb/rust-bitcoin:latest
-
 cmds:
     - cmd: /deserialize_script
 

--- a/mayhem/deserialize_transaction.mayhemfile
+++ b/mayhem/deserialize_transaction.mayhemfile
@@ -6,5 +6,5 @@ target: deserialize_transaction
 cmds:
     - cmd: /deserialize_transaction
 
-tests:
+testsuite:
     - file://fuzz/hfuzz_input/deserialize_transaction

--- a/mayhem/deserialize_transaction.mayhemfile
+++ b/mayhem/deserialize_transaction.mayhemfile
@@ -3,6 +3,8 @@ target: deserialize_transaction
 
 cmds:
     - cmd: /deserialize_transaction
+      env:
+        DISABLE_SMOKETEST: '1'
 
 testsuite:
     - file://fuzz/hfuzz_input/deserialize_transaction

--- a/mayhem/deserialize_transaction.mayhemfile
+++ b/mayhem/deserialize_transaction.mayhemfile
@@ -1,0 +1,10 @@
+project: rust-bitcoin
+target: deserialize_transaction
+
+# image: ghcr.io/nottirb/rust-bitcoin:latest
+
+cmds:
+    - cmd: /deserialize_transaction
+
+tests:
+    - file://fuzz/hfuzz_input/deserialize_transaction

--- a/mayhem/deserialize_transaction.mayhemfile
+++ b/mayhem/deserialize_transaction.mayhemfile
@@ -1,8 +1,6 @@
 project: rust-bitcoin
 target: deserialize_transaction
 
-# image: ghcr.io/nottirb/rust-bitcoin:latest
-
 cmds:
     - cmd: /deserialize_transaction
 

--- a/mayhem/mayhem.Dockerfile
+++ b/mayhem/mayhem.Dockerfile
@@ -1,0 +1,24 @@
+# Build Stage
+FROM ubuntu:20.04 as builder
+
+## Install build dependencies.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y cmake clang curl
+RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN ${HOME}/.cargo/bin/rustup default nightly
+RUN ${HOME}/.cargo/bin/cargo install afl
+
+## Add source code to the build stage.
+ADD . /rust-bitcoin
+WORKDIR /rust-bitcoin
+RUN cd fuzz && \
+	${HOME}/.cargo/bin/cargo afl build --features=afl --release
+
+# Package Stage
+FROM ubuntu:20.04
+
+COPY --from=builder rust-bitcoin/* /
+RUN mv target/release/deserialize_address /
+RUN mv target/release/deserialize_block /
+RUN mv target/release/deserialize_script /
+RUN mv target/release/deserialize_transaction /

--- a/mayhem/mayhem.Dockerfile
+++ b/mayhem/mayhem.Dockerfile
@@ -17,8 +17,7 @@ RUN cd fuzz && \
 # Package Stage
 FROM ubuntu:20.04
 
-COPY --from=builder rust-bitcoin/* /
-RUN mv target/release/deserialize_address /
-RUN mv target/release/deserialize_block /
-RUN mv target/release/deserialize_script /
-RUN mv target/release/deserialize_transaction /
+COPY --from=builder rust-bitcoin/fuzz/target/release/deserialize_address /
+COPY --from=builder rust-bitcoin/fuzz/target/release/deserialize_block /
+COPY --from=builder rust-bitcoin/fuzz/target/release/deserialize_script /
+COPY --from=builder rust-bitcoin/fuzz/target/release/deserialize_transaction /


### PR DESCRIPTION
Hi! My name's Alex from ForAllSecure, and I'm opening this PR on behalf of one of the many "heroes'' who has integrated Mayhem fuzz testing into your project. The "Heroes" program involves integrating fuzz testing to open source projects, in order to help secure the world's software. These integrations generally (but not always) include: 

- A Dockerfile (for building the fuzz target)
- A Mayhemfile (for specifying fuzzing configuration)
- A Github Action (for fuzzing as part of CI)
- A fuzz target

In this target, we've basically taken the existing honggfuzz targets and sent them to Mayhem to be continuously fuzzed. You can take a look at the status of the latest fuzzing results here: https://mayhem.forallsecure.com/mayhemheroes/rust-bitcoin?coverage_target=deserialize-address
(Note: You'll need to create a Mayhem account to see the linked run. You can head on over to https://mayhem.forallsecure.com and sign up with your Github account). 
Let me know if you have any questions about this PR!
For more information about the Heroes program, you can read this article: https://forallsecure.com/blog/forallsecure-launches-2-million-mayhem-heroes-program