### PR TITLE
Add new type for block version

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -18,7 +18,7 @@ use crate::blockdata::opcodes;
 use crate::blockdata::script;
 use crate::blockdata::locktime::absolute;
 use crate::blockdata::transaction::{OutPoint, Transaction, TxOut, TxIn, Sequence};
-use crate::blockdata::block::{Block, BlockHeader};
+use crate::blockdata::block::{Block, BlockHeader, BlockVersion};
 use crate::blockdata::witness::Witness;
 use crate::network::constants::Network;
 use crate::util::uint::Uint256;
@@ -115,7 +115,7 @@ pub fn genesis_block(network: Network) -> Block {
         Network::Bitcoin => {
             Block {
                 header: BlockHeader {
-                    version: 1,
+                    version: BlockVersion(1),
                     prev_blockhash: Hash::all_zeros(),
                     merkle_root,
                     time: 1231006505,
@@ -128,7 +128,7 @@ pub fn genesis_block(network: Network) -> Block {
         Network::Testnet => {
             Block {
                 header: BlockHeader {
-                    version: 1,
+                    version: BlockVersion(1),
                     prev_blockhash: Hash::all_zeros(),
                     merkle_root,
                     time: 1296688602,
@@ -141,7 +141,7 @@ pub fn genesis_block(network: Network) -> Block {
         Network::Signet => {
             Block {
                 header: BlockHeader {
-                    version: 1,
+                    version: BlockVersion(1),
                     prev_blockhash: Hash::all_zeros(),
                     merkle_root,
                     time: 1598918400,
@@ -154,7 +154,7 @@ pub fn genesis_block(network: Network) -> Block {
         Network::Regtest => {
             Block {
                 header: BlockHeader {
-                    version: 1,
+                    version: BlockVersion(1),
                     prev_blockhash: Hash::all_zeros(),
                     merkle_root,
                     time: 1296688602,
@@ -227,7 +227,7 @@ mod test {
     fn bitcoin_genesis_full_block() {
         let gen = genesis_block(Network::Bitcoin);
 
-        assert_eq!(gen.header.version, 1);
+        assert_eq!(gen.header.version, BlockVersion(1));
         assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
         assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 
@@ -240,7 +240,7 @@ mod test {
     #[test]
     fn testnet_genesis_full_block() {
         let gen = genesis_block(Network::Testnet);
-        assert_eq!(gen.header.version, 1);
+        assert_eq!(gen.header.version, BlockVersion(1));
         assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
         assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
         assert_eq!(gen.header.time, 1296688602);
@@ -252,7 +252,7 @@ mod test {
     #[test]
     fn signet_genesis_full_block() {
         let gen = genesis_block(Network::Signet);
-        assert_eq!(gen.header.version, 1);
+        assert_eq!(gen.header.version, BlockVersion(1));
         assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
         assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
         assert_eq!(gen.header.time, 1598918400);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ use std::io;
 use core2::io;
 
 pub use crate::address::{Address, AddressType};
-pub use crate::blockdata::block::{self, Block, BlockHeader};
+pub use crate::blockdata::block::{self, Block, BlockHeader, BlockVersion};
 pub use crate::blockdata::locktime::{self, absolute, relative};
 pub use crate::blockdata::script::{self, Script};
 #[allow(deprecated)]

--- a/src/util/bip152.rs
+++ b/src/util/bip152.rs
@@ -376,7 +376,7 @@ mod test {
     use crate::consensus::encode::{deserialize, serialize};
     use crate::hashes::hex::FromHex;
     use crate::{
-        Block, BlockHash, BlockHeader, OutPoint, Script, Sequence, Transaction, TxIn, TxMerkleNode,
+        Block, BlockHash, BlockHeader, BlockVersion, OutPoint, Script, Sequence, Transaction, TxIn, TxMerkleNode,
         TxOut, Txid, Witness,
     };
 
@@ -397,7 +397,7 @@ mod test {
     fn dummy_block() -> Block {
         Block {
             header: BlockHeader {
-                version: 1,
+                version: BlockVersion(1),
                 prev_blockhash: BlockHash::hash(&[0]),
                 merkle_root: TxMerkleNode::hash(&[1]),
                 time: 2,


### PR DESCRIPTION
Added new type `BlockVersion` for block header version field with inspiration from [Kixunil 's comment on #1215.](https://github.com/rust-bitcoin/rust-bitcoin/issues/1215#issue-1352273532)

I previously knew very little about the upgrading process so it was fun learning about it in writing this PR, however that also means it's probably not perfect yet, especially around BIP-9 signalling (fingers crossed it's all correct).

API for the type is kept simple but happy to change it up to add more functionality.