### PR TITLE
Improve `internals::hex`

### DIFF
--- a/internals/src/hex/buf_encoder.rs
+++ b/internals/src/hex/buf_encoder.rs
@@ -1,7 +1,7 @@
 //! Implements a buffered encoder.
 //!
-//! The main type of this module is [`BufEncoder`] which provides buffered hex encoding. Such is
-//! faster than the usual `write!(f, "{02x}", b)?` in a for loop because it reduces dynamic
+//! The main type of this module is [`BufEncoder`] which provides buffered hex encoding. Expected to
+//! be faster than the usual `write!(f, "{02x}", b)?` in a for loop because it reduces dynamic
 //! dispatch and decreases the number of allocations if a `String` is being created.
 
 pub use out_bytes::OutBytes;
@@ -28,7 +28,7 @@ pub trait AsOutBytes: out_bytes::Sealed {
     fn as_mut_out_bytes(&mut self) -> &mut OutBytes;
 }
 
-/// Implements `OutBytes`
+/// Implements `OutBytes`.
 ///
 /// This prevents the rest of the crate from accessing the field of `OutBytes`.
 mod out_bytes {
@@ -62,7 +62,7 @@ mod out_bytes {
         ///
         /// ## Panics
         ///
-        /// The method panics if pos is out of bounds or `bytes` don't fit into the buffer.
+        /// The method panics if `pos` is out of bounds or `bytes` don't fit into the buffer.
         #[cfg_attr(rust_v_1_46, track_caller)]
         pub(crate) fn write(&mut self, pos: usize, bytes: &[u8]) {
             self.0[pos..(pos + bytes.len())].copy_from_slice(bytes);
@@ -183,10 +183,10 @@ impl<T: AsOutBytes> BufEncoder<T> {
         }
     }
 
-    /// Encodes as many `bytes` as fit into the buffer as hex and return the remainder.
+    /// Encodes as many `bytes` as fit into the buffer as hex and returns the remainder.
     ///
     /// This method works just like `put_bytes` but instead of panicking it returns the unwritten
-    /// bytes. The method returns an empty slice if all bytes were written
+    /// bytes. The method returns an empty slice if all bytes were written.
     #[must_use = "this may write only part of the input buffer"]
     #[inline]
     #[cfg_attr(rust_v_1_46, track_caller)]
@@ -207,7 +207,7 @@ impl<T: AsOutBytes> BufEncoder<T> {
             .expect("we only write ASCII")
     }
 
-    /// Resets the buffer to become empty.
+    /// Resets the buffer to empty.
     #[inline]
     pub fn clear(&mut self) { self.pos = 0; }
 

--- a/internals/src/hex/display.rs
+++ b/internals/src/hex/display.rs
@@ -11,6 +11,7 @@ use super::Case;
 use crate::prelude::*;
 
 /// Extension trait for types that can be displayed as hex.
+///
 /// Types that have a single, obvious text representation being hex should **not** implement this
 /// trait and simply implement `Display` instead.
 ///
@@ -23,20 +24,20 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     /// This is usually a wrapper type holding a reference to `Self`.
     type Display: fmt::Display;
 
-    /// Display `Self` as a continuous sequence of ASCII hex chars.
+    /// Displays `Self` as a continuous sequence of ASCII hex chars.
     fn display_hex(self, case: Case) -> Self::Display;
 
-    /// Shorthand for `display_hex(Case::Lower)`.
+    /// Displays `Self` as a continuous sequence of ASCII hex lower case chars.
     ///
-    /// Avoids the requirement to import the `Case` type.
+    /// Shorthand for `display_hex(Case::Lower)`. Avoids the requirement to import the `Case` type.
     fn display_lower_hex(self) -> Self::Display { self.display_hex(Case::Lower) }
 
-    /// Shorthand for `display_hex(Case::Upper)`.
+    /// Displays `Self` as a continuous sequence of ASCII hex upper case chars.
     ///
-    /// Avoids the requirement to import the `Case` type.
+    /// Shorthand for `display_hex(Case::Upper)`. Avoids the requirement to import the `Case` type.
     fn display_upper_hex(self) -> Self::Display { self.display_hex(Case::Upper) }
 
-    /// Create a hex-encoded string.
+    /// Creates a hex-encoded string.
     ///
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
@@ -47,7 +48,7 @@ pub trait DisplayHex: Copy + sealed::IsRef {
         string
     }
 
-    /// Create a lower-hex-encoded string.
+    /// Creates a lower case hex-encoded string.
     ///
     /// A shorthand for `to_hex_string(Case::Lower)`, so that `Case` doesn't need to be imported.
     ///
@@ -56,7 +57,7 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_lower_hex_string(self) -> String { self.to_hex_string(Case::Lower) }
 
-    /// Create an upper-hex-encoded string.
+    /// Creates a upper case hex-encoded string.
     ///
     /// A shorthand for `to_hex_string(Case::Upper)`, so that `Case` doesn't need to be imported.
     ///

--- a/internals/src/hex/display.rs
+++ b/internals/src/hex/display.rs
@@ -36,6 +36,17 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     /// Avoids the requirement to import the `Case` type.
     fn display_upper_hex(self) -> Self::Display { self.display_hex(Case::Upper) }
 
+    /// Create a hex-encoded string.
+    ///
+    /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    fn to_hex_string(self, case: Case) -> String {
+        let mut string = String::new();
+        self.append_hex_to_string(case, &mut string);
+        string
+    }
+
     /// Create a lower-hex-encoded string.
     ///
     /// A shorthand for `to_hex_string(Case::Lower)`, so that `Case` doesn't need to be imported.
@@ -53,17 +64,6 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_upper_hex_string(self) -> String { self.to_hex_string(Case::Upper) }
-
-    /// Create a hex-encoded string.
-    ///
-    /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
-    #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    fn to_hex_string(self, case: Case) -> String {
-        let mut string = String::new();
-        self.append_hex_to_string(case, &mut string);
-        string
-    }
 
     /// Appends hex-encoded content to an existing `String`.
     ///

--- a/internals/src/hex/mod.rs
+++ b/internals/src/hex/mod.rs
@@ -43,9 +43,9 @@ impl Case {
     }
 }
 
-/// Encodes single byte as two ASCII chars using the given table.
+/// Encodes a single byte as two ASCII chars using the given table.
 ///
-/// The function guarantees only returning values from the provided table.
+/// The function guarantees to only return values from the provided table.
 #[inline]
 pub(crate) fn byte_to_hex(byte: u8, table: &[u8; 16]) -> [u8; 2] {
     [table[usize::from(byte.wrapping_shr(4))], table[usize::from(byte & 0x0F)]]


### PR DESCRIPTION
This is the first two patches from #1443 which are standalone improvements.

Refactor and improve docs in the `internals::hex` module.