### PR TITLE
Standardize derives on error types

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -54,7 +54,7 @@ use crate::prelude::*;
 use crate::taproot::TapBranchHash;
 
 /// Address error.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error.

--- a/bitcoin/src/base58.rs
+++ b/bitcoin/src/base58.rs
@@ -217,7 +217,7 @@ impl<T: Default + Copy> SmallVec<T> {
 }
 
 /// An error that might occur during base58 decoding.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Invalid character encountered.

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -19,7 +19,7 @@ use crate::prelude::*;
 use crate::{block, io, Block, BlockHash, Transaction};
 
 /// A BIP-152 error
-#[derive(Clone, PartialEq, Eq, Debug, Copy, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// An unknown version number was used.

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -428,7 +428,7 @@ impl fmt::Debug for DerivationPath {
 pub type KeySource = (Fingerprint, DerivationPath);
 
 /// A BIP32 error
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// A pk->pk derivation was attempted on a hardened key

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -632,7 +632,7 @@ fn is_block_time(n: u32) -> bool {
 }
 
 /// Catchall type for errors that relate to time locks.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// An error occurred while converting a `u32` to a lock time variant.
@@ -688,7 +688,7 @@ impl From<ParseIntError> for Error {
 }
 
 /// An error that occurs when converting a `u32` to a lock time variant.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConversionError {
     /// The expected timelock unit, height (blocks) or time (seconds).
     unit: LockTimeUnit,

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -263,7 +263,7 @@ impl fmt::Display for Time {
 }
 
 /// Errors related to relative lock times.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Input time in seconds was too large to be encoded to a 16 bit 512 second interval.

--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -150,7 +150,7 @@ where
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
 /// would help you.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Something did a non-minimal push; for more information see

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -415,8 +415,6 @@ impl<E: fmt::Debug, I: Iterator<Item=Result<u8, E>>> IterReader<E, I> {
     }
 
     fn decode<T: Decodable>(mut self) -> Result<T, DecodeError<E>> {
-        use crate::StdError;
-
         let result = T::consensus_decode(&mut self);
         match (result, self.error) {
             (Ok(_), None) if self.iterator.next().is_some() => {
@@ -424,7 +422,7 @@ impl<E: fmt::Debug, I: Iterator<Item=Result<u8, E>>> IterReader<E, I> {
             },
             (Ok(value), None) => Ok(value),
             (Ok(_), Some(error)) => panic!("{} silently ate the error: {:?}", core::any::type_name::<T>(), error),
-            (Err(ConsensusError::Io(io_error)), Some(de_error)) if io_error.kind() == io::ErrorKind::Other && io_error.source().is_none() => Err(DecodeError::Other(de_error)),
+            (Err(ConsensusError::Io(io_error)), Some(de_error)) if io_error == io::ErrorKind::Other => Err(DecodeError::Other(de_error)),
             (Err(consensus_error), None) => Err(DecodeError::Consensus(consensus_error)),
             (Err(ConsensusError::Io(io_error)), de_error) => panic!("Unexpected IO error {:?} returned from {}::consensus_decode(), deserialization error: {:?}", io_error, core::any::type_name::<T>(), de_error),
             (Err(consensus_error), Some(de_error)) => panic!("{} should've returned `Other` IO error because of deserialization error {:?} but it returned consensus error {:?} instead", core::any::type_name::<T>(), de_error, consensus_error),

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -78,7 +78,7 @@ impl FromStr for Signature {
 }
 
 /// A key-related error.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Hex encoding error

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -20,7 +20,7 @@ use crate::hashes::{Hash, hash160, hex, hex::FromHex};
 use crate::hash_types::{PubkeyHash, WPubkeyHash};
 
 /// A key-related error.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error

--- a/bitcoin/src/crypto/schnorr.rs
+++ b/bitcoin/src/crypto/schnorr.rs
@@ -242,7 +242,7 @@ impl Signature {
 }
 
 /// A schnorr sig related error.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -9,7 +9,7 @@ pub use crate::parse::ParseIntError;
 
 /// A general error code, other errors should implement conversions to/from this
 /// if appropriate.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Encoding error

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -16,7 +16,7 @@ use crate::prelude::*;
 /// Note that this is larger than the type from `core` so if it's passed through a deep call stack
 /// in a performance-critical application you may want to box it or throw away the context by
 /// converting to `core` type.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseIntError {
     input: String,
     // for displaying - see Display impl with nice error message below

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -563,7 +563,7 @@ impl_get_key_for_map!(BTreeMap);
 impl_get_key_for_map!(HashMap);
 
 /// Errors when getting a key.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum GetKeyError {
     /// A bip32 error.
@@ -648,7 +648,7 @@ pub enum SigningAlgorithm {
 }
 
 /// Errors encountered while calculating the sighash message.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SignError {
     /// An ECDSA key-related error occurred.
     EcdsaSig(ecdsa::Error),

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -205,7 +205,10 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Io(error_kind) => write!(f, "writer errored: {:?}", error_kind),
+            Error::Io(kind) => {
+                let e = io::Error::new(*kind, "");
+                write!(f, "writer errored: {}", e)
+            },
             Error::IndexOutOfInputsBounds { index, inputs_size } => write!(f, "Requested index ({}) is greater or equal than the number of transaction inputs ({})", index, inputs_size),
             Error::SingleWithoutCorrespondingOutput { index, outputs_size } => write!(f, "SIGHASH_SINGLE for input ({}) haven't a corresponding output (#outputs:{})", index, outputs_size),
             Error::PrevoutsSize => write!(f, "Number of supplied prevouts differs from the number of inputs in transaction"),

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -18,7 +18,7 @@
 use core::fmt;
 
 /// Crate error type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Tried to create a fixed-length hash from a slice with the wrong size (expected, got).
     InvalidLength(usize, usize),

--- a/hashes/src/hex.rs
+++ b/hashes/src/hex.rs
@@ -29,7 +29,7 @@ use core::{fmt, str};
 use crate::Hash;
 
 /// Hex decoding error.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Non-hexadecimal character.
     InvalidChar(u8),


### PR DESCRIPTION
Currently we use a variety of derives when creating error types. Since error types are part of the public API we want to get to a state where we can commit to not changing them.

Select a set of derived traits and standardize all our error types by deriving this set. Of note, `Copy` is included in the chosen set of derives which means we cannot have variants with an inner `io::Error`, instead use `io::ErrorKind`.

Standardize derived traits on error types to be:

`#[derive(Clone, Debug, PartialEq, Eq)]`

EDIT:

Now includes conversion of `io::ErrorKind` to `io::Error` in order to get at a `Display` implementation (`io::ErrorKind` does not implement `Display` until Rust 1.60).
 
