### PR TITLE
Improve `serialize()` by preallocating the buffer

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -531,6 +531,7 @@ mod tests {
 
 #[cfg(bench)]
 mod benches {
+    use crate::consensus::serialize;
     use super::Block;
     use crate::consensus::{deserialize, Encodable, Decodable};
     use test::{black_box, Bencher};
@@ -550,7 +551,30 @@ mod benches {
     }
 
     #[bench]
+    pub fn bench_block_serialize_alloc(bh: &mut Bencher) {
+        let raw_block = include_bytes!("../../test_data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw");
+        let block: Block = deserialize(&raw_block[..]).unwrap();
+
+        bh.iter(|| {
+            let mut data = vec![];
+            let result = block.consensus_encode(&mut data);
+            black_box(&result);
+        });
+    }
+
+    #[bench]
     pub fn bench_block_serialize(bh: &mut Bencher) {
+        let raw_block = include_bytes!("../../test_data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw");
+        let block: Block = deserialize(&raw_block[..]).unwrap();
+
+        bh.iter(|| {
+            let result = serialize(&block);
+            black_box(&result);
+        });
+    }
+
+    #[bench]
+    pub fn bench_block_serialize_prealloc(bh: &mut Bencher) {
         let raw_block = include_bytes!("../../test_data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw");
 
         let block: Block = deserialize(&raw_block[..]).unwrap();

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -532,9 +532,9 @@ mod tests {
 #[cfg(bench)]
 mod benches {
     use super::Block;
-    use crate::EmptyWrite;
     use crate::consensus::{deserialize, Encodable, Decodable};
     use test::{black_box, Bencher};
+    use crate::prelude::sink;
 
     #[bench]
     pub fn bench_stream_reader(bh: &mut Bencher) {
@@ -571,7 +571,7 @@ mod benches {
         let block: Block = deserialize(&raw_block[..]).unwrap();
 
         bh.iter(|| {
-            let size = block.consensus_encode(&mut EmptyWrite);
+            let size = block.consensus_encode(&mut sink());
             black_box(&size);
         });
     }

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -61,7 +61,7 @@ pub struct BlockHeader {
     pub nonce: u32,
 }
 
-impl_consensus_encoding!(BlockHeader, version, prev_blockhash, merkle_root, time, bits, nonce);
+impl_consensus_encoding!(BlockHeader, 80, version, prev_blockhash, merkle_root, time, bits, nonce);
 
 impl BlockHeader {
     /// Returns the block hash.

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -597,11 +597,11 @@ impl Script {
         } else if self.is_witness_program() {
             32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
             8 + // The serialized size of the TxOut's amount field
-            self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+            self.serialized_len() as u64 // The serialized size of this script_pubkey
         } else {
             32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
             8 + // The serialized size of the TxOut's amount field
-            self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+            self.serialized_len() as u64 // The serialized size of this script_pubkey
         };
 
         crate::Amount::from_sat(sats)

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -1437,10 +1437,10 @@ mod tests {
 #[cfg(bench)]
 mod benches {
     use super::Transaction;
-    use crate::EmptyWrite;
     use crate::consensus::{deserialize, Encodable};
     use crate::hashes::hex::FromHex;
     use test::{black_box, Bencher};
+    use crate::prelude::sink;
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
@@ -1475,7 +1475,7 @@ mod benches {
         let tx: Transaction = deserialize(&raw_tx).unwrap();
 
         bh.iter(|| {
-            let size = tx.consensus_encode(&mut EmptyWrite);
+            let size = tx.consensus_encode(&mut sink());
             black_box(&size);
         });
     }

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -1439,6 +1439,7 @@ mod benches {
     use super::Transaction;
     use crate::consensus::{deserialize, Encodable};
     use crate::hashes::hex::FromHex;
+    use crate::consensus::serialize;
     use test::{black_box, Bencher};
     use crate::prelude::sink;
 
@@ -1457,6 +1458,29 @@ mod benches {
 
     #[bench]
     pub fn bench_transaction_serialize(bh: &mut Bencher) {
+        let raw_tx = Vec::from_hex(SOME_TX).unwrap();
+        let tx: Transaction = deserialize(&raw_tx).unwrap();
+
+        bh.iter(|| {
+            let result = serialize(&tx);
+            black_box(&result);
+        });
+    }
+
+    #[bench]
+    pub fn bench_transaction_serialize_alloc(bh: &mut Bencher) {
+        let raw_tx = Vec::from_hex(SOME_TX).unwrap();
+        let tx: Transaction = deserialize(&raw_tx).unwrap();
+
+        bh.iter(|| {
+            let mut data = vec![];
+            let result = tx.consensus_encode(&mut data);
+            black_box(&result);
+        });
+    }
+
+    #[bench]
+    pub fn bench_transaction_serialize_prealloc(bh: &mut Bencher) {
         let raw_tx = Vec::from_hex(SOME_TX).unwrap();
         let tx: Transaction = deserialize(&raw_tx).unwrap();
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -900,6 +900,7 @@ impl Encodable for OutPoint {
         let len = self.txid.consensus_encode(w)?;
         Ok(len + self.vout.consensus_encode(w)?)
     }
+    const STATIC_SERIALIZED_LEN: usize = Txid::STATIC_SERIALIZED_LEN + u32::STATIC_SERIALIZED_LEN;
 }
 impl Decodable for OutPoint {
     fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -122,6 +122,12 @@ impl Encodable for Witness {
         w.emit_slice(&self.content[..])?;
         Ok(self.content.len() + len.len())
     }
+    fn serialized_len(&self) -> usize {
+        VarInt(self.witness_elements as u64).len() + self.content.len()
+    }
+    fn serialized_len_early_stop(&self, _threshold: usize) -> Result<usize, usize> {
+        Ok(self.serialized_len())
+    }
 }
 
 impl Witness {
@@ -180,14 +186,6 @@ impl Witness {
     /// Returns the number of elements this witness holds
     pub fn len(&self) -> usize {
         self.witness_elements as usize
-    }
-
-    /// Returns the bytes required when this Witness is consensus encoded
-    pub fn serialized_len(&self) -> usize {
-        self.iter()
-            .map(|el| VarInt(el.len() as u64).len() + el.len())
-            .sum::<usize>()
-            + VarInt(self.witness_elements as u64).len()
     }
 
     /// Clear the witness

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -633,6 +633,20 @@ macro_rules! impl_vec {
                 }
                 Ok(len)
             }
+            fn serialized_len(&self) -> usize {
+                if <$type>::STATIC_SERIALIZED_LEN == 0 {
+                    VarInt(self.len() as u64).serialized_len() + <$type>::STATIC_SERIALIZED_LEN * self.len()
+                } else {
+                    Encodable::serialized_len(&self)
+                }
+            }
+            fn serialized_len_early_stop(&self, threshold: usize) -> Result<usize, usize> {
+                if <$type>::STATIC_SERIALIZED_LEN == 0 {
+                    Encodable::serialized_len_early_stop(&self, threshold)
+                } else {
+                    Ok(self.serialized_len())
+                }
+            }
         }
 
         impl Decodable for Vec<$type> {

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -131,7 +131,8 @@ impl From<psbt::Error> for Error {
 
 /// Encode an object into a vector
 pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
-    let mut encoder = Vec::new();
+    let capacity = data.serialized_len_early_stop(512).unwrap_or_else(|e| e);
+    let mut encoder = Vec::with_capacity(capacity);
     let len = data.consensus_encode(&mut encoder).expect("in-memory writers don't error");
     debug_assert_eq!(len, encoder.len());
     encoder

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -422,6 +422,7 @@ macro_rules! impl_int_encodable {
                 w.$meth_enc(*self)?;
                 Ok(mem::size_of::<$ty>())
             }
+            const STATIC_SERIALIZED_LEN: usize = mem::size_of::<$ty>();
         }
     }
 }

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -306,6 +306,12 @@ pub trait Encodable {
     ///
     /// The only errors returned are errors propagated from the writer.
     fn consensus_encode<W: io::Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error>;
+
+    /// Returns the bytes needed when `self` is serialized
+    fn serialized_len(&self) -> usize {
+        self.consensus_encode(&mut sink()).unwrap()
+    }
+
 }
 
 /// Data which can be encoded in a consensus-consistent way

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -477,6 +477,12 @@ impl Encodable for VarInt {
             },
         }
     }
+    fn serialized_len(&self) -> usize {
+        self.len()
+    }
+    fn serialized_len_early_stop(&self, _threshold: usize) -> Result<usize, usize> {
+        Ok(self.len())
+    }
 }
 
 impl Decodable for VarInt {

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -16,6 +16,7 @@ macro_rules! impl_hashencode {
             fn consensus_encode<W: $crate::io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, $crate::io::Error> {
                 self.0.consensus_encode(w)
             }
+            const STATIC_SERIALIZED_LEN: usize = Self::LEN;
         }
 
         impl $crate::consensus::Decodable for $hashtype {
@@ -32,7 +33,7 @@ pub use newtypes::*;
 
 #[rustfmt::skip]
 mod newtypes {
-    use crate::hashes::{sha256, sha256d, hash160, hash_newtype};
+    use crate::hashes::{sha256, sha256d, hash160, hash_newtype, Hash};
 
     hash_newtype!(
         Txid, sha256d::Hash, 32, doc="A bitcoin transaction hash/transaction ID.

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -8,6 +8,10 @@
 
 macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
+        impl_consensus_encoding!($thing, 0, $($field),+);
+    );
+
+    ($thing:ident, $static:expr, $($field:ident),+) => (
         impl $crate::consensus::Encodable for $thing {
             #[inline]
             fn consensus_encode<R: $crate::io::Write + ?Sized>(
@@ -18,6 +22,7 @@ macro_rules! impl_consensus_encoding {
                 $(len += self.$field.consensus_encode(r)?;)+
                 Ok(len)
             }
+            const STATIC_SERIALIZED_LEN: usize = $static;
         }
 
         impl $crate::consensus::Decodable for $thing {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ mod internal_macros;
 mod parse;
 #[cfg(feature = "serde")]
 mod serde_utils;
+mod serialized_len;
 
 #[macro_use]
 pub mod network;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,27 +161,3 @@ mod prelude {
     #[cfg(not(feature = "hashbrown"))]
     pub use std::collections::HashSet;
 }
-
-#[cfg(bench)]
-use bench::EmptyWrite;
-
-#[cfg(bench)]
-mod bench {
-    use core::fmt::Arguments;
-
-    use crate::io::{IoSlice, Result, Write};
-
-    #[derive(Default, Clone, Debug, PartialEq, Eq)]
-    pub struct EmptyWrite;
-
-    impl Write for EmptyWrite {
-        fn write(&mut self, buf: &[u8]) -> Result<usize> { Ok(buf.len()) }
-        fn write_vectored(&mut self, bufs: &[IoSlice]) -> Result<usize> {
-            Ok(bufs.iter().map(|s| s.len()).sum())
-        }
-        fn flush(&mut self) -> Result<()> { Ok(()) }
-
-        fn write_all(&mut self, _: &[u8]) -> Result<()> { Ok(()) }
-        fn write_fmt(&mut self, _: Arguments) -> Result<()> { Ok(()) }
-    }
-}

--- a/src/serialized_len.rs
+++ b/src/serialized_len.rs
@@ -32,8 +32,11 @@ impl io::Write for WriteCounterThreshold {
 #[cfg(test)]
 mod test {
     use crate::OutPoint;
+    use bitcoin_hashes::Hash;
+
     use crate::consensus::{serialize, Encodable};
     use crate::constants::genesis_block;
+    use crate::{BlockHash, Witness};
 
     #[test]
     fn test_serialized_len() {
@@ -47,6 +50,24 @@ mod test {
 
         let out_point = OutPoint::default();
         assert_eq!(serialize(&out_point).len(), out_point.serialized_len());
+
+        assert_eq!(
+            Ok(8),
+            0u64.serialized_len_early_stop(1),
+            "STATIC_SERIALIZED_LEN is None for int type"
+        );
+
+        let mut witness = Witness::default();
+        witness.push(vec![0u8]);
+        assert_eq!(serialize(&witness).len(), witness.serialized_len());
+    }
+
+    #[test]
+    fn test_serialized_len_vec() {
+        let hashes = vec![BlockHash::all_zeros(); 10];
+        assert_eq!(serialize(&hashes).len(), 321);
+        assert_eq!(hashes.serialized_len(), 321);
+        assert_eq!(hashes.serialized_len_early_stop(1), Ok(321));
     }
 }
 

--- a/src/serialized_len.rs
+++ b/src/serialized_len.rs
@@ -31,6 +31,7 @@ impl io::Write for WriteCounterThreshold {
 
 #[cfg(test)]
 mod test {
+    use crate::OutPoint;
     use crate::consensus::{serialize, Encodable};
     use crate::constants::genesis_block;
 
@@ -43,6 +44,9 @@ mod test {
         let ser_stop = tx.serialized_len_early_stop(20);
         assert!(ser_stop.is_err());
         assert!(ser_stop.unwrap_err() > 20);
+
+        let out_point = OutPoint::default();
+        assert_eq!(serialize(&out_point).len(), out_point.serialized_len());
     }
 }
 

--- a/src/serialized_len.rs
+++ b/src/serialized_len.rs
@@ -1,0 +1,30 @@
+use crate::io;
+
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WriteCounterThreshold {
+    counter: usize,
+    threshold: usize,
+}
+
+impl WriteCounterThreshold {
+    pub(crate) fn new(threshold: usize) -> Self { Self { counter: 0, threshold } }
+    pub(crate) fn bytes_written(&self) -> usize { self.counter }
+
+    fn increment_counter(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.counter += buf.len();
+        if self.counter > self.threshold {
+            Err(io::Error::from(io::ErrorKind::Other))
+        } else {
+            Ok(buf.len())
+        }
+    }
+}
+
+impl io::Write for WriteCounterThreshold {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.increment_counter(buf) }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.increment_counter(buf)?;
+        Ok(())
+    }
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}


### PR DESCRIPTION
Supersede #1027 

In comparison to #1027, this is more straightforward, safer, and ready. On the cons maybe could be a little less performant in some cases.

Many more overrides are possible (like for `BlockHeader`, `Script`, `TxOut`, and smaller objects frequently used by downstream libs as key/value objects) but kept for a subsequent MR.

Benchmarks show great improvement for small objects without sacrificing big objects performance

* `*_serialize_alloc` is comparable to serialize on master
* `*_serialize` is this branch
* `*_serialize_prealloc` is considering known the size beforehand

```
test blockdata::block::benches::bench_block_serialize                      ... bench:     600,484 ns/iter (+/- 5,266)
test blockdata::block::benches::bench_block_serialize_alloc                ... bench:     618,795 ns/iter (+/- 4,810)
test blockdata::block::benches::bench_block_serialize_logic                ... bench:     145,143 ns/iter (+/- 985)
test blockdata::block::benches::bench_block_serialize_prealloc             ... bench:     615,802 ns/iter (+/- 7,502)
test blockdata::transaction::benches::bench_transaction_serialize          ... bench:         258 ns/iter (+/- 21)
test blockdata::transaction::benches::bench_transaction_serialize_alloc    ... bench:         521 ns/iter (+/- 18)
test blockdata::transaction::benches::bench_transaction_serialize_logic    ... bench:          19 ns/iter (+/- 0)
test blockdata::transaction::benches::bench_transaction_serialize_prealloc ... bench:          77 ns/iter (+/- 3)
test serialized_len::bench::bench_block_serialized_len                     ... bench:     141,516 ns/iter (+/- 4,184)
test serialized_len::bench::bench_block_serialized_len_early_stop          ... bench:         606 ns/iter (+/- 52)
test serialized_len::bench::bench_out_point_serialize                      ... bench:          35 ns/iter (+/- 0)
test serialized_len::bench::bench_out_point_serialize                      ... bench:          57 ns/iter (+/- 2)  # before impl custom serialized_len*()
test serialized_len::bench::bench_out_point_serialize_alloc                ... bench:         121 ns/iter (+/- 1)
test serialized_len::bench::bench_transaction_serialize_len                ... bench:         248 ns/iter (+/- 14)
test serialized_len::bench::bench_transaction_serialized_len               ... bench:          17 ns/iter (+/- 2)
```