### PR TITLE
Move sighash module to crate root

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -658,7 +658,7 @@ impl Transaction {
         script_pubkey: &Script,
         sighash_type: U,
     ) -> EncodeSigningDataResult<io::Error> {
-        use crate::util::sighash::{self, SighashCache};
+        use crate::sighash::{self, SighashCache};
         use EncodeSigningDataResult::*;
 
         assert!(input_index < self.input.len());  // Panic on OOB
@@ -708,7 +708,7 @@ impl Transaction {
     ) -> Sighash {
         assert!(input_index < self.input.len());  // Panic on OOB, enables expect below.
 
-        let cache = crate::util::sighash::SighashCache::new(self);
+        let cache = crate::sighash::SighashCache::new(self);
         cache.legacy_signature_hash(input_index, script_pubkey, sighash_u32)
             .expect("cache method doesn't error")
     }

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -9,7 +9,7 @@ use secp256k1::ecdsa;
 
 use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
-use crate::util::sighash::EcdsaSighashType;
+use crate::sighash::EcdsaSighashType;
 use crate::io::{self, Read, Write};
 use crate::prelude::*;
 use crate::VarInt;

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -89,6 +89,7 @@ pub mod error;
 pub mod hash_types;
 pub mod policy;
 pub mod pow;
+pub mod sighash;
 pub mod sign_message;
 pub mod util;
 
@@ -114,7 +115,7 @@ pub use crate::util::ecdsa::{self, EcdsaSig, EcdsaSigError};
 pub use crate::util::key::{KeyPair, PrivateKey, PublicKey, XOnlyPublicKey};
 pub use crate::util::merkleblock::MerkleBlock;
 pub use crate::util::schnorr::{self, SchnorrSig, SchnorrSigError};
-pub use crate::util::{psbt, sighash, Error};
+pub use crate::util::{psbt, Error};
 
 #[cfg(not(feature = "std"))]
 mod io_extras {

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -1080,7 +1080,7 @@ mod tests {
     use crate::internal_macros::{hex_into, hex_script, hex_decode, hex_from_slice};
     use crate::network::constants::Network;
     use crate::util::key::PublicKey;
-    use crate::util::sighash::{Annex, Error, Prevouts, ScriptPath, SighashCache};
+    use crate::sighash::{Annex, Error, Prevouts, ScriptPath, SighashCache};
     use crate::util::taproot::{TapTweakHash, TapSighashHash, TapBranchHash, TapLeafHash};
 
     extern crate serde_json;
@@ -1109,7 +1109,7 @@ mod tests {
     #[cfg(feature = "serde")]
     fn legacy_sighash() {
         use serde_json::Value;
-        use crate::util::sighash::SighashCache;
+        use crate::sighash::SighashCache;
 
         fn run_test_sighash(tx: &str, script: &str, input_index: usize, hash_type: i64, expected_result: &str) {
             let tx: Transaction = deserialize(&Vec::from_hex(tx).unwrap()[..]).unwrap();
@@ -1127,7 +1127,7 @@ mod tests {
         // These test vectors were stolen from libbtc, which is Copyright 2014 Jonas Schnelli MIT
         // They were transformed by replacing {...} with run_test_sighash(...), then the ones containing
         // OP_CODESEPARATOR in their pubkeys were removed
-        let data = include_str!("../../test_data/legacy_sighash.json");
+        let data = include_str!("../test_data/legacy_sighash.json");
 
         let testdata = serde_json::from_str::<Value>(data).unwrap().as_array().unwrap().clone();
         for t in testdata.iter().skip(1) {
@@ -1479,7 +1479,7 @@ mod tests {
     }
 
     fn bip_341_read_json() -> serde_json::Value {
-        let json_str = include_str!("../../test_data/bip341_tests.json");
+        let json_str = include_str!("../test_data/bip341_tests.json");
         serde_json::from_str(json_str).expect("JSON was not well-formatted")
     }
 

--- a/bitcoin/src/util/ecdsa.rs
+++ b/bitcoin/src/util/ecdsa.rs
@@ -13,7 +13,7 @@ use secp256k1;
 
 use crate::prelude::*;
 use crate::hashes::hex::{self, FromHex};
-use crate::util::sighash::{EcdsaSighashType, NonStandardSighashType};
+use crate::sighash::{EcdsaSighashType, NonStandardSighashType};
 
 /// An ECDSA signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -15,7 +15,6 @@ pub mod hash;
 pub mod merkleblock;
 pub mod psbt;
 pub mod taproot;
-pub mod sighash;
 
 pub(crate) mod endian;
 

--- a/bitcoin/src/util/psbt/map/input.rs
+++ b/bitcoin/src/util/psbt/map/input.rs
@@ -21,10 +21,9 @@ use crate::util::psbt::raw;
 use crate::util::psbt::serialize::Deserialize;
 use crate::util::psbt::{Error, error};
 use crate::util::key::PublicKey;
-use crate::util::sighash::{NonStandardSighashType, SighashTypeParseError, EcdsaSighashType, SchnorrSighashType};
+use crate::sighash::{NonStandardSighashType, SighashTypeParseError, EcdsaSighashType, SchnorrSighashType};
 use crate::util::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapBranchHash};
-use crate::util::sighash;
-use crate::{EcdsaSig, SchnorrSig};
+use crate::{sighash, EcdsaSig, SchnorrSig};
 
 /// Type: Non-Witness UTXO PSBT_IN_NON_WITNESS_UTXO = 0x00
 const PSBT_IN_NON_WITNESS_UTXO: u8 = 0x00;

--- a/bitcoin/src/util/psbt/mod.rs
+++ b/bitcoin/src/util/psbt/mod.rs
@@ -25,9 +25,9 @@ use crate::consensus::{encode, Encodable, Decodable};
 use crate::util::bip32::{self, ExtendedPrivKey, ExtendedPubKey, KeySource};
 use crate::util::ecdsa::{EcdsaSig, EcdsaSigError};
 use crate::util::key::{PublicKey, PrivateKey};
-use crate::util::sighash::{self, EcdsaSighashType, SighashCache};
+use crate::sighash::{self, EcdsaSighashType, SighashCache};
 
-pub use crate::util::sighash::Prevouts;
+pub use crate::sighash::Prevouts;
 
 #[macro_use]
 mod macros;
@@ -1130,7 +1130,7 @@ mod tests {
         use crate::util::psbt::map::{Map, Input, Output};
         use crate::util::psbt::raw;
         use crate::util::psbt::{PartiallySignedTransaction, Error};
-        use crate::util::sighash::EcdsaSighashType;
+        use crate::sighash::EcdsaSighashType;
         use std::collections::BTreeMap;
         use crate::blockdata::witness::Witness;
         use crate::internal_macros::hex_script;


### PR DESCRIPTION
Done as part of the effort to flatten the `util` module.

The `sighash` module can stand alone in the crate root, it provides a discreet set of functionality - the `SighashCache` and associated types.

Marking as high priority because this is part of flattening `util` which is a required step before we start crate smashing.