### PR TITLE
Add API method `absolute::LockTime::is_satisfied_by_lock`

### DIFF
--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -316,7 +316,8 @@ impl LockTime {
     /// mathematical sense) the smaller one being satisfied.
     ///
     /// This function is useful if you wish to check a lock time against various other locks e.g.,
-    /// filtering out locks which cannot be satisfied.
+    /// filtering out locks which cannot be satisfied. Can also be used to remove the smaller value
+    /// of two `OP_CHECKLOCKTIMEVERIFY` operations within one branch of the script.
     ///
     /// # Examples
     ///

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -318,7 +318,7 @@ impl LockTime {
     /// ```rust
     /// # use bitcoin::absolute::{LockTime, LockTime::*};
     /// # let n = LockTime::from_consensus(100);          // n OP_CHECKLOCKTIMEVERIFY
-    /// # let lock_time = LockTime::from_consensus(100);  // nLockTime
+    /// # let lock_time = LockTime::from_consensus(100 + 1);  // nLockTime
     ///
     /// let is_satisfied = match (n, lock_time) {
     ///     (Blocks(n), Blocks(lock_time)) => n <= lock_time,

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -62,11 +62,12 @@ impl LockTime {
         }
     }
 
-    /// Returns true if this [`relative::LockTime`] is satisfied by `other` lock.
+    /// Returns true if satisfaction of `other` lock time implies satisfaction of this
+    /// [`relative::LockTime`].
     ///
     /// This function is useful when checking sequence values against a lock, first one checks the
     /// sequence represents a relative lock time by converting to `LockTime` then use this function
-    /// to see if [`LockTime`] is satisfied by the newly created lock.
+    /// to see if satisfaction of the newly created lock time would imply satisfaction of `self`.
     ///
     /// # Examples
     ///
@@ -80,16 +81,16 @@ impl LockTime {
     ///
     /// let satisfied = match test_sequence.to_relative_lock_time() {
     ///     None => false, // Handle non-lock-time case.
-    ///     Some(test_lock) => lock.is_satisfied_by_lock(test_lock),
+    ///     Some(test_lock) => lock.is_implied_by(test_lock),
     /// };
     /// assert!(satisfied);
     /// ```
-    pub fn is_satisfied_by_lock(&self, other: LockTime) -> bool {
+    pub fn is_implied_by(&self, other: LockTime) -> bool {
         use LockTime::*;
 
         match (*self, other) {
-            (Blocks(n), Blocks(m)) => n.value() <= m.value(),
-            (Time(n), Time(m)) => n.value() <= m.value(),
+            (Blocks(this), Blocks(other)) => this.value() <= other.value(),
+            (Time(this), Time(other)) => this.value() <= other.value(),
             _ => false, // Not the same units.
         }
     }

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -65,9 +65,16 @@ impl LockTime {
     /// Returns true if satisfaction of `other` lock time implies satisfaction of this
     /// [`relative::LockTime`].
     ///
+    /// A lock time can only be satisfied by n blocks being mined or n seconds passing. If you have
+    /// two lock times (same unit) then the larger lock time being satisfied implies (in a
+    /// mathematical sense) the smaller one being satisfied.
+    ///
     /// This function is useful when checking sequence values against a lock, first one checks the
     /// sequence represents a relative lock time by converting to `LockTime` then use this function
     /// to see if satisfaction of the newly created lock time would imply satisfaction of `self`.
+    ///
+    /// Can also be used to remove the smaller value of two `OP_CHECKSEQUENCEVERIFY` operations
+    /// within one branch of the script.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Patch 1 is a docs improvement.

Patch 2 commit log:

When implementing the absolute lock time API we decided on _not_
supporting checking lock satisfaction with another lock, instead we
provided a pattern in the docs for doing so. Fast forward a months and
I, the primary author, then forgot to use the correct pattern when using
the API in `rust-miniscript` - this is a sure sign that the API is too
hard to use. In this time we worked on the relative lock API and came up
with a `is_satisfied_by_lock` method - this is identical to the required
use case in the absolute lock time module.
    
Add a method on `absolute::LockTime` for checking a lock against another
lock, add rustdoc comment explaining the methods function in filtering
prospective lock time values (how we use it in `rust-miniscript`).
