### PR TITLE
Run clippy in ci for `hashes`

### DIFF
--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -22,6 +22,11 @@ export CARGO_TERM_VERBOSE=true
 cargo build --all
 cargo test --all
 
+if [ "$DO_LINT" = true ]
+then
+    cargo clippy --all-features --all-targets -- -D warnings
+fi
+
 if [ "$DO_FEATURE_MATRIX" = true ]; then
     cargo build --all --no-default-features
     cargo test --all --no-default-features

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -469,7 +469,7 @@ mod tests {
 
         for test in tests {
             // Hash through high-level API, check hex encoding/decoding
-            let hash = ripemd160::Hash::hash(&test.input.as_bytes());
+            let hash = ripemd160::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, ripemd160::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -195,7 +195,7 @@ mod tests {
 
         for test in tests {
             // Hash through high-level API, check hex encoding/decoding
-            let hash = sha1::Hash::hash(&test.input.as_bytes());
+            let hash = sha1::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha1::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -371,7 +371,7 @@ mod tests {
 
         for test in tests {
             // Hash through high-level API, check hex encoding/decoding
-            let hash = sha256::Hash::hash(&test.input.as_bytes());
+            let hash = sha256::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha256::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -74,7 +74,7 @@ mod tests {
 
         for test in tests {
             // Hash through high-level API, check hex encoding/decoding
-            let hash = sha256d::Hash::hash(&test.input.as_bytes());
+            let hash = sha256d::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha256d::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -368,7 +368,7 @@ mod tests {
 
         for test in tests {
             // Hash through high-level API, check hex encoding/decoding
-            let hash = sha512::Hash::hash(&test.input.as_bytes());
+            let hash = sha512::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha512::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);


### PR DESCRIPTION
Currently we only run the linter in `bitcoin/contrib/test.sh`, we should do the same in the `hashes` ci script.

- Patch 1: Fix current clippy issues in `hashes` crate
- Patch 2: Run clippy in CI for `hashes` crate