### PR TITLE
Document non-functional no-std for bitcoinconsensus

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -38,8 +38,9 @@ secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes"
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false, features = ["alloc"] }
 
 base64 = { version = "0.21.3", optional = true }
-# Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
-bitcoinconsensus = { version = "0.20.2-0.5.0", default-features = false, optional = true }
+
+# Please note, bitocinconsensus does not currently work with no-std.
+bitcoinconsensus = { version = "0.20.2-0.5.0", optional = true }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }


### PR DESCRIPTION
The `rust-bitcoinconsensus` dependency is not able to be built with `--thumbv7m-none-eabi`. This means, at least as far as verifying our `no-std` build, `no-std` does not work when the `bitcoinconsensus` dependency is enabled.

Instead of fixing the problem, document that it is broken.

### Context

` cargo +nightly build --target thumbv7m-none-eabi` fails on every tag in `rust-bitcoinconsensus` back to v0.17.1

- https://github.com/rust-bitcoin/rust-bitcoin/pull/1165#issuecomment-1290314082