### PR TITLE
Use cargo install cross `--locked`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install target
         run: rustup target add s390x-unknown-linux-gnu
       - name: install cross
-        run: cargo install cross
+        run: cargo install cross --locked
       - name: run cross test
         run: cross test --target s390x-unknown-linux-gnu
 


### PR DESCRIPTION
`cross` currently fails to install, this has been reported already

https://github.com/cross-rs/cross/issues/1177

The workaround is to use `cargo install --locked`.