### PR TITLE
Remove `into_bytes` from `impl_array_newtype`

### DIFF
--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -32,13 +32,16 @@ macro_rules! impl_array_newtype {
             #[inline]
             pub fn as_bytes(&self) -> &[$ty; $len] { &self.0 }
 
-            /// Returns a clone of the underlying bytes.
+            /// Returns the underlying bytes.
             #[inline]
-            pub fn to_bytes(self) -> [$ty; $len] { self.0.clone() }
+            pub fn to_bytes(self) -> [$ty; $len] {
+                // We rely on `Copy` being implemented for $thing so conversion
+                // methods use the correct Rust naming conventions.
+                fn check_copy<T: Copy>() {}
+                check_copy::<$thing>();
 
-            /// Returns the underlying bytes (takes ownership).
-            #[inline]
-            pub fn into_bytes(self) -> [$ty; $len] { self.0 }
+                self.0
+            }
         }
 
         impl<'a> core::convert::From<&'a [$ty]> for $thing {


### PR DESCRIPTION
All the types that we define with `impl_array_newtype` are `Copy` so the correct conversion method to get the underlying byte array is `to_bytes`. We currently provide `into_bytes` as well as `to_bytes`, with one of them calling `clone` - this is unnecessary and against convention.

Remove `into_bytes` and for `to_bytes` just return the inner field. Add code comment to remind devs of correct usage of the macro in regards to deriving `Copy` and `Clone`.