### PR TITLE
Add MAX_MONEY

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -60,7 +60,13 @@ pub const MAX_SCRIPTNUM_VALUE: u32 = 0x80000000; // 2^31
 /// The maximum value allowed in an output (useful for sanity checking,
 /// since keeping everything below this value should prevent overflows
 /// if you are doing anything remotely sane with monetary values).
-pub fn max_money() -> u64 {
+pub const MAX_MONEY: u64 = 21_000_000 * COIN_VALUE;
+
+/// The maximum value allowed in an output (useful for sanity checking,
+/// since keeping everything below this value should prevent overflows
+/// if you are doing anything remotely sane with monetary values).
+#[deprecated(since = "0.30.0", note = "use constants::MAX_MONEY instead")]
+pub fn max_money(_: Network) -> u64 {
     21_000_000 * COIN_VALUE
 }
 


### PR DESCRIPTION
Alternate to #1410, this is trivial so I didn't think you would mind me throwing it up @Kixunil. 

The value is statically known which is better expressed as a constant. Also allows usage in const context.

Revert the recent change in `commit
64495cc5fee60ea06cfe7d887f6db123985dfc2a` and deprecate the `max_money` function.

Add MAX_MONEY constant to replace the `max_money` function.