### PR TITLE
Fix wrong newtype APIs

### DIFF
--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -115,6 +115,23 @@ mod test_macros {
 /// - hashes::hex::FromHex
 macro_rules! impl_bytes_newtype {
     ($t:ident, $len:literal) => {
+        impl $t {
+            /// Returns a reference the underlying bytes.
+            #[inline]
+            pub fn as_bytes(&self) -> &[u8; $len] { &self.0 }
+
+            /// Returns the underlying bytes.
+            #[inline]
+            pub fn to_bytes(self) -> [u8; $len] {
+                // We rely on `Copy` being implemented for $t so conversion
+                // methods use the correct Rust naming conventions.
+                fn check_copy<T: Copy>() {}
+                check_copy::<$t>();
+
+                self.0
+            }
+        }
+
         impl core::fmt::LowerHex for $t {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 for &ch in self.0.iter() {

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -149,7 +149,7 @@ impl PartiallySignedTransaction {
                                 }
                                 let derivation = DerivationPath::from(path);
                                 // Keys, according to BIP-174, must be unique
-                                if xpub_map.insert(xpub, (Fingerprint::from(&fingerprint[..]), derivation)).is_some() {
+                                if xpub_map.insert(xpub, (Fingerprint::from(fingerprint), derivation)).is_some() {
                                     return Err(encode::Error::ParseFailed("Repeated global xpub key"))
                                 }
                             } else {

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -6,6 +6,8 @@
 //! bytes from/as PSBT key-value pairs.
 //!
 
+use core::convert::TryInto;
+
 use crate::prelude::*;
 
 use crate::io;
@@ -150,7 +152,7 @@ impl Deserialize for KeySource {
             return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())
         }
 
-        let fprint: Fingerprint = Fingerprint::from(&bytes[0..4]);
+        let fprint: Fingerprint = bytes[0..4].try_into().expect("4 is the fingerprint length");
         let mut dpath: Vec<ChildNumber> = Default::default();
 
         let mut d = &bytes[4..];

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -27,29 +27,76 @@ macro_rules! impl_array_newtype {
             /// Returns whether the object, as an array, is empty. Always false.
             #[inline]
             pub fn is_empty(&self) -> bool { false }
+        }
 
-            /// Returns a reference the underlying bytes.
-            #[inline]
-            pub fn as_bytes(&self) -> &[$ty; $len] { &self.0 }
-
-            /// Returns the underlying bytes.
-            #[inline]
-            pub fn to_bytes(self) -> [$ty; $len] {
-                // We rely on `Copy` being implemented for $thing so conversion
-                // methods use the correct Rust naming conventions.
-                fn check_copy<T: Copy>() {}
-                check_copy::<$thing>();
-
-                self.0
+        impl<'a> core::convert::From<[$ty; $len]> for $thing {
+            fn from(data: [$ty; $len]) -> Self {
+                $thing(data)
             }
         }
 
-        impl<'a> core::convert::From<&'a [$ty]> for $thing {
-            fn from(data: &'a [$ty]) -> $thing {
-                assert_eq!(data.len(), $len);
-                let mut ret = [0; $len];
-                ret.copy_from_slice(&data[..]);
-                $thing(ret)
+        impl<'a> core::convert::From<&'a [$ty; $len]> for $thing {
+            fn from(data: &'a [$ty; $len]) -> Self {
+                $thing(*data)
+            }
+        }
+
+        impl<'a> core::convert::TryFrom<&'a [$ty]> for $thing {
+            type Error = core::array::TryFromSliceError;
+
+            fn try_from(data: &'a [$ty]) -> Result<Self, Self::Error> {
+                use core::convert::TryInto;
+
+                Ok($thing(data.try_into()?))
+            }
+        }
+
+        impl AsRef<[$ty; $len]> for $thing {
+            fn as_ref(&self) -> &[$ty; $len] {
+                &self.0
+            }
+        }
+
+        impl AsMut<[$ty; $len]> for $thing {
+            fn as_mut(&mut self) -> &mut [$ty; $len] {
+                &mut self.0
+            }
+        }
+
+        impl AsRef<[$ty]> for $thing {
+            fn as_ref(&self) -> &[$ty] {
+                &self.0
+            }
+        }
+
+        impl AsMut<[$ty]> for $thing {
+            fn as_mut(&mut self) -> &mut [$ty] {
+                &mut self.0
+            }
+        }
+
+        impl core::borrow::Borrow<[$ty; $len]> for $thing {
+            fn borrow(&self) -> &[$ty; $len] {
+                &self.0
+            }
+        }
+
+        impl core::borrow::BorrowMut<[$ty; $len]> for $thing {
+            fn borrow_mut(&mut self) -> &mut [$ty; $len] {
+                &mut self.0
+            }
+        }
+
+        // The following two are valid because `[T; N]: Borrow<[T]>`
+        impl core::borrow::Borrow<[$ty]> for $thing {
+            fn borrow(&self) -> &[$ty] {
+                &self.0
+            }
+        }
+
+        impl core::borrow::BorrowMut<[$ty]> for $thing {
+            fn borrow_mut(&mut self) -> &mut [$ty] {
+                &mut self.0
             }
         }
 


### PR DESCRIPTION
This fixes several API bugs:

* Use `TryFrom` instead of `From` for fallible conversions
* Move byte conversion methods from `impl_array_newtype` to `impl_bytes_newtype`
* Add missing trait impls like `AsRef`, `Borrow`, their mutable versions and infallible conversions from arrays

Closes #1336

Notably this change is much less bad than even I expected and some places actually get cleaner than before.