### PR TITLE
Run kani daily on a schedule

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,8 +1,8 @@
 # From https://model-checking.github.io/kani/install-github-ci.html
 name: Kani CI
 on:
-  pull_request:
-  push:
+  schedule:
+    - cron: '59 23 * * *'       # midnight every day.
 jobs:
   run-kani:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     <a href="https://docs.rs/bitcoin"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bitcoin-green"/></a>
     <a href="https://blog.rust-lang.org/2020/02/27/Rust-1.41.1.html"><img alt="Rustc Version 1.41.1+" src="https://img.shields.io/badge/rustc-1.41.1%2B-lightgrey.svg"/></a>
     <a href="https://gnusha.org/bitcoin-rust/"><img alt="Chat on IRC" src="https://img.shields.io/badge/irc-%23bitcoin--rust%20on%20libera.chat-blue"></a>
+    <a href="https://github.com/model-checking/kani"><imp alt="kani" src="https://github.com/rust-bitcoin/rust-bitcoin/actions/workflows/kani.yaml/badge.svg"></a>
     <img alt="Lines of code" src="https://img.shields.io/tokei/lines/github/rust-bitcoin/rust-bitcoin">
   </p>
 </div>


### PR DESCRIPTION
Running kani takes ages, instead of running it on every pull request we can just run it daily.