### PR TITLE
Redesign `hex::BufEncoder` to accept owned arrays

### DIFF
--- a/internals/src/hex/display.rs
+++ b/internals/src/hex/display.rs
@@ -177,7 +177,8 @@ macro_rules! fmt_hex_exact {
             const _: () = [()][($len > usize::max_value() / 2) as usize];
             assert_eq!($bytes.len(), $len);
             let mut buf = [0u8; $len * 2];
-            $crate::hex::display::fmt_hex_exact_fn($formatter, (&mut buf).into(), $bytes, $case)
+            let buf = $crate::hex::buf_encoder::AsOutBytes::as_mut_out_bytes(&mut buf);
+            $crate::hex::display::fmt_hex_exact_fn($formatter, buf, $bytes, $case)
         }
     }
 }
@@ -185,7 +186,7 @@ macro_rules! fmt_hex_exact {
 // Implementation detail of `write_hex_exact` macro to de-duplicate the code
 #[doc(hidden)]
 #[inline]
-pub fn fmt_hex_exact_fn(f: &mut fmt::Formatter, buf: OutBytes<'_>, bytes: &[u8], case: Case) -> fmt::Result {
+pub fn fmt_hex_exact_fn(f: &mut fmt::Formatter, buf: &mut OutBytes, bytes: &[u8], case: Case) -> fmt::Result {
     let mut encoder = BufEncoder::new(buf);
     encoder.put_bytes(bytes, case);
     f.pad_integral(true, "0x", encoder.as_str())

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -11,7 +11,6 @@
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Coding conventions
-#![forbid(unsafe_code)]
 #![deny(non_upper_case_globals)]
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]


### PR DESCRIPTION
Not being able to create an owned `BufEncoder` prevented returning it from functions which need to allocate the buffer on stack. Such is the case in WIP serde via consensus serialzation.

This change refactors `OutBytes` to be unsized, adds an `AsOutBytes` trait and uses that one instead of `Into` to perform the conversion.

Closes #1270 

This is meant as potentially mergeable demonstration. Interestingly, it was easier than I expected.