### PR TITLE
hashes: ci: Remove --all

### DIFF
--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -19,30 +19,30 @@ fi
 export CARGO_TERM_VERBOSE=true
 
 # Defaults / sanity checks
-cargo build --all
-cargo test --all
+cargo build
+cargo test
 
 if [ "$DO_FEATURE_MATRIX" = true ]; then
-    cargo build --all --no-default-features
-    cargo test --all --no-default-features
+    cargo build --no-default-features
+    cargo test --no-default-features
 
     # All features
-    cargo build --all --no-default-features --features="$FEATURES"
-    cargo test --all --no-default-features --features="$FEATURES"
+    cargo build --no-default-features --features="$FEATURES"
+    cargo test --no-default-features --features="$FEATURES"
     # Single features
     for feature in ${FEATURES}
     do
-        cargo build --all --no-default-features --features="$feature"
-        cargo test --all --no-default-features --features="$feature"
+        cargo build --no-default-features --features="$feature"
+        cargo test --no-default-features --features="$feature"
 		# All combos of two features
 		for featuretwo in ${FEATURES}; do
-			cargo build --all --no-default-features --features="$feature $featuretwo"
-			cargo test --all --no-default-features --features="$feature $featuretwo"
+			cargo build --no-default-features --features="$feature $featuretwo"
+			cargo test --no-default-features --features="$feature $featuretwo"
 		done
     done
 
     # Other combos
-    cargo test --all --no-default-features --features="std,schemars"
+    cargo test --no-default-features --features="std,schemars"
 fi
 
 if [ "$DO_SCHEMARS_TESTS" = true ]; then
@@ -51,7 +51,7 @@ fi
 
 # Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs" cargo doc --all --features="$FEATURES"
+    RUSTDOCFLAGS="--cfg docsrs" cargo doc --features="$FEATURES"
 fi
 
 # Webassembly stuff
@@ -69,11 +69,11 @@ if [ "$DO_ASAN" = true ]; then
     CC='clang -fsanitize=address -fno-omit-frame-pointer'                                        \
     RUSTFLAGS='-Zsanitizer=address -Clinker=clang -Cforce-frame-pointers=yes'                    \
     ASAN_OPTIONS='detect_leaks=1 detect_invalid_pointer_pairs=1 detect_stack_use_after_return=1' \
-    cargo test --lib --all --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
+    cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
     cargo clean
     CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
     RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
-    cargo test --lib --all --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
+    cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
 fi
 
 # Bench if told to, only works with non-stable toolchain (nightly, beta).


### PR DESCRIPTION
Currently we are using the `--all` flag in `cargo` commands in the `hashes` CI script. This flag (the deprecated version of `--workspace`) causes cargo to run the command for the whole workspace, this is not what we want because we run test individually for each crate using a ci script per crate.

The effect of this patch is to reduce re-runs of tests i.e., reduce machine usage during CI runs with no reduction of coverage - PROFIT!