### PR TITLE
Remove deprecated re-exports

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -7,7 +7,7 @@ use bitcoin::address::Address;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey};
+use bitcoin::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey};
 use bitcoin::PublicKey;
 
 fn main() {

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -37,7 +37,7 @@ use bitcoin::consensus::encode;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};
-use bitcoin::util::bip32::{
+use bitcoin::bip32::{
     ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey, Fingerprint, IntoDerivationPath,
 };
 use bitcoin::util::psbt::{self, Input, Psbt, PsbtSighashType};

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -87,7 +87,7 @@ use bitcoin::psbt::serialize::Serialize;
 use bitcoin::psbt::{self, Input, Output, Psbt, PsbtSighashType};
 use bitcoin::schnorr::TapTweak;
 use bitcoin::secp256k1::{Message, Secp256k1};
-use bitcoin::util::bip32::{
+use bitcoin::bip32::{
     ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey, Fingerprint,
 };
 use bitcoin::sighash::{self, SighashCache, SchnorrSighashType};

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -388,7 +388,7 @@ impl DerivationPath {
     /// Concatenate `self` with `path` and return the resulting new path.
     ///
     /// ```
-    /// use bitcoin::util::bip32::{DerivationPath, ChildNumber};
+    /// use bitcoin::bip32::{DerivationPath, ChildNumber};
     /// use std::str::FromStr;
     ///
     /// let base = DerivationPath::from_str("m/42").unwrap();

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -80,47 +80,6 @@ pub(crate) fn read_to_end<D: io::Read>(mut d: D) -> Result<Vec<u8>, io::Error> {
     Ok(result)
 }
 
-/// The `address` module now lives at the crate root, re-export everything so as not to break the
-/// API, however deprecate the re-exports so folks know to upgrade sooner or later.
-#[deprecated(since = "0.30.0", note = "Please use crate::address")]
-pub mod address {
-    pub use crate::address::*;
-}
-
-#[deprecated(since = "0.30.0", note = "Please use crate::bip32")]
-pub use crate::bip32;
-
-#[deprecated(since = "0.30.0", note = "Please use crate::bip158")]
-pub use crate::bip158;
-
-/// Functions from the `hash` module were renamed and moved to `../merkle_tree`.
-pub mod hash {
-    use crate::consensus::encode::Encodable;
-    use crate::hashes::Hash;
-    use crate::{io, merkle_tree};
-
-    /// Calculates the merkle root of a list of *hashes*, inline (in place) in `hashes`.
-    #[deprecated(since = "0.30.0", note = "Please use crate::merkle_tree::calculate_root_inline")]
-    pub fn bitcoin_merkle_root_inline<T>(hashes: &mut [T]) -> Option<T>
-    where
-        T: Hash + Encodable,
-    <T as Hash>::Engine: io::Write,
-    {
-        crate::merkle_tree::calculate_root_inline(hashes)
-    }
-
-    /// Calculates the merkle root of an iterator of *hashes*.
-    #[deprecated(since = "0.30.0", note = "Please use crate::merkle_tree::calculate_root")]
-    pub fn bitcoin_merkle_root<T, I>(hashes: I) -> Option<T>
-    where
-        T: Hash + Encodable,
-    <T as Hash>::Engine: io::Write,
-        I: Iterator<Item=T>,
-    {
-        merkle_tree::calculate_root(hashes)
-    }
-}
-
 /// The `misc` module was moved and re-named to `sign_message`.
 pub mod misc {
     use crate::prelude::*;

--- a/bitcoin/src/util/psbt/error.rs
+++ b/bitcoin/src/util/psbt/error.rs
@@ -11,7 +11,7 @@ use crate::consensus::encode;
 use crate::util::psbt::raw;
 
 use crate::hashes;
-use crate::util::bip32::ExtendedPubKey;
+use crate::bip32::ExtendedPubKey;
 
 /// Enum for marking psbt hash error.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/bitcoin/src/util/psbt/map/global.rs
+++ b/bitcoin/src/util/psbt/map/global.rs
@@ -12,7 +12,7 @@ use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::util::psbt::map::Map;
 use crate::util::psbt::{raw, PartiallySignedTransaction};
 use crate::util::psbt::Error;
-use crate::util::bip32::{ExtendedPubKey, Fingerprint, DerivationPath, ChildNumber};
+use crate::bip32::{ExtendedPubKey, Fingerprint, DerivationPath, ChildNumber};
 
 /// Type: Unsigned Transaction PSBT_GLOBAL_UNSIGNED_TX = 0x00
 const PSBT_GLOBAL_UNSIGNED_TX: u8 = 0x00;

--- a/bitcoin/src/util/psbt/map/input.rs
+++ b/bitcoin/src/util/psbt/map/input.rs
@@ -14,7 +14,7 @@ use crate::blockdata::witness::Witness;
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::consensus::encode;
 use crate::hashes::{self, hash160, ripemd160, sha256, sha256d};
-use crate::util::bip32::KeySource;
+use crate::bip32::KeySource;
 use crate::util::psbt;
 use crate::util::psbt::map::Map;
 use crate::util::psbt::raw;

--- a/bitcoin/src/util/psbt/map/output.rs
+++ b/bitcoin/src/util/psbt/map/output.rs
@@ -9,7 +9,7 @@ use crate::io;
 use crate::blockdata::script::Script;
 use crate::consensus::encode;
 use secp256k1::XOnlyPublicKey;
-use crate::util::bip32::KeySource;
+use crate::bip32::KeySource;
 use secp256k1;
 use crate::util::psbt::map::Map;
 use crate::util::psbt::raw;

--- a/bitcoin/src/util/psbt/mod.rs
+++ b/bitcoin/src/util/psbt/mod.rs
@@ -22,7 +22,7 @@ use crate::io;
 use crate::blockdata::script::Script;
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::consensus::{encode, Encodable, Decodable};
-use crate::util::bip32::{self, ExtendedPrivKey, ExtendedPubKey, KeySource};
+use crate::bip32::{self, ExtendedPrivKey, ExtendedPubKey, KeySource};
 use crate::util::ecdsa::{EcdsaSig, EcdsaSigError};
 use crate::util::key::{PublicKey, PrivateKey};
 use crate::sighash::{self, EcdsaSighashType, SighashCache};
@@ -894,7 +894,7 @@ mod tests {
     use crate::blockdata::transaction::{Transaction, TxIn, TxOut, OutPoint, Sequence};
     use crate::network::constants::Network::Bitcoin;
     use crate::consensus::encode::{deserialize, serialize, serialize_hex};
-    use crate::util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, KeySource};
+    use crate::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, KeySource};
     use crate::util::psbt::map::{Output, Input};
     use crate::util::psbt::raw;
     use crate::internal_macros::hex_script;
@@ -1815,7 +1815,7 @@ mod tests {
     #[cfg(feature = "rand")]
     fn sign_psbt() {
         use crate::WPubkeyHash;
-        use crate::util::bip32::{Fingerprint, DerivationPath};
+        use crate::bip32::{Fingerprint, DerivationPath};
 
         let unsigned_tx = Transaction {
             version: 2,

--- a/bitcoin/src/util/psbt/serialize.rs
+++ b/bitcoin/src/util/psbt/serialize.rs
@@ -15,7 +15,7 @@ use crate::blockdata::witness::Witness;
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::consensus::encode::{self, serialize, Decodable, Encodable, deserialize_partial};
 use secp256k1::{self, XOnlyPublicKey};
-use crate::util::bip32::{ChildNumber, Fingerprint, KeySource};
+use crate::bip32::{ChildNumber, Fingerprint, KeySource};
 use crate::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use crate::util::ecdsa::{EcdsaSig, EcdsaSigError};
 use crate::util::psbt;


### PR DESCRIPTION
Recently we added a bunch of deprecated re-exports while moving things out of the util module. Turns out while the code reads like it works, `deprecated` actually only works for functions, not types or modules etc.

Remove the non-functional deprecated lines and elect to _not_ re-export things we moved. Release 0.30 is going to break a lot of code but there is no real nice way to resolve that. We will need good release notes and a public apology probably :)

Fix import statements that still rely on `util::bip32` - these should have been fixed when we moved the `bip32` module.