### PR TITLE
Move the taproot module to crate root

### DIFF
--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -90,7 +90,7 @@ use bitcoin::psbt::{self, Input, Output, Psbt, PsbtSighashType};
 use bitcoin::schnorr::{self, TapTweak};
 use bitcoin::secp256k1::{Message, Secp256k1};
 use bitcoin::sighash::{self, SchnorrSighashType, SighashCache};
-use bitcoin::util::taproot::{
+use bitcoin::taproot::{
     LeafVersion, TapLeafHash, TapSighashHash, TaprootBuilder, TaprootSpendInfo,
 };
 use bitcoin::{

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -50,8 +50,8 @@ use crate::hash_types::{PubkeyHash, ScriptHash};
 use crate::hashes::{sha256, Hash, HashEngine};
 use crate::network::constants::Network;
 use crate::prelude::*;
+use crate::taproot::TapBranchHash;
 use crate::util::base58;
-use crate::util::taproot::TapBranchHash;
 
 /// Address error.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -36,7 +36,7 @@ use crate::OutPoint;
 
 use crate::crypto::key::PublicKey;
 use crate::address::WitnessVersion;
-use crate::util::taproot::{LeafVersion, TapBranchHash, TapLeafHash};
+use crate::taproot::{LeafVersion, TapBranchHash, TapLeafHash};
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 use crate::crypto::schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
 

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -16,7 +16,7 @@ use crate::sighash::EcdsaSighashType;
 use crate::io::{self, Read, Write};
 use crate::prelude::*;
 use crate::VarInt;
-use crate::util::taproot::TAPROOT_ANNEX_PREFIX;
+use crate::taproot::TAPROOT_ANNEX_PREFIX;
 
 /// The Witness is the data used to unlock bitcoins since the [segwit upgrade](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki)
 ///

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -28,7 +28,7 @@ use crate::io::{self, Cursor, Read};
 
 use crate::psbt;
 use crate::bip152::{ShortId, PrefilledTransaction};
-use crate::util::taproot::TapLeafHash;
+use crate::taproot::TapLeafHash;
 use crate::hashes::hex::ToHex;
 
 use crate::blockdata::transaction::{TxOut, Transaction, TxIn};

--- a/bitcoin/src/crypto/schnorr.rs
+++ b/bitcoin/src/crypto/schnorr.rs
@@ -15,7 +15,7 @@ pub use secp256k1::{self, constants, Secp256k1, KeyPair, XOnlyPublicKey, Verific
 
 use crate::prelude::*;
 
-use crate::util::taproot::{TapBranchHash, TapTweakHash};
+use crate::taproot::{TapBranchHash, TapTweakHash};
 use crate::sighash::SchnorrSighashType;
 
 /// Untweaked BIP-340 X-coord-only public key

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -106,6 +106,7 @@ pub mod pow;
 pub mod psbt;
 pub mod sighash;
 pub mod sign_message;
+pub mod taproot;
 pub mod util;
 
 #[cfg(feature = "std")]

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -20,9 +20,8 @@ use crate::bip32::KeySource;
 use crate::psbt::map::Map;
 use crate::psbt::serialize::Deserialize;
 use crate::psbt::{self, error, raw, Error};
-use crate::sighash::{NonStandardSighashType, SighashTypeParseError, EcdsaSighashType, SchnorrSighashType};
-use crate::util::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapBranchHash};
-use crate::sighash;
+use crate::sighash::{self, NonStandardSighashType, SighashTypeParseError, EcdsaSighashType, SchnorrSighashType};
+use crate::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapBranchHash};
 
 /// Type: Non-Witness UTXO PSBT_IN_NON_WITNESS_UTXO = 0x00
 const PSBT_IN_NON_WITNESS_UTXO: u8 = 0x00;

--- a/bitcoin/src/psbt/map/output.rs
+++ b/bitcoin/src/psbt/map/output.rs
@@ -15,9 +15,7 @@ use crate::psbt::map::Map;
 use crate::psbt::raw;
 use crate::psbt::Error;
 
-use crate::util::taproot::{ScriptLeaf, TapLeafHash};
-
-use crate::util::taproot::{NodeInfo, TaprootBuilder};
+use crate::taproot::{ScriptLeaf, TapLeafHash, NodeInfo, TaprootBuilder};
 
 /// Type: Redeem Script PSBT_OUT_REDEEM_SCRIPT = 0x00
 const PSBT_OUT_REDEEM_SCRIPT: u8 = 0x00;

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -19,12 +19,12 @@ use crate::bip32::{ChildNumber, Fingerprint, KeySource};
 use crate::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use crate::crypto::{ecdsa, schnorr};
 use crate::psbt;
-use crate::util::taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
+use crate::taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
 use crate::crypto::key::PublicKey;
 
 use super::map::{TapTree, PsbtSighashType};
 
-use crate::util::taproot::TaprootBuilder;
+use crate::taproot::TaprootBuilder;
 /// A trait for serializing a value as raw data for insertion into PSBT
 /// key-value pairs.
 pub trait Serialize {

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -18,7 +18,7 @@ use crate::consensus::{encode, Encodable};
 use crate::error::impl_std_error;
 use crate::hashes::{sha256, sha256d, Hash};
 use crate::prelude::*;
-use crate::util::taproot::{LeafVersion, TapLeafHash, TapSighashHash, TAPROOT_ANNEX_PREFIX};
+use crate::taproot::{LeafVersion, TapLeafHash, TapSighashHash, TAPROOT_ANNEX_PREFIX};
 use crate::{io, Script, Sequence, Sighash, Transaction, TxIn, TxOut};
 
 /// Used for signature hash for invalid use of SIGHASH_SINGLE.
@@ -1066,7 +1066,7 @@ mod tests {
     use crate::hashes::{Hash, HashEngine};
     use crate::internal_macros::{hex_decode, hex_from_slice, hex_into, hex_script};
     use crate::network::constants::Network;
-    use crate::util::taproot::{TapBranchHash, TapLeafHash, TapSighashHash, TapTweakHash};
+    use crate::taproot::{TapBranchHash, TapLeafHash, TapSighashHash, TapTweakHash};
 
     extern crate serde_json;
 

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -48,15 +48,19 @@ const MIDSTATE_TAPSIGHASH: [u8; 32] = [
 // f504a425d7f8783b1363868ae3e556586eee945dbc7888dd02a6e2c31873fe9f
 
 // Taproot test vectors from BIP-341 state the hashes without any reversing
+#[rustfmt::skip]
 sha256t_hash_newtype!(TapLeafHash, TapLeafTag, MIDSTATE_TAPLEAF, 64,
     doc="Taproot-tagged hash for tapscript Merkle tree leafs", false
 );
+#[rustfmt::skip]
 sha256t_hash_newtype!(TapBranchHash, TapBranchTag, MIDSTATE_TAPBRANCH, 64,
     doc="Taproot-tagged hash for tapscript Merkle tree branches", false
 );
+#[rustfmt::skip]
 sha256t_hash_newtype!(TapTweakHash, TapTweakTag, MIDSTATE_TAPTWEAK, 64,
     doc="Taproot-tagged hash for public key tweaks", false
 );
+#[rustfmt::skip]
 sha256t_hash_newtype!(TapSighashHash, TapSighashTag, MIDSTATE_TAPSIGHASH, 64,
     doc="Taproot-tagged hash for the taproot signature hash", false
 );
@@ -1437,7 +1441,7 @@ mod test {
     }
 
     fn bip_341_read_json() -> serde_json::Value {
-        let json_str = include_str!("../../tests/data/bip341_tests.json");
+        let json_str = include_str!("../tests/data/bip341_tests.json");
         serde_json::from_str(json_str).expect("JSON was not well-formatted")
     }
 }

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -7,7 +7,6 @@
 //!
 
 pub mod base58;
-pub mod taproot;
 
 /// The `misc` module was moved and re-named to `sign_message`.
 pub mod misc {


### PR DESCRIPTION
We are trying to flatten the `util` module. The `taproot` module can live in the crate root. If/when we create a `crypto` module/crate we may wish to pull some stuff out of this module but for now moving it gets us closer to removing `util` without making the directory structure any worse.

CC sanket1729, I did this after reviewing the `taproot` module during work on https://github.com/rust-bitcoin/rust-bitcoin/pull/1260 and your review comment. 