### PR TITLE
Re-export hashbrown when enabled

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -70,6 +70,11 @@ pub use {bech32, bitcoin_hashes as hashes, secp256k1};
 #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 pub use base64;
 
+// Re-export hashbrown when enabled
+#[cfg(feature = "hashbrown")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hashbrown")))]
+pub use hashbrown;
+
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate actual_serde as serde;


### PR DESCRIPTION
`hashbrown` used to be exported until commit 23ee0930c75c3c028572c521e0906fd4f95b6b92 which removed the `pub extern crate` declaration.

Found thanks to afilini (#1342)!