### PR TITLE
implement `From<PublicKey>` for `PubkeyHash`

### DIFF
--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -296,6 +296,12 @@ impl FromStr for PublicKey {
     }
 }
 
+impl From<PublicKey> for PubkeyHash {
+    fn from(key: PublicKey) -> PubkeyHash {
+        key.pubkey_hash()
+    }
+}
+
 /// A Bitcoin ECDSA private key
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]


### PR DESCRIPTION
Part of #1245.

Do we also want a method on `PubkeyHash` or is the `From` impl sufficient?

