### PR TITLE
ci: Remove incorrect code comment and cargo clean

### DIFF
--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -81,8 +81,6 @@ if [ "$DO_ASAN" = true ]; then
     CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
     RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
     cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
-    # Cleanup because we do not want to use a build that used these build flags again.
-    cargo clean
 fi
 
 # Bench if told to, only works with non-stable toolchain (nightly, beta).


### PR DESCRIPTION
Recently while trying to fix CI I (Tobin) added a call to `cargo clean` and a code comment justifying it. This was merged because while not incorrect it is redundant since calling `cargo` with different `RUSTFLAGS` triggers a rebuild.