### PR TITLE
WIP: Create base58 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["bitcoin", "internals"]
+members = ["bitcoin", "base58", "internals"]
 exclude = ["embedded", "fuzz"]

--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+Import `base58` module from `rust-bitcoin` when master branch was at tip:
+
+    commit TODO: FILL THIS IN BEFORE DOING PR

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -14,14 +14,13 @@ edition = "2018"
 # Please don't forget to add relevant features to docs.rs below.
 [features]
 default = ["std"]
-std = ["bitcoin_hashes/std"]
-alloc = ["bitcoin_hashes/alloc"]
+std = []
 
 [package.metadata.docs.rs]
 features = ["std"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-bitcoin_hashes = { version = "0.11.0", default-features = false }
 
 [dev-dependencies]
+bitcoin_hashes = { version = "0.11.0", default-features = false }

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bitcoin-base58"
+version = "0.1.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
+documentation = "https://docs.rs/bitcoin-base58"
+description = "Bitcoin base58 encoding format"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "encoding"]
+readme = "README.md"
+edition = "2018"
+
+# Please don't forget to add relevant features to docs.rs below.
+[features]
+default = ["std"]
+std = ["bitcoin_hashes/std"]
+alloc = ["bitcoin_hashes/alloc"]
+
+[package.metadata.docs.rs]
+features = ["std"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+bitcoin_hashes = { version = "0.11.0", default-features = false }
+
+[dev-dependencies]

--- a/base58/contrib/test.sh
+++ b/base58/contrib/test.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -ex
+
+FEATURES="std alloc"
+
+cargo --version
+rustc --version
+
+if [ "$DO_LINT" = true ]
+then
+    cargo clippy --all-features --all-targets -- -D warnings
+fi
+
+# Test each feature
+for feature in ${FEATURES}
+do
+    echo "********* Testing $feature *************"
+    cargo test --verbose --features="$feature"
+done
+
+# Build the docs if told to (this only works with the nightly toolchain)
+if [ "$DO_DOCS" = true ]; then
+    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly rustdoc --features="$FEATURES" -- -D rustdoc::broken-intra-doc-links
+fi

--- a/base58/contrib/test.sh
+++ b/base58/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="std alloc"
+FEATURES="std"
 
 cargo --version
 rustc --version

--- a/base58/src/checksum.rs
+++ b/base58/src/checksum.rs
@@ -1,0 +1,245 @@
+// Written by the Rust Bitcoin developers
+// SPDX-License-Identifier: CC0-1.0
+
+//! An implementation of the sha256 hashing algorithm.
+//!
+//! The sha256 function is then used to calculate a double sha256 checksum.
+//!
+
+use core::cmp;
+use core::convert::TryInto;
+
+const BLOCK_SIZE: usize = 64;
+
+/// Creates a double sha256 digest from `data` and returns the first 4 bytes.
+pub fn checksum(data: &[u8]) -> [u8; 4] {
+    let mut ret = [0_u8; 4];
+
+    let sha256d = hash(&hash(data));
+
+    ret.copy_from_slice(&sha256d[..4]);
+    ret
+}
+
+/// Returns the sha256 hash of `data`.
+fn hash(data: &[u8]) -> [u8; 32] {
+    let mut engine = HashEngine::default();
+    engine.input(data);
+    hash_from_engine(engine)
+}
+
+fn hash_from_engine(mut e: HashEngine) -> [u8; 32] {
+    // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
+    let data_len = e.length as u64;
+
+    let zeroes = [0; BLOCK_SIZE - 8];
+    e.input(&[0x80]);
+    if e.length % BLOCK_SIZE > zeroes.len() {
+        e.input(&zeroes);
+    }
+    let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
+    e.input(&zeroes[..pad_length]);
+    debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
+
+    e.input(&(8 * data_len).to_be_bytes());
+    debug_assert_eq!(e.length % BLOCK_SIZE, 0);
+
+    e.midstate().0
+}
+
+/// Engine to compute SHA256 hash function.
+#[derive(Clone)]
+pub struct HashEngine {
+    buffer: [u8; BLOCK_SIZE],
+    h: [u32; 8],
+    length: usize,
+}
+
+#[rustfmt::skip]
+impl Default for HashEngine {
+    fn default() -> Self {
+        HashEngine {
+            h: [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19],
+            length: 0,
+            buffer: [0; BLOCK_SIZE],
+        }
+    }
+}
+
+impl HashEngine {
+    fn midstate(&self) -> Midstate {
+        let mut ret = [0; 32];
+        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_exact_mut(4)) {
+            ret_bytes.copy_from_slice(&val.to_be_bytes());
+        }
+        Midstate(ret)
+    }
+
+    fn input(&mut self, mut inp: &[u8]) {
+        while !inp.is_empty() {
+            let buf_idx = self.length % BLOCK_SIZE;
+            let rem_len = BLOCK_SIZE - buf_idx;
+            let write_len = cmp::min(rem_len, inp.len());
+
+            self.buffer[buf_idx..buf_idx + write_len].copy_from_slice(&inp[..write_len]);
+            self.length += write_len;
+            if self.length % BLOCK_SIZE == 0 {
+                self.process_block();
+            }
+            inp = &inp[write_len..];
+        }
+    }
+}
+
+/// Output of the SHA256 hash function.
+#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+pub struct Midstate(pub [u8; 32]);
+
+macro_rules! Ch( ($x:expr, $y:expr, $z:expr) => ($z ^ ($x & ($y ^ $z))) );
+macro_rules! Maj( ($x:expr, $y:expr, $z:expr) => (($x & $y) | ($z & ($x | $y))) );
+macro_rules! Sigma0( ($x:expr) => ($x.rotate_left(30) ^ $x.rotate_left(19) ^ $x.rotate_left(10)) );
+macro_rules! Sigma1( ($x:expr) => ( $x.rotate_left(26) ^ $x.rotate_left(21) ^ $x.rotate_left(7)) );
+macro_rules! sigma0( ($x:expr) => ($x.rotate_left(25) ^ $x.rotate_left(14) ^ ($x >> 3)) );
+macro_rules! sigma1( ($x:expr) => ($x.rotate_left(15) ^ $x.rotate_left(13) ^ ($x >> 10)) );
+
+macro_rules! round(
+    // first round
+    ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr, $g:expr, $h:expr, $k:expr, $w:expr) => (
+        let t1 = $h.wrapping_add(Sigma1!($e)).wrapping_add(Ch!($e, $f, $g)).wrapping_add($k).wrapping_add($w);
+        let t2 = Sigma0!($a).wrapping_add(Maj!($a, $b, $c));
+        $d = $d.wrapping_add(t1);
+        $h = t1.wrapping_add(t2);
+    );
+    // later rounds we reassign $w before doing the first-round computation
+    ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr, $g:expr, $h:expr, $k:expr, $w:expr, $w1:expr, $w2:expr, $w3:expr) => (
+        $w = $w.wrapping_add(sigma1!($w1)).wrapping_add($w2).wrapping_add(sigma0!($w3));
+        round!($a, $b, $c, $d, $e, $f, $g, $h, $k, $w);
+    )
+);
+
+impl HashEngine {
+    // Algorithm copied from libsecp256k1
+    fn process_block(&mut self) {
+        debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
+
+        let mut w = [0u32; 16];
+        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks_exact(4)) {
+            *w_val = u32::from_be_bytes(buff_bytes.try_into().expect("4 byte slice"));
+        }
+
+        let mut a = self.h[0];
+        let mut b = self.h[1];
+        let mut c = self.h[2];
+        let mut d = self.h[3];
+        let mut e = self.h[4];
+        let mut f = self.h[5];
+        let mut g = self.h[6];
+        let mut h = self.h[7];
+
+        round!(a, b, c, d, e, f, g, h, 0x428a2f98, w[0]);
+        round!(h, a, b, c, d, e, f, g, 0x71374491, w[1]);
+        round!(g, h, a, b, c, d, e, f, 0xb5c0fbcf, w[2]);
+        round!(f, g, h, a, b, c, d, e, 0xe9b5dba5, w[3]);
+        round!(e, f, g, h, a, b, c, d, 0x3956c25b, w[4]);
+        round!(d, e, f, g, h, a, b, c, 0x59f111f1, w[5]);
+        round!(c, d, e, f, g, h, a, b, 0x923f82a4, w[6]);
+        round!(b, c, d, e, f, g, h, a, 0xab1c5ed5, w[7]);
+        round!(a, b, c, d, e, f, g, h, 0xd807aa98, w[8]);
+        round!(h, a, b, c, d, e, f, g, 0x12835b01, w[9]);
+        round!(g, h, a, b, c, d, e, f, 0x243185be, w[10]);
+        round!(f, g, h, a, b, c, d, e, 0x550c7dc3, w[11]);
+        round!(e, f, g, h, a, b, c, d, 0x72be5d74, w[12]);
+        round!(d, e, f, g, h, a, b, c, 0x80deb1fe, w[13]);
+        round!(c, d, e, f, g, h, a, b, 0x9bdc06a7, w[14]);
+        round!(b, c, d, e, f, g, h, a, 0xc19bf174, w[15]);
+
+        round!(a, b, c, d, e, f, g, h, 0xe49b69c1, w[0], w[14], w[9], w[1]);
+        round!(h, a, b, c, d, e, f, g, 0xefbe4786, w[1], w[15], w[10], w[2]);
+        round!(g, h, a, b, c, d, e, f, 0x0fc19dc6, w[2], w[0], w[11], w[3]);
+        round!(f, g, h, a, b, c, d, e, 0x240ca1cc, w[3], w[1], w[12], w[4]);
+        round!(e, f, g, h, a, b, c, d, 0x2de92c6f, w[4], w[2], w[13], w[5]);
+        round!(d, e, f, g, h, a, b, c, 0x4a7484aa, w[5], w[3], w[14], w[6]);
+        round!(c, d, e, f, g, h, a, b, 0x5cb0a9dc, w[6], w[4], w[15], w[7]);
+        round!(b, c, d, e, f, g, h, a, 0x76f988da, w[7], w[5], w[0], w[8]);
+        round!(a, b, c, d, e, f, g, h, 0x983e5152, w[8], w[6], w[1], w[9]);
+        round!(h, a, b, c, d, e, f, g, 0xa831c66d, w[9], w[7], w[2], w[10]);
+        round!(g, h, a, b, c, d, e, f, 0xb00327c8, w[10], w[8], w[3], w[11]);
+        round!(f, g, h, a, b, c, d, e, 0xbf597fc7, w[11], w[9], w[4], w[12]);
+        round!(e, f, g, h, a, b, c, d, 0xc6e00bf3, w[12], w[10], w[5], w[13]);
+        round!(d, e, f, g, h, a, b, c, 0xd5a79147, w[13], w[11], w[6], w[14]);
+        round!(c, d, e, f, g, h, a, b, 0x06ca6351, w[14], w[12], w[7], w[15]);
+        round!(b, c, d, e, f, g, h, a, 0x14292967, w[15], w[13], w[8], w[0]);
+
+        round!(a, b, c, d, e, f, g, h, 0x27b70a85, w[0], w[14], w[9], w[1]);
+        round!(h, a, b, c, d, e, f, g, 0x2e1b2138, w[1], w[15], w[10], w[2]);
+        round!(g, h, a, b, c, d, e, f, 0x4d2c6dfc, w[2], w[0], w[11], w[3]);
+        round!(f, g, h, a, b, c, d, e, 0x53380d13, w[3], w[1], w[12], w[4]);
+        round!(e, f, g, h, a, b, c, d, 0x650a7354, w[4], w[2], w[13], w[5]);
+        round!(d, e, f, g, h, a, b, c, 0x766a0abb, w[5], w[3], w[14], w[6]);
+        round!(c, d, e, f, g, h, a, b, 0x81c2c92e, w[6], w[4], w[15], w[7]);
+        round!(b, c, d, e, f, g, h, a, 0x92722c85, w[7], w[5], w[0], w[8]);
+        round!(a, b, c, d, e, f, g, h, 0xa2bfe8a1, w[8], w[6], w[1], w[9]);
+        round!(h, a, b, c, d, e, f, g, 0xa81a664b, w[9], w[7], w[2], w[10]);
+        round!(g, h, a, b, c, d, e, f, 0xc24b8b70, w[10], w[8], w[3], w[11]);
+        round!(f, g, h, a, b, c, d, e, 0xc76c51a3, w[11], w[9], w[4], w[12]);
+        round!(e, f, g, h, a, b, c, d, 0xd192e819, w[12], w[10], w[5], w[13]);
+        round!(d, e, f, g, h, a, b, c, 0xd6990624, w[13], w[11], w[6], w[14]);
+        round!(c, d, e, f, g, h, a, b, 0xf40e3585, w[14], w[12], w[7], w[15]);
+        round!(b, c, d, e, f, g, h, a, 0x106aa070, w[15], w[13], w[8], w[0]);
+
+        round!(a, b, c, d, e, f, g, h, 0x19a4c116, w[0], w[14], w[9], w[1]);
+        round!(h, a, b, c, d, e, f, g, 0x1e376c08, w[1], w[15], w[10], w[2]);
+        round!(g, h, a, b, c, d, e, f, 0x2748774c, w[2], w[0], w[11], w[3]);
+        round!(f, g, h, a, b, c, d, e, 0x34b0bcb5, w[3], w[1], w[12], w[4]);
+        round!(e, f, g, h, a, b, c, d, 0x391c0cb3, w[4], w[2], w[13], w[5]);
+        round!(d, e, f, g, h, a, b, c, 0x4ed8aa4a, w[5], w[3], w[14], w[6]);
+        round!(c, d, e, f, g, h, a, b, 0x5b9cca4f, w[6], w[4], w[15], w[7]);
+        round!(b, c, d, e, f, g, h, a, 0x682e6ff3, w[7], w[5], w[0], w[8]);
+        round!(a, b, c, d, e, f, g, h, 0x748f82ee, w[8], w[6], w[1], w[9]);
+        round!(h, a, b, c, d, e, f, g, 0x78a5636f, w[9], w[7], w[2], w[10]);
+        round!(g, h, a, b, c, d, e, f, 0x84c87814, w[10], w[8], w[3], w[11]);
+        round!(f, g, h, a, b, c, d, e, 0x8cc70208, w[11], w[9], w[4], w[12]);
+        round!(e, f, g, h, a, b, c, d, 0x90befffa, w[12], w[10], w[5], w[13]);
+        round!(d, e, f, g, h, a, b, c, 0xa4506ceb, w[13], w[11], w[6], w[14]);
+        round!(c, d, e, f, g, h, a, b, 0xbef9a3f7, w[14], w[12], w[7], w[15]);
+        round!(b, c, d, e, f, g, h, a, 0xc67178f2, w[15], w[13], w[8], w[0]);
+
+        self.h[0] = self.h[0].wrapping_add(a);
+        self.h[1] = self.h[1].wrapping_add(b);
+        self.h[2] = self.h[2].wrapping_add(c);
+        self.h[3] = self.h[3].wrapping_add(d);
+        self.h[4] = self.h[4].wrapping_add(e);
+        self.h[5] = self.h[5].wrapping_add(f);
+        self.h[6] = self.h[6].wrapping_add(g);
+        self.h[7] = self.h[7].wrapping_add(h);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin_hashes::{sha256, sha256d, Hash};
+
+    use super::*;
+
+    fn test_data<'a>() -> Vec<&'a str> {
+        vec!["this", "and also this", "and this even a bit longer"]
+    }
+
+    #[test]
+    fn same_digest_as_from_bitcoin_hashes() {
+        for s in test_data() {
+            let got = hash(s.as_bytes());
+            let want = sha256::Hash::hash(s.as_bytes()).into_inner();
+            assert_eq!(got, want)
+        }
+    }
+
+    #[test]
+    fn checksum_same_as_from_bitcoin_hashes() {
+        for s in test_data() {
+            let ours = checksum(s.as_bytes());
+            let sha256 = sha256d::Hash::hash(s.as_bytes());
+            assert_eq!(ours, sha256.into_inner()[..4]);
+        }
+    }
+}

