### PR TITLE
Re-export secp256k1 dependency as secp

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -63,7 +63,7 @@ extern crate alloc;
 // Re-export dependencies we control.
 #[cfg(feature = "bitcoinconsensus")]
 pub use bitcoinconsensus;
-pub use {bech32, bitcoin_hashes as hashes, secp256k1};
+pub use {bech32, bitcoin_hashes as hashes, secp256k1, secp256k1 as secp};
 
 // Re-export base64 when enabled
 #[cfg(feature = "base64")]


### PR DESCRIPTION
The identifier `secp156k1` is annoying to write [repeatedly]. To make `rust-bitcoin` more ergonomic and less annoying we can re-export `secp256k1` as `secp` so users can do `use bitcoin::secp::Foo` with no real loss of clarity.

Keep the full export for users who prefer the full name.

For context please see: https://github.com/rust-bitcoin/rust-bitcoin/discussions/984