### PR TITLE
Remove no_run

### DIFF
--- a/bitcoin/src/network/constants.rs
+++ b/bitcoin/src/network/constants.rs
@@ -104,7 +104,7 @@ impl Network {
 
     /// Converts a `Network` to its equivalent `bitcoind -chain` argument name.
     ///
-    /// ```bash,no_run
+    /// ```bash
     /// $ bitcoin-23.0/bin/bitcoind --help | grep -C 3 '\-chain=<chain>'
     /// Chain selection options:
     ///


### PR DESCRIPTION
`no_run` is not needed since we already mark this up as `bash` which rustc doesn't run when running examples.

While the keyword `bash` is not currently supported it may well be in the future and since only the `rust` keyword causes code to run any other string is effectively a wildcard, `no_run` is therefore meaningful only as a convention. Lets keep `bash` in case support is added later on.

cc sr-gi