### PR TITLE
Set default-features = false on honggfuzz dependency for MSRV

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ afl_fuzz = ["afl"]
 honggfuzz_fuzz = ["honggfuzz"]
 
 [dependencies]
-honggfuzz = { version = "0.5", optional = true }
+honggfuzz = { version = "0.5", optional = true, default-features = false }
 afl = { version = "0.4", optional = true }
 bitcoin = { path = ".." }
 


### PR DESCRIPTION
honggfuzz now has an MSRV of 1.47 without `arbitrary`, but in order
to get that we have to turn off default-features.