### PR TITLE
Add constants to `ChainHash` for each `Network`

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -167,12 +167,6 @@ pub fn genesis_block(network: Network) -> Block {
     }
 }
 
-// Mainnet value can be verified at https://github.com/lightning/bolts/blob/master/00-introduction.md
-const GENESIS_BLOCK_HASH_BITCOIN: [u8; 32] = [111, 226, 140, 10, 182, 241, 179, 114, 193, 166, 162, 70, 174, 99, 247, 79, 147, 30, 131, 101, 225, 90, 8, 156, 104, 214, 25, 0, 0, 0, 0, 0];
-const GENESIS_BLOCK_HASH_TESTNET: [u8; 32] = [67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151, 32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0];
-const GENESIS_BLOCK_HASH_SIGNET: [u8; 32] = [246, 30, 238, 59, 99, 163, 128, 164, 119, 160, 99, 175, 50, 178, 187, 201, 124, 159, 249, 240, 31, 44, 66, 37, 233, 115, 152, 129, 8, 0, 0, 0];
-const GENESIS_BLOCK_HASH_REGTEST: [u8; 32] = [6, 34, 110, 70, 17, 26, 11, 89, 202, 175, 18, 96, 67, 235, 91, 191, 40, 195, 79, 58, 94, 51, 42, 31, 199, 178, 183, 60, 241, 136, 145, 15];
-
 /// The uniquely identifying hash of the target blockchain.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainHash([u8; 32]);
@@ -180,16 +174,26 @@ impl_array_newtype!(ChainHash, u8, 32);
 impl_bytes_newtype!(ChainHash, 32);
 
 impl ChainHash {
+    // Mainnet value can be verified at https://github.com/lightning/bolts/blob/master/00-introduction.md
+    /// `ChainHash` for mainnet bitcoin.
+    pub const BITCOIN: Self = Self([111, 226, 140, 10, 182, 241, 179, 114, 193, 166, 162, 70, 174, 99, 247, 79, 147, 30, 131, 101, 225, 90, 8, 156, 104, 214, 25, 0, 0, 0, 0, 0]);
+    /// `ChainHash` for testnet bitcoin.
+    pub const TESTNET: Self = Self([67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151, 32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0]);
+    /// `ChainHash` for signet bitcoin.
+    pub const SIGNET: Self = Self([246, 30, 238, 59, 99, 163, 128, 164, 119, 160, 99, 175, 50, 178, 187, 201, 124, 159, 249, 240, 31, 44, 66, 37, 233, 115, 152, 129, 8, 0, 0, 0]);
+    /// `ChainHash` for regtest bitcoin.
+    pub const REGTEST: Self = Self([6, 34, 110, 70, 17, 26, 11, 89, 202, 175, 18, 96, 67, 235, 91, 191, 40, 195, 79, 58, 94, 51, 42, 31, 199, 178, 183, 60, 241, 136, 145, 15]);
+
     /// Returns the hash of the `network` genesis block for use as a chain hash.
     ///
     /// See [BOLT 0](https://github.com/lightning/bolts/blob/ffeece3dab1c52efdb9b53ae476539320fa44938/00-introduction.md#chain_hash)
     /// for specification.
     pub fn using_genesis_block(network: Network) -> Self {
         match network {
-            Network::Bitcoin => ChainHash(GENESIS_BLOCK_HASH_BITCOIN),
-            Network::Testnet => ChainHash(GENESIS_BLOCK_HASH_TESTNET),
-            Network::Signet => ChainHash(GENESIS_BLOCK_HASH_SIGNET),
-            Network::Regtest => ChainHash(GENESIS_BLOCK_HASH_REGTEST),
+            Network::Bitcoin => Self::BITCOIN,
+            Network::Testnet => Self::TESTNET,
+            Network::Signet => Self::SIGNET,
+            Network::Regtest => Self::REGTEST,
         }
     }
 }


### PR DESCRIPTION
`ChainHash::using_genesis_block` can't be made `const` because it uses a `match` expression, which is only valid in Rust 1.46. Add individual constants as a workaround so that `ChainHash` can be used in `const` contexts.