### PR TITLE
Change `max_money` to a constant.

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -60,9 +60,7 @@ pub const MAX_SCRIPTNUM_VALUE: u32 = 0x80000000; // 2^31
 /// The maximum value allowed in an output (useful for sanity checking,
 /// since keeping everything below this value should prevent overflows
 /// if you are doing anything remotely sane with monetary values).
-pub fn max_money() -> u64 {
-    21_000_000 * COIN_VALUE
-}
+pub const MAX_MONEY: u64 = 21_000_000 * COIN_VALUE;
 
 /// Constructs and returns the coinbase (and only) transaction of the Bitcoin genesis block
 fn bitcoin_genesis_tx() -> Transaction {


### PR DESCRIPTION
The value is statically known which is better expressed as a constant. Also allows usage in const context.