### PR TITLE
Add trait `FromStrHex` for tuple structs with single `u32` member

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -1403,6 +1403,7 @@ pub mod serde {
 mod verification {
     use std::cmp;
     use std::convert::TryInto;
+
     use super::*;
 
     // Note regarding the `unwind` parameter: this defines how many iterations

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -107,6 +107,7 @@ pub mod pow;
 pub mod psbt;
 pub mod sighash;
 pub mod sign_message;
+pub mod string;
 pub mod taproot;
 pub mod util;
 

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -84,6 +84,15 @@ pub(crate) fn int<T: Integer, S: AsRef<str> + Into<String>>(s: S) -> Result<T, P
     })
 }
 
+pub(crate) fn hex_u32<S: AsRef<str> + Into<String>>(s: S) -> Result<u32, ParseIntError> {
+    u32::from_str_radix(s.as_ref(), 16).map_err(|error| ParseIntError {
+        input: s.into(),
+        bits: u8::try_from(core::mem::size_of::<u32>() * 8).expect("max is 32 bits for u32"),
+        is_signed: u32::try_from(-1i8).is_ok(),
+        source: error,
+    })
+}
+
 impl_std_error!(ParseIntError, source);
 
 /// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using `fn`

--- a/bitcoin/src/string.rs
+++ b/bitcoin/src/string.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin string parsing utilities.
+//!
+//! This module provides utility types and traits
+//! to support handling and parsing strings within `rust-bitcoin`.
+
+use core::fmt;
+
+use bitcoin_internals::write_err;
+
+use crate::prelude::String;
+
+/// Trait that allows types to be initialized from hex strings
+pub trait FromHexStr: Sized {
+    /// An error occurred while parsing the hex string.
+    type Error;
+
+    /// Parses provided string as hex requiring 0x prefix.
+    ///
+    /// This is intended for user-supplied inputs or already-existing protocols in which 0x prefix is used.
+    fn from_hex_str<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, FromHexError<Self::Error>> {
+        if !s.as_ref().starts_with("0x") {
+            Err(FromHexError::MissingPrefix(s.into()))
+        } else {
+            Ok(Self::from_hex_str_no_prefix(s.as_ref().trim_start_matches("0x"))?)
+        }
+    }
+
+    /// Parses provided string as hex without requiring 0x prefix.
+    ///
+    /// This is **not** recommended for user-supplied inputs because of possible confusion with decimals.
+    /// It should be only used for existing protocols which always encode values as hex without 0x prefix.
+    fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error>;
+}
+
+/// Hex parsing error
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum FromHexError<E> {
+    /// The input was not a valid hex string, contains the error that occurred while parsing.
+    ParseHex(E),
+    /// The input is missing `0x` prefix, contains the invalid input.
+    MissingPrefix(String),
+}
+
+impl<E> From<E> for FromHexError<E> {
+    fn from(e: E) -> Self { FromHexError::ParseHex(e) }
+}
+
+impl<E: fmt::Display> fmt::Display for FromHexError<E>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::FromHexError::*;
+
+        match *self {
+            ParseHex(ref e) => write_err!(f, "failed to parse hex string"; e),
+            MissingPrefix(ref value) => write_err!(f, "the input value `{}` is missing the `0x` prefix", value; self),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl<E> std::error::Error for FromHexError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::FromHexError::*;
+
+        match *self {
+            ParseHex(ref e) => Some(e),
+            MissingPrefix(_) => None,
+        }
+    }
+}


### PR DESCRIPTION
Closes: #1112 

 - Adds new trait `FromStrHex` with 2 methods: `from_hex_str` and `from_hex_str_no_prefix`
 -  Impl new trait on each tuple struct with single u32 member. eg `Time(u32)`
 
As stated in the issue, grep through codebase with `\(u32\)` and `\(pub u32\)` to see all implementations and verify none were missed. 

NonStandardSighashType is an error type and should never be constructed from a hex string. Therefore, it has been omitted from this change.

Tests are somewhat redundant, but cover 4 cases each. 2 happy paths, 1 for each function. 1 case for malformed/invalid hex input, and 1 for calling no_prefix without a prefix