### PR TITLE
Implement conversion traits for lock types

### DIFF
--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -264,6 +264,12 @@ impl LockTime {
 
 impl_parse_str_through_int!(LockTime, from_consensus);
 
+impl From<u32> for LockTime {
+    fn from(t: u32) -> Self {
+        LockTime::from_consensus(t)
+    }
+}
+
 impl From<Height> for LockTime {
     fn from(h: Height) -> Self {
         LockTime::Blocks(h)
@@ -420,6 +426,14 @@ impl fmt::Display for Height {
     }
 }
 
+impl TryFrom<u32> for Height {
+    type Error = Error;
+
+    fn try_from(x: u32) -> Result<Self, Self::Error> {
+        Height::from_consensus(x)
+    }
+}
+
 impl FromHexStr for Height {
     type Error = Error;
 
@@ -510,6 +524,14 @@ impl Time {
 impl fmt::Display for Time {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl TryFrom<u32> for Time {
+    type Error = Error;
+
+    fn try_from(x: u32) -> Result<Self, Self::Error> {
+        Time::from_consensus(x)
     }
 }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -422,6 +422,12 @@ impl Default for Sequence {
     }
 }
 
+impl From<u32> for Sequence {
+    fn from(x: u32) -> Self {
+        Sequence::from_consensus(x)
+    }
+}
+
 impl From<Sequence> for u32 {
     fn from(sequence: Sequence) -> u32 {
         sequence.0


### PR DESCRIPTION
When we originally added `absolute::LockTime` and `Sequence` we decided to be conservative and only provide constructor methods with more descriptive names.
    
`Sequence` has a public inner field so there is not a lot of clarity gained between `Sequence(x)` and `Sequence::from(x)`.
    
As for `absolute::LockTime`, a `From` impl can call `from_consensus` providing a more ergonomic conversion method at the risk of being marginally less clear. We aim to make it hard for users of the library to misuse the library but we should not do so at the cost of ergonomics unless there is a _really_ clear benefit, in this instance that is not the case.
    
Add conversion methods `From` for the two types mentioned above. Also add `TryFrom` impls for `Height` and `Time` for similar reasons.

Fix: #1302 

Please wait for ACK from @Kixunil before merging, as he was the main proponent for not adding these methods originally.