### PR TITLE
Allow dead_code/unused_imports when fuzzing

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -46,6 +46,9 @@
 #![deny(missing_docs)]
 #![deny(unused_must_use)]
 
+// Instead of littering the codebase for non-fuzzing code just globally allow.
+#![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
+
 #[cfg(not(any(feature = "std", feature = "no-std")))]
 compile_error!("at least one of the `std` or `no-std` features must be enabled");
 

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -96,6 +96,9 @@
 
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
+// Instead of littering the codebase for non-fuzzing code just globally allow.
+#![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
+
 #[cfg(bench)] extern crate test;
 #[cfg(any(test, feature = "std"))] extern crate core;
 #[cfg(feature = "core2")] extern crate core2;


### PR DESCRIPTION
Littering the codebase with `#[cfg(not(fuzzing))]` is a bit messy just to quieten the linter during fuzzing. Instead just globally allow.

Done while debugging #1409  