### PR TITLE
Remove usage of `hashes::ToHex`

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -880,11 +880,13 @@ fn segwit_redeem_hash(pubkey_hash: &[u8]) -> crate::hashes::hash160::Hash {
 mod tests {
     use core::str::FromStr;
 
+    use bitcoin_internals::hex::display::DisplayHex;
+
     use secp256k1::XOnlyPublicKey;
 
     use super::*;
     use crate::crypto::key::PublicKey;
-    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::FromHex;
     use crate::internal_macros::{hex, hex_into, hex_script};
     use crate::network::constants::Network::{Bitcoin, Testnet};
 
@@ -1077,7 +1079,7 @@ mod tests {
         ];
         for vector in &valid_vectors {
             let addr: Address = vector.0.parse().unwrap();
-            assert_eq!(&addr.script_pubkey().as_bytes().to_hex(), vector.1);
+            assert_eq!(&addr.script_pubkey().as_bytes().to_lower_hex_string(), vector.1);
             roundtrips(&addr);
         }
 

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -192,7 +192,7 @@ impl ChainHash {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::hashes::hex::{ToHex, FromHex};
+    use crate::hashes::hex::FromHex;
     use crate::network::constants::Network;
     use crate::consensus::encode::serialize;
     use crate::blockdata::locktime::absolute;
@@ -215,7 +215,7 @@ mod test {
         assert_eq!(gen.output[0].value, 50 * COIN_VALUE);
         assert_eq!(gen.lock_time, absolute::PackedLockTime::ZERO);
 
-        assert_eq!(gen.wtxid().to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+        assert_eq!(gen.wtxid().to_string(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
     }
 
     #[test]
@@ -224,12 +224,12 @@ mod test {
 
         assert_eq!(gen.header.version, block::Version::ONE);
         assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
-        assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+        assert_eq!(gen.header.merkle_root.to_string(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 
         assert_eq!(gen.header.time, 1231006505);
         assert_eq!(gen.header.bits, CompactTarget::from_consensus(0x1d00ffff));
         assert_eq!(gen.header.nonce, 2083236893);
-        assert_eq!(gen.header.block_hash().to_hex(), "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+        assert_eq!(gen.header.block_hash().to_string(), "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
     }
 
     #[test]
@@ -237,11 +237,11 @@ mod test {
         let gen = genesis_block(Network::Testnet);
         assert_eq!(gen.header.version, block::Version::ONE);
         assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
-        assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+        assert_eq!(gen.header.merkle_root.to_string(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
         assert_eq!(gen.header.time, 1296688602);
         assert_eq!(gen.header.bits, CompactTarget::from_consensus(0x1d00ffff));
         assert_eq!(gen.header.nonce, 414098458);
-        assert_eq!(gen.header.block_hash().to_hex(), "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
+        assert_eq!(gen.header.block_hash().to_string(), "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
     }
 
     #[test]
@@ -249,11 +249,11 @@ mod test {
         let gen = genesis_block(Network::Signet);
         assert_eq!(gen.header.version, block::Version::ONE);
         assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
-        assert_eq!(gen.header.merkle_root.to_hex(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+        assert_eq!(gen.header.merkle_root.to_string(), "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
         assert_eq!(gen.header.time, 1598918400);
         assert_eq!(gen.header.bits, CompactTarget::from_consensus(0x1e0377ae));
         assert_eq!(gen.header.nonce, 52613770);
-        assert_eq!(gen.header.block_hash().to_hex(), "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6");
+        assert_eq!(gen.header.block_hash().to_string(), "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6");
     }
 
     // The *_chain_hash tests are sanity/regression tests, they verify that the const byte array
@@ -303,7 +303,7 @@ mod test {
     // Test vector taken from: https://github.com/lightning/bolts/blob/master/00-introduction.md
     #[test]
     fn mainnet_chain_hash_test_vector() {
-        let got = ChainHash::using_genesis_block(Network::Bitcoin).to_hex();
+        let got = ChainHash::using_genesis_block(Network::Bitcoin).to_string();
         let want = "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000";
         assert_eq!(got, want);
     }

--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -18,6 +18,7 @@ use crate::io;
 use core::convert::TryFrom;
 use core::{fmt, default::Default};
 use core::ops::Index;
+
 use bitcoin_internals::debug_from_display;
 #[cfg(feature = "bitcoinconsensus")]
 use bitcoin_internals::write_err;
@@ -1165,10 +1166,10 @@ impl serde::Serialize for Script {
     where
         S: serde::Serializer,
     {
-        use crate::hashes::hex::ToHex;
+        use bitcoin_internals::hex::display::DisplayHex;
 
         if serializer.is_human_readable() {
-            serializer.serialize_str(&self.to_hex())
+            serializer.serialize_str(&self.as_bytes().to_lower_hex_string())
         } else {
             serializer.serialize_bytes(self.as_bytes())
         }
@@ -1193,10 +1194,12 @@ impl Decodable for Script {
 mod test {
     use core::str::FromStr;
 
+    use bitcoin_internals::hex::display::DisplayHex;
+
     use super::*;
     use super::write_scriptint;
 
-    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::FromHex;
     use crate::consensus::encode::{deserialize, serialize};
     use crate::blockdata::opcodes;
     use crate::crypto::key::PublicKey;
@@ -1394,7 +1397,7 @@ mod test {
                                    .push_opcode(OP_EQUALVERIFY)
                                    .push_opcode(OP_CHECKSIG)
                                    .into_script();
-        assert_eq!(script.to_hex(), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
+        assert_eq!(script.as_ref().to_lower_hex_string(), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
     }
 
     #[test]
@@ -1426,7 +1429,7 @@ mod test {
         let data = Vec::<u8>::from_hex("aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a").unwrap();
         let op_return = Script::new_op_return(&data);
         assert!(op_return.is_op_return());
-        assert_eq!(op_return.to_hex(), "6a24aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a");
+        assert_eq!(op_return.to_bytes().to_lower_hex_string(), "6a24aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a");
     }
 
     #[test]
@@ -1434,71 +1437,71 @@ mod test {
         let simple = Builder::new()
             .push_verify()
             .into_script();
-        assert_eq!(simple.to_hex(), "69");
+        assert_eq!(simple.to_bytes().to_lower_hex_string(), "69");
         let simple2 = Builder::from(vec![])
             .push_verify()
             .into_script();
-        assert_eq!(simple2.to_hex(), "69");
+        assert_eq!(simple2.to_bytes().to_lower_hex_string(), "69");
 
         let nonverify = Builder::new()
             .push_verify()
             .push_verify()
             .into_script();
-        assert_eq!(nonverify.to_hex(), "6969");
+        assert_eq!(nonverify.to_bytes().to_lower_hex_string(), "6969");
         let nonverify2 = Builder::from(vec![0x69])
             .push_verify()
             .into_script();
-        assert_eq!(nonverify2.to_hex(), "6969");
+        assert_eq!(nonverify2.to_bytes().to_lower_hex_string(), "6969");
 
         let equal = Builder::new()
             .push_opcode(OP_EQUAL)
             .push_verify()
             .into_script();
-        assert_eq!(equal.to_hex(), "88");
+        assert_eq!(equal.to_bytes().to_lower_hex_string(), "88");
         let equal2 = Builder::from(vec![0x87])
             .push_verify()
             .into_script();
-        assert_eq!(equal2.to_hex(), "88");
+        assert_eq!(equal2.to_bytes().to_lower_hex_string(), "88");
 
         let numequal = Builder::new()
             .push_opcode(OP_NUMEQUAL)
             .push_verify()
             .into_script();
-        assert_eq!(numequal.to_hex(), "9d");
+        assert_eq!(numequal.to_bytes().to_lower_hex_string(), "9d");
         let numequal2 = Builder::from(vec![0x9c])
             .push_verify()
             .into_script();
-        assert_eq!(numequal2.to_hex(), "9d");
+        assert_eq!(numequal2.to_bytes().to_lower_hex_string(), "9d");
 
         let checksig = Builder::new()
             .push_opcode(OP_CHECKSIG)
             .push_verify()
             .into_script();
-        assert_eq!(checksig.to_hex(), "ad");
+        assert_eq!(checksig.to_bytes().to_lower_hex_string(), "ad");
         let checksig2 = Builder::from(vec![0xac])
             .push_verify()
             .into_script();
-        assert_eq!(checksig2.to_hex(), "ad");
+        assert_eq!(checksig2.to_bytes().to_lower_hex_string(), "ad");
 
         let checkmultisig = Builder::new()
             .push_opcode(OP_CHECKMULTISIG)
             .push_verify()
             .into_script();
-        assert_eq!(checkmultisig.to_hex(), "af");
+        assert_eq!(checkmultisig.to_bytes().to_lower_hex_string(), "af");
         let checkmultisig2 = Builder::from(vec![0xae])
             .push_verify()
             .into_script();
-        assert_eq!(checkmultisig2.to_hex(), "af");
+        assert_eq!(checkmultisig2.to_bytes().to_lower_hex_string(), "af");
 
         let trick_slice = Builder::new()
             .push_slice(&[0xae]) // OP_CHECKMULTISIG
             .push_verify()
             .into_script();
-        assert_eq!(trick_slice.to_hex(), "01ae69");
+        assert_eq!(trick_slice.to_bytes().to_lower_hex_string(), "01ae69");
         let trick_slice2 = Builder::from(vec![0x01, 0xae])
             .push_verify()
             .into_script();
-        assert_eq!(trick_slice2.to_hex(), "01ae69");
+        assert_eq!(trick_slice2.to_bytes().to_lower_hex_string(), "01ae69");
    }
 
     #[test]
@@ -1546,8 +1549,8 @@ mod test {
     #[test]
     fn script_hashes() {
         let script = hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac");
-        assert_eq!(script.script_hash().to_hex(), "8292bcfbef1884f73c813dfe9c82fd7e814291ea");
-        assert_eq!(script.wscript_hash().to_hex(), "3e1525eb183ad4f9b3c5fa3175bdca2a52e947b135bbb90383bf9f6408e2c324");
+        assert_eq!(script.script_hash().to_string(), "8292bcfbef1884f73c813dfe9c82fd7e814291ea");
+        assert_eq!(script.wscript_hash().to_string(), "3e1525eb183ad4f9b3c5fa3175bdca2a52e947b135bbb90383bf9f6408e2c324");
     }
 
     #[test]

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -383,7 +383,7 @@ impl serde::Serialize for Witness {
     where
         S: serde::Serializer,
     {
-        use crate::hashes::hex::ToHex;
+        use bitcoin_internals::hex::display::DisplayHex;
         use serde::ser::SerializeSeq;
 
         let human_readable = serializer.is_human_readable();
@@ -391,7 +391,7 @@ impl serde::Serialize for Witness {
 
         for elem in self.iter() {
             if human_readable {
-                seq.serialize_element(&elem.to_hex())?;
+                seq.serialize_element(&elem.to_lower_hex_string())?;
             } else {
                 seq.serialize_element(&elem)?;
             }
@@ -485,8 +485,10 @@ impl From<Vec<&[u8]>> for Witness {
 mod test {
     use super::*;
 
+    use bitcoin_internals::hex::display::DisplayHex;
+
     use crate::consensus::{deserialize, serialize};
-    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::FromHex;
     use crate::Transaction;
     use crate::secp256k1::ecdsa;
 
@@ -649,15 +651,15 @@ mod test {
 
         let expected_wit = ["304502210084622878c94f4c356ce49c8e33a063ec90f6ee9c0208540888cfab056cd1fca9022014e8dbfdfa46d318c6887afd92dcfa54510e057565e091d64d2ee3a66488f82c01", "026e181ffb98ebfe5a64c983073398ea4bcd1548e7b971b4c175346a25a1c12e95"];
         for (i, wit_el) in tx.input[0].witness.iter().enumerate() {
-            assert_eq!(expected_wit[i], wit_el.to_hex());
+            assert_eq!(expected_wit[i], wit_el.to_lower_hex_string());
         }
-        assert_eq!(expected_wit[1], tx.input[0].witness.last().unwrap().to_hex());
-        assert_eq!(expected_wit[0], tx.input[0].witness.second_to_last().unwrap().to_hex());
-        assert_eq!(expected_wit[0], tx.input[0].witness.nth(0).unwrap().to_hex());
-        assert_eq!(expected_wit[1], tx.input[0].witness.nth(1).unwrap().to_hex());
+        assert_eq!(expected_wit[1], tx.input[0].witness.last().unwrap().to_lower_hex_string());
+        assert_eq!(expected_wit[0], tx.input[0].witness.second_to_last().unwrap().to_lower_hex_string());
+        assert_eq!(expected_wit[0], tx.input[0].witness.nth(0).unwrap().to_lower_hex_string());
+        assert_eq!(expected_wit[1], tx.input[0].witness.nth(1).unwrap().to_lower_hex_string());
         assert_eq!(None, tx.input[0].witness.nth(2));
-        assert_eq!(expected_wit[0], tx.input[0].witness[0].to_hex());
-        assert_eq!(expected_wit[1], tx.input[0].witness[1].to_hex());
+        assert_eq!(expected_wit[0], tx.input[0].witness[0].to_lower_hex_string());
+        assert_eq!(expected_wit[1], tx.input[0].witness[1].to_lower_hex_string());
 
         let tx_bytes_back = serialize(&tx);
         assert_eq!(tx_bytes_back, tx_bytes);

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -21,6 +21,7 @@ use crate::prelude::*;
 use core::{fmt, mem, u32, convert::From};
 
 use bitcoin_internals::write_err;
+use bitcoin_internals::hex::display::DisplayHex;
 
 use crate::hashes::{sha256d, Hash, sha256};
 use crate::hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};
@@ -29,7 +30,6 @@ use crate::io::{self, Cursor, Read};
 use crate::psbt;
 use crate::bip152::{ShortId, PrefilledTransaction};
 use crate::taproot::TapLeafHash;
-use crate::hashes::hex::ToHex;
 
 use crate::blockdata::transaction::{TxOut, Transaction, TxIn};
 #[cfg(feature = "std")]
@@ -73,7 +73,7 @@ impl fmt::Display for Error {
             Error::OversizedVectorAllocation { requested: ref r, max: ref m } => write!(f,
                 "allocation of oversized vector: requested {}, maximum {}", r, m),
             Error::InvalidChecksum { expected: ref e, actual: ref a } => write!(f,
-                "invalid checksum: expected {}, actual {}", e.to_hex(), a.to_hex()),
+                "invalid checksum: expected {}, actual {}", e.to_lower_hex_string(), a.to_lower_hex_string()),
             Error::NonMinimalVarInt => write!(f, "non-minimal varint"),
             Error::ParseFailed(ref s) => write!(f, "parse failed: {}", s),
             Error::UnsupportedSegwitFlag(ref swflag) => write!(f,
@@ -124,7 +124,7 @@ pub fn serialize<T: Encodable + ?Sized>(data: &T) -> Vec<u8> {
 
 /// Encode an object into a hex-encoded string
 pub fn serialize_hex<T: Encodable + ?Sized>(data: &T) -> String {
-    serialize(data)[..].to_hex()
+    serialize(data)[..].to_lower_hex_string()
 }
 
 /// Deserialize an object from a vector, will error if said deserialization

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -548,7 +548,7 @@ mod tests {
     use super::{PrivateKey, PublicKey, SortKey};
     use secp256k1::Secp256k1;
     use std::str::FromStr;
-    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::FromHex;
     use crate::network::constants::Network::Testnet;
     use crate::network::constants::Network::Bitcoin;
     use crate::address::Address;
@@ -593,15 +593,15 @@ mod tests {
     fn test_pubkey_hash() {
         let pk = PublicKey::from_str("032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af").unwrap();
         let upk = PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap();
-        assert_eq!(pk.pubkey_hash().to_hex(), "9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4");
-        assert_eq!(upk.pubkey_hash().to_hex(), "ac2e7daf42d2c97418fd9f78af2de552bb9c6a7a");
+        assert_eq!(pk.pubkey_hash().to_string(), "9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4");
+        assert_eq!(upk.pubkey_hash().to_string(), "ac2e7daf42d2c97418fd9f78af2de552bb9c6a7a");
     }
 
     #[test]
     fn test_wpubkey_hash() {
         let pk = PublicKey::from_str("032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af").unwrap();
         let upk = PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap();
-        assert_eq!(pk.wpubkey_hash().unwrap().to_hex(), "9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4");
+        assert_eq!(pk.wpubkey_hash().unwrap().to_string(), "9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4");
         assert_eq!(upk.wpubkey_hash(), None);
     }
 

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -112,7 +112,7 @@ mod test_macros {
 
 /// Implements several traits for byte-based newtypes.
 /// Implements:
-/// - core::fmt::LowerHex (implies hashes::hex::ToHex)
+/// - core::fmt::LowerHex
 /// - core::fmt::Display
 /// - core::str::FromStr
 /// - hashes::hex::FromHex
@@ -169,8 +169,10 @@ macro_rules! impl_bytes_newtype {
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl $crate::serde::Serialize for $t {
             fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                use bitcoin_internals::hex::display::DisplayHex;
+
                 if s.is_human_readable() {
-                    s.serialize_str(&$crate::hashes::hex::ToHex::to_hex(self))
+                    s.serialize_str(&self.0.to_lower_hex_string())
                 } else {
                     s.serialize_bytes(&self[..])
                 }

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -503,10 +503,12 @@ mod tests {
 
     use secp256k1::rand::prelude::*;
 
+    use bitcoin_internals::hex::display::DisplayHex;
+
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
     use crate::hash_types::{TxMerkleNode, Txid};
-    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::FromHex;
     use crate::hashes::Hash;
     use crate::{merkle_tree, Block};
 
@@ -647,7 +649,7 @@ mod tests {
             mb.txn.extract_matches(&mut vec![], &mut vec![]).unwrap()
         );
         // Serialize again and check that it matches the original bytes
-        assert_eq!(mb_hex, serialize(&mb).to_hex().as_str());
+        assert_eq!(mb_hex, serialize(&mb).to_lower_hex_string());
     }
 
     /// Create a CMerkleBlock using a list of txids which will be found in the

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -782,11 +782,11 @@ impl crate::serde::Serialize for U256 {
     where
         S: crate::serde::Serializer,
     {
-        use crate::hashes::hex::ToHex;
+        use bitcoin_internals::hex::display::DisplayHex;
+
         let bytes = self.to_be_bytes();
         if serializer.is_human_readable() {
-            // TODO: fast hex encoding.
-            serializer.serialize_str(&bytes.to_hex())
+            serializer.serialize_str(&bytes.to_lower_hex_string())
         } else {
             serializer.serialize_bytes(&bytes)
         }

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -13,7 +13,9 @@ pub mod btreemap_byte_values {
 
     use serde;
 
-    use crate::hashes::hex::{FromHex, ToHex};
+    use bitcoin_internals::hex::display::DisplayHex;
+
+    use crate::hashes::hex::FromHex;
     use crate::prelude::*;
 
     pub fn serialize<S, T>(v: &BTreeMap<T, Vec<u8>>, s: S) -> Result<S::Ok, S::Error>
@@ -29,7 +31,7 @@ pub mod btreemap_byte_values {
         } else {
             let mut map = s.serialize_map(Some(v.len()))?;
             for (key, value) in v.iter() {
-                map.serialize_entry(key, &value.to_hex())?;
+                map.serialize_entry(key, &value.to_lower_hex_string())?;
             }
             map.end()
         }
@@ -237,7 +239,8 @@ pub mod hex_bytes {
 
     use serde;
 
-    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::FromHex;
+    use bitcoin_internals::hex::display::DisplayHex;
 
     pub fn serialize<T, S>(bytes: &T, s: S) -> Result<S::Ok, S::Error>
     where
@@ -248,7 +251,7 @@ pub mod hex_bytes {
         if !s.is_human_readable() {
             serde::Serialize::serialize(bytes, s)
         } else {
-            s.serialize_str(&bytes.as_ref().to_hex())
+            s.serialize_str(&bytes.as_ref().to_lower_hex_string())
         }
     }
 

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -1062,7 +1062,7 @@ mod tests {
     use crate::consensus::deserialize;
     use crate::crypto::key::PublicKey;
     use crate::hash_types::Sighash;
-    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::FromHex;
     use crate::hashes::{Hash, HashEngine};
     use crate::internal_macros::{hex_decode, hex_from_slice, hex_into, hex_script};
     use crate::network::constants::Network;
@@ -1403,11 +1403,11 @@ mod tests {
         let expected_sequences_hash = key_path["intermediary"]["hashSequences"].as_str().unwrap();
 
         // Compute all caches
-        assert_eq!(expected_amt_hash, cache.taproot_cache(&utxos).amounts.to_hex());
-        assert_eq!(expected_outputs_hash, cache.common_cache().outputs.to_hex());
-        assert_eq!(expected_prevouts_hash, cache.common_cache().prevouts.to_hex());
-        assert_eq!(expected_spks_hash, cache.taproot_cache(&utxos).script_pubkeys.to_hex());
-        assert_eq!(expected_sequences_hash, cache.common_cache().sequences.to_hex());
+        assert_eq!(expected_amt_hash, cache.taproot_cache(&utxos).amounts.to_string());
+        assert_eq!(expected_outputs_hash, cache.common_cache().outputs.to_string());
+        assert_eq!(expected_prevouts_hash, cache.common_cache().prevouts.to_string());
+        assert_eq!(expected_spks_hash, cache.taproot_cache(&utxos).script_pubkeys.to_string());
+        assert_eq!(expected_sequences_hash, cache.common_cache().sequences.to_string());
 
         for inp in key_path["inputSpending"].as_array().unwrap() {
             let tx_ind = inp["given"]["txinIndex"].as_u64().unwrap() as usize;

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -213,13 +213,12 @@ pub fn signed_msg_hash(msg: &str) -> sha256d::Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hashes::hex::ToHex;
 
     #[test]
     fn test_signed_msg_hash() {
         let hash = signed_msg_hash("test");
         assert_eq!(
-            hash.to_hex(),
+            hash.to_string(),
             "a6f87fe6d58a032c320ff8d1541656f0282c2c7bfcc69d61af4c8e8ed528e49c"
         );
     }

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -1090,9 +1090,11 @@ mod test {
 
     use secp256k1::{VerifyOnly, XOnlyPublicKey};
 
+    use bitcoin_internals::hex::display::DisplayHex;
+
     use super::*;
     use crate::crypto::schnorr::TapTweak;
-    use crate::hashes::hex::{FromHex, ToHex};
+    use crate::hashes::hex::FromHex;
     use crate::hashes::sha256t::Tag;
     use crate::hashes::{sha256, Hash, HashEngine};
     use crate::{Address, Network};
@@ -1140,19 +1142,19 @@ mod test {
         //   CHashWriter writer = HasherTapLeaf;
         //   writer.GetSHA256().GetHex()
         assert_eq!(
-            TapLeafHash::from_engine(TapLeafTag::engine()).to_hex(),
+            TapLeafHash::from_engine(TapLeafTag::engine()).to_string(),
             "5212c288a377d1f8164962a5a13429f9ba6a7b84e59776a52c6637df2106facb"
         );
         assert_eq!(
-            TapBranchHash::from_engine(TapBranchTag::engine()).to_hex(),
+            TapBranchHash::from_engine(TapBranchTag::engine()).to_string(),
             "53c373ec4d6f3c53c1f5fb2ff506dcefe1a0ed74874f93fa93c8214cbe9ffddf"
         );
         assert_eq!(
-            TapTweakHash::from_engine(TapTweakTag::engine()).to_hex(),
+            TapTweakHash::from_engine(TapTweakTag::engine()).to_string(),
             "8aa4229474ab0100b2d6f0687f031d1fc9d8eef92a042ad97d279bff456b15e4"
         );
         assert_eq!(
-            TapSighashHash::from_engine(TapSighashTag::engine()).to_hex(),
+            TapSighashHash::from_engine(TapSighashTag::engine()).to_string(),
             "dabc11914abcd8072900042a2681e52f8dba99ce82e224f97b5fdb7cd4b9c803"
         );
 
@@ -1162,19 +1164,19 @@ mod test {
         //   writer.GetSHA256().GetHex()
         // Note that Core writes the 0 length prefix when an empty vector is written.
         assert_eq!(
-            TapLeafHash::hash(&[0]).to_hex(),
+            TapLeafHash::hash(&[0]).to_string(),
             "ed1382037800c9dd938dd8854f1a8863bcdeb6705069b4b56a66ec22519d5829"
         );
         assert_eq!(
-            TapBranchHash::hash(&[0]).to_hex(),
+            TapBranchHash::hash(&[0]).to_string(),
             "92534b1960c7e6245af7d5fda2588db04aa6d646abc2b588dab2b69e5645eb1d"
         );
         assert_eq!(
-            TapTweakHash::hash(&[0]).to_hex(),
+            TapTweakHash::hash(&[0]).to_string(),
             "cd8737b5e6047fc3f16f03e8b9959e3440e1bdf6dd02f7bb899c352ad490ea1e"
         );
         assert_eq!(
-            TapSighashHash::hash(&[0]).to_hex(),
+            TapSighashHash::hash(&[0]).to_string(),
             "c2fd0de003889a09c4afcf676656a0d8a1fb706313ff7d509afb00c323c010cd"
         );
     }
@@ -1190,7 +1192,7 @@ mod test {
         let script = Script::from_hex(script_hex).unwrap();
         let control_block =
             ControlBlock::from_slice(&Vec::<u8>::from_hex(control_block_hex).unwrap()).unwrap();
-        assert_eq!(control_block_hex, control_block.serialize().to_hex());
+        assert_eq!(control_block_hex, control_block.serialize().to_lower_hex_string());
         assert!(control_block.verify_taproot_commitment(secp, out_pk.to_inner(), &script));
     }
 
@@ -1408,7 +1410,7 @@ mod test {
 
                     let leaf_hash = TapLeafHash::from_script(&script_ver.0, script_ver.1);
                     let ctrl_blk = spend_info.control_block(script_ver).unwrap();
-                    assert_eq!(leaf_hash.to_hex(), expected_leaf_hash);
+                    assert_eq!(leaf_hash.to_string(), expected_leaf_hash);
                     assert_eq!(ctrl_blk, expected_ctrl_blk);
                 }
             }

--- a/hashes/embedded/src/main.rs
+++ b/hashes/embedded/src/main.rs
@@ -9,7 +9,6 @@ extern crate bitcoin_hashes;
 #[cfg(feature = "alloc")] use alloc_cortex_m::CortexMHeap;
 #[cfg(feature = "alloc")] use core::alloc::Layout;
 #[cfg(feature = "alloc")] use cortex_m::asm;
-#[cfg(feature = "alloc")] use bitcoin_hashes::hex::ToHex;
 
 use bitcoin_hashes::{sha256, Hash, HashEngine};
 use core2::io::Write;
@@ -57,7 +56,7 @@ fn check_result(engine: sha256::HashEngine) {
     }
 
     #[cfg(feature = "alloc")]
-    if hash.to_hex() != hash_check.to_hex() {
+    if hash.to_string() != hash_check.to_hex() {
         debug::exit(debug::EXIT_FAILURE);
     }
 }

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -52,7 +52,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{hash160, Hash, HashEngine};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         #[cfg(any(feature = "std", feature = "alloc"))]
@@ -89,7 +89,7 @@ mod tests {
             let hash = hash160::Hash::hash(&test.input[..]);
             assert_eq!(hash, hash160::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = hash160::Hash::engine();

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -408,7 +408,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{Hash, HashEngine, ripemd160};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -472,7 +472,7 @@ mod tests {
             let hash = ripemd160::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, ripemd160::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = ripemd160::Hash::engine();

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -146,7 +146,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha1, Hash, HashEngine};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -198,7 +198,7 @@ mod tests {
             let hash = sha1::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha1::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = sha1::Hash::engine();

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -374,7 +374,7 @@ mod tests {
             let hash = sha256::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha256::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = sha256::Hash::engine();

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -49,7 +49,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha256d, Hash, HashEngine};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -77,7 +77,7 @@ mod tests {
             let hash = sha256d::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha256d::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = sha256d::Hash::engine();

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -123,8 +123,6 @@ macro_rules! sha256t_hash_newtype {
 mod tests {
     use crate::{sha256, sha256t};
     #[cfg(any(feature = "std", feature = "alloc"))]
-    use crate::hex::ToHex;
-    #[cfg(any(feature = "std", feature = "alloc"))]
     use crate::Hash;
 
     const TEST_MIDSTATE: [u8; 32] = [
@@ -154,11 +152,11 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test_sha256t() {
         assert_eq!(
-            TestHash::hash(&[0]).to_hex(),
+            TestHash::hash(&[0]).to_string(),
             "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
         );
         assert_eq!(
-            NewTypeHash::hash(&[0]).to_hex(),
+            NewTypeHash::hash(&[0]).to_string(),
             "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
         );
     }

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -311,7 +311,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha512, Hash, HashEngine};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -371,7 +371,7 @@ mod tests {
             let hash = sha512::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha512::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = sha512::Hash::engine();

--- a/internals/src/hex/buf_encoder.rs
+++ b/internals/src/hex/buf_encoder.rs
@@ -1,7 +1,7 @@
 //! Implements a buffered encoder.
 //!
-//! The main type of this module is [`BufEncoder`] which provides buffered hex encoding. Such is
-//! faster than the usual `write!(f, "{02x}", b)?` in a for loop because it reduces dynamic
+//! The main type of this module is [`BufEncoder`] which provides buffered hex encoding. Expected to
+//! be faster than the usual `write!(f, "{02x}", b)?` in a for loop because it reduces dynamic
 //! dispatch and decreases the number of allocations if a `String` is being created.
 
 pub use out_bytes::OutBytes;
@@ -28,7 +28,7 @@ pub trait AsOutBytes: out_bytes::Sealed {
     fn as_mut_out_bytes(&mut self) -> &mut OutBytes;
 }
 
-/// Implements `OutBytes`
+/// Implements `OutBytes`.
 ///
 /// This prevents the rest of the crate from accessing the field of `OutBytes`.
 mod out_bytes {
@@ -62,7 +62,7 @@ mod out_bytes {
         ///
         /// ## Panics
         ///
-        /// The method panics if pos is out of bounds or `bytes` don't fit into the buffer.
+        /// The method panics if `pos` is out of bounds or `bytes` don't fit into the buffer.
         #[cfg_attr(rust_v_1_46, track_caller)]
         pub(crate) fn write(&mut self, pos: usize, bytes: &[u8]) {
             self.0[pos..(pos + bytes.len())].copy_from_slice(bytes);
@@ -183,10 +183,10 @@ impl<T: AsOutBytes> BufEncoder<T> {
         }
     }
 
-    /// Encodes as many `bytes` as fit into the buffer as hex and return the remainder.
+    /// Encodes as many `bytes` as fit into the buffer as hex and returns the remainder.
     ///
     /// This method works just like `put_bytes` but instead of panicking it returns the unwritten
-    /// bytes. The method returns an empty slice if all bytes were written
+    /// bytes. The method returns an empty slice if all bytes were written.
     #[must_use = "this may write only part of the input buffer"]
     #[inline]
     #[cfg_attr(rust_v_1_46, track_caller)]
@@ -207,7 +207,7 @@ impl<T: AsOutBytes> BufEncoder<T> {
             .expect("we only write ASCII")
     }
 
-    /// Resets the buffer to become empty.
+    /// Resets the buffer to empty.
     #[inline]
     pub fn clear(&mut self) { self.pos = 0; }
 

--- a/internals/src/hex/display.rs
+++ b/internals/src/hex/display.rs
@@ -11,6 +11,7 @@ use super::Case;
 use crate::prelude::*;
 
 /// Extension trait for types that can be displayed as hex.
+///
 /// Types that have a single, obvious text representation being hex should **not** implement this
 /// trait and simply implement `Display` instead.
 ///
@@ -23,20 +24,20 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     /// This is usually a wrapper type holding a reference to `Self`.
     type Display: fmt::Display;
 
-    /// Display `Self` as a continuous sequence of ASCII hex chars.
+    /// Displays `Self` as a continuous sequence of ASCII hex chars.
     fn display_hex(self, case: Case) -> Self::Display;
 
-    /// Shorthand for `display_hex(Case::Lower)`.
+    /// Displays `Self` as a continuous sequence of ASCII hex lower case chars.
     ///
-    /// Avoids the requirement to import the `Case` type.
+    /// Shorthand for `display_hex(Case::Lower)`. Avoids the requirement to import the `Case` type.
     fn display_lower_hex(self) -> Self::Display { self.display_hex(Case::Lower) }
 
-    /// Shorthand for `display_hex(Case::Upper)`.
+    /// Displays `Self` as a continuous sequence of ASCII hex upper case chars.
     ///
-    /// Avoids the requirement to import the `Case` type.
+    /// Shorthand for `display_hex(Case::Upper)`. Avoids the requirement to import the `Case` type.
     fn display_upper_hex(self) -> Self::Display { self.display_hex(Case::Upper) }
 
-    /// Create a hex-encoded string.
+    /// Creates a hex-encoded string.
     ///
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
@@ -47,7 +48,7 @@ pub trait DisplayHex: Copy + sealed::IsRef {
         string
     }
 
-    /// Create a lower-hex-encoded string.
+    /// Creates a lower case hex-encoded string.
     ///
     /// A shorthand for `to_hex_string(Case::Lower)`, so that `Case` doesn't need to be imported.
     ///
@@ -56,7 +57,7 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_lower_hex_string(self) -> String { self.to_hex_string(Case::Lower) }
 
-    /// Create an upper-hex-encoded string.
+    /// Creates a upper case hex-encoded string.
     ///
     /// A shorthand for `to_hex_string(Case::Upper)`, so that `Case` doesn't need to be imported.
     ///

--- a/internals/src/hex/display.rs
+++ b/internals/src/hex/display.rs
@@ -36,6 +36,17 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     /// Avoids the requirement to import the `Case` type.
     fn display_upper_hex(self) -> Self::Display { self.display_hex(Case::Upper) }
 
+    /// Create a hex-encoded string.
+    ///
+    /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    fn to_hex_string(self, case: Case) -> String {
+        let mut string = String::new();
+        self.append_hex_to_string(case, &mut string);
+        string
+    }
+
     /// Create a lower-hex-encoded string.
     ///
     /// A shorthand for `to_hex_string(Case::Lower)`, so that `Case` doesn't need to be imported.
@@ -53,17 +64,6 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_upper_hex_string(self) -> String { self.to_hex_string(Case::Upper) }
-
-    /// Create a hex-encoded string.
-    ///
-    /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
-    #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    fn to_hex_string(self, case: Case) -> String {
-        let mut string = String::new();
-        self.append_hex_to_string(case, &mut string);
-        string
-    }
 
     /// Appends hex-encoded content to an existing `String`.
     ///

--- a/internals/src/hex/mod.rs
+++ b/internals/src/hex/mod.rs
@@ -43,9 +43,9 @@ impl Case {
     }
 }
 
-/// Encodes single byte as two ASCII chars using the given table.
+/// Encodes a single byte as two ASCII chars using the given table.
 ///
-/// The function guarantees only returning values from the provided table.
+/// The function guarantees to only return values from the provided table.
 #[inline]
 pub(crate) fn byte_to_hex(byte: u8, table: &[u8; 16]) -> [u8; 2] {
     [table[usize::from(byte.wrapping_shr(4))], table[usize::from(byte & 0x0F)]]


### PR DESCRIPTION
In #1268 we introduced the `DisplayHex` trait, combined with `Display` for types with obvious hex format we can now remove the usage of `hashes::ToHex`.

Note: Does not remove `ToHex` from `hashes`. In general I'm a bit confused as to where we are going with `hex` so this is part progress part exploration to get a better understanding of whats in @Kixunil's code/head :)

### Footgun

While working on this I found that hashes can be formatted with both `to_string` and `to_lower_hex_string` - I think this is because hashes get automatically dereferenced to byte slices and `to_lower_hex_string` is implemented for slices. This is a footgun for those hashes that are displayed backwards because `to_lower_hex_string` does not display backwards. As a user of the library I would expect `to_string` and `to_lower_hex_string` to return the same things.

### Question

Am I being brain dead; the use statement seems klunky
```rust
use bitcoin_internals::hex::display::DisplayHex;
```
And using the re-export in `exts` seems no better.