### PR TITLE
Upgrade secp26k1 version to 0.25.1

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -37,7 +37,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitcoin-internals = { path = "../internals" }
 bech32 = { version = "0.9.0", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { version = "0.24.0", default-features = false, features = ["bitcoin_hashes"] }
+secp256k1 = { version = "0.25.1", default-features = false, features = ["bitcoin-hashes"] }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }
@@ -50,7 +50,7 @@ hashbrown = { version = "0.8", optional = true }
 serde_json = "1.0.0"
 serde_test = "1.0.19"
 serde_derive = "1.0.103"
-secp256k1 = { version = "0.24.0", features = [ "recovery", "rand-std" ] }
+secp256k1 = { version = "0.25.1", features = [ "recovery", "rand-std" ] }
 bincode = "1.3.1"
 
 [[example]]


### PR DESCRIPTION
Draft because secp256k1 v0.25.1 is not released yet.

Upgrade the version of `secp256k1` to the latest release.