### PR TITLE
Address validity invariant cleanups

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -386,6 +386,7 @@ impl From<WitnessVersion> for opcodes::All {
 
 /// The method used to produce an address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum Payload {
     /// P2PKH address.
     PubkeyHash(PubkeyHash),

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -537,8 +537,9 @@ impl Payload {
         Payload::WitnessProgram(prog)
     }
 
-    /// Returns a byte slice of the payload
-    pub fn as_bytes(&self) -> &[u8] {
+    /// Returns a byte slice of the inner program of the payload. If the payload
+    /// is a script hash or pubkey hash, a reference to the hash is returned.
+    fn inner_prog_as_bytes(&self) -> &[u8] {
         match self {
             Payload::ScriptHash(hash) => hash.as_ref(),
             Payload::PubkeyHash(hash) => hash.as_ref(),
@@ -930,7 +931,7 @@ impl Address {
     /// given key. For taproot addresses, the supplied key is assumed to be tweaked
     pub fn is_related_to_pubkey(&self, pubkey: &PublicKey) -> bool {
         let pubkey_hash = pubkey.pubkey_hash();
-        let payload = self.payload.as_bytes();
+        let payload = self.payload.inner_prog_as_bytes();
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
 
         (*pubkey_hash.as_ref() == *payload)
@@ -943,7 +944,7 @@ impl Address {
     /// This will only work for Taproot addresses. The Public Key is
     /// assumed to have already been tweaked.
     pub fn is_related_to_xonly_pubkey(&self, xonly_pubkey: &XOnlyPublicKey) -> bool {
-        let payload = self.payload.as_bytes();
+        let payload = self.payload.inner_prog_as_bytes();
         payload == xonly_pubkey.serialize()
     }
 }

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -848,10 +848,20 @@ impl Address {
 	self.address_type_internal()
     }
 
+    /// Checks whether or not the address is following Bitcoin standardness rules when
+    /// *spending* from this address. This method should *NOT* called by senders. For forward
+    /// compatibility, the senders must send to any [`Address`]. Receivers can use this method to
+    /// check whether or not they can spend from this address.
+    ///
+    /// SegWit addresses with unassigned witness versions or non-standard program sizes are
+    /// considered non-standard.
+    pub fn is_spend_standard(&self) -> bool { self.address_type().is_some() }
+
     /// Checks whether or not the address is following Bitcoin standardness rules.
     ///
     /// SegWit addresses with unassigned witness versions or non-standard program sizes are
     /// considered non-standard.
+    #[deprecated(since = "0.30.0", note = "Use Address::is_spend_standard instead")]
     pub fn is_standard(&self) -> bool { self.address_type().is_some() }
 
     /// Constructs an [`Address`] from an output script (`scriptPubkey`).

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1742,6 +1742,7 @@ mod tests {
     #[cfg(feature = "rand-std")]
     fn sign_psbt() {
         use crate::WPubkeyHash;
+        use crate::address::WitnessProgram;
         use crate::bip32::{Fingerprint, DerivationPath};
 
         let unsigned_tx = Transaction {
@@ -1771,9 +1772,12 @@ mod tests {
         psbt.inputs[0].bip32_derivation = map;
 
         // Second input is unspendable by us e.g., from another wallet that supports future upgrades.
+        let unknown_prog = WitnessProgram::new(
+            crate::address::WitnessVersion::V4, vec![0xaa; 34]
+        ).unwrap();
         let txout_unknown_future = TxOut{
             value: 10,
-            script_pubkey: ScriptBuf::new_witness_program(crate::address::WitnessVersion::V4, &[0xaa; 34]),
+            script_pubkey: ScriptBuf::new_witness_program(&unknown_prog),
         };
         psbt.inputs[1].witness_utxo = Some(txout_unknown_future);
 


### PR DESCRIPTION
Fixes #1561. 

Highlights:

- Segwitv0 programs with lengths apart from 20 or 32 are invalid `Address` struct. Such Addresses are useless and we should not parse/create them.
- Renamed `is_standard` to `is_spend_standard`. 