### PR TITLE
Drop Network arg from max_money()

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -60,7 +60,7 @@ pub const MAX_SCRIPTNUM_VALUE: u32 = 0x80000000; // 2^31
 /// The maximum value allowed in an output (useful for sanity checking,
 /// since keeping everything below this value should prevent overflows
 /// if you are doing anything remotely sane with monetary values).
-pub fn max_money(_: Network) -> u64 {
+pub fn max_money() -> u64 {
     21_000_000 * COIN_VALUE
 }
 


### PR DESCRIPTION
Amount of coins available stay in the same across Bitcoin network: signet, testnet, mainet. From my understanding this is a leftover from some potential multi-chain support.

For more context: https://github.com/lightningdevkit/rust-lightning/pull/1839#discussion_r1019753069

If there is already an existent PR, it can be closed, however didn't find one.