### PR TITLE
Move `base58` to the crate root

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -36,6 +36,7 @@ use bech32;
 use bitcoin_internals::write_err;
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 
+use crate::base58;
 use crate::blockdata::constants::{
     MAX_SCRIPT_ELEMENT_SIZE, PUBKEY_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST,
     SCRIPT_ADDRESS_PREFIX_MAIN, SCRIPT_ADDRESS_PREFIX_TEST,
@@ -51,7 +52,6 @@ use crate::hashes::{sha256, Hash, HashEngine};
 use crate::network::constants::Network;
 use crate::prelude::*;
 use crate::taproot::TapBranchHash;
-use crate::util::base58;
 
 /// Address error.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/bitcoin/src/base58.rs
+++ b/bitcoin/src/base58.rs
@@ -16,6 +16,7 @@ use crate::hashes::{sha256d, Hash};
 
 static BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
+#[rustfmt::skip]
 static BASE58_DIGITS: [Option<u8>; 128] = [
     None,     None,     None,     None,     None,     None,     None,     None,     // 0-7
     None,     None,     None,     None,     None,     None,     None,     None,     // 8-15

--- a/bitcoin/src/base58.rs
+++ b/bitcoin/src/base58.rs
@@ -7,12 +7,11 @@
 //! strings respectively.
 //!
 
-use crate::prelude::*;
-
-use core::{fmt, str, iter, slice};
 use core::convert::TryInto;
+use core::{fmt, iter, slice, str};
 
 use crate::hashes::{sha256d, Hash};
+use crate::prelude::*;
 
 static BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
@@ -38,9 +37,7 @@ static BASE58_DIGITS: [Option<u8>; 128] = [
 
 /// Decodes a base58-encoded string into a byte vector.
 #[deprecated(since = "0.30.0", note = "Use base58::decode() instead")]
-pub fn from(data: &str) -> Result<Vec<u8>, Error> {
-    decode(data)
-}
+pub fn from(data: &str) -> Result<Vec<u8>, Error> { decode(data) }
 
 /// Decodes a base58-encoded string into a byte vector.
 pub fn decode(data: &str) -> Result<Vec<u8>, Error> {
@@ -54,7 +51,9 @@ pub fn decode(data: &str) -> Result<Vec<u8>, Error> {
         }
         let mut carry = match BASE58_DIGITS[d58 as usize] {
             Some(d58) => d58 as u32,
-            None => { return Err(Error::BadByte(d58)); }
+            None => {
+                return Err(Error::BadByte(d58));
+            }
         };
         for d256 in scratch.iter_mut().rev() {
             carry += *d256 as u32 * 58;
@@ -65,9 +64,7 @@ pub fn decode(data: &str) -> Result<Vec<u8>, Error> {
     }
 
     // Copy leading zeroes directly
-    let mut ret: Vec<u8> = data.bytes().take_while(|&x| x == BASE58_CHARS[0])
-                                       .map(|_| 0)
-                                       .collect();
+    let mut ret: Vec<u8> = data.bytes().take_while(|&x| x == BASE58_CHARS[0]).map(|_| 0).collect();
     // Copy rest of string
     ret.extend(scratch.into_iter().skip_while(|&x| x == 0));
     Ok(ret)
@@ -75,9 +72,7 @@ pub fn decode(data: &str) -> Result<Vec<u8>, Error> {
 
 /// Decodes a base58check-encoded string into a byte vector verifying the checksum.
 #[deprecated(since = "0.30.0", note = "Use base58::decode_check() instead")]
-pub fn from_check(data: &str) -> Result<Vec<u8>, Error> {
-    decode_check(data)
-}
+pub fn from_check(data: &str) -> Result<Vec<u8>, Error> { decode_check(data) }
 
 /// Decodes a base58check-encoded string into a byte vector verifying the checksum.
 pub fn decode_check(data: &str) -> Result<Vec<u8>, Error> {
@@ -87,7 +82,8 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, Error> {
     }
     let check_start = ret.len() - 4;
 
-    let hash_check = sha256d::Hash::hash(&ret[..check_start])[..4].try_into().expect("4 byte slice");
+    let hash_check =
+        sha256d::Hash::hash(&ret[..check_start])[..4].try_into().expect("4 byte slice");
     let data_check = ret[check_start..].try_into().expect("4 byte slice");
 
     let expected = u32::from_le_bytes(hash_check);
@@ -103,33 +99,23 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, Error> {
 
 /// Encodes `data` as a base58 string.
 #[deprecated(since = "0.30.0", note = "Use base58::encode() instead")]
-pub fn encode_slice(data: &[u8]) -> String {
-    encode(data)
-}
+pub fn encode_slice(data: &[u8]) -> String { encode(data) }
 
 /// Encodes `data` as a base58 string (see also `base58::encode_check()`).
-pub fn encode(data: &[u8]) -> String {
-    encode_iter(data.iter().cloned())
-}
+pub fn encode(data: &[u8]) -> String { encode_iter(data.iter().cloned()) }
 
 /// Encodes `data` as a base58 string including the checksum.
 ///
 /// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 #[deprecated(since = "0.30.0", note = "Use base58::encode_check() instead")]
-pub fn check_encode_slice(data: &[u8]) -> String {
-    encode_check(data)
-}
+pub fn check_encode_slice(data: &[u8]) -> String { encode_check(data) }
 
 /// Encodes `data` as a base58 string including the checksum.
 ///
 /// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 pub fn encode_check(data: &[u8]) -> String {
     let checksum = sha256d::Hash::hash(data);
-    encode_iter(
-        data.iter()
-            .cloned()
-            .chain(checksum[0..4].iter().cloned())
-    )
+    encode_iter(data.iter().cloned().chain(checksum[0..4].iter().cloned()))
 }
 
 /// Encodes `data` as base58, including the checksum, into a formatter.
@@ -145,15 +131,13 @@ pub fn check_encode_slice_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::
 /// The checksum is the first four bytes of the sha256d of the data, concatenated onto the end.
 pub fn encode_check_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
     let checksum = sha256d::Hash::hash(data);
-    let iter = data.iter()
-        .cloned()
-        .chain(checksum[0..4].iter().cloned());
+    let iter = data.iter().cloned().chain(checksum[0..4].iter().cloned());
     format_iter(fmt, iter)
 }
 
 fn encode_iter<I>(data: I) -> String
 where
-    I: Iterator<Item=u8> + Clone,
+    I: Iterator<Item = u8> + Clone,
 {
     let mut ret = String::new();
     format_iter(&mut ret, data).expect("writing into string shouldn't fail");
@@ -162,8 +146,8 @@ where
 
 fn format_iter<I, W>(writer: &mut W, data: I) -> Result<(), fmt::Error>
 where
-    I: Iterator<Item=u8> + Clone,
-    W: fmt::Write
+    I: Iterator<Item = u8> + Clone,
+    W: fmt::Write,
 {
     let mut ret = SmallVec::new();
 
@@ -210,13 +194,7 @@ struct SmallVec<T> {
 }
 
 impl<T: Default + Copy> SmallVec<T> {
-    fn new() -> SmallVec<T> {
-        SmallVec {
-            len: 0,
-            stack: [T::default(); 100],
-            heap: Vec::new(),
-        }
-    }
+    fn new() -> SmallVec<T> { SmallVec { len: 0, stack: [T::default(); 100], heap: Vec::new() } }
 
     fn push(&mut self, val: T) {
         if self.len < 100 {
@@ -263,10 +241,13 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::BadByte(b) => write!(f, "invalid base58 character {:#x}", b),
-            Error::BadChecksum(exp, actual) => write!(f, "base58ck checksum {:#x} does not match expected {:#x}", actual, exp),
+            Error::BadChecksum(exp, actual) =>
+                write!(f, "base58ck checksum {:#x} does not match expected {:#x}", actual, exp),
             Error::InvalidLength(ell) => write!(f, "length {} invalid for this base58 type", ell),
-            Error::InvalidExtendedKeyVersion(ref v) => write!(f, "extended key version {:#04x?} is invalid for this base58 type", v),
-            Error::InvalidAddressVersion(ref v) => write!(f, "address version {} is invalid for this base58 type", v),
+            Error::InvalidExtendedKeyVersion(ref v) =>
+                write!(f, "extended key version {:#04x?} is invalid for this base58 type", v),
+            Error::InvalidAddressVersion(ref v) =>
+                write!(f, "address version {} is invalid for this base58 type", v),
             Error::TooShort(_) => write!(f, "base58ck data not even long enough for a checksum"),
         }
     }
@@ -307,9 +288,13 @@ mod tests {
         assert_eq!(&encode(&[0, 0, 0, 0, 13, 36][..]), "1111211");
 
         // Long input (>100 bytes => has to use heap)
-        let res = encode("BitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBit\
-        coinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoin".as_bytes());
-        let exp = "ZqC5ZdfpZRi7fjA8hbhX5pEE96MdH9hEaC1YouxscPtbJF16qVWksHWR4wwvx7MotFcs2ChbJqK8KJ9X\
+        let res = encode(
+            "BitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBit\
+        coinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoin"
+                .as_bytes(),
+        );
+        let exp =
+            "ZqC5ZdfpZRi7fjA8hbhX5pEE96MdH9hEaC1YouxscPtbJF16qVWksHWR4wwvx7MotFcs2ChbJqK8KJ9X\
         wZznwWn1JFDhhTmGo9v6GjAVikzCsBWZehu7bm22xL8b5zBR5AsBygYRwbFJsNwNkjpyFuDKwmsUTKvkULCvucPJrN5\
         QUdxpGakhqkZFL7RU4yT";
         assert_eq!(&res, exp);
@@ -332,8 +317,10 @@ mod tests {
         assert_eq!(decode("111211").ok(), Some(vec![0u8, 0, 0, 13, 36]));
 
         // Addresses
-        assert_eq!(decode_check("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").ok(),
-                   Some(Vec::from_hex("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap()));
+        assert_eq!(
+            decode_check("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").ok(),
+            Some(Vec::from_hex("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap())
+        );
         // Non Base58 char.
         assert_eq!(decode("¢").unwrap_err(), Error::BadByte(194));
     }
@@ -348,7 +335,6 @@ mod tests {
         // Check that empty slice passes roundtrip.
         assert_eq!(decode_check(&encode_check(&[])), Ok(vec![]));
         // Check that `len > 4` is enforced.
-        assert_eq!(decode_check(&encode(&[1,2,3])), Err(Error::TooShort(3)));
-
+        assert_eq!(decode_check(&encode(&[1, 2, 3])), Err(Error::TooShort(3)));
     }
 }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -18,6 +18,7 @@ use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 #[cfg(feature = "serde")]
 use serde;
 
+use crate::base58;
 use crate::crypto::key::{self, KeyPair, PrivateKey, PublicKey};
 use crate::hash_types::XpubIdentifier;
 use crate::hashes::{hex, sha512, Hash, HashEngine, Hmac, HmacEngine};
@@ -25,7 +26,6 @@ use crate::internal_macros::impl_bytes_newtype;
 use crate::io::Write;
 use crate::network::constants::Network;
 use crate::prelude::*;
-use crate::util::base58;
 
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -14,11 +14,10 @@ use core::fmt::{self, Write};
 use bitcoin_internals::write_err;
 pub use secp256k1::{self, Secp256k1, XOnlyPublicKey, KeyPair};
 
-use crate::io;
+use crate::{base58, io};
 use crate::network::constants::Network;
 use crate::hashes::{Hash, hash160, hex, hex::FromHex};
 use crate::hash_types::{PubkeyHash, WPubkeyHash};
-use crate::util::base58;
 
 /// A key-related error.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -92,6 +92,7 @@ mod serde_utils;
 pub mod network;
 pub mod address;
 pub mod amount;
+pub mod base58;
 pub mod bip152;
 pub mod bip158;
 pub mod bip32;

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -6,8 +6,6 @@
 //! Functions needed by all parts of the Bitcoin library.
 //!
 
-pub mod base58;
-
 /// The `misc` module was moved and re-named to `sign_message`.
 pub mod misc {
     use crate::prelude::*;


### PR DESCRIPTION
Move `base58` module to the carte root, direct `rustfmt` to not format the digits array. Run formatter as a separate patch.