--- a/base58/src/hex.rs
+++ b/base58/src/hex.rs
@@ -1,0 +1,107 @@
+// Written by the Rust Bitcoin developers
+// SPDX-License-Identifier: CC0-1.0
+
+//! Hex encoding and decoding.
+//!
+//! This module is only used to decode base58 checksum in unit tests.
+//!
+
+use core::fmt;
+
+/// Decodes a hex string into a byte array.
+pub fn decode(hex: &str) -> Result<Vec<u8>, Error> {
+    if hex.len() % 2 != 0 {
+        return Err(Error::OddLengthString(hex.len()));
+    }
+
+    let mut out: Vec<u8> = Vec::with_capacity(hex.len() / 2);
+
+    let mut b = 0;
+    let mut idx = 0;
+    for c in hex.bytes() {
+        b <<= 4;
+        match c {
+            b'A'..=b'F' => b |= c - b'A' + 10,
+            b'a'..=b'f' => b |= c - b'a' + 10,
+            b'0'..=b'9' => b |= c - b'0',
+            d => return Err(Error::InvalidChar(d)),
+        }
+        if (idx & 1) == 1 {
+            out.push(b);
+            b = 0;
+        }
+        idx += 1;
+    }
+    Ok(out)
+}
+
+/// Encodes `data` into a hex string.
+fn encode(data: &[u8]) -> String {
+    let digits = data.len() * 2;
+
+    let mut target: Vec<u8> = Vec::with_capacity(digits);
+
+    const HEX_TABLE: [u8; 16] = *b"0123456789abcdef";
+
+    for &b in data {
+        target.push(HEX_TABLE[usize::from(b >> 4)]);
+        target.push(HEX_TABLE[usize::from(b & 0b00001111)]);
+    }
+    String::from_utf8(target).expect("we only write valid digits")
+}
+
+/// Hex decoding error.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Error {
+    /// Non-hexadecimal character.
+    InvalidChar(u8),
+    /// Purported hex string had odd length.
+    OddLengthString(usize),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::InvalidChar(ch) => write!(f, "invalid hex character {}", ch),
+            Error::OddLengthString(ell) => write!(f, "odd hex string length {}", ell),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match *self {
+            InvalidChar(_) | OddLengthString(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_roundtrip() {
+        let lower = "0123456789abcdef";
+        let upper = "0123456789ABCDEF";
+        let bytes = vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
+
+        let parse = decode(lower).expect("parse lowercase string");
+        assert_eq!(parse, bytes);
+        let ser = encode(&parse);
+        assert_eq!(ser, lower);
+
+        let parse = decode(upper).expect("parse uppercase string");
+        assert_eq!(parse, bytes);
+        let ser = encode(&parse);
+        assert_eq!(ser, lower);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_digit() { let _ = decode("invalid-hex").unwrap(); }
+}

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -25,14 +25,15 @@ secp-recovery = ["secp256k1/recovery"]
 # The no-std feature doesn't disable std - you need to turn off the std feature for that by disabling default.
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
-std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std", "bitcoin-internals/std"]
-no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
+std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std", "bitcoin-internals/std", "bitcoin-base58/std"]
+no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc", "bitcoin-base58/alloc"]
 
 [package.metadata.docs.rs]
 features = [ "std", "secp-recovery", "base64", "rand", "serde", "bitcoinconsensus" ]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+bitcoin-base58 = { path  = "../base58", default-features = false }
 bitcoin-internals = { path = "../internals" }
 bech32 = { version = "0.9.0", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -26,7 +26,7 @@ secp-recovery = ["secp256k1/recovery"]
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
 std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std", "bitcoin-internals/std", "bitcoin-base58/std"]
-no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc", "bitcoin-base58/alloc"]
+no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
 
 [package.metadata.docs.rs]
 features = [ "std", "secp-recovery", "base64", "rand", "serde", "bitcoinconsensus" ]

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -30,6 +30,7 @@ use bech32;
 use bitcoin_internals::write_err;
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 
+use crate::base58;
 use crate::blockdata::constants::{
     MAX_SCRIPT_ELEMENT_SIZE, PUBKEY_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST,
     SCRIPT_ADDRESS_PREFIX_MAIN, SCRIPT_ADDRESS_PREFIX_TEST,
@@ -42,7 +43,6 @@ use crate::hashes::{sha256, Hash, HashEngine};
 use crate::internal_macros::serde_string_impl;
 use crate::network::constants::Network;
 use crate::prelude::*;
-use crate::util::base58;
 use crate::util::key::PublicKey;
 use crate::util::schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
 use crate::util::taproot::TapBranchHash;

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -523,13 +523,13 @@ impl<'a> fmt::Display for AddressEncoding<'a> {
                 let mut prefixed = [0; 21];
                 prefixed[0] = self.p2pkh_prefix;
                 prefixed[1..].copy_from_slice(&hash[..]);
-                base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
+                base58::encode_check_to_fmt(fmt, &prefixed[..])
             }
             Payload::ScriptHash(hash) => {
                 let mut prefixed = [0; 21];
                 prefixed[0] = self.p2sh_prefix;
                 prefixed[1..].copy_from_slice(&hash[..]);
-                base58::check_encode_slice_to_fmt(fmt, &prefixed[..])
+                base58::encode_check_to_fmt(fmt, &prefixed[..])
             }
             Payload::WitnessProgram { version, program: prog } => {
                 let mut upper_writer;
@@ -838,7 +838,7 @@ impl FromStr for Address {
         if s.len() > 50 {
             return Err(Error::Base58(base58::Error::InvalidLength(s.len() * 11 / 15)));
         }
-        let data = base58::from_check(s)?;
+        let data = base58::decode_check(s)?;
         if data.len() != 21 {
             return Err(Error::Base58(base58::Error::InvalidLength(data.len())));
         }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -775,7 +775,7 @@ impl ExtendedPubKey {
 
 impl fmt::Display for ExtendedPrivKey {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        base58::check_encode_slice_to_fmt(fmt, &self.encode()[..])
+        base58::encode_check_to_fmt(fmt, &self.encode()[..])
     }
 }
 
@@ -783,7 +783,7 @@ impl FromStr for ExtendedPrivKey {
     type Err = Error;
 
     fn from_str(inp: &str) -> Result<ExtendedPrivKey, Error> {
-        let data = base58::from_check(inp)?;
+        let data = base58::decode_check(inp)?;
 
         if data.len() != 78 {
             return Err(base58::Error::InvalidLength(data.len()).into());
@@ -795,7 +795,7 @@ impl FromStr for ExtendedPrivKey {
 
 impl fmt::Display for ExtendedPubKey {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        base58::check_encode_slice_to_fmt(fmt, &self.encode()[..])
+        base58::encode_check_to_fmt(fmt, &self.encode()[..])
     }
 }
 
@@ -803,7 +803,7 @@ impl FromStr for ExtendedPubKey {
     type Err = Error;
 
     fn from_str(inp: &str) -> Result<ExtendedPubKey, Error> {
-        let data = base58::from_check(inp)?;
+        let data = base58::decode_check(inp)?;
 
         if data.len() != 78 {
             return Err(base58::Error::InvalidLength(data.len()).into());

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -63,7 +63,7 @@ extern crate alloc;
 // Re-export dependencies we control.
 #[cfg(feature = "bitcoinconsensus")]
 pub use bitcoinconsensus;
-pub use {bech32, bitcoin_hashes as hashes, secp256k1};
+pub use {bech32, bitcoin_hashes as hashes, secp256k1, bitcoin_base58 as base58};
 
 #[cfg(feature = "serde")]
 #[macro_use]

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -239,8 +239,10 @@ pub enum Error {
     BadByte(u8),
     /// Checksum was not correct (expected, actual).
     BadChecksum(u32, u32),
-    /// The length (in bytes) of the object was not correct, note that if the length is excessively
-    /// long the provided length may be an estimate (and the checksum step may be skipped).
+    /// The length (in bytes) of the object was not correct.
+    ///
+    /// Note that if the length is excessively long the provided length may be an estimate (and the
+    /// checksum step may be skipped).
     InvalidLength(usize),
     /// Extended Key version byte(s) were not recognized.
     InvalidExtendedKeyVersion([u8; 4]),

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -11,11 +11,9 @@ use crate::prelude::*;
 
 use core::{fmt, str, iter, slice};
 
-use bitcoin_internals::write_err;
-use crate::hashes::{sha256d, Hash, hex};
-use secp256k1;
+use crate::hashes::{sha256d, Hash};
 
-use crate::util::{endian, key};
+use crate::util::endian;
 
 /// An error that might occur during base58 decoding
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
@@ -35,11 +33,6 @@ pub enum Error {
     InvalidAddressVersion(u8),
     /// Checked data was less than 4 bytes
     TooShort(usize),
-    /// Secp256k1 error while parsing a secret key
-    Secp256k1(secp256k1::Error),
-    /// Hex decoding error
-    // TODO: Remove this as part of crate-smashing, there should not be any key related errors in this module
-    Hex(hex::Error)
 }
 
 impl fmt::Display for Error {
@@ -51,8 +44,6 @@ impl fmt::Display for Error {
             Error::InvalidExtendedKeyVersion(ref v) => write!(f, "extended key version {:#04x?} is invalid for this base58 type", v),
             Error::InvalidAddressVersion(ref v) => write!(f, "address version {} is invalid for this base58 type", v),
             Error::TooShort(_) => write!(f, "base58ck data not even long enough for a checksum"),
-            Error::Secp256k1(ref e) => write_err!(f, "secp256k1 error while parsing secret key"; e),
-            Error::Hex(ref e) => write_err!(f, "hexadecimal decoding error"; e)
         }
     }
 }
@@ -70,8 +61,6 @@ impl std::error::Error for Error {
             | InvalidExtendedKeyVersion(_)
             | InvalidAddressVersion(_)
             | TooShort(_) => None,
-            Secp256k1(e) => Some(e),
-            Hex(e) => Some(e),
         }
     }
 }
@@ -257,18 +246,6 @@ pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::
         .cloned()
         .chain(checksum[0..4].iter().cloned());
     format_iter(fmt, iter)
-}
-
-#[doc(hidden)]
-impl From<key::Error> for Error {
-    fn from(e: key::Error) -> Self {
-        match e {
-            key::Error::Secp256k1(e) => Error::Secp256k1(e),
-            key::Error::Base58(e) => e,
-            key::Error::InvalidKeyPrefix(_) => Error::Secp256k1(secp256k1::Error::InvalidPublicKey),
-            key::Error::Hex(e) => Error::Hex(e)
-        }
-    }
 }
 
 #[cfg(test)]

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -13,23 +13,22 @@ use crate::hashes::{sha256d, Hash};
 use crate::prelude::*;
 use crate::util::endian;
 
-/// An error that might occur during base58 decoding
+/// An error that might occur during base58 decoding.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 #[non_exhaustive]
 pub enum Error {
-    /// Invalid character encountered
+    /// Invalid character encountered.
     BadByte(u8),
-    /// Checksum was not correct (expected, actual)
+    /// Checksum was not correct (expected, actual).
     BadChecksum(u32, u32),
-    /// The length (in bytes) of the object was not correct
-    /// Note that if the length is excessively long the provided length may be
-    /// an estimate (and the checksum step may be skipped).
+    /// The length (in bytes) of the object was not correct, note that if the length is excessively
+    /// long the provided length may be an estimate (and the checksum step may be skipped).
     InvalidLength(usize),
-    /// Extended Key version byte(s) were not recognized
+    /// Extended Key version byte(s) were not recognized.
     InvalidExtendedKeyVersion([u8; 4]),
-    /// Address version byte were not recognized
+    /// Address version byte were not recognized.
     InvalidAddressVersion(u8),
-    /// Checked data was less than 4 bytes
+    /// Checked data was less than 4 bytes.
     TooShort(usize),
 }
 
@@ -121,7 +120,7 @@ static BASE58_DIGITS: [Option<u8>; 128] = [
     Some(55), Some(56), Some(57), None,     None,     None,     None,     None,     // 120-127
 ];
 
-/// Decode base58-encoded string into a byte vector
+/// Decodes a base58-encoded string into a byte vector.
 pub fn from(data: &str) -> Result<Vec<u8>, Error> {
     // 11/15 is just over log_256(58)
     let mut scratch = vec![0u8; 1 + data.len() * 11 / 15];
@@ -152,7 +151,7 @@ pub fn from(data: &str) -> Result<Vec<u8>, Error> {
     Ok(ret)
 }
 
-/// Decode a base58check-encoded string
+/// Decodes a base58check-encoded string into a byte vector verifying the checksum.
 pub fn from_check(data: &str) -> Result<Vec<u8>, Error> {
     let mut ret: Vec<u8> = from(data)?;
     if ret.len() < 4 {
@@ -220,13 +219,14 @@ where
 }
 
 
-/// Directly encode a slice as base58
+/// Encodes `data` as a base58 string.
 pub fn encode_slice(data: &[u8]) -> String {
     encode_iter(data.iter().cloned())
 }
 
-/// Obtain a string with the base58check encoding of a slice
-/// (Tack the first 4 256-digits of the object's Bitcoin hash onto the end.)
+/// Encodes `data` as a base58 string including the checksum.
+///
+/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
 pub fn check_encode_slice(data: &[u8]) -> String {
     let checksum = sha256d::Hash::hash(data);
     encode_iter(
@@ -236,8 +236,9 @@ pub fn check_encode_slice(data: &[u8]) -> String {
     )
 }
 
-/// Obtain a string with the base58check encoding of a slice
-/// (Tack the first 4 256-digits of the object's Bitcoin hash onto the end.)
+/// Encodes `data` as base58, including the checksum, into a formatter.
+///
+/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
 pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
     let checksum = sha256d::Hash::hash(data);
     let iter = data.iter()

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -7,12 +7,10 @@
 //! strings respectively.
 //!
 
-use crate::prelude::*;
-
 use core::{fmt, str, iter, slice};
 
 use crate::hashes::{sha256d, Hash};
-
+use crate::prelude::*;
 use crate::util::endian;
 
 /// An error that might occur during base58 decoding

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -72,7 +72,7 @@ struct SmallVec<T> {
 }
 
 impl<T: Default + Copy> SmallVec<T> {
-    pub fn new() -> SmallVec<T> {
+    fn new() -> SmallVec<T> {
         SmallVec {
             len: 0,
             stack: [T::default(); 100],
@@ -80,7 +80,7 @@ impl<T: Default + Copy> SmallVec<T> {
         }
     }
 
-    pub fn push(&mut self, val: T) {
+    fn push(&mut self, val: T) {
         if self.len < 100 {
             self.stack[self.len] = val;
             self.len += 1;
@@ -89,12 +89,12 @@ impl<T: Default + Copy> SmallVec<T> {
         }
     }
 
-    pub fn iter(&self) -> iter::Chain<slice::Iter<T>, slice::Iter<T>> {
+    fn iter(&self) -> iter::Chain<slice::Iter<T>, slice::Iter<T>> {
         // If len<100 then we just append an empty vec
         self.stack[0..self.len].iter().chain(self.heap.iter())
     }
 
-    pub fn iter_mut(&mut self) -> iter::Chain<slice::IterMut<T>, slice::IterMut<T>> {
+    fn iter_mut(&mut self) -> iter::Chain<slice::IterMut<T>, slice::IterMut<T>> {
         // If len<100 then we just append an empty vec
         self.stack[0..self.len].iter_mut().chain(self.heap.iter_mut())
     }

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -107,7 +107,7 @@ pub fn encode(data: &[u8]) -> String {
 
 /// Encodes `data` as a base58 string including the checksum.
 ///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+/// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 #[deprecated(since = "0.30.0", note = "Use base58::encode_check() instead")]
 pub fn check_encode_slice(data: &[u8]) -> String {
     encode_check(data)
@@ -115,7 +115,7 @@ pub fn check_encode_slice(data: &[u8]) -> String {
 
 /// Encodes `data` as a base58 string including the checksum.
 ///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+/// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 pub fn encode_check(data: &[u8]) -> String {
     let checksum = sha256d::Hash::hash(data);
     encode_iter(
@@ -127,7 +127,7 @@ pub fn encode_check(data: &[u8]) -> String {
 
 /// Encodes `data` as base58, including the checksum, into a formatter.
 ///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+/// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 #[deprecated(since = "0.30.0", note = "Use base58::encode_check_to_fmt() instead")]
 pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
     encode_check_to_fmt(fmt, data)
@@ -135,7 +135,7 @@ pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::
 
 /// Encodes a slice as base58, including the checksum, into a formatter.
 ///
-/// The checksum is the first 4 256-digits of the object's Bitcoin hash, concatenated onto the end.
+/// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 pub fn encode_check_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
     let checksum = sha256d::Hash::hash(data);
     let iter = data.iter()

--- a/bitcoin/src/util/base58.rs
+++ b/bitcoin/src/util/base58.rs
@@ -36,8 +36,8 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::BadByte(b) => write!(f, "invalid base58 character 0x{:x}", b),
-            Error::BadChecksum(exp, actual) => write!(f, "base58ck checksum 0x{:x} does not match expected 0x{:x}", actual, exp),
+            Error::BadByte(b) => write!(f, "invalid base58 character {:#x}", b),
+            Error::BadChecksum(exp, actual) => write!(f, "base58ck checksum {:#x} does not match expected {:#x}", actual, exp),
             Error::InvalidLength(ell) => write!(f, "length {} invalid for this base58 type", ell),
             Error::InvalidExtendedKeyVersion(ref v) => write!(f, "extended key version {:#04x?} is invalid for this base58 type", v),
             Error::InvalidAddressVersion(ref v) => write!(f, "address version {} is invalid for this base58 type", v),

--- a/bitcoin/src/util/key.rs
+++ b/bitcoin/src/util/key.rs
@@ -360,9 +360,9 @@ impl PrivateKey {
         ret[1..33].copy_from_slice(&self.inner[..]);
         let privkey = if self.compressed {
             ret[33] = 1;
-            base58::check_encode_slice(&ret[..])
+            base58::encode_check(&ret[..])
         } else {
-            base58::check_encode_slice(&ret[..33])
+            base58::encode_check(&ret[..33])
         };
         fmt.write_str(&privkey)
     }
@@ -377,7 +377,7 @@ impl PrivateKey {
 
     /// Parse WIF encoded private key.
     pub fn from_wif(wif: &str) -> Result<PrivateKey, Error> {
-        let data = base58::from_check(wif)?;
+        let data = base58::decode_check(wif)?;
 
         let compressed = match data.len() {
             33 => false,

--- a/bitcoin/src/util/key.rs
+++ b/bitcoin/src/util/key.rs
@@ -14,11 +14,10 @@ use core::fmt::{self, Write};
 use bitcoin_internals::write_err;
 pub use secp256k1::{self, Secp256k1, XOnlyPublicKey, KeyPair};
 
-use crate::io;
+use crate::{base58, io};
 use crate::network::constants::Network;
 use crate::hashes::{Hash, hash160, hex, hex::FromHex};
 use crate::hash_types::{PubkeyHash, WPubkeyHash};
-use crate::util::base58;
 
 /// A key-related error.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -10,7 +10,6 @@ pub mod key;
 pub mod ecdsa;
 pub mod schnorr;
 pub mod amount;
-pub mod base58;
 pub mod bip152;
 pub mod hash;
 pub mod merkleblock;
@@ -18,6 +17,9 @@ pub mod psbt;
 pub mod taproot;
 pub mod uint;
 pub mod sighash;
+
+// Deprecated since 0.30.0, remove this at some stage.
+pub use bitcoin_base58 as base58;
 
 pub(crate) mod endian;
 


### PR DESCRIPTION
This is not ready to look at, leaving open as a place holder for when we get to this work.


- Patch 1-9 are from: https://github.com/rust-bitcoin/rust-bitcoin/pull/1264
- Patch 9: creates a crate out of `base58`
- Patch 10: removes dependency on `bitcoin_hashes`.

