### PR TITLE
Enable fuzzing of hashes in CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -4,14 +4,13 @@ on: [push, pull_request]
 
 jobs:
 
-  fuzz:
+  bitcoin:
     if: ${{ !github.event.act }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        bitcoin_fuzz_target: [deser_net_msg, deserialize_address, deserialize_amount, deserialize_block, deserialize_psbt, deserialize_script, deserialize_transaction, deserialize_prefilled_transaction, deserialize_witness, outpoint_string, script_bytes_to_asm_fmt]
-        hashes_fuzz_target: [sha1, ripemd160, sha256, sha512, cbor, json]
+        fuzz_target: [deser_net_msg, deserialize_address, deserialize_amount, deserialize_block, deserialize_psbt, deserialize_script, deserialize_transaction, deserialize_prefilled_transaction, deserialize_witness, outpoint_string, script_bytes_to_asm_fmt]
     steps:
       - name: Install test dependencies
         run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
@@ -29,20 +28,45 @@ jobs:
           toolchain: 1.58
           override: true
           profile: minimal
-      - name: bitcoin
-        run: cd bitcoin/fuzz && ./travis-fuzz.sh "${{ matrix.bitcoin_fuzz_target }}"
-      - run: echo "${{ matrix.bitcoin_fuzz_target }}.rs" >executed_${{ matrix.bitcoin_fuzz_target }}
+      - name: fuzz
+        run: cd bitcoin/fuzz && ./travis-fuzz.sh "${{ matrix.fuzz_target }}"
+      - run: echo "${{ matrix.fuzz_target }}.rs" >executed_${{ matrix.fuzz_target }}
       - uses: actions/upload-artifact@v2
         with:
-          name: executed_${{ matrix.bitcoin_fuzz_target }}
-          path: executed_${{ matrix.bitcoin_fuzz_target }}
-      - name: hashes
-        run: cd hashes/fuzz && ./travis-fuzz.sh "${{ matrix.hashes_fuzz_target }}"
-      - run: echo "${{ matrix.hashes_fuzz_target }}.rs" >executed_${{ matrix.hashes_fuzz_target }}
+          name: executed_${{ matrix.fuzz_target }}
+          path: executed_${{ matrix.fuzz_target }}
+
+  hashes:
+    if: ${{ !github.event.act }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        fuzz_target: [sha1, ripemd160, sha256, sha512, cbor, json]
+    steps:
+      - name: Install test dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache-fuzz
+        with:
+          path: |
+            ~/.cargo/bin
+            fuzz/target
+            target
+          key: cache-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58
+          override: true
+          profile: minimal
+      - name: fuzz
+        run: cd hashes/fuzz && ./travis-fuzz.sh "${{ matrix.fuzz_target }}"
+      - run: echo "${{ matrix.fuzz_target }}.rs" >executed_${{ matrix.fuzz_target }}
       - uses: actions/upload-artifact@v2
         with:
-          name: executed_${{ matrix.hashes_fuzz_target }}
-          path: executed_${{ matrix.hashes_fuzz_target }}
+          name: executed_${{ matrix.fuzz_target }}
+          path: executed_${{ matrix.fuzz_target }}
 
   verify-execution:
     if: ${{ !github.event.act }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fuzz_target: [deser_net_msg, deserialize_address, deserialize_amount, deserialize_block, deserialize_psbt, deserialize_script, deserialize_transaction, deserialize_prefilled_transaction, deserialize_witness, outpoint_string, script_bytes_to_asm_fmt]
+        bitcoin_fuzz_target: [deser_net_msg, deserialize_address, deserialize_amount, deserialize_block, deserialize_psbt, deserialize_script, deserialize_transaction, deserialize_prefilled_transaction, deserialize_witness, outpoint_string, script_bytes_to_asm_fmt]
+        hashes_fuzz_target: [sha1, ripemd160, sha256, sha512, cbor, json]
     steps:
       - name: Install test dependencies
         run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
@@ -28,13 +29,20 @@ jobs:
           toolchain: 1.58
           override: true
           profile: minimal
-      - name: fuzz
-        run: cd bitcoin/fuzz && ./travis-fuzz.sh "${{ matrix.fuzz_target }}"
-      - run: echo "${{ matrix.fuzz_target }}.rs" >executed_${{ matrix.fuzz_target }}
+      - name: bitcoin
+        run: cd bitcoin/fuzz && ./travis-fuzz.sh "${{ matrix.bitcoin_fuzz_target }}"
+      - run: echo "${{ matrix.bitcoin_fuzz_target }}.rs" >executed_${{ matrix.bitcoin_fuzz_target }}
       - uses: actions/upload-artifact@v2
         with:
-          name: executed_${{ matrix.fuzz_target }}
-          path: executed_${{ matrix.fuzz_target }}
+          name: executed_${{ matrix.bitcoin_fuzz_target }}
+          path: executed_${{ matrix.bitcoin_fuzz_target }}
+      - name: hashes
+        run: cd hashes/fuzz && ./travis-fuzz.sh "${{ matrix.hashes_fuzz_target }}"
+      - run: echo "${{ matrix.hashes_fuzz_target }}.rs" >executed_${{ matrix.hashes_fuzz_target }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: executed_${{ matrix.hashes_fuzz_target }}
+          path: executed_${{ matrix.hashes_fuzz_target }}
 
   verify-execution:
     if: ${{ !github.event.act }}
@@ -46,5 +54,5 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
       - run: find executed_* -type f -exec cat {} + | sort > executed
-      - run: ls bitcoin/fuzz/fuzz_targets | sort > expected
+      - run: ./contrib/list_fuzz_targets.sh > expected
       - run: diff expected executed

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -46,6 +46,9 @@
 #![deny(missing_docs)]
 #![deny(unused_must_use)]
 
+// Instead of littering the codebase for non-fuzzing code just globally allow.
+#![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
+
 #[cfg(not(any(feature = "std", feature = "no-std")))]
 compile_error!("at least one of the `std` or `no-std` features must be enabled");
 

--- a/contrib/list_fuzz_targets.sh
+++ b/contrib/list_fuzz_targets.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# List all fuzz targets
+
+set -e
+
+for dir in bitcoin/fuzz/fuzz_targets hashes/fuzz/fuzz_targets
+do
+    ls $dir
+done | sort
+
+exit 0

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -49,6 +49,7 @@ fn from_engine(e: HashEngine) -> Hash {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{hash160, Hash, HashEngine};

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -245,6 +245,7 @@ impl<'de, T: Hash + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha256, HashEngine, HmacEngine, Hash, Hmac};

--- a/hashes/src/impls.rs
+++ b/hashes/src/impls.rs
@@ -102,6 +102,7 @@ mod tests {
     macro_rules! write_test {
         ($mod:ident, $exp_empty:expr, $exp_256:expr, $exp_64k:expr,) => {
             #[test]
+            #[cfg(not(fuzzing))]
             fn $mod() {
                 let mut engine = $mod::Hash::engine();
                 engine.write_all(&[]).unwrap();
@@ -180,6 +181,7 @@ mod tests {
     );
 
     #[test]
+    #[cfg(not(fuzzing))]
     fn hmac() {
         let mut engine = hmac::HmacEngine::<sha256::Hash>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[]).unwrap();

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -96,6 +96,9 @@
 
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
+// Instead of littering the codebase for non-fuzzing code just globally allow.
+#![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
+
 #[cfg(bench)] extern crate test;
 #[cfg(any(test, feature = "std"))] extern crate core;
 #[cfg(feature = "core2")] extern crate core2;

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -405,6 +405,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{Hash, HashEngine, ripemd160};

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -143,6 +143,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha1, Hash, HashEngine};

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -324,6 +324,7 @@ mod tests {
     use crate::{Hash, HashEngine, sha256};
 
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::hex::{FromHex, ToHex};
@@ -388,6 +389,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(fuzzing))]
     fn midstate() {
         // Test vector obtained by doing an asset issuance on Elements
         let mut engine = sha256::Hash::engine();
@@ -414,6 +416,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(fuzzing))]
     fn engine_with_state() {
         let mut engine = sha256::Hash::engine();
         let midstate_engine = sha256::HashEngine::from_midstate(engine.midstate(), 0);

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -46,6 +46,7 @@ mod tests {
     use crate::sha256;
 
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha256d, Hash, HashEngine};

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -151,6 +151,7 @@ mod tests {
     sha256t_hash_newtype!(NewTypeHash, NewTypeTag, TEST_MIDSTATE, 64, doc="test hash", true);
 
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test_sha256t() {
         assert_eq!(

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -308,6 +308,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(not(fuzzing))]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha512, Hash, HashEngine};

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -285,6 +285,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(not(fuzzing))]
     fn test_siphash_2_4() {
         let vecs: [[u8; 8]; 64] = [
             [0x31, 0x0e, 0x0e, 0xdd, 0x47, 0xdb, 0x6f, 0x72],


### PR DESCRIPTION
Draft builds on #1420 and #1421 and I'm not sure if this will work.

Currently we do not run fuzzing in CI for hashes, lets enable it.