### PR TITLE
Use `sha256d::Hash` type for sighash encoding

### DIFF
--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -69,7 +69,6 @@ See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
     impl_hashencode!(Txid);
     impl_hashencode!(Wtxid);
     impl_hashencode!(BlockHash);
-    impl_hashencode!(Sighash);
 
     impl_hashencode!(TxMerkleNode);
     impl_hashencode!(WitnessMerkleNode);

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -729,9 +729,10 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
         } else if sighash == EcdsaSighashType::Single && input_index < self.tx.output.len() {
             let mut single_enc = Sighash::engine();
             self.tx.output[input_index].consensus_encode(&mut single_enc)?;
-            Sighash::from_engine(single_enc).consensus_encode(&mut writer)?;
+            let hash = Sighash::from_engine(single_enc);
+            writer.write_all(&hash[..])?;
         } else {
-            zero_hash.consensus_encode(&mut writer)?;
+            writer.write_all(&zero_hash[..])?;
         }
 
         self.tx.lock_time.consensus_encode(&mut writer)?;


### PR DESCRIPTION
From BIP143:

> If sighash type is SINGLE and the input index is smaller than the number of outputs, hashOutputs is the double SHA256 of the output amount with scriptPubKey of the same index as the input;

Currently we are using a `Sighash` which wraps double sha256 so while technically correct this means we are relying on `Sighash` to implement `Encodable`. We can remove this requirement by directly using the `sha256d::Hash` type to hash the outputs data.

Fix: #1549