### PR TITLE
Improve CI script

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -102,9 +102,9 @@ fi
 # Bench if told to, only works with non-stable toolchain (nightly, beta).
 if [ "$DO_BENCH" = true ]
 then
-    if [ "NIGHTLY" = false ]
+    if [ "$NIGHTLY" = false ]
     then
-        if [ -n "TOOLCHAIN" ]
+        if [ -n "$TOOLCHAIN" ]
         then
             echo "TOOLCHAIN is set to a non-nightly toolchain but DO_BENCH requires a nightly toolchain"
         else

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -78,7 +78,7 @@ fi
 # Test each feature
 for feature in ${FEATURES}
 do
-    echo "********* Testing "$feature" *************"
+    echo "********* Testing $feature *************"
     cargo test --verbose --features="$feature"
 done
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,12 +2,6 @@
 
 FEATURES="base64 bitcoinconsensus serde rand secp-recovery"
 
-# Use toolchain if explicitly specified
-if [ -n "$TOOLCHAIN" ]
-then
-    alias cargo="cargo +$TOOLCHAIN"
-fi
-
 if [ "$DO_COV" = true ]
 then
     export RUSTFLAGS="-C link-dead-code"
@@ -104,9 +98,9 @@ if [ "$DO_BENCH" = true ]
 then
     if [ "$NIGHTLY" = false ]
     then
-        if [ -n "$TOOLCHAIN" ]
+        if [ -n "$RUSTUP_TOOLCHAIN" ]
         then
-            echo "TOOLCHAIN is set to a non-nightly toolchain but DO_BENCH requires a nightly toolchain"
+            echo "RUSTUP_TOOLCHAIN is set to a non-nightly toolchain but DO_BENCH requires a nightly toolchain"
         else
             echo "DO_BENCH requires a nightly toolchain"
         fi


### PR DESCRIPTION
Done while investigating the fuzzing issue, use `shellcheck` to lint the CI script.