### PR TITLE
hashes: Use `internals::hex` for hex encoding

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -22,6 +22,7 @@ alloc = ["core2/alloc"]
 serde-std = ["serde/std"]
 
 [dependencies]
+bitcoin-internals = { path = "../internals" }
 # Only enable this if you explicitly do not want to use "std", otherwise enable "serde-std".
 serde = { version = "1.0", default-features = false, optional = true }
 # Only enable this if you explicitly do not want to use an allocator, otherwise enable "alloc".

--- a/hashes/embedded/src/main.rs
+++ b/hashes/embedded/src/main.rs
@@ -9,7 +9,6 @@ extern crate bitcoin_hashes;
 #[cfg(feature = "alloc")] use alloc_cortex_m::CortexMHeap;
 #[cfg(feature = "alloc")] use core::alloc::Layout;
 #[cfg(feature = "alloc")] use cortex_m::asm;
-#[cfg(feature = "alloc")] use bitcoin_hashes::hex::ToHex;
 
 use bitcoin_hashes::{sha256, Hash, HashEngine};
 use core2::io::Write;
@@ -57,7 +56,7 @@ fn check_result(engine: sha256::HashEngine) {
     }
 
     #[cfg(feature = "alloc")]
-    if hash.to_hex() != hash_check.to_hex() {
+    if hash.to_string() != hash_check.to_string() {
         debug::exit(debug::EXIT_FAILURE);
     }
 }

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -52,7 +52,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{hash160, Hash, HashEngine};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         #[cfg(any(feature = "std", feature = "alloc"))]
@@ -89,7 +89,7 @@ mod tests {
             let hash = hash160::Hash::hash(&test.input[..]);
             assert_eq!(hash, hash160::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = hash160::Hash::engine();

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -28,7 +28,7 @@ macro_rules! hash_trait_impls {
             }
         }
 
-        hex_fmt_impl!(Hash $(, $gen: $gent)*);
+        hex_fmt_impl!(Hash, $bits / 8 $(, $gen: $gent)*);
         serde_impl!(Hash, $bits / 8 $(, $gen: $gent)*);
         borrow_slice_impl!(Hash $(, $gen: $gent)*);
 

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -408,7 +408,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{Hash, HashEngine, ripemd160};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -472,7 +472,7 @@ mod tests {
             let hash = ripemd160::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, ripemd160::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = ripemd160::Hash::engine();

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -146,7 +146,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha1, Hash, HashEngine};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -198,7 +198,7 @@ mod tests {
             let hash = sha1::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha1::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = sha1::Hash::engine();

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -374,7 +374,7 @@ mod tests {
             let hash = sha256::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha256::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = sha256::Hash::engine();

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -119,7 +119,7 @@ impl Hash {
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 pub struct Midstate(pub [u8; 32]);
 
-hex_fmt_impl!(Midstate);
+hex_fmt_impl!(Midstate, 32);
 serde_impl!(Midstate, 32);
 borrow_slice_impl!(Midstate);
 

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -49,7 +49,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha256d, Hash, HashEngine};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -77,7 +77,7 @@ mod tests {
             let hash = sha256d::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha256d::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = sha256d::Hash::engine();

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -123,8 +123,6 @@ macro_rules! sha256t_hash_newtype {
 mod tests {
     use crate::{sha256, sha256t};
     #[cfg(any(feature = "std", feature = "alloc"))]
-    use crate::hex::ToHex;
-    #[cfg(any(feature = "std", feature = "alloc"))]
     use crate::Hash;
 
     const TEST_MIDSTATE: [u8; 32] = [
@@ -154,11 +152,11 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test_sha256t() {
         assert_eq!(
-            TestHash::hash(&[0]).to_hex(),
+            TestHash::hash(&[0]).to_string(),
             "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
         );
         assert_eq!(
-            NewTypeHash::hash(&[0]).to_hex(),
+            NewTypeHash::hash(&[0]).to_string(),
             "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
         );
     }

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -311,7 +311,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
         use crate::{sha512, Hash, HashEngine};
-        use crate::hex::{FromHex, ToHex};
+        use crate::hex::FromHex;
 
         #[derive(Clone)]
         struct Test {
@@ -371,7 +371,7 @@ mod tests {
             let hash = sha512::Hash::hash(test.input.as_bytes());
             assert_eq!(hash, sha512::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(&hash[..], &test.output[..]);
-            assert_eq!(&hash.to_hex(), &test.output_str);
+            assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
             let mut engine = sha512::Hash::engine();

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -15,22 +15,20 @@
 #[macro_export]
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
 macro_rules! hex_fmt_impl(
-    ($ty:ident) => (
-        $crate::hex_fmt_impl!($ty, );
+    ($ty:ident, $len:expr) => (
+        $crate::hex_fmt_impl!($ty, $len, );
     );
-    ($ty:ident, $($gen:ident: $gent:ident),*) => (
+    ($ty:ident, $len:expr, $($gen:ident: $gent:ident),*) => (
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::LowerHex for $ty<$($gen),*> {
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
                 #[allow(unused_imports)]
-                use $crate::{Hash as _, HashEngine as _, hex};
+                use $crate::Hash as _;
+                use bitcoin_internals::hex::Case;
 
-                if f.alternate() {
-                    write!(f, "0x")?;
-                }
                 if $ty::<$($gen),*>::DISPLAY_BACKWARD {
-                    hex::format_hex_reverse(&self.0, f)
+                    bitcoin_internals::fmt_hex_exact!(f, $len, self.0.iter().rev(), Case::Lower)
                 } else {
-                    hex::format_hex(&self.0, f)
+                    bitcoin_internals::fmt_hex_exact!(f, $len, self.0.iter(), Case::Lower)
                 }
             }
         }
@@ -121,7 +119,7 @@ macro_rules! hash_newtype {
         #[repr(transparent)]
         pub struct $newtype($hash);
 
-        $crate::hex_fmt_impl!($newtype);
+        $crate::hex_fmt_impl!($newtype, $len);
         $crate::serde_impl!($newtype, $len);
         $crate::borrow_slice_impl!($newtype);
 

--- a/internals/src/hex/buf_encoder.rs
+++ b/internals/src/hex/buf_encoder.rs
@@ -129,9 +129,9 @@ mod out_bytes {
     impl Sealed for OutBytes {}
 
     // As a sanity check we only provide conversions for even, non-empty arrays.
-    // Weird lengths 66 and 130 are provided for serialized public keys.
+    // Weird lengths 66 and 130 are provided for serialized public keys, 40 is for ripemd160 hashes.
     impl_from_array!(
-        2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 64, 66, 128, 130, 256, 512,
+        2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 40, 64, 66, 128, 130, 256, 512,
         1024, 2048, 4096, 8192
     );
 
@@ -176,8 +176,7 @@ impl<T: AsOutBytes> BufEncoder<T> {
     /// The method panics if the bytes wouldn't fit the buffer.
     #[inline]
     #[cfg_attr(rust_v_1_46, track_caller)]
-    pub fn put_bytes(&mut self, bytes: &[u8], case: Case) {
-        assert!(bytes.len() <= self.space_remaining());
+    pub fn put_bytes<'a>(&mut self, bytes: impl IntoIterator<Item = &'a u8>, case: Case) {
         for byte in bytes {
             self.put_byte(*byte, case);
         }

--- a/internals/src/hex/display.rs
+++ b/internals/src/hex/display.rs
@@ -172,10 +172,10 @@ macro_rules! fmt_hex_exact {
 // Implementation detail of `write_hex_exact` macro to de-duplicate the code
 #[doc(hidden)]
 #[inline]
-pub fn fmt_hex_exact_fn(
+pub fn fmt_hex_exact_fn<'a>(
     f: &mut fmt::Formatter,
     buf: &mut OutBytes,
-    bytes: &[u8],
+    bytes: impl IntoIterator<Item = &'a u8>,
     case: Case,
 ) -> fmt::Result {
     let mut encoder = BufEncoder::new(buf);


### PR DESCRIPTION
Now we have fast encoding in `internals` we can use it in `hashes`, paves the way for removing the `ToHex` trait.

- Patch 1 is from #1443, I've split this out into a separate PR to aid review and because this is limited in scope to `hashes`.
- Patch 2 makes an change in `internals` from byte slice to iterator - please check carefully @Kixunil (chuckle, that is a redundant request).