### PR TITLE
`AsMut` impls for `Magic`

### DIFF
--- a/bitcoin/src/network/constants.rs
+++ b/bitcoin/src/network/constants.rs
@@ -265,6 +265,18 @@ impl AsRef<[u8; 4]> for Magic {
     }
 }
 
+impl AsMut<[u8]> for Magic {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl AsMut<[u8; 4]> for Magic {
+    fn as_mut(&mut self) -> &mut [u8; 4] {
+        &mut self.0
+    }
+}
+
 impl Borrow<[u8]> for Magic {
     fn borrow(&self) -> &[u8] {
         &self.0


### PR DESCRIPTION
Follow up to https://github.com/rust-bitcoin/rust-bitcoin/pull/1288#discussion_r982152738

Implemented `AsMut<[u8]>` and `AsMut<[u8;4]>` for `Magic`.