### PR TITLE
Use correct path for bip158 in rustdoc

### DIFF
--- a/src/bip158.rs
+++ b/src/bip158.rs
@@ -464,7 +464,7 @@ impl<'a, R: io::Read> BitStreamReader<'a, R> {
     ///
     /// # Examples
     /// ```
-    /// # use bitcoin::util::bip158::BitStreamReader;
+    /// # use bitcoin::bip158::BitStreamReader;
     /// # let data = vec![0xff];
     /// # let mut input = data.as_slice();
     /// let mut reader = BitStreamReader::new(&mut input); // input contains all 1's


### PR DESCRIPTION
Recently we moved the `bip158` module but I missed one of the import statements in rustdoc - if only I could work out how to lint rustdocs.