### PR TITLE
Try to fix up sighash export mess

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -382,12 +382,9 @@ mod psbt_sign {
     use std::ops::Deref;
 
     use bitcoin::psbt::{Input, Prevouts, Psbt, PsbtSighashType};
-    use bitcoin::util::sighash::{self, SighashCache};
+    use bitcoin::sighash::{self, SighashCache, EcdsaSighashType, SchnorrSighashType};
     use bitcoin::util::taproot::TapLeafHash;
-    use bitcoin::{
-        EcdsaSig, EcdsaSigError, EcdsaSighashType, PrivateKey, SchnorrSighashType, Script,
-        Transaction, TxOut,
-    };
+    use bitcoin::{EcdsaSig, EcdsaSigError, PrivateKey, Script, Transaction, TxOut};
     use secp256k1::{Message, Secp256k1, Signing};
 
     /// Signs the input at `input_index` with private key `sk`.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -36,7 +36,7 @@ use crate::internal_macros::{impl_consensus_encoding, serde_struct_human_string_
 use crate::parse::impl_parse_str_through_int;
 
 #[cfg(doc)]
-use crate::util::sighash::SchnorrSighashType;
+use crate::sighash::{EcdsaSighashType, SchnorrSighashType};
 
 /// A reference to a transaction output.
 ///
@@ -1014,13 +1014,6 @@ impl From<&Transaction> for Wtxid {
     }
 }
 
-#[deprecated(since = "0.30.0", note = "use crate::NonStandardSighashType instead")]
-pub use crate::util::sighash::NonStandardSighashType;
-#[deprecated(since = "0.30.0", note = "use crate::EcdsaSighashType instead")]
-pub use crate::util::sighash::EcdsaSighashType;
-#[deprecated(since = "0.30.0", note = "use crate::SighashTypeParseError instead")]
-pub use crate::util::sighash::SighashTypeParseError;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1032,6 +1025,7 @@ mod tests {
     use crate::blockdata::locktime::absolute;
     use crate::consensus::encode::serialize;
     use crate::consensus::encode::deserialize;
+    use crate::sighash::EcdsaSighashType;
 
     use crate::hashes::hex::FromHex;
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -109,11 +109,7 @@ pub use crate::util::ecdsa::{self, EcdsaSig, EcdsaSigError};
 pub use crate::util::key::{KeyPair, PrivateKey, PublicKey, XOnlyPublicKey};
 pub use crate::util::merkleblock::MerkleBlock;
 pub use crate::util::schnorr::{self, SchnorrSig, SchnorrSigError};
-pub use crate::util::sighash::{
-    EcdsaSighashType, NonStandardSighashType, SchnorrSighashType, SighashCache,
-    SighashTypeParseError,
-};
-pub use crate::util::{psbt, Error};
+pub use crate::util::{psbt, sighash, Error};
 
 #[cfg(not(feature = "std"))]
 mod io_extras {

--- a/bitcoin/src/util/psbt/mod.rs
+++ b/bitcoin/src/util/psbt/mod.rs
@@ -497,7 +497,7 @@ mod tests {
         //! Create a full PSBT value with various fields filled and make sure it can be JSONized.
         use crate::hashes::sha256d;
         use crate::util::psbt::map::Input;
-        use crate::EcdsaSighashType;
+        use crate::sighash::EcdsaSighashType;
 
         // create some values to use in the PSBT
         let tx = Transaction {

--- a/bitcoin/src/util/schnorr.rs
+++ b/bitcoin/src/util/schnorr.rs
@@ -16,7 +16,7 @@ pub use secp256k1::{self, constants, Secp256k1, KeyPair, XOnlyPublicKey, Verific
 use crate::prelude::*;
 
 use crate::util::taproot::{TapBranchHash, TapTweakHash};
-use crate::SchnorrSighashType;
+use crate::sighash::SchnorrSighashType;
 
 /// Untweaked BIP-340 X-coord-only public key
 pub type UntweakedPublicKey = XOnlyPublicKey;

--- a/bitcoin/src/util/sighash.rs
+++ b/bitcoin/src/util/sighash.rs
@@ -1006,7 +1006,8 @@ impl<R: DerefMut<Target=Transaction>> SighashCache<R> {
     ///
     /// This allows in-line signing such as
     /// ```
-    /// use bitcoin::{absolute, EcdsaSighashType, SighashCache, Transaction, Script};
+    /// use bitcoin::{absolute, Transaction, Script};
+    /// use bitcoin::sighash::{EcdsaSighashType, SighashCache};
     ///
     /// let mut tx_to_sign = Transaction { version: 2, lock_time: absolute::PackedLockTime::ZERO, input: Vec::new(), output: Vec::new() };
     /// let input_count = tx_to_sign.input.len();
@@ -1069,7 +1070,7 @@ mod tests {
 
     use secp256k1::{self, SecretKey, XOnlyPublicKey};
 
-    use crate::{Script, Transaction, TxIn, TxOut, EcdsaSighashType, Address};
+    use crate::{Script, Transaction, TxIn, TxOut, Address};
     use crate::blockdata::locktime::absolute;
     use crate::consensus::deserialize;
     use crate::hashes::hex::{FromHex, ToHex};


### PR DESCRIPTION
Recently we moved a few types from `transaction` to `sighash`, while doing so I erroneously annotated code with the `deprecated` attribute hoping it would give downstream users a gentle upgrade experience. It turns out `deprecated` only works on functions.

During that same work, we re-exported from the crate root a bunch of types from the `sighash` module that probably should not have been re-exported. We are currently trying to create a nice clean API surface, in an effort to move in the right direction we should remove the re-exports and just re-export the `sighash` module.

Try to clean up the sighash export mess by doing:

- Remove the re-exports from the `transaction` module
- Remove crate level re-exports of `sighash` module types
- Re-export `sighash` module

Note, this patch is a breaking API change, justified by the fact that there is no good way to gently lead downstream when moving types since types cannot be deprecated with the `deprecated` attribute.