### PR TITLE
Fix `test_data` dir exclusion

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/bitcoin/"
 description = "General purpose library for using and interoperating with Bitcoin and other cryptocurrencies."
 keywords = [ "crypto", "bitcoin" ]
 readme = "README.md"
-exclude = ["./test_data"]
+exclude = ["test_data/"]
 edition = "2018"
 
 # Please don't forget to add relevant features to docs.rs below


### PR DESCRIPTION
I noted our released crate `0.29.1` was bigger than expected and noted with `cargo package --list` that even with our exclude the `test_data` dir was included. I am also going to backport this.

As specified in the doc:

`foo/` matches any directory with the name `foo` anywhere in the package.

