### PR TITLE
Move/re-name the `util::misc` module

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -86,6 +86,7 @@ pub mod consensus;
 pub mod error;
 pub mod hash_types;
 pub mod policy;
+pub mod sign_message;
 pub mod util;
 
 #[cfg(feature = "std")]

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -15,7 +15,6 @@ pub mod bip32;
 pub mod bip152;
 pub mod hash;
 pub mod merkleblock;
-pub mod misc;
 pub mod psbt;
 pub mod taproot;
 pub mod uint;
@@ -119,3 +118,53 @@ pub mod address {
 
 #[deprecated(since = "0.30.0", note = "Please use crate::bip158")]
 pub use crate::bip158;
+
+/// The `misc` module was moved and re-named to `sign_message`.
+pub mod misc {
+    use crate::prelude::*;
+
+    /// Search for `needle` in the vector `haystack` and remove every
+    /// instance of it, returning the number of instances removed.
+    /// Loops through the vector opcode by opcode, skipping pushed data.
+    // For why we deprecated see: https://github.com/rust-bitcoin/rust-bitcoin/pull/1259#discussion_r968613736
+    #[deprecated(since = "0.30.0", note = "No longer supported")]
+    pub fn script_find_and_remove(haystack: &mut Vec<u8>, needle: &[u8]) -> usize {
+        use crate::blockdata::opcodes;
+
+        if needle.len() > haystack.len() {
+            return 0;
+        }
+        if needle.is_empty() {
+            return 0;
+        }
+
+        let mut top = haystack.len() - needle.len();
+        let mut n_deleted = 0;
+
+        let mut i = 0;
+        while i <= top {
+            if &haystack[i..(i + needle.len())] == needle {
+                for j in i..top {
+                    haystack.swap(j + needle.len(), j);
+                }
+                n_deleted += 1;
+                // This is ugly but prevents infinite loop in case of overflow
+                let overflow = top < needle.len();
+                top = top.wrapping_sub(needle.len());
+                if overflow {
+                    break;
+                }
+            } else {
+                i += match opcodes::All::from((*haystack)[i]).classify(opcodes::ClassifyContext::Legacy) {
+                    opcodes::Class::PushBytes(n) => n as usize + 1,
+                    opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA1) => 2,
+                    opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA2) => 3,
+                    opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA4) => 5,
+                    _ => 1
+                };
+            }
+        }
+        haystack.truncate(top.wrapping_add(needle.len()));
+        n_deleted
+    }
+}


### PR DESCRIPTION
Done as part of [flattening util](https://github.com/rust-bitcoin/rust-bitcoin/issues/639).

Move some code out of `misc` then re-name the module to `signature` and move it to the crate root.

- Patch 1: Move a single public function, needs review that destination module is ok. I did consider re-naming the function to remove `script_` prefix but decided to leave it as is.
- Patch 2: Re-names `misc` -> `signature` and puts it in the crate root
- Patch 3: Runs the formatter on `signature` module

All changes include deprecated re-exports.