### PR TITLE
Add `Script::builder` convenience function

### DIFF
--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -354,6 +354,11 @@ impl Script {
     /// Creates a new empty script.
     pub fn new() -> Script { Script(vec![].into_boxed_slice()) }
 
+    /// Creates a new script builder
+    pub fn builder() -> Builder {
+      Builder::new()
+    }
+
     /// Generates P2PK-type of scriptPubkey.
     pub fn new_p2pk(pubkey: &PublicKey) -> Script {
         Builder::new()


### PR DESCRIPTION
Add a convenience function to `Script` to create a new builder, so that `Builder` doesn't need to be imported. This is a pretty common pattern in Rust for types which have associated builders.