### PR TITLE
Improve test coverage for docs build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,7 @@ jobs:
           DO_LINT: true
           AS_DEPENDENCY: false
           DO_NO_STD: true
+          DO_DOCS: true
           DO_FEATURE_MATRIX: true
           DO_SCHEMARS_TESTS: true # Currently only used in hashes crate.
         run: ./contrib/test.sh
@@ -55,7 +56,7 @@ jobs:
           DO_BENCH: true
           AS_DEPENDENCY: false
           DO_NO_STD: true
-          DO_DOCS: true
+          DO_DOCSRS: true
         run: ./contrib/test.sh
 
   MSRV:

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -81,7 +81,7 @@ cargo run --example taproot-psbt --features=rand-std,bitcoinconsensus
 
 # Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly rustdoc --all-features -- -D rustdoc::broken-intra-doc-links -D warnings || exit 1
+    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly rustdoc --all-features -- -D rustdoc::broken-intra-doc-links -D warnings
 fi
 
 # Fuzz if told to

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -80,8 +80,14 @@ cargo run --example ecdsa-psbt --features=bitcoinconsensus
 cargo run --example taproot-psbt --features=rand-std,bitcoinconsensus
 
 # Build the docs if told to (this only works with the nightly toolchain)
+if [ "$DO_DOCSRS" = true ]; then
+    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
+fi
+
+# Build the docs with a stable toolchain, in unison with the DO_DOCSRS command
+# above this checks that we feature guarded docs imports correctly.
 if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly rustdoc --all-features -- -D rustdoc::broken-intra-doc-links -D warnings
+    RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
 fi
 
 # Fuzz if told to

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -57,8 +57,14 @@ if [ "$DO_SCHEMARS_TESTS" = true ]; then
 fi
 
 # Build the docs if told to (this only works with the nightly toolchain)
+if [ "$DO_DOCSRS" = true ]; then
+    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
+fi
+
+# Build the docs with a stable toolchain, in unison with the DO_DOCSRS command
+# above this checks that we feature guarded docs imports correctly.
 if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs" cargo doc --features="$FEATURES"
+    RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
 fi
 
 # Webassembly stuff

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -22,7 +22,7 @@
 //! SHA512/256 is a hash function that uses the sha512 alogrithm but it truncates
 //! the output to 256 bits. It has different initial constants than sha512 so it
 //! produces an entirely different hash compared to sha512. More information at
-//! https://eprint.iacr.org/2010/548.pdf.
+//! <https://eprint.iacr.org/2010/548.pdf>.
 
 use core::str;
 use core::ops::Index;
@@ -35,7 +35,7 @@ use crate::{hex, sha512, sha512::BLOCK_SIZE, Error};
 /// SHA512/256 is a hash function that uses the sha512 alogrithm but it truncates
 /// the output to 256 bits. It has different initial constants than sha512 so it
 /// produces an entirely different hash compared to sha512. More information at
-/// https://eprint.iacr.org/2010/548.pdf.
+/// <https://eprint.iacr.org/2010/548.pdf>.
 #[derive(Clone)]
 pub struct HashEngine(sha512::HashEngine);
 
@@ -73,7 +73,7 @@ impl crate::HashEngine for HashEngine {
 crate::internal_macros::hash_type! {
     256,
     false,
-    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at https://eprint.iacr.org/2010/548.pdf. ",
+    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>. ",
     "crate::util::json_hex_string::len_32"
 }
 


### PR DESCRIPTION
Currently the docs build commands in `hashes` and `bitcoin` differ, they should be the same.
    
Add a command `cargo doc` to improve coverage e.g., recently we botched the feature guarding but since CI only runs `cargo rustdoc` with custom compiler conditional set we didn't catch it.
 
Done after seeing: https://github.com/rust-bitcoin/rust-bitcoin/pull/1504 and CI should fail on this PR until 1504 is in.

