### PR TITLE
Improve doc of `Script::push_verify`

### DIFF
--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -987,9 +987,16 @@ impl Builder {
         self
     }
 
-    /// Adds an `OP_VERIFY` to the script, unless the most-recently-added
-    /// opcode has an alternate `VERIFY` form, in which case that opcode
-    /// is replaced e.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+    /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
+    ///
+    /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
+    /// in the script right after. To save space this function appends `VERIFY` only if
+    /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
+    /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+    /// 
+    /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
+    /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
+    /// semantics.
     pub fn push_verify(mut self) -> Builder {
         match self.1 {
             Some(opcodes::all::OP_EQUAL) => {


### PR DESCRIPTION
This rewords the doc to have a reasonable summary, adds a little background explaining the opcode behavior and the effect of the function when called multiple times.

Closes #1154