### PR TITLE
Add a comment to delineate test_macros re-export

### DIFF
--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -117,6 +117,7 @@ macro_rules! debug_from_display {
     };
 }
 pub(crate) use debug_from_display;
+// We use test_macros module to keep things organised, re-export everything for ease of use.
 #[cfg(test)]
 pub(crate) use test_macros::*;
 


### PR DESCRIPTION
The formatter removes an empty line that is clearly better to have. Add a rustdoc comment to at least delineate the line a bit.