### PR TITLE
Fix clippy warnings

### DIFF
--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -730,25 +730,25 @@ impl Decodable for CheckedData {
 // References
 impl<'a, T: Encodable> Encodable for &'a T {
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        (&**self).consensus_encode(w)
+        (**self).consensus_encode(w)
     }
 }
 
 impl<'a, T: Encodable> Encodable for &'a mut T {
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        (&**self).consensus_encode(w)
+        (**self).consensus_encode(w)
     }
 }
 
 impl<T: Encodable> Encodable for rc::Rc<T> {
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        (&**self).consensus_encode(w)
+        (**self).consensus_encode(w)
     }
 }
 
 impl<T: Encodable> Encodable for sync::Arc<T> {
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        (&**self).consensus_encode(w)
+        (**self).consensus_encode(w)
     }
 }
 

--- a/bitcoin/src/util/psbt/mod.rs
+++ b/bitcoin/src/util/psbt/mod.rs
@@ -302,7 +302,7 @@ impl Decodable for PartiallySignedTransaction {
         global.unsigned_tx_checks()?;
 
         let inputs: Vec<Input> = {
-            let inputs_len: usize = (&global.unsigned_tx.input).len();
+            let inputs_len: usize = global.unsigned_tx.input.len();
 
             let mut inputs: Vec<Input> = Vec::with_capacity(inputs_len);
 
@@ -314,7 +314,7 @@ impl Decodable for PartiallySignedTransaction {
         };
 
         let outputs: Vec<Output> = {
-            let outputs_len: usize = (&global.unsigned_tx.output).len();
+            let outputs_len: usize = global.unsigned_tx.output.len();
 
             let mut outputs: Vec<Output> = Vec::with_capacity(outputs_len);
 
@@ -818,7 +818,7 @@ mod tests {
             assert_eq!(psbt.outputs.len(), 2);
 
             let tx_input = &psbt.unsigned_tx.input[0];
-            let psbt_non_witness_utxo = (&psbt.inputs[0].non_witness_utxo).as_ref().unwrap();
+            let psbt_non_witness_utxo = psbt.inputs[0].non_witness_utxo.as_ref().unwrap();
 
             assert_eq!(tx_input.previous_output.txid, psbt_non_witness_utxo.txid());
             assert!(psbt_non_witness_utxo.output[tx_input.previous_output.vout as usize]
@@ -826,7 +826,7 @@ mod tests {
                     .is_p2pkh()
             );
             assert_eq!(
-                (&psbt.inputs[0].sighash_type).as_ref().unwrap().ecdsa_hash_ty().unwrap(),
+                psbt.inputs[0].sighash_type.as_ref().unwrap().ecdsa_hash_ty().unwrap(),
                 EcdsaSighashType::All
             );
         }

--- a/bitcoin/src/util/taproot.rs
+++ b/bitcoin/src/util/taproot.rs
@@ -282,12 +282,9 @@ impl TaprootSpendInfo {
         for leaves in node.leaves {
             let key = (leaves.script, leaves.ver);
             let value = leaves.merkle_branch;
-            match info.script_map.get_mut(&key) {
-                Some(set) => {
-                    set.insert(value);
-                    continue; // NLL fix
-                }
-                None => {}
+            if let Some(set) = info.script_map.get_mut(&key) {
+                set.insert(value);
+                continue; // NLL fix
             }
             let mut set = BTreeSet::new();
             set.insert(value);


### PR DESCRIPTION
Clippy recently upgraded and a few two new warnings types popped up in our codebase, fix them both in a single patch so CI passes for all commits.

1. Remove unneeded explicit borrow
2. Use `if let Some` instead of pattern match