### PR TITLE
Add rand-std feature

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -52,7 +52,7 @@ hashbrown = { version = "0.8", optional = true }
 serde_json = "1.0.0"
 serde_test = "1.0.19"
 serde_derive = "1.0.103"
-secp256k1 = { version = "0.25.0", features = [ "recovery", "rand-std" ] }
+secp256k1 = { version = "0.25.0", features = ["recovery"] }
 bincode = "1.3.1"
 
 [[example]]
@@ -60,7 +60,7 @@ name = "bip32"
 
 [[example]]
 name = "handshake"
-required-features = ["std"]
+required-features = ["std", "rand-std"]
 
 [[example]]
 name = "ecdsa-psbt"
@@ -68,4 +68,4 @@ required-features = ["std", "bitcoinconsensus"]
 
 [[example]]
 name = "taproot-psbt"
-required-features = ["std", "bitcoinconsensus"]
+required-features = ["std", "rand-std", "bitcoinconsensus"]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -15,7 +15,8 @@ edition = "2018"
 # Please don't forget to add relevant features to docs.rs below
 [features]
 default = [ "std", "secp-recovery" ]
-rand = ["secp256k1/rand-std"]
+rand-std = ["secp256k1/rand-std"]
+rand = ["secp256k1/rand"]
 serde = ["actual-serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -31,9 +31,9 @@ if [ "$DO_LINT" = true ]
 then
     cargo clippy --all-features --all-targets -- -D warnings
     cargo clippy --example bip32 -- -D warnings
-    cargo clippy --example handshake -- -D warnings
+    cargo clippy --example handshake --features=rand-std -- -D warnings
     cargo clippy --example ecdsa-psbt --features=bitcoinconsensus -- -D warnings
-    cargo clippy --example taproot-psbt --features=bitcoinconsensus -- -D warnings
+    cargo clippy --example taproot-psbt --features=rand-std,bitcoinconsensus -- -D warnings
 fi
 
 echo "********* Testing std *************"
@@ -77,7 +77,7 @@ do
 done
 
 cargo run --example ecdsa-psbt --features=bitcoinconsensus
-cargo run --example taproot-psbt --features=bitcoinconsensus
+cargo run --example taproot-psbt --features=rand-std,bitcoinconsensus
 
 # Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCS" = true ]; then

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -8,24 +8,23 @@
 //! # Example: creating a new address from a randomly-generated key pair
 //!
 //! ```rust
-//! use bitcoin::network::constants::Network;
-//! use bitcoin::address::Address;
-//! use bitcoin::PublicKey;
-//! use bitcoin::secp256k1::Secp256k1;
-//! use bitcoin::secp256k1::rand::thread_rng;
+//! # #[cfg(feature = "rand-std")] {
+//! use bitcoin::{Address, PublicKey, Network};
+//! use bitcoin::secp256k1::{rand, Secp256k1};
 //!
 //! // Generate random key pair.
 //! let s = Secp256k1::new();
-//! let public_key = PublicKey::new(s.generate_keypair(&mut thread_rng()).1);
+//! let public_key = PublicKey::new(s.generate_keypair(&mut rand::thread_rng()).1);
 //!
 //! // Generate pay-to-pubkey-hash address.
 //! let address = Address::p2pkh(&public_key, Network::Bitcoin);
+//! # }
 //! ```
 //!
-//! # Note: creating a new address requires the rand feature flag
+//! # Note: creating a new address requires the rand-std feature flag
 //!
 //! ```toml
-//! bitcoin = { version = "...", features = ["rand"] }
+//! bitcoin = { version = "...", features = ["rand-std"] }
 //! ```
 
 use core::convert::TryFrom;

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -816,7 +816,6 @@ mod tests {
     use super::{deserialize, serialize, Error, CheckedData, VarInt};
     use super::{Transaction, BlockHash, FilterHash, TxMerkleNode, TxOut, TxIn};
     use crate::consensus::{Encodable, deserialize_partial, Decodable};
-    use secp256k1::rand::{thread_rng, Rng};
     #[cfg(feature = "std")]
     use crate::network::{Address, message_blockdata::Inventory};
 
@@ -1088,7 +1087,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rand-std")]
     fn serialization_round_trips() {
+        use secp256k1::rand::{thread_rng, Rng};
+
         macro_rules! round_trip {
             ($($val_type:ty),*) => {
                 $(

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -499,20 +499,23 @@ impl Decodable for MerkleBlock {
 
 #[cfg(test)]
 mod tests {
-    use core::cmp::min;
-
+    #[cfg(feature = "rand-std")]
     use secp256k1::rand::prelude::*;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::hash_types::{TxMerkleNode, Txid};
+    #[cfg(feature = "rand-std")]
+    use crate::hash_types::TxMerkleNode;
     use crate::hashes::hex::{FromHex, ToHex};
+    #[cfg(feature = "rand-std")]
     use crate::hashes::Hash;
-    use crate::{merkle_tree, Block};
+    use crate::{Block, Txid};
 
     /// accepts `pmt_test_$num`
+    #[cfg(feature = "rand-std")]
     fn pmt_test_from_name(name: &str) { pmt_test(name[9..].parse().unwrap()) }
 
+    #[cfg(feature = "rand-std")]
     macro_rules! pmt_tests {
     ($($name:ident),* $(,)?) => {
          $(
@@ -523,6 +526,7 @@ mod tests {
          )*
     }
 }
+    #[cfg(feature = "rand-std")]
     pmt_tests!(
         pmt_test_1,
         pmt_test_4,
@@ -538,7 +542,11 @@ mod tests {
         pmt_test_4095
     );
 
+    #[cfg(feature = "rand-std")]
     fn pmt_test(tx_count: usize) {
+        use core::cmp::min;
+        use crate::merkle_tree;
+
         let mut rng = thread_rng();
         // Create some fake tx ids
         let tx_ids = (1..=tx_count)
@@ -713,6 +721,7 @@ mod tests {
         assert_eq!(index.len(), 0);
     }
 
+    #[cfg(feature = "rand-std")]
     impl PartialMerkleTree {
         /// Flip one bit in one of the hashes - this should break the authentication
         fn damage(&mut self, rng: &mut ThreadRng) {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -887,7 +887,7 @@ mod tests {
     use crate::hash_types::Txid;
 
     use secp256k1::{Secp256k1, self};
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand-std")]
     use secp256k1::{All, SecretKey};
 
     use crate::blockdata::script::ScriptBuf;
@@ -1685,7 +1685,7 @@ mod tests {
         assert_eq!(psbt1, psbt2);
     }
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand-std")]
     fn gen_keys() -> (PrivateKey, PublicKey, Secp256k1<All>) {
         use secp256k1::rand::thread_rng;
 
@@ -1699,7 +1699,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand-std")]
     fn get_key_btree_map() {
         let (priv_key, pk, secp) = gen_keys();
 
@@ -1811,7 +1811,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand-std")]
     fn sign_psbt() {
         use crate::WPubkeyHash;
         use crate::bip32::{Fingerprint, DerivationPath};

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -225,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "secp-recovery", feature = "base64"))]
+    #[cfg(all(feature = "secp-recovery", feature = "base64", feature = "rand-std"))]
     fn test_message_signature() {
         use core::str::FromStr;
 


### PR DESCRIPTION
This PR uncovered incorrect feature gating in `secp256k1`, fixed in https://github.com/rust-bitcoin/rust-secp256k1/pull/519

Currently we enable "secp256k1/rand-std" in the "rand" feature, this is incorrect because it means "rand" implies "std" which it does not.
    
Add a "rand-std" feature that turns on "seck256k1/rand-std" and make the "rand" feature turn on "seck256k1/rand".

Fix: #1384