### PR TITLE
Remove code deprecated last release

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -242,62 +242,6 @@ impl FromStr for WitnessVersion {
 }
 
 impl WitnessVersion {
-    /// Converts 5-bit unsigned integer value matching single symbol from Bech32(m) address encoding
-    /// ([`bech32::u5`]) into [`WitnessVersion`] variant.
-    ///
-    /// # Returns
-    /// Version of the Witness program.
-    ///
-    /// # Errors
-    /// If the integer does not correspond to any witness version, errors with
-    /// [`Error::InvalidWitnessVersion`].
-    #[deprecated(since = "0.29.0", note = "use try_from instead")]
-    pub fn from_u5(value: bech32::u5) -> Result<Self, Error> { Self::try_from(value) }
-
-    /// Converts an 8-bit unsigned integer value into [`WitnessVersion`] variant.
-    ///
-    /// # Returns
-    /// Version of the Witness program.
-    ///
-    /// # Errors
-    /// If the integer does not correspond to any witness version, errors with
-    /// [`Error::InvalidWitnessVersion`].
-    #[deprecated(since = "0.29.0", note = "use try_from instead")]
-    pub fn from_num(no: u8) -> Result<Self, Error> { Self::try_from(no) }
-
-    /// Converts bitcoin script opcode into [`WitnessVersion`] variant.
-    ///
-    /// # Returns
-    /// Version of the Witness program (for opcodes in range of `OP_0`..`OP_16`).
-    ///
-    /// # Errors
-    /// If the opcode does not correspond to any witness version, errors with
-    /// [`Error::MalformedWitnessVersion`].
-    #[deprecated(since = "0.29.0", note = "use try_from instead")]
-    pub fn from_opcode(opcode: opcodes::All) -> Result<Self, Error> { Self::try_from(opcode) }
-
-    /// Converts bitcoin script [`Instruction`] (parsed opcode) into [`WitnessVersion`] variant.
-    ///
-    /// # Returns
-    /// Version of the Witness program for [`Instruction::Op`] and [`Instruction::PushBytes`] with
-    /// byte value within `1..=16` range.
-    ///
-    /// # Errors
-    /// If the opcode does not correspond to any witness version, errors with
-    /// [`Error::MalformedWitnessVersion`] for the rest of opcodes.
-    #[deprecated(since = "0.29.0", note = "use try_from instead")]
-    pub fn from_instruction(instruction: Instruction) -> Result<Self, Error> {
-        Self::try_from(instruction)
-    }
-
-    /// Returns integer version number representation for a given [`WitnessVersion`] value.
-    ///
-    /// NB: this is not the same as an integer representation of the opcode signifying witness
-    /// version in bitcoin script. Thus, there is no function to directly convert witness version
-    /// into a byte since the conversion requires context (bitcoin script or just a version number).
-    #[deprecated(since = "0.29.0", note = "use to_num instead")]
-    pub fn into_num(self) -> u8 { self.to_num() }
-
     /// Returns integer version number representation for a given [`WitnessVersion`] value.
     ///
     /// NB: this is not the same as an integer representation of the opcode signifying witness

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -724,13 +724,6 @@ impl All {
         }
     }
 
