### PR TITLE
Clean up the `base58` module

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -523,13 +523,13 @@ impl<'a> fmt::Display for AddressEncoding<'a> {
                 let mut prefixed = [0; 21];
                 prefixed[0] = self.p2pkh_prefix;
                 prefixed[1..].copy_from_slice(&hash[..]);
-                base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
+                base58::encode_check_to_fmt(fmt, &prefixed[..])
             }
             Payload::ScriptHash(hash) => {
                 let mut prefixed = [0; 21];
                 prefixed[0] = self.p2sh_prefix;
                 prefixed[1..].copy_from_slice(&hash[..]);
-                base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
+                base58::encode_check_to_fmt(fmt, &prefixed[..])
             }
             Payload::WitnessProgram { version, program: prog } => {
                 let mut upper_writer;
@@ -839,7 +839,7 @@ impl FromStr for Address {
         if s.len() > 50 {
             return Err(Error::Base58(base58::Error::InvalidLength(s.len() * 11 / 15)));
         }
-        let data = base58::from_check(s)?;
+        let data = base58::decode_check(s)?;
         if data.len() != 21 {
             return Err(Error::Base58(base58::Error::InvalidLength(data.len())));
         }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -780,7 +780,7 @@ impl ExtendedPubKey {
 
 impl fmt::Display for ExtendedPrivKey {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        base58::check_encode_slice_to_fmt(fmt, &self.encode()[..])
+        base58::encode_check_to_fmt(fmt, &self.encode()[..])
     }
 }
 
@@ -788,7 +788,7 @@ impl FromStr for ExtendedPrivKey {
     type Err = Error;
 
     fn from_str(inp: &str) -> Result<ExtendedPrivKey, Error> {
-        let data = base58::from_check(inp)?;
+        let data = base58::decode_check(inp)?;
 
         if data.len() != 78 {
             return Err(base58::Error::InvalidLength(data.len()).into());
@@ -800,7 +800,7 @@ impl FromStr for ExtendedPrivKey {
 
 impl fmt::Display for ExtendedPubKey {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        base58::check_encode_slice_to_fmt(fmt, &self.encode()[..])
+        base58::encode_check_to_fmt(fmt, &self.encode()[..])
     }
 }
 
@@ -808,7 +808,7 @@ impl FromStr for ExtendedPubKey {
     type Err = Error;
 
     fn from_str(inp: &str) -> Result<ExtendedPubKey, Error> {
-        let data = base58::from_check(inp)?;
+        let data = base58::decode_check(inp)?;
 
         if data.len() != 78 {
             return Err(base58::Error::InvalidLength(data.len()).into());

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -73,7 +73,7 @@ struct SmallVec<T> {
 }
 
 impl<T: Default + Copy> SmallVec<T> {
-    pub fn new() -> SmallVec<T> {
+    fn new() -> SmallVec<T> {
         SmallVec {
             len: 0,
             stack: [T::default(); 100],
@@ -81,7 +81,7 @@ impl<T: Default + Copy> SmallVec<T> {
         }
     }
 
-    pub fn push(&mut self, val: T) {
+    fn push(&mut self, val: T) {
         if self.len < 100 {
             self.stack[self.len] = val;
             self.len += 1;
@@ -90,12 +90,12 @@ impl<T: Default + Copy> SmallVec<T> {
         }
     }
 
-    pub fn iter(&self) -> iter::Chain<slice::Iter<T>, slice::Iter<T>> {
+    fn iter(&self) -> iter::Chain<slice::Iter<T>, slice::Iter<T>> {
         // If len<100 then we just append an empty vec
         self.stack[0..self.len].iter().chain(self.heap.iter())
     }
 
-    pub fn iter_mut(&mut self) -> iter::Chain<slice::IterMut<T>, slice::IterMut<T>> {
+    fn iter_mut(&mut self) -> iter::Chain<slice::IterMut<T>, slice::IterMut<T>> {
         // If len<100 then we just append an empty vec
         self.stack[0..self.len].iter_mut().chain(self.heap.iter_mut())
     }

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -245,8 +245,10 @@ pub enum Error {
     BadByte(u8),
     /// Checksum was not correct (expected, actual).
     BadChecksum(u32, u32),
-    /// The length (in bytes) of the object was not correct, note that if the length is excessively
-    /// long the provided length may be an estimate (and the checksum step may be skipped).
+    /// The length (in bytes) of the object was not correct.
+    ///
+    /// Note that if the length is excessively long the provided length may be an estimate (and the
+    /// checksum step may be skipped).
     InvalidLength(usize),
     /// Extended Key version byte(s) were not recognized.
     InvalidExtendedKeyVersion([u8; 4]),

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -14,23 +14,22 @@ use core::convert::TryInto;
 
 use crate::hashes::{sha256d, Hash};
 
-/// An error that might occur during base58 decoding
+/// An error that might occur during base58 decoding.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 #[non_exhaustive]
 pub enum Error {
-    /// Invalid character encountered
+    /// Invalid character encountered.
     BadByte(u8),
-    /// Checksum was not correct (expected, actual)
+    /// Checksum was not correct (expected, actual).
     BadChecksum(u32, u32),
-    /// The length (in bytes) of the object was not correct
-    /// Note that if the length is excessively long the provided length may be
-    /// an estimate (and the checksum step may be skipped).
+    /// The length (in bytes) of the object was not correct, note that if the length is excessively
+    /// long the provided length may be an estimate (and the checksum step may be skipped).
     InvalidLength(usize),
-    /// Extended Key version byte(s) were not recognized
+    /// Extended Key version byte(s) were not recognized.
     InvalidExtendedKeyVersion([u8; 4]),
-    /// Address version byte were not recognized
+    /// Address version byte were not recognized.
     InvalidAddressVersion(u8),
-    /// Checked data was less than 4 bytes
+    /// Checked data was less than 4 bytes.
     TooShort(usize),
 }
 
@@ -122,7 +121,7 @@ static BASE58_DIGITS: [Option<u8>; 128] = [
     Some(55), Some(56), Some(57), None,     None,     None,     None,     None,     // 120-127
 ];
 
-/// Decode base58-encoded string into a byte vector
+/// Decodes a base58-encoded string into a byte vector.
 pub fn from(data: &str) -> Result<Vec<u8>, Error> {
     // 11/15 is just over log_256(58)
     let mut scratch = vec![0u8; 1 + data.len() * 11 / 15];
@@ -153,7 +152,7 @@ pub fn from(data: &str) -> Result<Vec<u8>, Error> {
     Ok(ret)
 }
 
-/// Decode a base58check-encoded string
+/// Decodes a base58check-encoded string into a byte vector verifying the checksum.
 pub fn from_check(data: &str) -> Result<Vec<u8>, Error> {
     let mut ret: Vec<u8> = from(data)?;
     if ret.len() < 4 {
@@ -226,13 +225,14 @@ where
 }
 
 
-/// Directly encode a slice as base58
+/// Encodes `data` as a base58 string.
 pub fn encode_slice(data: &[u8]) -> String {
     encode_iter(data.iter().cloned())
 }
 
-/// Obtain a string with the base58check encoding of a slice
-/// (Tack the first 4 256-digits of the object's Bitcoin hash onto the end.)
+/// Encodes `data` as a base58 string including the checksum.
+///
+/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
 pub fn check_encode_slice(data: &[u8]) -> String {
     let checksum = sha256d::Hash::hash(data);
     encode_iter(
@@ -242,8 +242,9 @@ pub fn check_encode_slice(data: &[u8]) -> String {
     )
 }
 
-/// Obtain a string with the base58check encoding of a slice
-/// (Tack the first 4 256-digits of the object's Bitcoin hash onto the end.)
+/// Encodes `data` as base58, including the checksum, into a formatter.
+///
+/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
 pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
     let checksum = sha256d::Hash::hash(data);
     let iter = data.iter()

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -36,7 +36,13 @@ static BASE58_DIGITS: [Option<u8>; 128] = [
 ];
 
 /// Decodes a base58-encoded string into a byte vector.
+#[deprecated(since = "0.30.0", note = "Use base58::decode() instead")]
 pub fn from(data: &str) -> Result<Vec<u8>, Error> {
+    decode(data)
+}
+
+/// Decodes a base58-encoded string into a byte vector.
+pub fn decode(data: &str) -> Result<Vec<u8>, Error> {
     // 11/15 is just over log_256(58)
     let mut scratch = vec![0u8; 1 + data.len() * 11 / 15];
     // Build in base 256
@@ -67,8 +73,14 @@ pub fn from(data: &str) -> Result<Vec<u8>, Error> {
 }
 
 /// Decodes a base58check-encoded string into a byte vector verifying the checksum.
+#[deprecated(since = "0.30.0", note = "Use base58::decode_check() instead")]
 pub fn from_check(data: &str) -> Result<Vec<u8>, Error> {
-    let mut ret: Vec<u8> = from(data)?;
+    decode_check(data)
+}
+
+/// Decodes a base58check-encoded string into a byte vector verifying the checksum.
+pub fn decode_check(data: &str) -> Result<Vec<u8>, Error> {
+    let mut ret: Vec<u8> = decode(data)?;
     if ret.len() < 4 {
         return Err(Error::TooShort(ret.len()));
     }
@@ -89,14 +101,28 @@ pub fn from_check(data: &str) -> Result<Vec<u8>, Error> {
 }
 
 /// Encodes `data` as a base58 string.
+#[deprecated(since = "0.30.0", note = "Use base58::encode() instead")]
 pub fn encode_slice(data: &[u8]) -> String {
+    encode(data)
+}
+
+/// Encodes `data` as a base58 string (see also `base58::encode_check()`).
+pub fn encode(data: &[u8]) -> String {
     encode_iter(data.iter().cloned())
 }
 
 /// Encodes `data` as a base58 string including the checksum.
 ///
 /// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+#[deprecated(since = "0.30.0", note = "Use base58::encode_check() instead")]
 pub fn check_encode_slice(data: &[u8]) -> String {
+    encode_check(data)
+}
+
+/// Encodes `data` as a base58 string including the checksum.
+///
+/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+pub fn encode_check(data: &[u8]) -> String {
     let checksum = sha256d::Hash::hash(data);
     encode_iter(
         data.iter()
@@ -108,7 +134,15 @@ pub fn check_encode_slice(data: &[u8]) -> String {
 /// Encodes `data` as base58, including the checksum, into a formatter.
 ///
 /// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+#[deprecated(since = "0.30.0", note = "Use base58::encode_check_to_fmt() instead")]
 pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
+    encode_check_to_fmt(fmt, data)
+}
+
+/// Encodes a slice as base58, including the checksum, into a formatter.
+///
+/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+pub fn encode_check_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
     let checksum = sha256d::Hash::hash(data);
     let iter = data.iter()
         .cloned()
@@ -260,17 +294,17 @@ mod tests {
     #[test]
     fn test_base58_encode() {
         // Basics
-        assert_eq!(&encode_slice(&[0][..]), "1");
-        assert_eq!(&encode_slice(&[1][..]), "2");
-        assert_eq!(&encode_slice(&[58][..]), "21");
-        assert_eq!(&encode_slice(&[13, 36][..]), "211");
+        assert_eq!(&encode(&[0][..]), "1");
+        assert_eq!(&encode(&[1][..]), "2");
+        assert_eq!(&encode(&[58][..]), "21");
+        assert_eq!(&encode(&[13, 36][..]), "211");
 
         // Leading zeroes
-        assert_eq!(&encode_slice(&[0, 13, 36][..]), "1211");
-        assert_eq!(&encode_slice(&[0, 0, 0, 0, 13, 36][..]), "1111211");
+        assert_eq!(&encode(&[0, 13, 36][..]), "1211");
+        assert_eq!(&encode(&[0, 0, 0, 0, 13, 36][..]), "1111211");
 
         // Long input (>100 bytes => has to use heap)
-        let res = encode_slice("BitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBit\
+        let res = encode("BitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBit\
         coinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoin".as_bytes());
         let exp = "ZqC5ZdfpZRi7fjA8hbhX5pEE96MdH9hEaC1YouxscPtbJF16qVWksHWR4wwvx7MotFcs2ChbJqK8KJ9X\
         wZznwWn1JFDhhTmGo9v6GjAVikzCsBWZehu7bm22xL8b5zBR5AsBygYRwbFJsNwNkjpyFuDKwmsUTKvkULCvucPJrN5\
@@ -279,39 +313,39 @@ mod tests {
 
         // Addresses
         let addr = Vec::from_hex("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap();
-        assert_eq!(&check_encode_slice(&addr[..]), "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH");
+        assert_eq!(&encode_check(&addr[..]), "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH");
     }
 
     #[test]
     fn test_base58_decode() {
         // Basics
-        assert_eq!(from("1").ok(), Some(vec![0u8]));
-        assert_eq!(from("2").ok(), Some(vec![1u8]));
-        assert_eq!(from("21").ok(), Some(vec![58u8]));
-        assert_eq!(from("211").ok(), Some(vec![13u8, 36]));
+        assert_eq!(decode("1").ok(), Some(vec![0u8]));
+        assert_eq!(decode("2").ok(), Some(vec![1u8]));
+        assert_eq!(decode("21").ok(), Some(vec![58u8]));
+        assert_eq!(decode("211").ok(), Some(vec![13u8, 36]));
 
         // Leading zeroes
-        assert_eq!(from("1211").ok(), Some(vec![0u8, 13, 36]));
-        assert_eq!(from("111211").ok(), Some(vec![0u8, 0, 0, 13, 36]));
+        assert_eq!(decode("1211").ok(), Some(vec![0u8, 13, 36]));
+        assert_eq!(decode("111211").ok(), Some(vec![0u8, 0, 0, 13, 36]));
 
         // Addresses
-        assert_eq!(from_check("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").ok(),
+        assert_eq!(decode_check("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").ok(),
                    Some(Vec::from_hex("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap()));
         // Non Base58 char.
-        assert_eq!(from("¢").unwrap_err(), Error::BadByte(194));
+        assert_eq!(decode("¢").unwrap_err(), Error::BadByte(194));
     }
 
     #[test]
     fn test_base58_roundtrip() {
         let s = "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs";
-        let v: Vec<u8> = from_check(s).unwrap();
-        assert_eq!(check_encode_slice(&v[..]), s);
-        assert_eq!(from_check(&check_encode_slice(&v[..])).ok(), Some(v));
+        let v: Vec<u8> = decode_check(s).unwrap();
+        assert_eq!(encode_check(&v[..]), s);
+        assert_eq!(decode_check(&encode_check(&v[..])).ok(), Some(v));
 
         // Check that empty slice passes roundtrip.
-        assert_eq!(from_check(&check_encode_slice(&[])), Ok(vec![]));
+        assert_eq!(decode_check(&encode_check(&[])), Ok(vec![]));
         // Check that `len > 4` is enforced.
-        assert_eq!(from_check(&encode_slice(&[1,2,3])), Err(Error::TooShort(3)));
+        assert_eq!(decode_check(&encode(&[1,2,3])), Err(Error::TooShort(3)));
 
     }
 }

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -113,7 +113,7 @@ pub fn encode(data: &[u8]) -> String {
 
 /// Encodes `data` as a base58 string including the checksum.
 ///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+/// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 #[deprecated(since = "0.30.0", note = "Use base58::encode_check() instead")]
 pub fn check_encode_slice(data: &[u8]) -> String {
     encode_check(data)
@@ -121,7 +121,7 @@ pub fn check_encode_slice(data: &[u8]) -> String {
 
 /// Encodes `data` as a base58 string including the checksum.
 ///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+/// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 pub fn encode_check(data: &[u8]) -> String {
     let checksum = sha256d::Hash::hash(data);
     encode_iter(
@@ -133,7 +133,7 @@ pub fn encode_check(data: &[u8]) -> String {
 
 /// Encodes `data` as base58, including the checksum, into a formatter.
 ///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+/// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 #[deprecated(since = "0.30.0", note = "Use base58::encode_check_to_fmt() instead")]
 pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
     encode_check_to_fmt(fmt, data)
@@ -141,7 +141,7 @@ pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::
 
 /// Encodes a slice as base58, including the checksum, into a formatter.
 ///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+/// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 pub fn encode_check_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
     let checksum = sha256d::Hash::hash(data);
     let iter = data.iter()

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -37,8 +37,8 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::BadByte(b) => write!(f, "invalid base58 character 0x{:x}", b),
-            Error::BadChecksum(exp, actual) => write!(f, "base58ck checksum 0x{:x} does not match expected 0x{:x}", actual, exp),
+            Error::BadByte(b) => write!(f, "invalid base58 character {:#x}", b),
+            Error::BadChecksum(exp, actual) => write!(f, "base58ck checksum {:#x} does not match expected {:#x}", actual, exp),
             Error::InvalidLength(ell) => write!(f, "length {} invalid for this base58 type", ell),
             Error::InvalidExtendedKeyVersion(ref v) => write!(f, "extended key version {:#04x?} is invalid for this base58 type", v),
             Error::InvalidAddressVersion(ref v) => write!(f, "address version {} is invalid for this base58 type", v),

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -14,92 +14,6 @@ use core::convert::TryInto;
 
 use crate::hashes::{sha256d, Hash};
 
-/// An error that might occur during base58 decoding.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-#[non_exhaustive]
-pub enum Error {
-    /// Invalid character encountered.
-    BadByte(u8),
-    /// Checksum was not correct (expected, actual).
-    BadChecksum(u32, u32),
-    /// The length (in bytes) of the object was not correct, note that if the length is excessively
-    /// long the provided length may be an estimate (and the checksum step may be skipped).
-    InvalidLength(usize),
-    /// Extended Key version byte(s) were not recognized.
-    InvalidExtendedKeyVersion([u8; 4]),
-    /// Address version byte were not recognized.
-    InvalidAddressVersion(u8),
-    /// Checked data was less than 4 bytes.
-    TooShort(usize),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::BadByte(b) => write!(f, "invalid base58 character {:#x}", b),
-            Error::BadChecksum(exp, actual) => write!(f, "base58ck checksum {:#x} does not match expected {:#x}", actual, exp),
-            Error::InvalidLength(ell) => write!(f, "length {} invalid for this base58 type", ell),
-            Error::InvalidExtendedKeyVersion(ref v) => write!(f, "extended key version {:#04x?} is invalid for this base58 type", v),
-            Error::InvalidAddressVersion(ref v) => write!(f, "address version {} is invalid for this base58 type", v),
-            Error::TooShort(_) => write!(f, "base58ck data not even long enough for a checksum"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use self::Error::*;
-
-        match self {
-            BadByte(_)
-            | BadChecksum(_, _)
-            | InvalidLength(_)
-            | InvalidExtendedKeyVersion(_)
-            | InvalidAddressVersion(_)
-            | TooShort(_) => None,
-        }
-    }
-}
-
-/// Vector-like object that holds the first 100 elements on the stack. If more space is needed it
-/// will be allocated on the heap.
-struct SmallVec<T> {
-    len: usize,
-    stack: [T; 100],
-    heap: Vec<T>,
-}
-
-impl<T: Default + Copy> SmallVec<T> {
-    fn new() -> SmallVec<T> {
-        SmallVec {
-            len: 0,
-            stack: [T::default(); 100],
-            heap: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, val: T) {
-        if self.len < 100 {
-            self.stack[self.len] = val;
-            self.len += 1;
-        } else {
-            self.heap.push(val);
-        }
-    }
-
-    fn iter(&self) -> iter::Chain<slice::Iter<T>, slice::Iter<T>> {
-        // If len<100 then we just append an empty vec
-        self.stack[0..self.len].iter().chain(self.heap.iter())
-    }
-
-    fn iter_mut(&mut self) -> iter::Chain<slice::IterMut<T>, slice::IterMut<T>> {
-        // If len<100 then we just append an empty vec
-        self.stack[0..self.len].iter_mut().chain(self.heap.iter_mut())
-    }
-}
-
 static BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 static BASE58_DIGITS: [Option<u8>; 128] = [
@@ -174,6 +88,43 @@ pub fn from_check(data: &str) -> Result<Vec<u8>, Error> {
     Ok(ret)
 }
 
+/// Encodes `data` as a base58 string.
+pub fn encode_slice(data: &[u8]) -> String {
+    encode_iter(data.iter().cloned())
+}
+
+/// Encodes `data` as a base58 string including the checksum.
+///
+/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+pub fn check_encode_slice(data: &[u8]) -> String {
+    let checksum = sha256d::Hash::hash(data);
+    encode_iter(
+        data.iter()
+            .cloned()
+            .chain(checksum[0..4].iter().cloned())
+    )
+}
+
+/// Encodes `data` as base58, including the checksum, into a formatter.
+///
+/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
+    let checksum = sha256d::Hash::hash(data);
+    let iter = data.iter()
+        .cloned()
+        .chain(checksum[0..4].iter().cloned());
+    format_iter(fmt, iter)
+}
+
+fn encode_iter<I>(data: I) -> String
+where
+    I: Iterator<Item=u8> + Clone,
+{
+    let mut ret = String::new();
+    format_iter(&mut ret, data).expect("writing into string shouldn't fail");
+    ret
+}
+
 fn format_iter<I, W>(writer: &mut W, data: I) -> Result<(), fmt::Error>
 where
     I: Iterator<Item=u8> + Clone,
@@ -215,42 +166,90 @@ where
     Ok(())
 }
 
-fn encode_iter<I>(data: I) -> String
-where
-    I: Iterator<Item=u8> + Clone,
-{
-    let mut ret = String::new();
-    format_iter(&mut ret, data).expect("writing into string shouldn't fail");
-    ret
+/// Vector-like object that holds the first 100 elements on the stack. If more space is needed it
+/// will be allocated on the heap.
+struct SmallVec<T> {
+    len: usize,
+    stack: [T; 100],
+    heap: Vec<T>,
 }
 
+impl<T: Default + Copy> SmallVec<T> {
+    fn new() -> SmallVec<T> {
+        SmallVec {
+            len: 0,
+            stack: [T::default(); 100],
+            heap: Vec::new(),
+        }
+    }
 
-/// Encodes `data` as a base58 string.
-pub fn encode_slice(data: &[u8]) -> String {
-    encode_iter(data.iter().cloned())
+    fn push(&mut self, val: T) {
+        if self.len < 100 {
+            self.stack[self.len] = val;
+            self.len += 1;
+        } else {
+            self.heap.push(val);
+        }
+    }
+
+    fn iter(&self) -> iter::Chain<slice::Iter<T>, slice::Iter<T>> {
+        // If len<100 then we just append an empty vec
+        self.stack[0..self.len].iter().chain(self.heap.iter())
+    }
+
+    fn iter_mut(&mut self) -> iter::Chain<slice::IterMut<T>, slice::IterMut<T>> {
+        // If len<100 then we just append an empty vec
+        self.stack[0..self.len].iter_mut().chain(self.heap.iter_mut())
+    }
 }
 
-/// Encodes `data` as a base58 string including the checksum.
-///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
-pub fn check_encode_slice(data: &[u8]) -> String {
-    let checksum = sha256d::Hash::hash(data);
-    encode_iter(
-        data.iter()
-            .cloned()
-            .chain(checksum[0..4].iter().cloned())
-    )
+/// An error that might occur during base58 decoding.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[non_exhaustive]
+pub enum Error {
+    /// Invalid character encountered.
+    BadByte(u8),
+    /// Checksum was not correct (expected, actual).
+    BadChecksum(u32, u32),
+    /// The length (in bytes) of the object was not correct, note that if the length is excessively
+    /// long the provided length may be an estimate (and the checksum step may be skipped).
+    InvalidLength(usize),
+    /// Extended Key version byte(s) were not recognized.
+    InvalidExtendedKeyVersion([u8; 4]),
+    /// Address version byte were not recognized.
+    InvalidAddressVersion(u8),
+    /// Checked data was less than 4 bytes.
+    TooShort(usize),
 }
 
-/// Encodes `data` as base58, including the checksum, into a formatter.
-///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
-pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
-    let checksum = sha256d::Hash::hash(data);
-    let iter = data.iter()
-        .cloned()
-        .chain(checksum[0..4].iter().cloned());
-    format_iter(fmt, iter)
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::BadByte(b) => write!(f, "invalid base58 character {:#x}", b),
+            Error::BadChecksum(exp, actual) => write!(f, "base58ck checksum {:#x} does not match expected {:#x}", actual, exp),
+            Error::InvalidLength(ell) => write!(f, "length {} invalid for this base58 type", ell),
+            Error::InvalidExtendedKeyVersion(ref v) => write!(f, "extended key version {:#04x?} is invalid for this base58 type", v),
+            Error::InvalidAddressVersion(ref v) => write!(f, "address version {} is invalid for this base58 type", v),
+            Error::TooShort(_) => write!(f, "base58ck data not even long enough for a checksum"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match self {
+            BadByte(_)
+            | BadChecksum(_, _)
+            | InvalidLength(_)
+            | InvalidExtendedKeyVersion(_)
+            | InvalidAddressVersion(_)
+            | TooShort(_) => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/bitcoin/src/util/key.rs
+++ b/bitcoin/src/util/key.rs
@@ -360,9 +360,9 @@ impl PrivateKey {
         ret[1..33].copy_from_slice(&self.inner[..]);
         let privkey = if self.compressed {
             ret[33] = 1;
-            base58::check_encode_slice(&ret[..])
+            base58::encode_check(&ret[..])
         } else {
-            base58::check_encode_slice(&ret[..33])
+            base58::encode_check(&ret[..33])
         };
         fmt.write_str(&privkey)
     }
@@ -377,7 +377,7 @@ impl PrivateKey {
 
     /// Parse WIF encoded private key.
     pub fn from_wif(wif: &str) -> Result<PrivateKey, Error> {
-        let data = base58::from_check(wif)?;
+        let data = base58::decode_check(wif)?;
 
         let compressed = match data.len() {
             33 => false,


### PR DESCRIPTION
Do some clean up work to the `base58` module in preparation for splitting it out into its own crate. 

- Patches 1-6: Basic clean up.
- Patch 7: Re-names the public API functions.
- Patch 8: Fixes rustdoc comment as suggested during review.
- Patch 9: Improves documentation on checksum, also as suggested during review.