### PR TITLE
Introduce mutagen

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -53,6 +53,7 @@ serde_test = "1.0.19"
 serde_derive = "1.0.103"
 secp256k1 = { version = "0.24.0", features = [ "recovery", "rand-std" ] }
 bincode = "1.3.1"
+mutagen = { git = "https://github.com/llogiq/mutagen" }
 
 [[example]]
 name = "bip32"

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -10,6 +10,10 @@
 use core::fmt::{self, LowerHex, UpperHex};
 use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 
+#[cfg(test)]
+#[allow(unused_imports)]
+use mutagen::mutate;
+
 use crate::consensus::encode::{self, Decodable, Encodable};
 #[cfg(doc)]
 use crate::consensus::Params;
@@ -322,6 +326,7 @@ impl U256 {
     const ONE: U256 = U256(0, 1);
 
     /// Creates [`U256`] from a big-endian array of `u8`s.
+    #[cfg_attr(test, mutate)]
     fn from_be_bytes(a: [u8; 32]) -> U256 {
         let (high, low) = split_in_half(a);
         let big = u128::from_be_bytes(high);
@@ -330,6 +335,7 @@ impl U256 {
     }
 
     /// Creates a [`U256`] from a little-endian array of `u8`s.
+    #[cfg_attr(test, mutate)]
     fn from_le_bytes(a: [u8; 32]) -> U256 {
         let (high, low) = split_in_half(a);
         let little = u128::from_le_bytes(high);
@@ -338,6 +344,7 @@ impl U256 {
     }
 
     /// Converts `Self` to a big-endian array of `u8`s.
+    #[cfg_attr(test, mutate)]
     fn to_be_bytes(self) -> [u8; 32] {
         let mut out = [0; 32];
         out[..16].copy_from_slice(&self.0.to_be_bytes());
@@ -346,6 +353,7 @@ impl U256 {
     }
 
     /// Converts `Self` to a little-endian array of `u8`s.
+    #[cfg_attr(test, mutate)]
     fn to_le_bytes(self) -> [u8; 32] {
         let mut out = [0; 32];
         out[..16].copy_from_slice(&self.1.to_le_bytes());
@@ -377,8 +385,10 @@ impl U256 {
         ret.wrapping_inc()
     }
 
+    #[cfg_attr(test, mutate)]
     fn is_zero(&self) -> bool { self.0 == 0 && self.1 == 0 }
 
+    #[cfg_attr(test, mutate)]
     fn is_one(&self) -> bool { self.0 == 0 && self.1 == 1 }
 
     fn is_max(&self) -> bool { self.0 == u128::max_value() && self.1 == u128::max_value() }
@@ -449,6 +459,7 @@ impl U256 {
     /// # Panics
     ///
     /// If `rhs` is zero.
+    #[cfg_attr(test, mutate)]
     fn div_rem(self, rhs: Self) -> (Self, Self) {
         let mut sub_copy = self;
         let mut shift_copy = rhs;
@@ -571,6 +582,7 @@ impl U256 {
 
     /// Returns `self` incremented by 1 wrapping around at the boundary of the type.
     #[must_use = "this returns the result of the increment, without modifying the original"]
+    #[cfg_attr(test, mutate)]
     fn wrapping_inc(&self) -> U256 {
         let mut ret = U256::ZERO;
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -391,6 +391,7 @@ impl U256 {
     #[cfg_attr(test, mutate)]
     fn is_one(&self) -> bool { self.0 == 0 && self.1 == 1 }
 
+    #[cfg_attr(test, mutate)]
     fn is_max(&self) -> bool { self.0 == u128::max_value() && self.1 == u128::max_value() }
 
     /// Returns the low 32 bits.
@@ -1530,6 +1531,16 @@ mod tests {
         assert_eq!(U256::MAX.inverse(), U256::ONE);
         assert_eq!(U256::ONE.inverse(), U256::MAX);
         assert_eq!(U256::ZERO.inverse(), U256::MAX);
+    }
+
+    #[test]
+    fn u256_is_max() {
+        let x = u128::max_value();
+
+        let low = U256::from(x);
+        assert!(!low.is_max());
+        let max = (low << 128) + low;
+        assert!(max.is_max())
     }
 
     #[test]

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -412,6 +412,7 @@ impl U256 {
     }
 
     /// Returns the least number of bits needed to represent the number.
+    #[cfg_attr(test, mutate)]
     fn bits(&self) -> u32 {
         if self.0 > 0 {
             256 - self.0.leading_zeros()
@@ -940,6 +941,11 @@ mod tests {
         assert_eq!(U256::from(300_u64).bits(), 9);
         assert_eq!(U256::from(60000_u64).bits(), 16);
         assert_eq!(U256::from(70000_u64).bits(), 17);
+
+        let x = U256::from(u128::max_value());
+        assert_eq!(x.bits(), 128);
+        let x = x + U256::ONE;
+        assert_eq!(x.bits(), 129);
 
         // Try to read the following lines out loud quickly
         let mut shl = U256::from(70000_u64);


### PR DESCRIPTION
Introduce [mutagen](https://github.com/llogiq/mutagen) to the codebase.

- Patch 1: Introduce mutagen and mutate a bunch of already tested methods
- Patch 2: Mutate `U256::bits()` and fix tests as required
- Patch 2: Mutate `U256::is_max()` and fix tests as required

Going forward, the idea is to add mutation to functions/methods along with the required fixes, each in its own patch (and possibly its own PR). I'll probably batch a few patches together for a single file like I do here with patch 2 and 3.

For context on this PR see: https://github.com/rust-bitcoin/rust-bitcoin/pull/1484