### PR TITLE
Exclude tests when fuzzing

### DIFF
--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -49,6 +49,7 @@ fn from_engine(e: HashEngine) -> Hash {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{hash160, Hash, HashEngine};

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -245,6 +245,7 @@ impl<'de, T: Hash + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha256, HashEngine, HmacEngine, Hash, Hmac};

--- a/hashes/src/impls.rs
+++ b/hashes/src/impls.rs
@@ -102,6 +102,7 @@ mod tests {
     macro_rules! write_test {
         ($mod:ident, $exp_empty:expr, $exp_256:expr, $exp_64k:expr,) => {
             #[test]
+            #[cfg(not(fuzzing))]
             fn $mod() {
                 let mut engine = $mod::Hash::engine();
                 engine.write_all(&[]).unwrap();
@@ -180,6 +181,7 @@ mod tests {
     );
 
     #[test]
+    #[cfg(not(fuzzing))]
     fn hmac() {
         let mut engine = hmac::HmacEngine::<sha256::Hash>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[]).unwrap();

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -405,6 +405,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{Hash, HashEngine, ripemd160};

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -143,6 +143,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha1, Hash, HashEngine};

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -324,6 +324,7 @@ mod tests {
     use crate::{Hash, HashEngine, sha256};
 
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::hex::{FromHex, ToHex};
@@ -388,6 +389,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(fuzzing))]
     fn midstate() {
         // Test vector obtained by doing an asset issuance on Elements
         let mut engine = sha256::Hash::engine();
@@ -414,6 +416,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(fuzzing))]
     fn engine_with_state() {
         let mut engine = sha256::Hash::engine();
         let midstate_engine = sha256::HashEngine::from_midstate(engine.midstate(), 0);

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -46,6 +46,7 @@ mod tests {
     use crate::sha256;
 
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha256d, Hash, HashEngine};

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -151,6 +151,7 @@ mod tests {
     sha256t_hash_newtype!(NewTypeHash, NewTypeTag, TEST_MIDSTATE, 64, doc="test hash", true);
 
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test_sha256t() {
         assert_eq!(

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -308,6 +308,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha512, Hash, HashEngine};

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -285,6 +285,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(not(fuzzing))]
     fn test_siphash_2_4() {
         let vecs: [[u8; 8]; 64] = [
             [0x31, 0x0e, 0x0e, 0xdd, 0x47, 0xdb, 0x6f, 0x72],


### PR DESCRIPTION
Currently we run a bunch of unit tests that check the state of data structures during hashing however we hobble these data structures when fuzzing so the tests fail and are meaningless.

Exclude unit tests that test state if fuzzing.

Fix: #1409 

I'm not totally sure I'm not being brain dead here but I think this is the problem :)