### PR TITLE
Make secp256k1 optional

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -14,7 +14,9 @@ edition = "2018"
 
 # Please don't forget to add relevant features to docs.rs below
 [features]
-default = [ "std", "secp-recovery" ]
+default = ["std"]
+crypto-std = ["secp256k1/std", "crypto"] # Enable this feature to use ECC (i.e. keys and sigs).
+crypto = ["secp256k1/alloc"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 rand = ["secp256k1/rand-std"]
@@ -27,7 +29,7 @@ rust_v_1_53 = []
 # The no-std feature doesn't disable std - you need to turn off the std feature for that by disabling default.
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
-std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std", "bitcoin-internals/std"]
+std = ["bitcoin_hashes/std", "bech32/std", "bitcoin-internals/std"]
 no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
 
 [package.metadata.docs.rs]
@@ -38,7 +40,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitcoin-internals = { path = "../internals" }
 bech32 = { version = "0.9.0", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { version = "0.25.0", default-features = false, features = ["bitcoin_hashes"] }
+
+secp256k1 = { version = "0.25.0", default-features = false, features = ["bitcoin_hashes"], optional = true }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }
@@ -59,15 +62,16 @@ mutagen = { git = "https://github.com/llogiq/mutagen" }
 
 [[example]]
 name = "bip32"
+required-features = ["crypto"]
 
 [[example]]
 name = "handshake"
-required-features = ["std"]
+required-features = ["std", "crypto"]
 
 [[example]]
 name = "ecdsa-psbt"
-required-features = ["std", "bitcoinconsensus"]
+required-features = ["std", "crypto", "bitcoinconsensus"]
 
 [[example]]
 name = "taproot-psbt"
-required-features = ["std", "bitcoinconsensus"]
+required-features = ["std", "crypto", "bitcoinconsensus"]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2018"
 # Please don't forget to add relevant features to docs.rs below
 [features]
 default = [ "std", "secp-recovery" ]
-rand = ["secp256k1/rand-std"]
-serde = ["actual-serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
+rand = ["secp256k1/rand-std"]
+serde = ["actual-serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
 rust_v_1_53 = []
 

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="base64 bitcoinconsensus serde rand secp-recovery"
+FEATURES="base64 bitcoinconsensus serde rand secp-recovery crypto"
 
 if [ "$DO_COV" = true ]
 then
@@ -30,10 +30,10 @@ fi
 if [ "$DO_LINT" = true ]
 then
     cargo clippy --all-features --all-targets -- -D warnings
-    cargo clippy --example bip32 -- -D warnings
-    cargo clippy --example handshake -- -D warnings
-    cargo clippy --example ecdsa-psbt --features=bitcoinconsensus -- -D warnings
-    cargo clippy --example taproot-psbt --features=bitcoinconsensus -- -D warnings
+    cargo clippy --example bip32 --features=crypto -- -D warnings
+    cargo clippy --example handshake --features=crypto  -- -D warnings
+    cargo clippy --example ecdsa-psbt --features=crypto,bitcoinconsensus -- -D warnings
+    cargo clippy --example taproot-psbt --features=crypto,bitcoinconsensus -- -D warnings
 fi
 
 echo "********* Testing std *************"
@@ -65,8 +65,8 @@ then
         cargo build --verbose --features="no-std $feature"
     done
 
-    cargo run --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
-    cargo run --no-default-features --features no-std --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+    cargo run --features=crypto --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+    cargo run --no-default-features --features=no-std,crypto --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
 fi
 
 # Test each feature
@@ -76,8 +76,8 @@ do
     cargo test --verbose --features="$feature"
 done
 
-cargo run --example ecdsa-psbt --features=bitcoinconsensus
-cargo run --example taproot-psbt --features=bitcoinconsensus
+cargo run --example ecdsa-psbt --features=crypto,bitcoinconsensus
+cargo run --example taproot-psbt --features=crypto,bitcoinconsensus
 
 # Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCS" = true ]; then
@@ -115,7 +115,7 @@ if [ "$AS_DEPENDENCY" = true ]
 then
     cargo new dep_test 2> /dev/null # Mute warning about workspace, fixed below.
     cd dep_test
-    echo 'bitcoin = { path = "..", features = ["serde"] }\n\n' >> Cargo.toml
+    echo 'bitcoin = { path = "..", features = ["serde", "crypto"] }\n\n' >> Cargo.toml
     # Adding an empty workspace section excludes this crate from the rust-bitcoin workspace.
     echo '[workspace]\n\n' >> Cargo.toml
 

--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -15,7 +15,7 @@ cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 alloc-cortex-m = "0.4.1"
-bitcoin = { path="../", default-features = false, features = ["no-std", "secp-lowmemory"] }
+bitcoin = { path="../", default-features = false, features = ["no-std", "secp-lowmemory", "crypto"] }
 
 
 [[bin]]

--- a/bitcoin/fuzz/Cargo.toml
+++ b/bitcoin/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ honggfuzz_fuzz = ["honggfuzz"]
 [dependencies]
 honggfuzz = { version = "0.5", optional = true, default-features = false }
 afl = { version = "0.4", optional = true }
-bitcoin = { path = "../" }
+bitcoin = { path = "../", features = ["std", "crypto-std"] }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -8,10 +8,12 @@
 use core::convert::TryInto;
 use core::ops::Index;
 
+#[cfg(feature = "crypto")]
 use secp256k1::ecdsa;
 
 use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
+#[cfg(feature = "crypto")]
 use crate::sighash::EcdsaSighashType;
 use crate::io::{self, Read, Write};
 use crate::prelude::*;
@@ -271,6 +273,8 @@ impl Witness {
 
     /// Pushes a DER-encoded ECDSA signature with a signature hash type as a new element on the
     /// witness, requires an allocation.
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     pub fn push_bitcoin_signature(&mut self, signature: &ecdsa::SerializedSignature, hash_type: EcdsaSighashType) {
         // Note that a maximal length ECDSA signature is 72 bytes, plus the sighash type makes 73
         let mut sig = [0; 73];
@@ -492,6 +496,7 @@ mod test {
     use crate::consensus::{deserialize, serialize};
     use crate::hashes::hex::{FromHex, ToHex};
     use crate::Transaction;
+    #[cfg(feature = "crypto")]
     use crate::secp256k1::ecdsa;
 
     fn append_u32_vec(mut v: Vec<u8>, n: &[u32]) -> Vec<u8> {
@@ -573,6 +578,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "crypto")]
     fn test_push_ecdsa_sig() {
         // The very first signature in block 734,958
         let sig_bytes =

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -26,6 +26,7 @@ use crate::hashes::{sha256d, Hash, sha256};
 use crate::hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};
 use crate::io::{self, Cursor, Read};
 
+#[cfg(feature = "crypto")]
 use crate::psbt;
 use crate::bip152::{ShortId, PrefilledTransaction};
 use crate::taproot::TapLeafHash;
@@ -42,6 +43,8 @@ pub enum Error {
     /// And I/O error.
     Io(io::Error),
     /// PSBT-related error.
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     Psbt(psbt::Error),
     /// Tried to allocate an oversized vector.
     OversizedVectorAllocation {
@@ -69,6 +72,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref e) => write_err!(f, "IO error"; e),
+            #[cfg(feature = "crypto")]
             Error::Psbt(ref e) => write_err!(f, "PSBT error"; e),
             Error::OversizedVectorAllocation { requested: ref r, max: ref m } => write!(f,
                 "allocation of oversized vector: requested {}, maximum {}", r, m),
@@ -90,6 +94,7 @@ impl std::error::Error for Error {
 
         match self {
             Io(e) => Some(e),
+            #[cfg(feature = "crypto")]
             Psbt(e) => Some(e),
             OversizedVectorAllocation { .. }
             | InvalidChecksum { .. }
@@ -108,6 +113,7 @@ impl From<io::Error> for Error {
 }
 
 #[doc(hidden)]
+#[cfg(feature = "crypto")]
 impl From<psbt::Error> for Error {
     fn from(e: psbt::Error) -> Error {
         Error::Psbt(e)

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -372,6 +372,7 @@ enum DecodeError<E> {
 fn consensus_error_into_serde<E: serde::de::Error>(error: ConsensusError) -> E {
     match error {
         ConsensusError::Io(error) => panic!("unexpected IO error {:?}", error),
+        #[cfg(feature = "crypto")]
         ConsensusError::Psbt(_) => panic!("PSBT shouldn't implement consensus encoding"),
         ConsensusError::OversizedVectorAllocation { requested, max } => E::custom(format_args!("the requested allocation of {} items exceeds maximum of {}", requested, max)),
         ConsensusError::InvalidChecksum { expected, actual } => E::invalid_value(Unexpected::Bytes(&actual), &DisplayExpected(format_args!("checksum {:02x}{:02x}{:02x}{:02x}", expected[0], expected[1], expected[2], expected[3]))),

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -46,6 +46,8 @@ See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
     hash_newtype!(Wtxid, sha256d::Hash, 32, doc="A bitcoin witness transaction ID.");
     hash_newtype!(BlockHash, sha256d::Hash, 32, doc="A bitcoin block hash.");
     hash_newtype!(Sighash, sha256d::Hash, 32, doc="Hash of the transaction according to the signature algorithm");
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     impl secp256k1::ThirtyTwoByteHash for Sighash {
         fn into_32(self) -> [u8; 32] {
             use hashes::Hash;

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -52,6 +52,7 @@ pub(crate) use test_macros::*;
 #[cfg(test)]
 mod test_macros {
     use crate::hashes::hex::FromHex;
+    #[cfg(feature = "crypto")]
     use crate::PublicKey;
 
     /// Trait used to create a value from hex string for testing purposes.
@@ -68,6 +69,7 @@ mod test_macros {
         fn test_from_hex(hex: &str) -> Self { Self::from_hex(hex).unwrap() }
     }
 
+    #[cfg(feature = "crypto")]
     impl TestFromHex for PublicKey {
         fn test_from_hex(hex: &str) -> Self {
             PublicKey::from_slice(&Vec::from_hex(hex).unwrap()).unwrap()

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -73,6 +73,8 @@ pub extern crate bitcoinconsensus;
 #[cfg(feature = "hashbrown")]
 #[cfg_attr(docsrs, doc(cfg(feature = "hashbrown")))]
 pub extern crate hashbrown;
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub extern crate secp256k1;
 
 #[cfg(feature = "serde")]
@@ -94,15 +96,21 @@ pub mod amount;
 pub mod base58;
 pub mod bip152;
 pub mod bip158;
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub mod bip32;
 pub mod blockdata;
 pub mod consensus;
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub mod crypto;
 pub mod error;
 pub mod hash_types;
 pub mod merkle_tree;
 pub mod policy;
 pub mod pow;
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub mod psbt;
 pub mod sighash;
 pub mod sign_message;
@@ -132,7 +140,11 @@ pub use crate::blockdata::transaction::{self, OutPoint, Sequence, Transaction, T
 pub use crate::blockdata::witness::{self, Witness};
 pub use crate::blockdata::{constants, opcodes};
 pub use crate::consensus::encode::VarInt;
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub use crate::crypto::key::{self, PrivateKey, PublicKey};
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub use crate::crypto::{ecdsa, schnorr};
 pub use crate::error::Error;
 pub use crate::hash_types::*;

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -5,6 +5,8 @@
 //! This module is for special serde serializations.
 //!
 
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub mod btreemap_byte_values {
     //! Module for serialization of BTreeMaps with hex byte values.
     #![allow(missing_docs)]
@@ -74,6 +76,8 @@ pub mod btreemap_byte_values {
     }
 }
 
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub mod btreemap_as_seq {
     //! Module for serialization of BTreeMaps as lists of sequences because
     //! serde_json will not serialize hashmaps with non-string keys be default.
@@ -146,6 +150,8 @@ pub mod btreemap_as_seq {
     }
 }
 
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub mod btreemap_as_seq_byte_values {
     //! Module for serialization of BTreeMaps as lists of sequences because
     //! serde_json will not serialize hashmaps with non-string keys be default.
@@ -231,6 +237,8 @@ pub mod btreemap_as_seq_byte_values {
     }
 }
 
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub mod hex_bytes {
     //! Module for serialization of byte arrays as hex strings.
     #![allow(missing_docs)]

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -12,7 +12,7 @@ use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 use core::{fmt, str};
 
-use crate::{io, Script, ScriptBuf, Transaction, TxIn, TxOut, Sequence, Sighash};
+use crate::{io, Script, ScriptBuf, Sequence, Sighash, Transaction, TxIn, TxOut};
 use crate::blockdata::transaction::EncodeSigningDataResult;
 use crate::blockdata::witness::Witness;
 use crate::consensus::{encode, Encodable};
@@ -1049,14 +1049,17 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+    #[cfg(feature = "crypto")]
     use crate::address::Address;
     use crate::blockdata::locktime::absolute;
     use crate::consensus::deserialize;
+    #[cfg(feature = "crypto")]
     use crate::crypto::key::PublicKey;
     use crate::hash_types::Sighash;
     use crate::hashes::hex::FromHex;
     use crate::hashes::{Hash, HashEngine};
     use crate::internal_macros::{hex_from_slice, hex_script};
+    #[cfg(feature = "crypto")]
     use crate::network::constants::Network;
     use crate::taproot::{TapLeafHash, TapSighashHash};
 
@@ -1370,8 +1373,9 @@ mod tests {
         assert_eq!(expected, hash.into_inner());
     }
 
-    #[cfg(feature = "serde")]
     #[test]
+    #[cfg(feature = "serde")]
+    #[cfg(feature = "crypto")]
     fn bip_341_sighash_tests() {
         fn sighash_deser_numeric<'de, D>(deserializer: D) -> Result<SchnorrSighashType, D::Error>
         where
@@ -1599,12 +1603,14 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "crypto")]
     fn p2pkh_hex(pk: &str) -> ScriptBuf {
         let pk: PublicKey = PublicKey::from_str(pk).unwrap();
         Address::p2pkh(&pk, Network::Bitcoin).script_pubkey()
     }
 
     #[test]
+    #[cfg(feature = "crypto")]
     fn bip143_p2wpkh() {
         let tx = deserialize::<Transaction>(
             &Vec::from_hex(
@@ -1644,6 +1650,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "crypto")]
     fn bip143_p2wpkh_nested_in_p2sh() {
         let tx = deserialize::<Transaction>(
             &Vec::from_hex(

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -24,8 +24,12 @@ mod message_signing {
     use secp256k1;
     use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 
-    use crate::address::{Address, AddressType};
+    #[cfg(feature = "crypto")]
+    use crate::address::Address;
+    use crate::address::AddressType;
+    #[cfg(feature = "crypto")]
     use crate::crypto::key::PublicKey;
+    #[cfg(feature = "crypto")]
     use crate::hashes::sha256d;
     #[cfg(feature = "base64")]
     use crate::prelude::*;
@@ -132,6 +136,8 @@ mod message_signing {
         /// Attempt to recover a public key from the signature and the signed message.
         ///
         /// To get the message hash from a message, use [super::signed_msg_hash].
+        #[cfg(feature = "crypto")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
         pub fn recover_pubkey<C: secp256k1::Verification>(
             &self,
             secp_ctx: &secp256k1::Secp256k1<C>,
@@ -145,6 +151,8 @@ mod message_signing {
         /// Verify that the signature signs the message and was signed by the given address.
         ///
         /// To get the message hash from a message, use [super::signed_msg_hash].
+        #[cfg(feature = "crypto")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
         pub fn is_signed_by_address<C: secp256k1::Verification>(
             &self,
             secp_ctx: &secp256k1::Secp256k1<C>,

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -9,10 +9,13 @@ use core::cmp::Reverse;
 use core::convert::TryFrom;
 use core::fmt;
 
+#[cfg(feature = "crypto")]
 use bitcoin_internals::write_err;
+#[cfg(feature = "crypto")]
 use secp256k1::{self, Scalar, Secp256k1};
 
 use crate::consensus::Encodable;
+#[cfg(feature = "crypto")]
 use crate::crypto::schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey, XOnlyPublicKey};
 use crate::hashes::{sha256, sha256t_hash_newtype, Hash, HashEngine};
 use crate::prelude::*;
@@ -64,6 +67,8 @@ sha256t_hash_newtype!(TapSighashHash, TapSighashTag, MIDSTATE_TAPSIGHASH, 64,
     doc="Taproot-tagged hash for the taproot signature hash", false
 );
 
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 impl secp256k1::ThirtyTwoByteHash for TapSighashHash {
     fn into_32(self) -> [u8; 32] { self.into_inner() }
 }
@@ -71,6 +76,8 @@ impl secp256k1::ThirtyTwoByteHash for TapSighashHash {
 impl TapTweakHash {
     /// Creates a new BIP341 [`TapTweakHash`] from key and tweak. Produces `H_taptweak(P||R)` where
     /// `P` is the internal key and `R` is the merkle root.
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     pub fn from_key_and_tweak(
         internal_key: UntweakedPublicKey,
         merkle_root: Option<TapBranchHash>,
@@ -87,6 +94,8 @@ impl TapTweakHash {
     }
 
     /// Converts a `TapTweakHash` into a `Scalar` ready for use with key tweaking API.
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     pub fn to_scalar(self) -> Scalar {
         // This is statistically extremely unlikely to panic.
         Scalar::from_be_bytes(self.into_inner()).expect("hash value greater than curve order")
@@ -149,6 +158,8 @@ pub const TAPROOT_CONTROL_MAX_SIZE: usize =
     TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
 
 // type alias for versioned tap script corresponding merkle proof
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 type ScriptMerkleProofMap = BTreeMap<(ScriptBuf, LeafVersion), BTreeSet<TaprootMerkleBranch>>;
 
 /// Represents taproot spending information.
@@ -173,6 +184,8 @@ type ScriptMerkleProofMap = BTreeMap<(ScriptBuf, LeafVersion), BTreeSet<TaprootM
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub struct TaprootSpendInfo {
     /// The BIP341 internal key.
     internal_key: UntweakedPublicKey,
@@ -189,6 +202,7 @@ pub struct TaprootSpendInfo {
     script_map: ScriptMerkleProofMap,
 }
 
+#[cfg(feature = "crypto")]
 impl TaprootSpendInfo {
     /// Creates a new [`TaprootSpendInfo`] from a list of scripts (with default script version) and
     /// weights of satisfaction for that script.
@@ -302,10 +316,14 @@ impl TaprootSpendInfo {
     }
 }
 
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 impl From<TaprootSpendInfo> for TapTweakHash {
     fn from(spend_info: TaprootSpendInfo) -> TapTweakHash { spend_info.tap_tweak() }
 }
 
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 impl From<&TaprootSpendInfo> for TapTweakHash {
     fn from(spend_info: &TaprootSpendInfo) -> TapTweakHash { spend_info.tap_tweak() }
 }
@@ -452,6 +470,8 @@ impl TaprootBuilder {
     ///
     /// Returns the unmodified builder as Err if the builder is not finalizable.
     /// See also [`TaprootBuilder::is_finalizable`]
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     pub fn finalize<C: secp256k1::Verification>(
         mut self,
         secp: &Secp256k1<C>,
@@ -469,6 +489,8 @@ impl TaprootBuilder {
         }
     }
 
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     pub(crate) fn branch(&self) -> &[Option<NodeInfo>] { &self.branch }
 
     /// Inserts a leaf at `depth`.
@@ -720,6 +742,8 @@ impl_try_from!(Box<[sha256::Hash]>);
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 pub struct ControlBlock {
     /// The tapleaf version.
     pub leaf_version: LeafVersion,
@@ -731,6 +755,7 @@ pub struct ControlBlock {
     pub merkle_branch: TaprootMerkleBranch,
 }
 
+#[cfg(feature = "crypto")]
 impl ControlBlock {
     /// Constructs a `ControlBlock` from slice. This is an extra witness element that provides the
     /// proof that taproot script pubkey is correctly computed with some specified leaf hash. This
@@ -972,6 +997,8 @@ pub enum TaprootBuilderError {
     /// Two nodes at depth 0 are not allowed.
     OverCompleteTree,
     /// Invalid taproot internal key.
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     InvalidInternalKey(secp256k1::Error),
     /// Called finalize on a empty tree.
     EmptyTree,
@@ -995,6 +1022,7 @@ impl fmt::Display for TaprootBuilderError {
                 "Attempted to create a tree with two nodes at depth 0. There must\
                 only be a exactly one node at depth 0",
             ),
+            #[cfg(feature = "crypto")]
             TaprootBuilderError::InvalidInternalKey(ref e) => {
                 write_err!(f, "invalid internal x-only key"; e)
             }
@@ -1012,6 +1040,7 @@ impl std::error::Error for TaprootBuilderError {
         use self::TaprootBuilderError::*;
 
         match self {
+            #[cfg(feature = "crypto")]
             InvalidInternalKey(e) => Some(e),
             InvalidMerkleTreeDepth(_) | NodeNotInDfsOrder | OverCompleteTree | EmptyTree => None,
         }
@@ -1031,8 +1060,12 @@ pub enum TaprootError {
     /// Invalid control block size.
     InvalidControlBlockSize(usize),
     /// Invalid taproot internal key.
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     InvalidInternalKey(secp256k1::Error),
     /// Invalid parity for internal key.
+    #[cfg(feature = "crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
     InvalidParity(secp256k1::InvalidParityValue),
     /// Empty tap tree.
     EmptyTree,
@@ -1058,8 +1091,10 @@ impl fmt::Display for TaprootError {
                 "Control Block size({}) must be of the form 33 + 32*m where  0 <= m <= {} ",
                 sz, TAPROOT_CONTROL_MAX_NODE_COUNT
             ),
+            #[cfg(feature = "crypto")]
             TaprootError::InvalidInternalKey(ref e) =>
                 write_err!(f, "invalid internal x-only key"; e),
+            #[cfg(feature = "crypto")]
             TaprootError::InvalidParity(_) => write!(f, "invalid parity value for internal key"),
             TaprootError::EmptyTree => write!(f, "Taproot Tree must contain at least one script"),
         }
@@ -1073,28 +1108,35 @@ impl std::error::Error for TaprootError {
         use self::TaprootError::*;
 
         match self {
+            #[cfg(feature = "crypto")]
             InvalidInternalKey(e) => Some(e),
             InvalidMerkleBranchSize(_)
             | InvalidMerkleTreeDepth(_)
             | InvalidTaprootLeafVersion(_)
             | InvalidControlBlockSize(_)
-            | InvalidParity(_)
             | EmptyTree => None,
+            #[cfg(feature = "crypto")]
+            InvalidParity(_) => None,
         }
     }
 }
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "crypto")]
     use core::str::FromStr;
 
+    #[cfg(feature = "crypto")]
     use secp256k1::{VerifyOnly, XOnlyPublicKey};
 
     use super::*;
+    #[cfg(feature = "crypto")]
     use crate::crypto::schnorr::TapTweak;
+    #[cfg(feature = "crypto")]
     use crate::hashes::hex::{FromHex, ToHex};
     use crate::hashes::sha256t::Tag;
     use crate::hashes::{sha256, Hash, HashEngine};
+    #[cfg(feature = "crypto")]
     use crate::{Address, Network};
     extern crate serde_json;
 
@@ -1133,6 +1175,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "crypto")]
     fn test_vectors_core() {
         //! Test vectors taken from Core
 
@@ -1179,6 +1222,7 @@ mod test {
         );
     }
 
+    #[cfg(feature = "crypto")]
     fn _verify_tap_commitments(
         secp: &Secp256k1<VerifyOnly>,
         out_spk_hex: &str,
@@ -1195,6 +1239,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "crypto")]
     fn control_block_verify() {
         let secp = Secp256k1::verification_only();
         // test vectors obtained from printing values in feature_taproot.py from Bitcoin Core
@@ -1247,6 +1292,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "crypto")]
     fn build_huffman_tree() {
         let secp = Secp256k1::verification_only();
         let internal_key = UntweakedPublicKey::from_str(
@@ -1306,6 +1352,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "crypto")]
     fn taptree_builder() {
         let secp = Secp256k1::verification_only();
         let internal_key = UntweakedPublicKey::from_str(
@@ -1352,6 +1399,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "crypto")]
     fn bip_341_tests() {
         fn process_script_trees(
             v: &serde_json::Value,
@@ -1434,6 +1482,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "crypto")]
     fn bip_341_read_json() -> serde_json::Value {
         let json_str = include_str!("../tests/data/bip341_tests.json");
         serde_json::from_str(json_str).expect("JSON was not well-formatted")

--- a/bitcoin/tests/psbt.rs
+++ b/bitcoin/tests/psbt.rs
@@ -1,6 +1,8 @@
 //! Tests PSBT integration vectors from BIP 174
 //! defined at <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#test-vectors>
 
+#![cfg(feature = "crypto")]
+
 use std::collections::BTreeMap;
 use std::str::FromStr;
 

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -22,26 +22,35 @@
 
 #![cfg(feature = "serde")]
 
+#[cfg(feature = "crypto")]
 use std::collections::BTreeMap;
+#[cfg(feature = "crypto")]
 use std::str::FromStr;
 
 use bincode::serialize;
+#[cfg(feature = "crypto")]
 use bitcoin::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, KeySource};
 use bitcoin::blockdata::locktime::{absolute, relative};
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::hex::FromHex;
+#[cfg(feature = "crypto")]
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+#[cfg(feature = "crypto")]
 use bitcoin::psbt::raw::{self, Key, Pair, ProprietaryKey};
+#[cfg(feature = "crypto")]
 use bitcoin::psbt::{Input, Output, Psbt, PsbtSighashType};
+#[cfg(feature = "crypto")]
 use bitcoin::schnorr::{self, UntweakedPublicKey};
+#[cfg(feature = "crypto")]
+use bitcoin::secp256k1::Secp256k1;
+#[cfg(feature = "crypto")]
 use bitcoin::sighash::{EcdsaSighashType, SchnorrSighashType};
+#[cfg(feature = "crypto")]
 use bitcoin::taproot::{ControlBlock, LeafVersion, TaprootBuilder, TaprootSpendInfo};
-use bitcoin::{
-    ecdsa, Address, Block, Network, OutPoint, PrivateKey, PublicKey, ScriptBuf, Sequence, Target,
-    Transaction, TxIn, TxOut, Txid, Work,
-};
-use secp256k1::Secp256k1;
+#[cfg(feature = "crypto")]
+use bitcoin::{ecdsa, Address, Network, OutPoint, PrivateKey, PublicKey, Sequence, Txid};
+use bitcoin::{Block, ScriptBuf, Target, Transaction, TxIn, TxOut, Work};
 
 /// Implicitly does regression test for `BlockHeader` also.
 #[test]
@@ -143,6 +152,7 @@ fn serde_regression_witness() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_address() {
     let s = include_str!("data/serde/public_key_hex");
     let pk = PublicKey::from_str(s.trim()).unwrap();
@@ -154,6 +164,7 @@ fn serde_regression_address() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_extended_priv_key() {
     let s = include_str!("data/serde/extended_priv_key");
     let key = ExtendedPrivKey::from_str(s.trim()).unwrap();
@@ -163,6 +174,7 @@ fn serde_regression_extended_priv_key() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_extended_pub_key() {
     let s = include_str!("data/serde/extended_pub_key");
     let key = ExtendedPubKey::from_str(s.trim()).unwrap();
@@ -172,6 +184,7 @@ fn serde_regression_extended_pub_key() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_ecdsa_sig() {
     let s = include_str!("data/serde/ecdsa_sig_hex");
     let sig = ecdsa::Signature {
@@ -185,6 +198,7 @@ fn serde_regression_ecdsa_sig() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_control_block() {
     let s = include_str!("data/serde/control_block_hex");
     let block = ControlBlock::from_slice(&Vec::<u8>::from_hex(s.trim()).unwrap()).unwrap();
@@ -195,6 +209,7 @@ fn serde_regression_control_block() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_child_number() {
     let num = ChildNumber::Normal { index: 0xDEADBEEF };
     let got = serialize(&num).unwrap();
@@ -203,6 +218,7 @@ fn serde_regression_child_number() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_private_key() {
     let sk = PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
     let got = serialize(&sk).unwrap();
@@ -211,6 +227,7 @@ fn serde_regression_private_key() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_public_key() {
     let s = include_str!("data/serde/public_key_hex");
     let pk = PublicKey::from_str(s.trim()).unwrap();
@@ -220,6 +237,7 @@ fn serde_regression_public_key() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_psbt() {
     let tx = Transaction {
         version: 1,
@@ -319,6 +337,7 @@ fn serde_regression_psbt() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_raw_pair() {
     let pair = Pair {
         key: Key { type_value: 1u8, key: vec![0u8, 1u8, 2u8, 3u8] },
@@ -330,6 +349,7 @@ fn serde_regression_raw_pair() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_proprietary_key() {
     let key = ProprietaryKey {
         prefix: vec![0u8, 1u8, 2u8, 3u8],
@@ -342,6 +362,7 @@ fn serde_regression_proprietary_key() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_schnorr_sig() {
     let s = include_str!("data/serde/schnorr_sig_hex");
     let sig = schnorr::Signature {
@@ -355,6 +376,7 @@ fn serde_regression_schnorr_sig() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_taproot_builder() {
     let ver = LeafVersion::from_consensus(0).unwrap();
     let script = ScriptBuf::from(vec![0u8, 1u8, 2u8]);
@@ -366,6 +388,7 @@ fn serde_regression_taproot_builder() {
 }
 
 #[test]
+#[cfg(feature = "crypto")]
 fn serde_regression_taproot_spend_info() {
     let secp = Secp256k1::verification_only();
     let internal_key = UntweakedPublicKey::from_str(


### PR DESCRIPTION
Add feature "crypto" and feature gate anything that touches `secp256k1` behind it.

Fix: #526 

### Note

Does not add `doc(cfg` for private functions, do we want that?