-    /// Encode as a byte
-    #[inline]
-    #[deprecated(since = "0.29.0", note = "use to_u8 instead")]
-    pub fn into_u8(self) -> u8 {
-        self.to_u8()
-    }
-
     /// Encodes [`All`] as a byte.
     #[inline]
     pub const fn to_u8(self) -> u8 {
@@ -849,13 +842,6 @@ ordinary_opcode! {
 }
 
 impl Ordinary {
-    /// Encode as a byte
-    #[inline]
-    #[deprecated(since = "0.29.0", note = "use to_u8 instead")]
-    pub fn into_u8(self) -> u8 {
-        self.to_u8()
-    }
-
     /// Encodes [`All`] as a byte.
     #[inline]
     pub fn to_u8(self) -> u8 {

--- a/bitcoin/src/network/constants.rs
+++ b/bitcoin/src/network/constants.rs
@@ -167,12 +167,6 @@ impl ServiceFlags {
         (self.0 | flags.0) == self.0
     }
 
-    /// Get the integer representation of this [ServiceFlags].
-    #[deprecated(since = "0.29.0", note = "use to_u64 instead")]
-    pub fn as_u64(self) -> u64 {
-        self.to_u64()
-    }
-
     /// Gets the integer representation of this [`ServiceFlags`].
     pub fn to_u64(self) -> u64 {
         self.0

--- a/bitcoin/src/network/message.rs
+++ b/bitcoin/src/network/message.rs
@@ -39,19 +39,6 @@ pub const MAX_MSG_SIZE: usize = 5_000_000;
 pub struct CommandString(Cow<'static, str>);
 
 impl CommandString {
-    /// Convert from various string types into a [CommandString].
-    ///
-    /// Supported types are:
-    /// - `&'static str`
-    /// - `String`
-    ///
-    /// Returns an error if and only if the string is
-    /// larger than 12 characters in length.
-    #[deprecated(note = "Use `TryFrom::try_from` or `CommandString::try_from_static`", since = "0.29.0")]
-    pub fn try_from<S: Into<Cow<'static, str>>>(s: S) -> Result<CommandString, CommandStringError> {
-        Self::try_from_static_cow(s.into())
-    }
-
     /// Convert `&'static str` to `CommandString`
     ///
     /// This is more efficient for string literals than non-static conversions because it avoids

--- a/bitcoin/src/util/amount.rs
+++ b/bitcoin/src/util/amount.rs
@@ -491,12 +491,6 @@ impl Amount {
         Amount(satoshi)
     }
 
-    /// Get the number of satoshis in this [Amount].
-    #[deprecated(since = "0.29.0", note = "use to_sat instead")]
-    pub fn as_sat(self) -> u64 {
-        self.to_sat()
-    }
-
     /// Gets the number of satoshis in this [`Amount`].
     pub fn to_sat(self) -> u64 {
         self.0
@@ -552,14 +546,6 @@ impl Amount {
     /// Please be aware of the risk of using floating-point numbers.
     pub fn to_float_in(self, denom: Denomination) -> f64 {
         f64::from_str(&self.to_string_in(denom)).unwrap()
-    }
-
-    /// Express this [Amount] as a floating-point value in Bitcoin.
-    ///
-    /// Equivalent to `to_float_in(Denomination::Bitcoin)`.
-    #[deprecated(since = "0.29.0", note = "use to_btc instead")]
-    pub fn as_btc(self) -> f64 {
-        self.to_btc()
     }
 
     /// Express this [`Amount`] as a floating-point value in Bitcoin.
@@ -874,12 +860,6 @@ impl SignedAmount {
         SignedAmount(satoshi)
     }
 
-    /// Get the number of satoshis in this [SignedAmount].
-    #[deprecated(since = "0.29.0", note = "use to_sat instead")]
-    pub fn as_sat(self) -> i64 {
-        self.to_sat()
-    }
-
     /// Gets the number of satoshis in this [`SignedAmount`].
     pub fn to_sat(self) -> i64 {
         self.0
@@ -935,16 +915,6 @@ impl SignedAmount {
     /// Please be aware of the risk of using floating-point numbers.
     pub fn to_float_in(self, denom: Denomination) -> f64 {
         f64::from_str(&self.to_string_in(denom)).unwrap()
-    }
-
-    /// Express this [SignedAmount] as a floating-point value in Bitcoin.
-    ///
-    /// Equivalent to `to_float_in(Denomination::Bitcoin)`.
-    ///
-    /// Please be aware of the risk of using floating-point numbers.
-    #[deprecated(since = "0.29.0", note = "use to_btc instead")]
-    pub fn as_btc(self) -> f64 {
-        self.to_btc()
     }
 
     /// Express this [`SignedAmount`] as a floating-point value in Bitcoin.

--- a/bitcoin/src/util/psbt/map/output.rs
+++ b/bitcoin/src/util/psbt/map/output.rs
@@ -148,17 +148,6 @@ impl TapTree {
         self.0.branch()[0].as_ref().expect("from_inner only parses is_complete builders")
     }
 
-    /// Constructs [`TapTree`] from a [`TaprootBuilder`] if it is complete binary tree.
-    ///
-    /// # Returns
-    /// A [`TapTree`] iff the `builder` is complete, otherwise return [`IncompleteTapTree`]
-    /// error with the content of incomplete `builder` instance.
-    #[deprecated(since = "0.29.0", note = "use try_from instead")]
-    pub fn from_builder(builder: TaprootBuilder) -> Result<Self, IncompleteTapTree> {
-        Self::try_from(builder)
-    }
-
-
     /// Converts self into builder [`TaprootBuilder`]. The builder is guaranteed to be finalized.
     pub fn into_builder(self) -> TaprootBuilder {
         self.0

--- a/bitcoin/src/util/psbt/raw.rs
+++ b/bitcoin/src/util/psbt/raw.rs
@@ -147,13 +147,6 @@ impl<Subtype> Decodable for ProprietaryKey<Subtype> where Subtype: Copy + From<u
 }
 
 impl<Subtype> ProprietaryKey<Subtype> where Subtype: Copy + From<u8> + Into<u8> {
-    /// Constructs [ProprietaryKey] from [Key]; returns
-    /// [Error::InvalidProprietaryKey] if `key` do not starts with 0xFC byte
-    #[deprecated(since = "0.29.0", note = "use try_from instead")]
-    pub fn from_key(key: Key) -> Result<Self, Error> {
-        Self::try_from(key)
-    }
-
     /// Constructs full [Key] corresponding to this proprietary key type
     pub fn to_key(&self) -> Key {
         Key {

--- a/bitcoin/src/util/schnorr.rs
+++ b/bitcoin/src/util/schnorr.rs
@@ -171,13 +171,6 @@ impl TweakedKeyPair {
         TweakedKeyPair(pair)
     }
 
-    /// Returns the underlying key pair
-    #[inline]
-    #[deprecated(since = "0.29.0", note = "use to_inner instead")]
-    pub fn into_inner(self) -> KeyPair {
-        self.0
-    }
-
     /// Returns the underlying key pair.
     #[inline]
     pub fn to_inner(self) -> KeyPair {

--- a/bitcoin/src/util/sighash.rs
+++ b/bitcoin/src/util/sighash.rs
@@ -443,12 +443,6 @@ impl SchnorrSighashType {
         }
     }
 
-    /// Creates a [`SchnorrSighashType`] from raw `u8`.
-    #[deprecated(since = "0.29.0", note = "use from_consensus_u8 instead")]
-    pub fn from_u8(hash_ty: u8) -> Result<Self, Error> {
-        Self::from_consensus_u8(hash_ty)
-    }
-
     /// Constructs a [`SchnorrSighashType`] from a raw `u8`.
     pub fn from_consensus_u8(hash_ty: u8) -> Result<Self, Error> {
     use SchnorrSighashType::*;

--- a/bitcoin/src/util/taproot.rs
+++ b/bitcoin/src/util/taproot.rs
@@ -717,16 +717,6 @@ impl TaprootMerkleBranch {
         }
     }
 
-    /// Creates a merkle proof from list of hashes.
-    ///
-    /// # Errors
-    ///
-    /// If inner proof length is more than [`TAPROOT_CONTROL_MAX_NODE_COUNT`] (128).
-    #[deprecated(since = "0.29.0", note = "use try_from instead")]
-    pub fn from_inner(inner: Vec<sha256::Hash>) -> Result<Self, TaprootError> {
-        Self::try_from(inner)
-    }
-
     /// Returns the inner list of hashes.
     pub fn into_inner(self) -> Vec<sha256::Hash> {
         self.0


### PR DESCRIPTION
We give one release cycle for deprecating old code so as to make the upgrade path easier for downstream users.

Remove code deprecated during the last release (v0.29.0).

(Check out my diff stats - all red ;)