### PR TITLE
Implement From for hash types

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -425,6 +425,30 @@ impl std::error::Error for Bip34Error {
     }
 }
 
+impl From<BlockHeader> for BlockHash {
+    fn from(header: BlockHeader) -> BlockHash {
+        header.block_hash()
+    }
+}
+
+impl From<&BlockHeader> for BlockHash {
+    fn from(header: &BlockHeader) -> BlockHash {
+        header.block_hash()
+    }
+}
+
+impl From<Block> for BlockHash {
+    fn from(block: Block) -> BlockHash {
+        block.block_hash()
+    }
+}
+
+impl From<&Block> for BlockHash {
+    fn from(block: &Block) -> BlockHash {
+        block.block_hash()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::hashes::hex::FromHex;

--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -760,6 +760,30 @@ impl From<Vec<u8>> for Script {
     fn from(v: Vec<u8>) -> Script { Script(v.into_boxed_slice()) }
 }
 
+impl From<Script> for ScriptHash {
+    fn from(script: Script) -> ScriptHash {
+        script.script_hash()
+    }
+}
+
+impl From<&Script> for ScriptHash {
+    fn from(script: &Script) -> ScriptHash {
+        script.script_hash()
+    }
+}
+
+impl From<Script> for WScriptHash {
+    fn from(script: Script) -> WScriptHash {
+        script.wscript_hash()
+    }
+}
+
+impl From<&Script> for WScriptHash {
+    fn from(script: &Script) -> WScriptHash {
+        script.wscript_hash()
+    }
+}
+
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Instruction<'a> {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -990,6 +990,30 @@ impl Decodable for Transaction {
     }
 }
 
+impl From<Transaction> for Txid {
+    fn from(tx: Transaction) -> Txid {
+        tx.txid()
+    }
+}
+
+impl From<&Transaction> for Txid {
+    fn from(tx: &Transaction) -> Txid {
+        tx.txid()
+    }
+}
+
+impl From<Transaction> for Wtxid {
+    fn from(tx: Transaction) -> Wtxid {
+        tx.wtxid()
+    }
+}
+
+impl From<&Transaction> for Wtxid {
+    fn from(tx: &Transaction) -> Wtxid {
+        tx.wtxid()
+    }
+}
+
 #[deprecated(since = "0.30.0", note = "use crate::NonStandardSighashType instead")]
 pub use crate::util::sighash::NonStandardSighashType;
 #[deprecated(since = "0.30.0", note = "use crate::EcdsaSighashType instead")]

--- a/bitcoin/src/util/bip32.rs
+++ b/bitcoin/src/util/bip32.rs
@@ -831,6 +831,18 @@ impl FromStr for ExtendedPubKey {
     }
 }
 
+impl From<ExtendedPubKey> for XpubIdentifier {
+    fn from(key: ExtendedPubKey) -> XpubIdentifier {
+        key.identifier()
+    }
+}
+
+impl From<&ExtendedPubKey> for XpubIdentifier {
+    fn from(key: &ExtendedPubKey) -> XpubIdentifier {
+        key.identifier()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/bitcoin/src/util/taproot.rs
+++ b/bitcoin/src/util/taproot.rs
@@ -107,6 +107,18 @@ impl TapLeafHash {
     }
 }
 
+impl From<ScriptLeaf> for TapLeafHash {
+    fn from(leaf: ScriptLeaf) -> TapLeafHash {
+        leaf.leaf_hash()
+    }
+}
+
+impl From<&ScriptLeaf> for TapLeafHash {
+    fn from(leaf: &ScriptLeaf) -> TapLeafHash {
+        leaf.leaf_hash()
+    }
+}
+
 impl TapBranchHash {
     /// Computes branch hash given two hashes of the nodes underneath it.
     pub fn from_node_hashes(a: sha256::Hash, b: sha256::Hash) -> TapBranchHash {
@@ -308,6 +320,18 @@ impl TaprootSpendInfo {
             leaf_version: script_ver.1,
             merkle_branch: smallest.clone(),
         })
+    }
+}
+
+impl From<TaprootSpendInfo> for TapTweakHash {
+    fn from(spend_info: TaprootSpendInfo) -> TapTweakHash {
+        spend_info.tap_tweak()
+    }
+}
+
+impl From<&TaprootSpendInfo> for TapTweakHash {
+    fn from(spend_info: &TaprootSpendInfo) -> TapTweakHash {
+        spend_info.tap_tweak()
     }
 }
 


### PR DESCRIPTION
Reopening #1280 on the right branch + implemented `From` for references of types that were done in #1280.