### PR TITLE
hashes: Do not implement `Deref`

### DIFF
--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -17,6 +17,7 @@ panic-halt = "0.2.0"
 alloc-cortex-m = "0.4.1"
 bitcoin = { path="../", default-features = false, features = ["no-std", "secp-lowmemory"] }
 
+
 [[bin]]
 name = "embedded"
 test = false

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -28,9 +28,9 @@ macro_rules! hex_fmt_impl(
                     write!(f, "0x")?;
                 }
                 if $ty::<$($gen),*>::DISPLAY_BACKWARD {
-                    hex::format_hex_reverse(&self.0, f)
+                    hex::format_hex_reverse(self.as_ref(), f)
                 } else {
-                    hex::format_hex(&self.0, f)
+                    hex::format_hex(self.as_ref(), f)
                 }
             }
         }
@@ -65,14 +65,6 @@ macro_rules! borrow_slice_impl(
         impl<$($gen: $gent),*> $crate::_export::_core::convert::AsRef<[u8]> for $ty<$($gen),*>  {
             fn as_ref(&self) -> &[u8] {
                 &self[..]
-            }
-        }
-
-        impl<$($gen: $gent),*> $crate::_export::_core::ops::Deref for $ty<$($gen),*> {
-            type Target = [u8];
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
             }
         }
     )
@@ -240,10 +232,18 @@ mod test {
     use crate::{Hash, sha256};
 
     #[test]
-    fn borrow_slice_impl_to_vec() {
-        // Test that the borrow_slice_impl macro gives to_vec.
+    fn hash_as_ref() {
         let hash = sha256::Hash::hash(&[3, 50]);
-        assert_eq!(hash.to_vec().len(), sha256::Hash::LEN);
+        assert_eq!(hash.as_ref(), hash.as_inner());
+    }
+
+    #[test]
+    fn hash_borrow() {
+        use core::borrow::Borrow;
+
+        let hash = sha256::Hash::hash(&[3, 50]);
+        let borrowed: &[u8] = hash.borrow();
+        assert_eq!(borrowed, hash.as_inner());
     }
 
     hash_newtype!(TestHash, crate::sha256d::Hash, 32, doc="Test hash.");


### PR DESCRIPTION
Currently we implement `Deref` for hashes. From the docs [0]

 > Deref should only be implemented for smart pointers to avoid confusion

Furthermore because we implement `Deref` as well as implement `internals::hex::display::DisplayHex` for slices hashes get coerced into slices and `to_lower_hex_string` can be called on them, this is incorrect because `DisplayHex` does not account for hashes that display backwards so we end up with the wrong string.

This is an API breaking change, and I have not built any other crates in our stack to check if anything breaks. 

[0] https://doc.rust-lang.org/std/ops/trait.Deref.html