### PR TITLE
Use hex from internals rather than hashes

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -26,6 +26,8 @@ serde-std = ["serde/std"]
 serde = { version = "1.0", default-features = false, optional = true }
 # Only enable this if you explicitly do not want to use an allocator, otherwise enable "alloc".
 core2 = { version = "0.3.0", optional = true, default_features = false }
+# TODO: change to proper version before release
+internals = { path = "../internals", package = "bitcoin-internals" }
 
 # Do NOT use this as a feature! Use the `schemars` feature instead. Can only be used with "std" enabled.
 actual-schemars = { package = "schemars", version = "<=0.8.3", optional = true }

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -119,7 +119,7 @@ impl Hash {
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 pub struct Midstate(pub [u8; 32]);
 
-hex_fmt_impl!(Midstate);
+crate::internal_macros::arr_newtype_fmt_impl!(Midstate, 32);
 serde_impl!(Midstate, 32);
 borrow_slice_impl!(Midstate);
 

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -15,33 +15,41 @@
 #[macro_export]
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
 macro_rules! hex_fmt_impl(
-    ($ty:ident) => (
-        $crate::hex_fmt_impl!($ty, );
+    ($reverse:expr, $ty:ident) => (
+        $crate::hex_fmt_impl!($reverse, $ty, );
     );
-    ($ty:ident, $($gen:ident: $gent:ident),*) => (
+    ($reverse:expr, $ty:ident, $($gen:ident: $gent:ident),*) => (
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::LowerHex for $ty<$($gen),*> {
+            #[inline]
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
-                #[allow(unused_imports)]
-                use $crate::{Hash as _, HashEngine as _, hex};
-
-                if f.alternate() {
-                    write!(f, "0x")?;
-                }
-                if $ty::<$($gen),*>::DISPLAY_BACKWARD {
-                    hex::format_hex_reverse(self.as_ref(), f)
+                if $reverse {
+                    $crate::_export::_core::fmt::LowerHex::fmt(&self.0.backward_hex(), f)
                 } else {
-                    hex::format_hex(self.as_ref(), f)
+                    $crate::_export::_core::fmt::LowerHex::fmt(&self.0.forward_hex(), f)
+                }
+            }
+        }
+
+        impl<$($gen: $gent),*> $crate::_export::_core::fmt::UpperHex for $ty<$($gen),*> {
+            #[inline]
+            fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
+                if $reverse {
+                    $crate::_export::_core::fmt::UpperHex::fmt(&self.0.backward_hex(), f)
+                } else {
+                    $crate::_export::_core::fmt::UpperHex::fmt(&self.0.forward_hex(), f)
                 }
             }
         }
 
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::Display for $ty<$($gen),*> {
+            #[inline]
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
-                $crate::_export::_core::fmt::LowerHex::fmt(self, f)
+                $crate::_export::_core::fmt::LowerHex::fmt(&self, f)
             }
         }
 
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::Debug for $ty<$($gen),*> {
+            #[inline]
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
                 write!(f, "{:#}", self)
             }
@@ -113,7 +121,7 @@ macro_rules! hash_newtype {
         #[repr(transparent)]
         pub struct $newtype($hash);
 
-        $crate::hex_fmt_impl!($newtype);
+        $crate::hex_fmt_impl!($reverse, $newtype);
         $crate::serde_impl!($newtype, $len);
         $crate::borrow_slice_impl!($newtype);
 

--- a/internals/src/hex/buf_encoder.rs
+++ b/internals/src/hex/buf_encoder.rs
@@ -6,6 +6,7 @@
 
 pub use out_bytes::OutBytes;
 
+use core::borrow::Borrow;
 use super::Case;
 
 /// Trait for types that can be soundly converted to `OutBytes`.
@@ -26,6 +27,17 @@ pub trait AsOutBytes: out_bytes::Sealed {
 
     /// Performs the conversion.
     fn as_mut_out_bytes(&mut self) -> &mut OutBytes;
+}
+
+/// A buffer with compile-time-known length.
+///
+/// This is essentially `Default + AsOutBytes` but supports lengths 1.41 doesn't.
+pub trait FixedLenBuf: Sized + AsOutBytes {
+    /// Creates an uninitialized buffer.
+    ///
+    /// The current implementtions initialize the buffer with zeroes but it should be treated a
+    /// uninitialized anyway.
+    fn uninit() -> Self;
 }
 
 /// Implements `OutBytes`
@@ -97,6 +109,12 @@ mod out_bytes {
     macro_rules! impl_from_array {
         ($($len:expr),* $(,)?) => {
             $(
+                impl super::FixedLenBuf for [u8; $len] {
+                    fn uninit() -> Self {
+                        [0u8; $len]
+                    }
+                }
+
                 impl AsOutBytes for [u8; $len] {
                     fn as_out_bytes(&self) -> &OutBytes {
                         OutBytes::from_bytes(self)
@@ -108,6 +126,17 @@ mod out_bytes {
                 }
 
                 impl Sealed for [u8; $len] {}
+
+                impl<'a> super::super::display::DisplayHex for &'a [u8; $len / 2] {
+                    type Display = super::super::display::DisplayArray<core::slice::Iter<'a, u8>, [u8; $len]>;
+                    fn as_hex(self) -> Self::Display {
+                        super::super::display::DisplayArray::new(self.iter())
+                    }
+
+                    fn hex_reserve_suggestion(self) -> usize {
+                        $len
+                    }
+                }
             )*
         }
     }
@@ -131,7 +160,7 @@ mod out_bytes {
     // As a sanity check we only provide conversions for even, non-empty arrays.
     // Weird lengths 66 and 130 are provided for serialized public keys.
     impl_from_array!(
-        2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 64, 66, 128, 130, 256, 512,
+        2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 40, 64, 66, 128, 130, 256, 512,
         1024, 2048, 4096, 8192
     );
 
@@ -176,10 +205,19 @@ impl<T: AsOutBytes> BufEncoder<T> {
     /// The method panics if the bytes wouldn't fit the buffer.
     #[inline]
     #[cfg_attr(rust_v_1_46, track_caller)]
-    pub fn put_bytes(&mut self, bytes: &[u8], case: Case) {
-        assert!(bytes.len() <= self.space_remaining());
+    pub fn put_bytes<I>(&mut self, bytes: I, case: Case) where I: IntoIterator, I::Item: Borrow<u8> {
+        self.put_bytes_inner(bytes.into_iter(), case)
+    }
+
+    #[inline]
+    #[cfg_attr(rust_v_1_46, track_caller)]
+    fn put_bytes_inner<I>(&mut self, bytes: I, case: Case) where I: Iterator, I::Item: Borrow<u8> {
+        // May give the compiler better optimization opportunity
+        if let Some(max) = bytes.size_hint().1 {
+            assert!(max <= self.space_remaining());
+        }
         for byte in bytes {
-            self.put_byte(*byte, case);
+            self.put_byte(*byte.borrow(), case);
         }
     }
 


### PR DESCRIPTION
`bitcoin-internals` contains a more performant implementation of hex encoding than what `bitcoin_hashes` uses internally. This switches the implementations for formatting trait implementations as a step towards moving over completely.

The public macros are also changed to delegate to inner type which is technically a breaking change but we will break the API anyway and the consuers should only call the macro on the actual hash newtypes where the inner types already have the appropriate implementations.

Apart from removing reliance on internal hex from public API this reduces duplicated code generated and compiled. E.g. if you created 10 hash newtypes of SHA256 the formatting implementation would be instantiated 11 times despite being the same.

To do all this some other changes were required to the hex infrastructure. Mainly modifying `put_bytes` to accept iterator (so that `iter().rev()` can be used) and adding a new `DisplayArray` type. The iterator idea was invented by Tobin C. Harding, this commit just adds a bound check and generalizes over `u8` and `&u8` returning iterators.

While it may seem that `DisplayByteSlice` would suffice it'd create and initialize a large array even for small arrays wasting performance. Knowing the exact length `DisplayArray` fixes this.

Another part of refactoring is changing from returning `impl Display` to return `impl LowerHex + UpperHex`. This makes selecting casing less annoying since the consumer no longer needs to import `Case` without cluttering the API with convenience methods.