### PR TITLE
hashes: Improve feature gating

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["internals/std"]
+std = ["alloc", "internals/std"]
 alloc = ["internals/alloc"]
 schemars = ["actual-schemars", "dyn-clone"]
 serde-std = ["serde/std"]

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -49,12 +49,12 @@ fn from_engine(e: HashEngine) -> Hash {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test() {
         use crate::{hash160, Hash, HashEngine};
 
         #[derive(Clone)]
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         struct Test {
             input: Vec<u8>,
             output: Vec<u8>,

--- a/hashes/src/hex.rs
+++ b/hashes/src/hex.rs
@@ -15,12 +15,13 @@
 //! Hex encoding and decoding.
 //!
 
-#[cfg(any(feature = "std", feature = "alloc"))]
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use crate::alloc::vec::Vec;
 
-#[cfg(any(test, feature = "std"))]
+#[cfg(feature = "std")]
 use std::io;
-#[cfg(all(not(test), not(feature = "std"), feature = "core2"))]
+#[cfg(all(feature = "core2", not(feature = "std")))]
 use core2::io;
 
 use core::{fmt, str};
@@ -201,7 +202,7 @@ impl_fromhex_array!(384);
 impl_fromhex_array!(512);
 
 #[cfg(test)]
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
     use internals::hex::exts::DisplayHex;

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -245,7 +245,7 @@ impl<'de, T: Hash + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test() {
         use crate::{sha256, HashEngine, HmacEngine, Hash, Hmac};
 

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -102,8 +102,7 @@
 #[cfg(bench)] extern crate test;
 #[cfg(any(test, feature = "std"))] extern crate core;
 #[cfg(feature = "core2")] extern crate core2;
-#[cfg(feature = "alloc")] extern crate alloc;
-#[cfg(all(not(feature = "alloc"), feature = "std"))] use std as alloc;
+#[cfg(all(feature = "alloc", not(feature = "std")))] extern crate alloc;
 #[cfg(feature = "serde")] pub extern crate serde;
 #[cfg(all(test,feature = "serde"))] extern crate serde_test;
 

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -405,7 +405,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test() {
         use crate::{Hash, HashEngine, ripemd160};
 

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -143,7 +143,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test() {
         use crate::{sha1, Hash, HashEngine};
 

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -324,7 +324,7 @@ mod tests {
     use crate::{Hash, HashEngine, sha256};
 
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test() {
         #[derive(Clone)]
         struct Test {

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -44,7 +44,7 @@ fn from_engine(e: sha256::HashEngine) -> Hash {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test() {
         use crate::{sha256, sha256d, Hash, HashEngine};
 

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -122,7 +122,7 @@ macro_rules! sha256t_hash_newtype {
 #[cfg(test)]
 mod tests {
     use crate::{sha256, sha256t};
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     use crate::Hash;
 
     const TEST_MIDSTATE: [u8; 32] = [
@@ -143,13 +143,13 @@ mod tests {
     }
 
     /// A hash tagged with `$name`.
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     pub type TestHash = sha256t::Hash<TestHashTag>;
 
     sha256t_hash_newtype!(NewTypeHash, NewTypeTag, TEST_MIDSTATE, 64, doc="test hash", true);
 
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test_sha256t() {
         assert_eq!(
             TestHash::hash(&[0]).to_string(),

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -308,7 +308,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test() {
         use crate::{sha512, Hash, HashEngine};
 

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -86,7 +86,7 @@ fn from_engine(e: HashEngine) -> Hash {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn test() {
         use crate::{sha512_256, Hash, HashEngine};
 


### PR DESCRIPTION
Currently we have a few things mixed up in the feature gating of `hashes`.
    
Observe that:
- `io::Write` and `io::Read` is not related to allocation but rather provided by `core2`
- "std" should be able to enable "alloc".
    
Improve feature gating by doing:
    
- Enable "alloc" from "std" and simplify `cfg` codebase wide.
- Enable "internals/alloc" from "alloc".
- Fix feature gating to use the minimal requirement i.e., "alloc".

Please note one anomaly, `internals` does not set "std" as the default feature but `hashes` does. 