### PR TITLE
Move `merkleblock` into `merkle_tree`

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -128,7 +128,7 @@ pub use crate::pow::{CompactTarget, Target, Work};
 pub use crate::amount::{Amount, Denomination, SignedAmount};
 pub use crate::util::ecdsa::{self, EcdsaSig, EcdsaSigError};
 pub use crate::util::key::{KeyPair, PrivateKey, PublicKey, XOnlyPublicKey};
-pub use crate::util::merkleblock::MerkleBlock;
+pub use crate::merkle_tree::MerkleBlock;
 pub use crate::util::schnorr::{self, SchnorrSig, SchnorrSigError};
 pub use crate::util::{psbt, Error};
 

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -53,7 +53,7 @@ use crate::blockdata::block::{self, Block};
 use crate::blockdata::transaction::Transaction;
 use crate::blockdata::constants::{MAX_BLOCK_WEIGHT, MIN_TRANSACTION_WEIGHT};
 use crate::consensus::encode::{self, Decodable, Encodable};
-use crate::util::merkleblock::MerkleBlockError::*;
+use crate::merkle_tree::MerkleBlockError::*;
 
 /// An error when verifying the merkle block.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -164,7 +164,7 @@ impl PartialMerkleTree {
     /// ```rust
     /// use bitcoin::hash_types::Txid;
     /// use bitcoin::hashes::hex::FromHex;
-    /// use bitcoin::util::merkleblock::PartialMerkleTree;
+    /// use bitcoin::merkle_tree::{MerkleBlock, PartialMerkleTree};
     ///
     /// // Block 80000
     /// let txids: Vec<Txid> = [
@@ -520,6 +520,8 @@ impl Decodable for MerkleBlock {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use core::cmp::min;
 
     use crate::hashes::Hash;
@@ -528,7 +530,6 @@ mod tests {
     use secp256k1::rand::prelude::*;
 
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::util::merkleblock::{MerkleBlock, PartialMerkleTree};
     use crate::{merkle_tree, Block};
 
     /// accepts `pmt_test_$num`

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn both_merkle_root_functions_return_the_same_result() {
         // testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
-        let segwit_block = include_bytes!("../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw");
+        let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw");
         let block: Block = deserialize(&segwit_block[..]).expect("Failed to deserialize block");
         assert!(block.check_merkle_root()); // Sanity check.
 

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -14,6 +14,8 @@
 //! let root = merkle_tree::calculate_root(tx_hashes.into_iter());
 //! ```
 
+mod block;
+
 use core::iter;
 
 use crate::prelude::*;
@@ -23,6 +25,8 @@ use core::cmp::min;
 
 use crate::hashes::Hash;
 use crate::consensus::encode::Encodable;
+
+pub use block::{MerkleBlock, PartialMerkleTree, MerkleBlockError};
 
 /// Calculates the merkle root of a list of *hashes*, inline (in place) in `hashes`.
 ///

--- a/bitcoin/src/network/message.rs
+++ b/bitcoin/src/network/message.rs
@@ -24,7 +24,7 @@ use crate::network::message_compact_blocks;
 use crate::network::constants::Magic;
 use crate::consensus::encode::{CheckedData, Decodable, Encodable, VarInt};
 use crate::consensus::{encode, serialize};
-use crate::util::merkleblock::MerkleBlock;
+use crate::merkle_tree::MerkleBlock;
 
 /// The maximum number of [super::message_blockdata::Inventory] items in an `inv` message.
 ///
@@ -469,6 +469,8 @@ impl Decodable for RawNetworkMessage {
 
 #[cfg(test)]
 mod test {
+    use super::*;
+
     use std::net::Ipv4Addr;
     use super::{RawNetworkMessage, NetworkMessage, CommandString};
     use crate::network::constants::{ServiceFlags, Magic, Network};
@@ -484,7 +486,6 @@ mod test {
     use crate::blockdata::transaction::Transaction;
     use crate::blockdata::script::Script;
     use crate::network::message_bloom::{FilterAdd, FilterLoad, BloomFlags};
-    use crate::MerkleBlock;
     use crate::network::message_compact_blocks::{GetBlockTxn, SendCmpct};
     use crate::bip152::BlockTransactionsRequest;
 

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -10,7 +10,6 @@ pub mod key;
 pub mod ecdsa;
 pub mod schnorr;
 pub mod base58;
-pub mod merkleblock;
 pub mod psbt;
 pub mod taproot;
 


### PR DESCRIPTION
Re-done after review comments below. This is now PR 1 in the `merkle_tree::block` series :)

Move the `merkleblock` module into the `merkle_tree` module in a submodule called `block`. In order to do the minimum amount of changes in this patch DO NOT rename types to improved naming and reduce stutter.
    
Note:
    
- block module is private
- the three types are re-exported from `merkle_block`
- the `MerkleBlock` re-export from the crate root is left in place.
    
This patch purposefully does the minimum amount of changes because there a whole bunch of improvements to the old "merkleblock" module that are coming next in a separate PR.

