### PR TITLE
Use dtonlnay instead of actions-rs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,63 +3,99 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  Tests:
-    name: Tests
+  Stable:
+    name: Test - stable toolchain
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - rust: stable
-            env:
-              DO_COV: true
-              DO_LINT: true
-              AS_DEPENDENCY: false
-              DO_NO_STD: true
-              DO_FEATURE_MATRIX: true # Currently only used in hashes crate.
-              DO_SCHEMARS_TESTS: true # Currently only used in hashes crate.
-          - rust: beta
-            env:
-              AS_DEPENDENCY: false
-              DO_NO_STD: true
-          - rust: nightly
-            env:
-              DO_BENCH: true
-              AS_DEPENDENCY: false
-              DO_NO_STD: true
-              DO_DOCS: true
-          - rust: 1.41.1
-            env:
-              AS_DEPENDENCY: false
-          - rust: 1.47
-            env:
-              AS_DEPENDENCY: false
-              DO_NO_STD: true
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Running test script
-        env: ${{ matrix.env }}
+        env:
+          DO_COV: true
+          DO_LINT: true
+          AS_DEPENDENCY: false
+          DO_NO_STD: true
+          DO_FEATURE_MATRIX: true # Currently only used in hashes crate.
+          DO_SCHEMARS_TESTS: true # Currently only used in hashes crate.
+        run: ./contrib/test.sh
+
+  Beta:
+    name: Test - beta toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@beta
+      - name: Running test script
+        env:
+          AS_DEPENDENCY: false
+          DO_NO_STD: true
+        run: ./contrib/test.sh
+
+  Nightly:
+    name: Test - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Running test script
+        env:
+          DO_BENCH: true
+          AS_DEPENDENCY: false
+          DO_NO_STD: true
+          DO_DOCS: true
+        run: ./contrib/test.sh
+
+  MSRV:
+    name: Test - 1.41.1 toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@1.41.1
+      - name: Running test script
+        env:
+          DO_FEATURE_MATRIX: true # Currently only used in hashes crate.
+        run: ./contrib/test.sh
+
+  NoStd:
+    name: Test - 1.47 toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@1.47
+      - name: Running test script
+        env:
+          DO_NO_STD: true
         run: ./contrib/test.sh
 
   Arch32bit:
-    name: Testing 32-bit version
+    name: Test 32-bit version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Add architecture i386
         run: sudo dpkg --add-architecture i386
       - name: Install i686 gcc
@@ -70,18 +106,14 @@ jobs:
         run: cargo test --target i686-unknown-linux-gnu
 
   Cross:
-    name: Cross testing
+    name: Cross test
     if: ${{ !github.event.act }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Install target
         run: rustup target add s390x-unknown-linux-gnu
       - name: install cross
@@ -96,17 +128,15 @@ jobs:
       CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         run: sudo apt update && sudo apt install -y qemu-system-arm gcc-arm-none-eabi
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rust-src
-          target: thumbv7m-none-eabi
+          targets: thumbv7m-none-eabi
+      - name: Install src
+        run: rustup component add rust-src
       - name: Run bitcoin/embedded
         run: cd bitcoin/embedded && cargo run --target thumbv7m-none-eabi
       - name: Run hashes/embedded no alloc
@@ -119,14 +149,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rust-src
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install src
+        run: rustup component add rust-src
       - name: Running address sanitizer
         env:
           DO_ASAN: true
@@ -137,13 +164,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Running WASM build
         env:
           DO_WASM: true


### PR DESCRIPTION
Done on top of #1508

Currently we use the `actions-rs` GitHub action to run our tests. It seems the project is now unmaintained [0].
    
Well known Rust developer dtonlnay maintains a GitHub action that can be used instead.
    
Replace all uses of `actions-rs/toolchain` with `dtonlnay/rust-toolchain`. Note that with the new action there is no way to configure the toolchain, instead a different `uses` statement is required - this means we have to split our jobs up by toolchain. This is arguably cleaner anyways.
    
Note that with this patch applied the "no-std" tests are now _not_ run for MSRV since we explicitly support "no-std" only for the 1.47 and above toolchains - strange that this was working?
    
[0] https://github.com/actions-rs/toolchain/issues/216
