### PR TITLE
Export the DisplayHex trait from within prelude

### DIFF
--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -53,7 +53,6 @@ use crate::prelude::*;
 use alloc::rc::Rc;
 use alloc::sync::Arc;
 use bitcoin_internals::debug_from_display;
-use bitcoin_internals::hex::display::DisplayHex;
 use crate::io;
 use core::cmp::Ordering;
 use core::convert::TryFrom;

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -489,7 +489,6 @@ impl From<Vec<&[u8]>> for Witness {
 mod test {
     use super::*;
 
-    use bitcoin_internals::hex::display::DisplayHex;
     use crate::consensus::{deserialize, serialize};
     use crate::internal_macros::hex;
     use crate::Transaction;

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -21,7 +21,6 @@ use crate::prelude::*;
 use core::{fmt, mem, u32, convert::From};
 
 use bitcoin_internals::write_err;
-use bitcoin_internals::hex::display::DisplayHex;
 
 use crate::hashes::{sha256d, Hash, sha256};
 use crate::hash_types::{BlockHash, FilterHash, TxMerkleNode, FilterHeader};

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -9,7 +9,6 @@ use core::str::FromStr;
 use core::{fmt, iter};
 
 use bitcoin_internals::write_err;
-use bitcoin_internals::hex::display::DisplayHex;
 use secp256k1;
 
 use crate::prelude::*;

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -187,6 +187,8 @@ mod prelude {
 
     #[cfg(not(feature = "hashbrown"))]
     pub use std::collections::HashSet;
+
+    pub use bitcoin_internals::hex::display::DisplayHex;
 }
 
 #[cfg(bench)]

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -499,7 +499,6 @@ impl Decodable for MerkleBlock {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin_internals::hex::display::DisplayHex;
     #[cfg(feature = "rand-std")]
     use secp256k1::rand::prelude::*;
 

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -6,7 +6,6 @@
 //! <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki>.
 //!
 
-use bitcoin_internals::hex::display::DisplayHex;
 use crate::prelude::*;
 use core::fmt;
 use core::convert::TryFrom;

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -44,7 +44,6 @@ pub(crate) trait Deserialize: Sized {
 impl PartiallySignedTransaction {
     /// Serialize a value as bytes in hex.
     pub fn serialize_hex(&self) -> String {
-        use bitcoin_internals::hex::display::DisplayHex;
         self.serialize().to_lower_hex_string()
     }
 

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -1387,7 +1387,6 @@ mod tests {
             })
         }
 
-        use bitcoin_internals::hex::display::DisplayHex;
         use secp256k1::{self, SecretKey, XOnlyPublicKey};
 
         use crate::consensus::serde as con_serde;

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -1094,7 +1094,6 @@ impl std::error::Error for TaprootError {
 mod test {
     use core::str::FromStr;
 
-    use bitcoin_internals::hex::display::DisplayHex;
     use secp256k1::{VerifyOnly, XOnlyPublicKey};
 
     use super::*;


### PR DESCRIPTION
We use `internals::hex::display::DisplayHex` in many places, we can improve ergonomics of the `internals` crate by re-exporting it from the `prelude` module.