### PR TITLE
Change `#[cfg(docsrs)]` to `#[cfg(doc)]` on `use`

### DIFF
--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -24,7 +24,7 @@ use crate::prelude::*;
 use crate::parse::{self, impl_parse_str_through_int};
 use crate::string::FromHexStr;
 
-#[cfg(docsrs)]
+#[cfg(doc)]
 use crate::absolute;
 
 /// The Threshold for deciding whether a lock time value is a height or a time (see [Bitcoin Core]).

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -13,7 +13,7 @@ use core::convert::TryFrom;
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
 
-#[cfg(docsrs)]
+#[cfg(doc)]
 use crate::relative;
 
 /// A relative lock time value, representing either a block height or time (512 second intervals).


### PR DESCRIPTION
The additional `use` items were added to improve the style of documentation. Because they were only used for doc they were `cfg`ed. But because this is independent from being built by `docs.rs` the `cfg` should've been `doc` not `docsrs`.

IOW `docsrs` means roughly `all(doc, nightly)` and the added items are unrelated to `nightly`.

Do we want CI for this kind of thing? It feels a bit too much to me but if someone sends a PR I probably won't reject it.