### PR TITLE
Fix ASAN in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Running address sanitizer
         env:
           DO_ASAN: true
-        run: ./hashes/contrib/test.sh
+        run: cd hashes && ./contrib/test.sh
 
   WASM:
     name: WebAssembly Build # hashes crate only.
@@ -170,4 +170,4 @@ jobs:
       - name: Running WASM build
         env:
           DO_WASM: true
-        run: ./hashes/contrib/test.sh
+        run: cd hashes && ./contrib/test.sh

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -81,6 +81,8 @@ if [ "$DO_ASAN" = true ]; then
     CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
     RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
     cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
+    # Cleanup because we do not want to use a build that used these build flags again.
+    cargo clean
 fi
 
 # Bench if told to, only works with non-stable toolchain (nightly, beta).


### PR DESCRIPTION
When we merged `hashes` into `rust-bitcoin` we ran the test script a couple of times using `./hashes/contrib/test.sh` this causes the `cargo` commands in the CI script to be run from the crate root which is not what we want.

This showed up recently because `cargo test` was getting run in `bitcoin` after building with address/memory sanitazation configured into the build.

While we are at it run `cargo clean` after the last sanitizer build just to future proof the CI script in case we later accidentally re-use the same build with plain old `cargo` (without `-Zbuild-std etc.`).