### PR TITLE
upgrade secp256k1 to 0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bech32 = { version = "0.9.0", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { version = "0.24.0", default-features = false, features = ["bitcoin_hashes"] }
+secp256k1 = { version = "0.25.0", default-features = false, features = ["bitcoin_hashes"] }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }
@@ -47,7 +47,7 @@ hashbrown = { version = "0.8", optional = true }
 [dev-dependencies]
 serde_json = "<1.0.45"
 serde_test = "1"
-secp256k1 = { version = "0.24.0", features = [ "recovery", "rand-std" ] }
+secp256k1 = { version = "0.25.0", features = [ "recovery", "rand-std" ] }
 bincode = "1.3.1"
 
 [[example]]

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -423,7 +423,7 @@ impl Script {
     pub fn is_empty(&self) -> bool { self.0.is_empty() }
 
     /// Returns the script data as a byte slice.
-    pub fn as_bytes(&self) -> &[u8] { &*self.0 }
+    pub fn as_bytes(&self) -> &[u8] { &self.0 }
 
     /// Returns a copy of the script data.
     pub fn to_bytes(&self) -> Vec<u8> { self.0.clone().into_vec() }

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -163,7 +163,7 @@ impl core::str::FromStr for OutPoint {
             return Err(ParseOutPointError::TooLong);
         }
         let find = s.find(':');
-        if find == None || find != s.rfind(':') {
+        if find.is_none() || find != s.rfind(':') {
             return Err(ParseOutPointError::Format);
         }
         let colon = find.unwrap();

--- a/src/blockdata/witness.rs
+++ b/src/blockdata/witness.rs
@@ -179,7 +179,7 @@ impl Witness {
 
     /// Returns the number of elements this witness holds
     pub fn len(&self) -> usize {
-        self.witness_elements as usize
+        self.witness_elements
     }
 
     /// Returns the bytes required when this Witness is consensus encoded

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -438,7 +438,7 @@ impl Encodable for VarInt {
             },
             _ => {
                 w.emit_u8(0xFF)?;
-                (self.0 as u64).consensus_encode(w)?;
+                self.0.consensus_encode(w)?;
                 Ok(9)
             },
         }

--- a/src/util/bip152.rs
+++ b/src/util/bip152.rs
@@ -276,7 +276,7 @@ impl Decodable for BlockTransactionsRequest {
                 // Since the number of indices ultimately represent transactions,
                 // we can limit the number of indices to the maximum number of
                 // transactions that would be allowed in a vector.
-                let byte_size = (nb_indexes as usize)
+                let byte_size = nb_indexes
                     .checked_mul(mem::size_of::<Transaction>())
                     .ok_or(encode::Error::ParseFailed("Invalid length"))?;
                 if byte_size > encode::MAX_VEC_SIZE {

--- a/src/util/bip32.rs
+++ b/src/util/bip32.rs
@@ -637,7 +637,7 @@ impl ExtendedPrivKey {
             Network::Bitcoin => [0x04, 0x88, 0xAD, 0xE4],
             Network::Testnet | Network::Signet | Network::Regtest => [0x04, 0x35, 0x83, 0x94],
         }[..]);
-        ret[4] = self.depth as u8;
+        ret[4] = self.depth;
         ret[5..9].copy_from_slice(&self.parent_fingerprint[..]);
         ret[9..13].copy_from_slice(&endian::u32_to_array_be(u32::from(self.child_number)));
         ret[13..45].copy_from_slice(&self.chain_code[..]);
@@ -775,7 +775,7 @@ impl ExtendedPubKey {
             Network::Bitcoin => [0x04u8, 0x88, 0xB2, 0x1E],
             Network::Testnet | Network::Signet | Network::Regtest => [0x04u8, 0x35, 0x87, 0xCF],
         }[..]);
-        ret[4] = self.depth as u8;
+        ret[4] = self.depth;
         ret[5..9].copy_from_slice(&self.parent_fingerprint[..]);
         ret[9..13].copy_from_slice(&endian::u32_to_array_be(u32::from(self.child_number)));
         ret[13..45].copy_from_slice(&self.chain_code[..]);

--- a/src/util/misc.rs
+++ b/src/util/misc.rs
@@ -366,7 +366,7 @@ mod tests {
         let signature = super::MessageSignature::from_base64(signature_base64).expect("message signature");
 
         let pubkey = PublicKey::from_slice(
-            &::base64::decode(&pubkey_base64).expect("base64 string")
+            &::base64::decode(pubkey_base64).expect("base64 string")
         ).expect("pubkey slice");
 
         let p2pkh = Address::p2pkh(&pubkey, Network::Bitcoin);


### PR DESCRIPTION
heya, I've got a conflict in another dependency that now uses the newer version of secp256k1, so figured I would submit this small PR 

also fixes some clippy warnings that appear to be new in rust 1.66