### PR TITLE
Add `from_bytes(Vec<u8>)` to `ScriptBuf`

### DIFF
--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -1163,7 +1163,16 @@ impl ScriptBuf {
             .into_script()
     }
 
+    /// Converts byte vector into script.
+    ///
+    /// This method doesn't (re)allocate.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        ScriptBuf(bytes)
+    }
+
     /// Converts the script into a byte vector.
+    ///
+    /// This method doesn't (re)allocate.
     pub fn into_bytes(self) -> Vec<u8> { self.0 }
 
     /// Computes the P2SH output corresponding to this redeem script.


### PR DESCRIPTION
This is useful when one already has bytes allocated in a vec that can be reused.

The change also documents that the mirror method `into_bytes()` doesn't allocate.