### PR TITLE
Run cargo fmt

### DIFF
--- a/examples/ecdsa-psbt.rs
+++ b/examples/ecdsa-psbt.rs
@@ -43,8 +43,8 @@ use bitcoin::util::bip32::{
 };
 use bitcoin::util::psbt::{self, Input, Psbt, PsbtSighashType};
 use bitcoin::{
-    address, Address, Amount, Network, OutPoint, PrivateKey, PublicKey, Script,
-    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+    address, Address, Amount, Network, OutPoint, PrivateKey, PublicKey, Script, Sequence,
+    Transaction, TxIn, TxOut, Txid, Witness,
 };
 
 use self::psbt_sign::*;

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -117,7 +117,6 @@ macro_rules! debug_from_display {
     };
 }
 pub(crate) use debug_from_display;
-
 #[cfg(test)]
 pub(crate) use test_macros::*;
 


### PR DESCRIPTION
A few trivial formatting errors have snuck into the codebase.

Run `cargo +nightly fmt`

FTR we have an open PR to run formatter in CI: https://github.com/rust-bitcoin/rust-bitcoin/pull/1111