### PR TITLE
Move amount module out of util

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -1241,13 +1241,13 @@ pub mod serde {
     //! #[derive(Serialize, Deserialize)]
     //! # #[serde(crate = "actual_serde")]
     //! pub struct HasAmount {
-    //!     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    //!     #[serde(with = "bitcoin::amount::serde::as_btc")]
     //!     pub amount: Amount,
     //! }
     //! ```
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use crate::util::amount::{Amount, Denomination, SignedAmount};
+    use crate::amount::{Amount, Denomination, SignedAmount};
 
     /// This trait is used only to avoid code duplication and naming collisions
     /// of the different serde serialization crates.
@@ -1334,7 +1334,7 @@ pub mod serde {
         //! Use with `#[serde(with = "amount::serde::as_sat")]`.
 
         use serde::{Deserializer, Serializer};
-        use crate::util::amount::serde::SerdeAmount;
+        use crate::amount::serde::SerdeAmount;
 
         pub fn serialize<A: SerdeAmount, S: Serializer>(a: &A, s: S) -> Result<S::Ok, S::Error> {
             a.ser_sat(s)
@@ -1349,7 +1349,7 @@ pub mod serde {
             //! Use with `#[serde(default, with = "amount::serde::as_sat::opt")]`.
 
             use serde::{Deserializer, Serializer, de};
-            use crate::util::amount::serde::SerdeAmountForOpt;
+            use crate::amount::serde::SerdeAmountForOpt;
             use core::fmt;
             use core::marker::PhantomData;
 
@@ -1398,7 +1398,7 @@ pub mod serde {
         //! Use with `#[serde(with = "amount::serde::as_btc")]`.
 
         use serde::{Deserializer, Serializer};
-        use crate::util::amount::serde::SerdeAmount;
+        use crate::amount::serde::SerdeAmount;
 
         pub fn serialize<A: SerdeAmount, S: Serializer>(a: &A, s: S) -> Result<S::Ok, S::Error> {
             a.ser_btc(s)
@@ -1413,7 +1413,7 @@ pub mod serde {
             //! Use with `#[serde(default, with = "amount::serde::as_btc::opt")]`.
 
             use serde::{Deserializer, Serializer, de};
-            use crate::util::amount::serde::SerdeAmountForOpt;
+            use crate::amount::serde::SerdeAmountForOpt;
             use core::fmt;
             use core::marker::PhantomData;
 
@@ -1957,9 +1957,9 @@ mod tests {
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
         #[serde(crate = "actual_serde")]
         struct T {
-            #[serde(with = "crate::util::amount::serde::as_sat")]
+            #[serde(with = "crate::amount::serde::as_sat")]
             pub amt: Amount,
-            #[serde(with = "crate::util::amount::serde::as_sat")]
+            #[serde(with = "crate::amount::serde::as_sat")]
             pub samt: SignedAmount,
         }
 
@@ -1988,9 +1988,9 @@ mod tests {
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
         #[serde(crate = "actual_serde")]
         struct T {
-            #[serde(with = "crate::util::amount::serde::as_btc")]
+            #[serde(with = "crate::amount::serde::as_btc")]
             pub amt: Amount,
-            #[serde(with = "crate::util::amount::serde::as_btc")]
+            #[serde(with = "crate::amount::serde::as_btc")]
             pub samt: SignedAmount,
         }
 
@@ -2024,9 +2024,9 @@ mod tests {
         #[derive(Serialize, Deserialize, PartialEq, Debug, Eq)]
         #[serde(crate = "actual_serde")]
         struct T {
-            #[serde(default, with = "crate::util::amount::serde::as_btc::opt")]
+            #[serde(default, with = "crate::amount::serde::as_btc::opt")]
             pub amt: Option<Amount>,
-            #[serde(default, with = "crate::util::amount::serde::as_btc::opt")]
+            #[serde(default, with = "crate::amount::serde::as_btc::opt")]
             pub samt: Option<SignedAmount>,
         }
 
@@ -2069,9 +2069,9 @@ mod tests {
         #[derive(Serialize, Deserialize, PartialEq, Debug, Eq)]
         #[serde(crate = "actual_serde")]
         struct T {
-            #[serde(default, with = "crate::util::amount::serde::as_sat::opt")]
+            #[serde(default, with = "crate::amount::serde::as_sat::opt")]
             pub amt: Option<Amount>,
-            #[serde(default, with = "crate::util::amount::serde::as_sat::opt")]
+            #[serde(default, with = "crate::amount::serde::as_sat::opt")]
             pub samt: Option<SignedAmount>,
         }
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -80,6 +80,7 @@ mod serde_utils;
 #[macro_use]
 pub mod network;
 pub mod address;
+pub mod amount;
 pub mod bip152;
 pub mod bip158;
 pub mod bip32;
@@ -109,7 +110,7 @@ pub use crate::consensus::encode::VarInt;
 pub use crate::hash_types::*;
 pub use crate::network::constants::Network;
 pub use crate::pow::{CompactTarget, Target, Work};
-pub use crate::util::amount::{Amount, Denomination, SignedAmount};
+pub use crate::amount::{Amount, Denomination, SignedAmount};
 pub use crate::util::ecdsa::{self, EcdsaSig, EcdsaSigError};
 pub use crate::util::key::{KeyPair, PrivateKey, PublicKey, XOnlyPublicKey};
 pub use crate::util::merkleblock::MerkleBlock;

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -9,7 +9,6 @@
 pub mod key;
 pub mod ecdsa;
 pub mod schnorr;
-pub mod amount;
 pub mod base58;
 pub mod hash;
 pub mod merkleblock;

--- a/fuzz/fuzz_targets/deserialize_amount.rs
+++ b/fuzz/fuzz_targets/deserialize_amount.rs
@@ -4,22 +4,22 @@ fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
 
     // signed
-    let samt = match bitcoin::util::amount::SignedAmount::from_str(&data_str) {
+    let samt = match bitcoin::amount::SignedAmount::from_str(&data_str) {
         Ok(amt) => amt,
         Err(_) => return,
     };
-    let samt_roundtrip = match bitcoin::util::amount::SignedAmount::from_str(&samt.to_string()) {
+    let samt_roundtrip = match bitcoin::amount::SignedAmount::from_str(&samt.to_string()) {
         Ok(amt) => amt,
         Err(_) => return,
     };
     assert_eq!(samt, samt_roundtrip);
 
     // unsigned
-    let amt = match bitcoin::util::amount::Amount::from_str(&data_str) {
+    let amt = match bitcoin::amount::Amount::from_str(&data_str) {
         Ok(amt) => amt,
         Err(_) => return,
     };
-    let amt_roundtrip = match bitcoin::util::amount::Amount::from_str(&amt.to_string()) {
+    let amt_roundtrip = match bitcoin::amount::Amount::from_str(&amt.to_string()) {
         Ok(amt) => amt,
         Err(_) => return,
     };


### PR DESCRIPTION
Done as part of flattening the `util` module. Simply move the `amount` module out of the `util` module and to the crate root. Justified by the fact that the `Amount` type is more-or-less a "primitive" bitcoin type.