### PR TITLE
Fix typo in the SHA512 documentation

### DIFF
--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -80,7 +80,7 @@ impl crate::HashEngine for HashEngine {
     engine_input_impl!();
 }
 
-/// Output of the SHA256 hash function.
+/// Output of the SHA512 hash function.
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(


### PR DESCRIPTION
Saw the typo and since this typo also exists in crates.io, I thought it'd be good to quickly change it.

Though maybe this should be replaced altogether with the `hash_type` macro since every other hash function implementation is using that.