### PR TITLE
Implement `From` for hash types

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -449,6 +449,18 @@ impl std::error::Error for Bip34Error {
     }
 }
 
+impl From<BlockHeader> for BlockHash {
+    fn from(header: BlockHeader) -> BlockHash {
+        header.block_hash()
+    }
+}
+
+impl From<Block> for BlockHash {
+    fn from(block: Block) -> BlockHash {
+        block.block_hash()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::hashes::hex::FromHex;

--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -772,6 +772,18 @@ impl From<Vec<u8>> for Script {
     fn from(v: Vec<u8>) -> Script { Script(v.into_boxed_slice()) }
 }
 
+impl From<Script> for ScriptHash {
+    fn from(script: Script) -> ScriptHash {
+        script.script_hash()
+    }
+}
+
+impl From<Script> for WScriptHash {
+    fn from(script: Script) -> WScriptHash {
+        script.wscript_hash()
+    }
+}
+
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Instruction<'a> {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1017,6 +1017,18 @@ impl Decodable for Transaction {
     }
 }
 
+impl From<Transaction> for Txid {
+    fn from(tx: Transaction) -> Txid {
+        tx.txid()
+    }
+}
+
+impl From<Transaction> for Wtxid {
+    fn from(tx: Transaction) -> Wtxid {
+        tx.wtxid()
+    }
+}
+
 /// Legacy Hashtype of an input's signature
 #[deprecated(since = "0.28.0", note = "Please use [`EcdsaSighashType`] instead")]
 pub type SigHashType = EcdsaSighashType;

--- a/bitcoin/src/util/bip32.rs
+++ b/bitcoin/src/util/bip32.rs
@@ -837,6 +837,12 @@ impl FromStr for ExtendedPubKey {
     }
 }
 
+impl From<ExtendedPubKey> for XpubIdentifier {
+    fn from(key: ExtendedPubKey) -> XpubIdentifier {
+        key.identifier()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/bitcoin/src/util/taproot.rs
+++ b/bitcoin/src/util/taproot.rs
@@ -107,6 +107,12 @@ impl TapLeafHash {
     }
 }
 
+impl From<ScriptLeaf> for TapLeafHash {
+    fn from(leaf: ScriptLeaf) -> TapLeafHash {
+        leaf.leaf_hash()
+    }
+}
+
 impl TapBranchHash {
     /// Computes branch hash given two hashes of the nodes underneath it.
     pub fn from_node_hashes(a: sha256::Hash, b: sha256::Hash) -> TapBranchHash {
@@ -308,6 +314,12 @@ impl TaprootSpendInfo {
             leaf_version: script_ver.1,
             merkle_branch: smallest.clone(),
         })
+    }
+}
+
+impl From<TaprootSpendInfo> for TapTweakHash {
+    fn from(spend_info: TaprootSpendInfo) -> TapTweakHash {
+        spend_info.tap_tweak()
     }
 }
 


### PR DESCRIPTION
Part of #1245.

Implemented `From` for a some obvious hash types:
- `From<Block>` and `From<BlockHeader>` for `BlockHash`
- `From<Script>` for `ScriptHash` and `WScriptHash`
- `From<Transaction>` for `Txid` and `Wtxid`
- `From<ExtendedPubKey`> for `XpubIdentifier`
- `From<ScriptLeaf>` for `TapLeafHash`
- ` From<TaprootSpendInfo>` for `TapTweakHash`

Hash types that were left out:
- `SigHash`, `WitnessCommitment`, `FilterHash`, `FilterHeader` and `TapBranchHash` require multiple inputs to compute.
- `WPubKeyHash`, `TxMerkleNode` and `WitnessMerkleNode`  can return `None` in some cases.
- `TapSigHash` can return encoding related error.

Let me know if I've missed any or should have implemented any of the ones I left out.