### PR TITLE
Patch hashes and update the code

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,26 +14,26 @@ jobs:
             env:
               DO_COV: true
               DO_LINT: true
-              AS_DEPENDENCY: true
+              AS_DEPENDENCY: false
               DO_NO_STD: true
               DO_FEATURE_MATRIX: true # Currently only used in hashes crate.
               DO_SCHEMARS_TESTS: true # Currently only used in hashes crate.
           - rust: beta
             env:
-              AS_DEPENDENCY: true
+              AS_DEPENDENCY: false
               DO_NO_STD: true
           - rust: nightly
             env:
               DO_BENCH: true
-              AS_DEPENDENCY: true
+              AS_DEPENDENCY: false
               DO_NO_STD: true
               DO_DOCS: true
           - rust: 1.41.1
             env:
-              AS_DEPENDENCY: true
+              AS_DEPENDENCY: false
           - rust: 1.47
             env:
-              AS_DEPENDENCY: true
+              AS_DEPENDENCY: false
               DO_NO_STD: true
     steps:
       - name: Checkout Crate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = ["bitcoin", "hashes", "internals"]
+
+[patch.crates-io.bitcoin_hashes]
+path = "hashes"

--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -27,3 +27,6 @@ bench = false
 codegen-units = 1 # better optimizations
 debug = true # symbols are nice and they don't increase the size on Flash
 lto = true # better optimizations
+
+[patch.crates-io.bitcoin_hashes]
+path = "../../hashes"

--- a/bitcoin/fuzz/Cargo.toml
+++ b/bitcoin/fuzz/Cargo.toml
@@ -63,3 +63,6 @@ path = "fuzz_targets/script_bytes_to_asm_fmt.rs"
 [[bin]]
 name = "deserialize_witness"
 path = "fuzz_targets/deserialize_witness.rs"
+
+[patch.crates-io.bitcoin_hashes]
+path = "../../hashes"

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -46,6 +46,12 @@ See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
     hash_newtype!(Wtxid, sha256d::Hash, 32, doc="A bitcoin witness transaction ID.");
     hash_newtype!(BlockHash, sha256d::Hash, 32, doc="A bitcoin block hash.");
     hash_newtype!(Sighash, sha256d::Hash, 32, doc="Hash of the transaction according to the signature algorithm");
+    impl secp256k1::ThirtyTwoByteHash for Sighash {
+        fn into_32(self) -> [u8; 32] {
+            use hashes::Hash;
+            *self.as_inner()
+        }
+    }
 
     hash_newtype!(PubkeyHash, hash160::Hash, 20, doc="A hash of a public key.");
     hash_newtype!(ScriptHash, hash160::Hash, 20, doc="A hash of Bitcoin Script bytecode.");

--- a/bitcoin/src/network/message.rs
+++ b/bitcoin/src/network/message.rs
@@ -582,7 +582,7 @@ mod test {
                 flags: BloomFlags::All,
             }),
             NetworkMessage::FilterAdd(FilterAdd { data: script.as_bytes().to_vec() }),
-            NetworkMessage::FilterAdd(FilterAdd { data: hash([29u8; 32]).to_vec() }),
+            NetworkMessage::FilterAdd(FilterAdd { data: hash([29u8; 32]).as_ref().to_vec() }),
             NetworkMessage::FilterClear,
             NetworkMessage::GetCFilters(GetCFilters {
                 filter_type: 2,

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -357,7 +357,7 @@ impl PartiallySignedTransaction {
             }
         };
 
-        Ok((Message::from_slice(&sighash).expect("sighashes are 32 bytes"), hash_ty))
+        Ok((Message::from(sighash), hash_ty))
     }
 
     /// Returns the spending utxo for this PSBT's input at `input_index`.

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -963,15 +963,9 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
         self.segwit_cache.get_or_insert_with(|| {
             let common_cache = Self::common_cache_minimal_borrow(common_cache, tx);
             SegwitCache {
-                prevouts: sha256d::Hash::from_inner(
-                    sha256::Hash::hash(&common_cache.prevouts).into_inner(),
-                ),
-                sequences: sha256d::Hash::from_inner(
-                    sha256::Hash::hash(&common_cache.sequences).into_inner(),
-                ),
-                outputs: sha256d::Hash::from_inner(
-                    sha256::Hash::hash(&common_cache.outputs).into_inner(),
-                ),
+                prevouts: common_cache.prevouts.hash_again(),
+                sequences: common_cache.sequences.hash_again(),
+                outputs: common_cache.outputs.hash_again(),
             }
         })
     }

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -79,7 +79,7 @@ impl TapTweakHash {
         // always hash the key
         eng.input(&internal_key.serialize());
         if let Some(h) = merkle_root {
-            eng.input(&h);
+            eng.input(h.as_ref());
         } else {
             // nothing to hash
         }
@@ -116,11 +116,11 @@ impl TapBranchHash {
     pub fn from_node_hashes(a: sha256::Hash, b: sha256::Hash) -> TapBranchHash {
         let mut eng = TapBranchHash::engine();
         if a < b {
-            eng.input(&a);
-            eng.input(&b);
+            eng.input(a.as_ref());
+            eng.input(b.as_ref());
         } else {
-            eng.input(&b);
-            eng.input(&a);
+            eng.input(b.as_ref());
+            eng.input(a.as_ref());
         };
         TapBranchHash::from_engine(eng)
     }
@@ -673,7 +673,7 @@ impl TaprootMerkleBranch {
     /// The number of bytes written to the writer.
     pub fn encode<Write: io::Write>(&self, mut writer: Write) -> io::Result<usize> {
         for hash in self.0.iter() {
-            writer.write_all(hash)?;
+            writer.write_all(hash.as_ref())?;
         }
         Ok(self.0.len() * sha256::Hash::LEN)
     }
@@ -1101,8 +1101,8 @@ mod test {
     fn tag_engine(tag_name: &str) -> sha256::HashEngine {
         let mut engine = sha256::Hash::engine();
         let tag_hash = sha256::Hash::hash(tag_name.as_bytes());
-        engine.input(&tag_hash[..]);
-        engine.input(&tag_hash[..]);
+        engine.input(tag_hash.as_ref());
+        engine.input(tag_hash.as_ref());
         engine
     }
 


### PR DESCRIPTION
This patches `bitcoin_hashes` to use the version in the repository and fixes the code after removal of `Deref`.