### PR TITLE
Unify `TapLeafHash` and `TapBranchHash` into `TapNodeHash` while tree construction

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -50,7 +50,7 @@ use crate::hash_types::{PubkeyHash, ScriptHash};
 use crate::hashes::{sha256, Hash, HashEngine};
 use crate::network::constants::Network;
 use crate::prelude::*;
-use crate::taproot::TapBranchHash;
+use crate::taproot::TapNodeHash;
 
 /// Address error.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -479,7 +479,7 @@ impl Payload {
     pub fn p2tr<C: Verification>(
         secp: &Secp256k1<C>,
         internal_key: UntweakedPublicKey,
-        merkle_root: Option<TapBranchHash>,
+        merkle_root: Option<TapNodeHash>,
     ) -> Payload {
         let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
         Payload::WitnessProgram {
@@ -627,7 +627,7 @@ impl Address {
     pub fn p2tr<C: Verification>(
         secp: &Secp256k1<C>,
         internal_key: UntweakedPublicKey,
-        merkle_root: Option<TapBranchHash>,
+        merkle_root: Option<TapNodeHash>,
         network: Network,
     ) -> Address {
         Address { network, payload: Payload::p2tr(secp, internal_key, merkle_root) }

--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -76,7 +76,7 @@ use crate::OutPoint;
 
 use crate::key::PublicKey;
 use crate::address::WitnessVersion;
-use crate::taproot::{LeafVersion, TapBranchHash, TapLeafHash};
+use crate::taproot::{LeafVersion, TapNodeHash, TapLeafHash};
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 use crate::schnorr::{TapTweak, TweakedPublicKey, UntweakedPublicKey};
 
@@ -245,7 +245,7 @@ impl Script {
     #[inline]
     pub fn to_v1_p2tr<C: Verification>(&self, secp: &Secp256k1<C>, internal_key: UntweakedPublicKey) -> ScriptBuf {
         let leaf_hash = self.tapscript_leaf_hash();
-        let merkle_root = TapBranchHash::from_inner(leaf_hash.into_inner());
+        let merkle_root = TapNodeHash::from(leaf_hash);
         ScriptBuf::new_v1_p2tr(secp, internal_key, Some(merkle_root))
     }
 
@@ -1133,7 +1133,7 @@ impl ScriptBuf {
 
     /// Generates P2TR for script spending path using an internal public key and some optional
     /// script tree merkle root.
-    pub fn new_v1_p2tr<C: Verification>(secp: &Secp256k1<C>, internal_key: UntweakedPublicKey, merkle_root: Option<TapBranchHash>) -> Self {
+    pub fn new_v1_p2tr<C: Verification>(secp: &Secp256k1<C>, internal_key: UntweakedPublicKey, merkle_root: Option<TapNodeHash>) -> Self {
         let (output_key, _) = internal_key.tap_tweak(secp, merkle_root);
         ScriptBuf::new_witness_program(WitnessVersion::V1, &output_key.serialize())
     }

--- a/bitcoin/src/crypto/schnorr.rs
+++ b/bitcoin/src/crypto/schnorr.rs
@@ -15,7 +15,7 @@ pub use secp256k1::{self, constants, Secp256k1, KeyPair, XOnlyPublicKey, Verific
 
 use crate::prelude::*;
 
-use crate::taproot::{TapBranchHash, TapTweakHash};
+use crate::taproot::{TapNodeHash, TapTweakHash};
 use crate::sighash::SchnorrSighashType;
 
 /// Untweaked BIP-340 X-coord-only public key
@@ -69,7 +69,7 @@ pub trait TapTweak {
     ///
     /// # Returns
     /// The tweaked key and its parity.
-    fn tap_tweak<C: Verification>(self, secp: &Secp256k1<C>, merkle_root: Option<TapBranchHash>) -> Self::TweakedAux;
+    fn tap_tweak<C: Verification>(self, secp: &Secp256k1<C>, merkle_root: Option<TapNodeHash>) -> Self::TweakedAux;
 
     /// Directly converts an [`UntweakedPublicKey`] to a [`TweakedPublicKey`]
     ///
@@ -94,7 +94,7 @@ impl TapTweak for UntweakedPublicKey {
     ///
     /// # Returns
     /// The tweaked key and its parity.
-    fn tap_tweak<C: Verification>(self, secp: &Secp256k1<C>, merkle_root: Option<TapBranchHash>) -> (TweakedPublicKey, secp256k1::Parity) {
+    fn tap_tweak<C: Verification>(self, secp: &Secp256k1<C>, merkle_root: Option<TapNodeHash>) -> (TweakedPublicKey, secp256k1::Parity) {
         let tweak = TapTweakHash::from_key_and_tweak(self, merkle_root).to_scalar();
         let (output_key, parity) = self.add_tweak(secp, &tweak).expect("Tap tweak failed");
 
@@ -123,7 +123,7 @@ impl TapTweak for UntweakedKeyPair {
     ///
     /// # Returns
     /// The tweaked key and its parity.
-    fn tap_tweak<C: Verification>(self, secp: &Secp256k1<C>, merkle_root: Option<TapBranchHash>) -> TweakedKeyPair {
+    fn tap_tweak<C: Verification>(self, secp: &Secp256k1<C>, merkle_root: Option<TapNodeHash>) -> TweakedKeyPair {
         let (pubkey, _parity) = XOnlyPublicKey::from_keypair(&self);
         let tweak = TapTweakHash::from_key_and_tweak(pubkey, merkle_root).to_scalar();
         let tweaked = self.add_xonly_tweak(secp, &tweak).expect("Tap tweak failed");

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -20,7 +20,7 @@ use crate::psbt::map::Map;
 use crate::psbt::serialize::Deserialize;
 use crate::psbt::{self, error, raw, Error};
 use crate::sighash::{self, NonStandardSighashType, SighashTypeParseError, EcdsaSighashType, SchnorrSighashType};
-use crate::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapBranchHash};
+use crate::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapNodeHash};
 
 /// Type: Non-Witness UTXO PSBT_IN_NON_WITNESS_UTXO = 0x00
 const PSBT_IN_NON_WITNESS_UTXO: u8 = 0x00;
@@ -124,7 +124,7 @@ pub struct Input {
     /// Taproot Internal key.
     pub tap_internal_key: Option<XOnlyPublicKey>,
     /// Taproot Merkle root.
-    pub tap_merkle_root: Option<TapBranchHash>,
+    pub tap_merkle_root: Option<TapNodeHash>,
     /// Proprietary key-value pairs for this input.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
@@ -338,7 +338,7 @@ impl Input {
             }
             PSBT_IN_TAP_MERKLE_ROOT => {
                 impl_psbt_insert_pair! {
-                    self.tap_merkle_root <= <raw_key: _>|< raw_value: TapBranchHash>
+                    self.tap_merkle_root <= <raw_key: _>|< raw_value: TapNodeHash>
                 }
             }
             PSBT_IN_PROPRIETARY => {

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -460,7 +460,7 @@ mod tests {
     fn taptree_hidden() {
         let mut builder = compose_taproot_builder(0x51, &[2, 2, 2]);
         builder = builder.add_leaf_with_ver(3, ScriptBuf::from_hex("b9").unwrap(), LeafVersion::from_consensus(0xC2).unwrap()).unwrap();
-        builder = builder.add_hidden_node(3, sha256::Hash::all_zeros()).unwrap();
+        builder = builder.add_hidden_node(3, TapNodeHash::all_zeros()).unwrap();
         assert!(TapTree::try_from(builder).is_err());
     }
 

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -21,7 +21,7 @@ use crate::bip32::{ChildNumber, Fingerprint, KeySource};
 use crate::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use crate::crypto::{ecdsa, schnorr};
 use crate::psbt::{self, Error, PartiallySignedTransaction};
-use crate::taproot::{TapBranchHash, TapLeafHash, ControlBlock, LeafVersion};
+use crate::taproot::{TapNodeHash, TapLeafHash, ControlBlock, LeafVersion};
 use crate::crypto::key::PublicKey;
 
 use super::map::{Map, Input, Output, TapTree, PsbtSighashType};
@@ -123,7 +123,7 @@ impl_psbt_de_serialize!(Witness);
 impl_psbt_hash_de_serialize!(ripemd160::Hash);
 impl_psbt_hash_de_serialize!(sha256::Hash);
 impl_psbt_hash_de_serialize!(TapLeafHash);
-impl_psbt_hash_de_serialize!(TapBranchHash);
+impl_psbt_hash_de_serialize!(TapNodeHash);
 impl_psbt_hash_de_serialize!(hash160::Hash);
 impl_psbt_hash_de_serialize!(sha256d::Hash);
 

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -1391,7 +1391,7 @@ mod tests {
         use secp256k1::{self, SecretKey, XOnlyPublicKey};
 
         use crate::consensus::serde as con_serde;
-        use crate::taproot::{TapBranchHash, TapTweakHash};
+        use crate::taproot::{TapNodeHash, TapTweakHash};
 
         #[derive(serde::Deserialize)]
         #[serde(crate = "actual_serde")]
@@ -1428,7 +1428,7 @@ mod tests {
         struct KpsInputSpendingGiven {
             txin_index: usize,
             internal_privkey: SecretKey,
-            merkle_root: Option<TapBranchHash>,
+            merkle_root: Option<TapNodeHash>,
             #[serde(deserialize_with = "sighash_deser_numeric")]
             hash_type: SchnorrSighashType,
         }


### PR DESCRIPTION
This does not completely fix #1393 but is a simple starter. Unfortunately, we still need hash_new_type for `TapNodeHash` because is exported as the Merkle root in taproot psbt. This requires serialization and display/from_str methods.

This also adds a method 1) `TapNodeHash::from_script` to deal with single leaf case cleanly. As a nice side effect, this removes the ugly uses of `sha256::Hash` that I had used to represent both `TapLeafHash` and `TapBranchHash`

Does not fix
1) Exporting `TapTweakHash`. This requires some changes to macros we use.
2) Safer usage of `TapNodeHash` by not making it `hash_new_type` and having guarded constructors. As mentioned above, this is required for psbts and sharing Merkle roots. Perhaps, we might need a new type while constructing trees that is not `hash_new_type`, and convert it to another type that represents the final Merkle root. 

My overall feeling is that this is best addressed with more examples than changing and complicating existing code. 

I don't feel strongly about the rename, so can go back if `TapBranchHash` instead of `TapNodeHash`.