### PR TITLE
Improve rustdocs build

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 exclude = ["tests/"]
 edition = "2018"
 
-# Please don't forget to add relevant features to docs.rs below
+# Please don't forget to add relevant features to docs.rs below.
 [features]
 default = [ "std", "secp-recovery" ]
 rand-std = ["secp256k1/rand-std"]
@@ -32,7 +32,7 @@ std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std", "bitcoin-internals/s
 no-std = ["core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
 
 [package.metadata.docs.rs]
-features = [ "std", "secp-recovery", "base64", "rand", "serde", "bitcoinconsensus" ]
+features = [ "std", "base64", "rand-std", "rand", "serde", "bitcoinconsensus", "secp-recovery", "bitocinconsensus-std", "rust_v_1_53" ]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -11,6 +11,7 @@ keywords = [ "crypto", "bitcoin", "hash", "digest" ]
 readme = "README.md"
 edition = "2018"
 
+# Please don't forget to add relevant features to docs.rs below.
 [features]
 default = ["std"]
 std = ["internals/alloc"]
@@ -20,6 +21,10 @@ schemars = ["actual-schemars", "dyn-clone"]
 # And you can still just disable std by disabling default features, without enabling these two.
 alloc = ["core2/alloc", "internals/alloc"]
 serde-std = ["serde/std"]
+
+[package.metadata.docs.rs]
+features = ["std", "io", "alloc", "schemars", "serde-std"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Only enable this if you explicitly do not want to use "std", otherwise enable "serde-std".

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -22,7 +22,7 @@
 //! SHA512/256 is a hash function that uses the sha512 alogrithm but it truncates
 //! the output to 256 bits. It has different initial constants than sha512 so it
 //! produces an entirely different hash compared to sha512. More information at
-//! https://eprint.iacr.org/2010/548.pdf.
+//! <https://eprint.iacr.org/2010/548.pdf>.
 
 use core::str;
 use core::ops::Index;
@@ -35,7 +35,7 @@ use crate::{hex, sha512, sha512::BLOCK_SIZE, Error};
 /// SHA512/256 is a hash function that uses the sha512 alogrithm but it truncates
 /// the output to 256 bits. It has different initial constants than sha512 so it
 /// produces an entirely different hash compared to sha512. More information at
-/// https://eprint.iacr.org/2010/548.pdf.
+/// <https://eprint.iacr.org/2010/548.pdf>.
 #[derive(Clone)]
 pub struct HashEngine(sha512::HashEngine);
 
@@ -73,7 +73,7 @@ impl crate::HashEngine for HashEngine {
 crate::internal_macros::hash_type! {
     256,
     false,
-    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at https://eprint.iacr.org/2010/548.pdf. ",
+    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>. ",
     "crate::util::json_hex_string::len_32"
 }
 


### PR DESCRIPTION
Improve rustdocs build

- Patch 1: Adds a `package.metadata.docs.rs` in `hashes` and adds _all_ features (not dependencies) to the list (is this correct?)
 - Patch 2: Fixes some rustdoc build warnings in `hashes`