### PR TITLE
[update] macro to implement Debug from Display and add Display implementation where needed

### DIFF
--- a/src/blockdata/opcodes.rs
+++ b/src/blockdata/opcodes.rs
@@ -14,7 +14,7 @@
 #[cfg(feature = "serde")] use crate::prelude::*;
 
 use core::{fmt, convert::From};
-use crate::internal_macros::display_from_debug;
+use crate::internal_macros::debug_from_display;
 
 // Note: I am deliberately not implementing PartialOrd or Ord on the
 //       opcode enum. If you want to check ranges of opcodes, etc.,
@@ -549,7 +549,7 @@ pub mod all {
     pub const OP_INVALIDOPCODE: All = All {code: 0xff};
 }
 
-impl fmt::Debug for All {
+impl fmt::Display for All {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("OP_")?;
         match *self {
@@ -745,7 +745,7 @@ impl From<u8> for All {
     }
 }
 
-display_from_debug!(All);
+debug_from_display!(All);
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
@@ -786,19 +786,6 @@ pub enum Class {
     Ordinary(Ordinary)
 }
 
-display_from_debug!(Class);
-
-#[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl serde::Serialize for Class {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
-}
-
 macro_rules! ordinary_opcode {
     ($($op:ident),*) => (
         #[repr(u8)]
@@ -806,6 +793,14 @@ macro_rules! ordinary_opcode {
         #[derive(Copy, Clone, PartialEq, Eq, Debug)]
         pub enum Ordinary {
             $( $op = all::$op.code ),*
+        }
+
+        impl fmt::Display for Ordinary {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match *self {
+                   $(Ordinary::$op => { f.pad(stringify!($op)) }),*
+                }
+            }
         }
 
         impl Ordinary {
@@ -866,7 +861,6 @@ impl Ordinary {
     pub fn to_u8(self) -> u8 {
         self as u8
     }
-
 }
 
 #[cfg(test)]
@@ -1068,10 +1062,10 @@ mod tests {
         roundtrip!(unique, OP_NUMEQUAL);
         roundtrip!(unique, OP_NUMEQUALVERIFY);
         roundtrip!(unique, OP_NUMNOTEQUAL);
-        roundtrip!(unique, OP_LESSTHAN );
-        roundtrip!(unique, OP_GREATERTHAN );
-        roundtrip!(unique, OP_LESSTHANOREQUAL );
-        roundtrip!(unique, OP_GREATERTHANOREQUAL );
+        roundtrip!(unique, OP_LESSTHAN);
+        roundtrip!(unique, OP_GREATERTHAN);
+        roundtrip!(unique, OP_LESSTHANOREQUAL);
+        roundtrip!(unique, OP_GREATERTHANOREQUAL);
         roundtrip!(unique, OP_MIN);
         roundtrip!(unique, OP_MAX);
         roundtrip!(unique, OP_WITHIN);

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -18,7 +18,7 @@ use crate::io;
 use core::convert::TryFrom;
 use core::{fmt, default::Default};
 use core::ops::Index;
-use crate::internal_macros::display_from_debug;
+use crate::internal_macros::debug_from_display;
 
 #[cfg(feature = "serde")] use serde;
 
@@ -121,9 +121,16 @@ impl core::str::FromStr for Script {
 }
 
 /// An object which can be used to construct a script piece by piece.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Builder(Vec<u8>, Option<opcodes::All>);
-display_from_debug!(Builder);
+
+impl fmt::Display for Builder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Script::bytes_to_asm_fmt(self.0.as_ref(), f)
+    }
+}
+
+debug_from_display!(Builder);
 
 impl<I> Index<I> for Builder
 where

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -107,16 +107,16 @@ macro_rules! impl_array_newtype {
 }
 pub(crate) use impl_array_newtype;
 
-macro_rules! display_from_debug {
+macro_rules! debug_from_display {
     ($thing:ident) => {
-        impl core::fmt::Display for $thing {
+        impl core::fmt::Debug for $thing {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
-                core::fmt::Debug::fmt(self, f)
+                core::fmt::Display::fmt(self, f)
             }
         }
     };
 }
-pub(crate) use display_from_debug;
+pub(crate) use debug_from_display;
 
 #[cfg(test)]
 macro_rules! hex_script (($s:expr) => (<$crate::Script as core::str::FromStr>::from_str($s).unwrap()));

--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -127,7 +127,7 @@ macro_rules! construct_uint {
                 let your_bits = other.bits();
 
                 // Check for division by 0
-                assert!(your_bits != 0, "attempted to divide {} by zero", self);
+                assert!(your_bits != 0, "attempted to divide {:#x} by zero", self);
 
                 // Early return in case we are dividing by a larger number than us
                 if my_bits < your_bits {
@@ -393,10 +393,12 @@ macro_rules! construct_uint {
             }
         }
 
-        impl core::fmt::Debug for $name {
+        impl core::fmt::LowerHex for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let &$name(ref data) = self;
-                write!(f, "0x")?;
+                if f.alternate() {
+                    write!(f, "0x")?;
+                }
                 for ch in data.iter().rev() {
                     write!(f, "{:016x}", ch)?;
                 }
@@ -404,7 +406,11 @@ macro_rules! construct_uint {
             }
         }
 
-        $crate::internal_macros::display_from_debug!($name);
+        impl core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f,"{:#x}", self)
+            }
+        }
 
         impl $crate::consensus::Encodable for $name {
             #[inline]
@@ -565,15 +571,23 @@ mod tests {
 
     #[test]
     pub fn uint256_display_test() {
-        assert_eq!(format!("{}", Uint256::from_u64(0xDEADBEEF).unwrap()),
+        assert_eq!(format!("{:#x}", Uint256::from_u64(0xDEADBEEF).unwrap()),
                    "0x00000000000000000000000000000000000000000000000000000000deadbeef");
-        assert_eq!(format!("{}", Uint256::from_u64(u64::max_value()).unwrap()),
+        assert_eq!(format!("{:x}", Uint256::from_u64(0xDEADBEEF).unwrap()),
+                   "00000000000000000000000000000000000000000000000000000000deadbeef");
+        assert_eq!(format!("{:#x}", Uint256::from_u64(u64::max_value()).unwrap()),
                    "0x000000000000000000000000000000000000000000000000ffffffffffffffff");
 
         let max_val = Uint256([0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
                                0xFFFFFFFFFFFFFFFF]);
-        assert_eq!(format!("{}", max_val),
+        assert_eq!(format!("{:#x}", max_val),
                    "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    }
+
+    #[test]
+    pub fn uint256_debug_test() {
+        assert_eq!(format!("{:?}", Uint256::from_u64(0xDEADBEEF).unwrap()),
+                   "0x00000000000000000000000000000000000000000000000000000000deadbeef");
     }
 
     #[test]


### PR DESCRIPTION
Related to issue : [1201](https://github.com/rust-bitcoin/rust-bitcoin/issues/1201)

> Replaced macro **impl_display_from_debug** with **impl_debug_from_display**

> Added implementation of Display trait where needed.  