### PR TITLE
Add standard constants to lock times

### DIFF
--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -103,7 +103,7 @@ pub enum LockTime {
 impl LockTime {
     /// If [`crate::Transaction::lock_time`] is set to zero it is ignored, in other words a
     /// transaction with nLocktime==0 is able to be included immediately in any block.
-    pub const ZERO: LockTime = LockTime::Blocks(Height(0));
+    pub const ZERO: LockTime = LockTime::Blocks(Height::ZERO);
 
     /// Constructs a `LockTime` from an nLockTime value or the argument to OP_CHEKCLOCKTIMEVERIFY.
     ///
@@ -393,6 +393,25 @@ impl<'de> serde::Deserialize<'de> for LockTime {
 pub struct Height(u32);
 
 impl Height {
+    /// Absolute block height 0, the genesis block.
+    pub const ZERO: Self = Height(0);
+
+    /// The minimum absolute block height (0), the genesis block.
+    pub const MIN: Self = Self::ZERO;
+
+    /// The maximum absolute block height.
+    pub const MAX: Self = Height(LOCK_TIME_THRESHOLD - 1);
+
+    /// The minimum absolute block height (0), the genesis block.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MIN`].
+    pub fn min_value() -> Self { Self::MIN }
+
+    /// The maximum absolute block height.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MAX`].
+    pub fn max_value() -> Self { Self::MAX }
+
     /// Constructs a new block height.
     ///
     /// # Errors
@@ -490,6 +509,22 @@ impl TryFrom<String> for Height {
 pub struct Time(u32);
 
 impl Time {
+    /// The minimum absolute block time (Tue Nov 05 1985 00:53:20 GMT+0000).
+    pub const MIN: Self = Time(LOCK_TIME_THRESHOLD);
+
+    /// The maximum absolute block time (Sun Feb 07 2106 06:28:15 GMT+0000).
+    pub const MAX: Self = Time(u32::max_value());
+
+    /// The minimum absolute block time.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MIN`].
+    pub fn min_value() -> Self { Self::MIN }
+
+    /// The maximum absolute block time.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MAX`].
+    pub fn max_value() -> Self { Self::MAX }
+
     /// Constructs a new block time.
     ///
     /// # Errors

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -203,6 +203,25 @@ impl fmt::Display for LockTime {
 pub struct Height(u16);
 
 impl Height {
+    /// Relative block height 0, can be included in any block.
+    pub const ZERO: Self = Height(0);
+
+    /// The minimum relative block height (0), can be included in any block.
+    pub const MIN: Self = Self::ZERO;
+
+    /// The maximum relative block height.
+    pub const MAX: Self = Height(u16::max_value());
+
+    /// The minimum relative block height (0), can be included in any block.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MIN`].
+    pub fn min_value() -> Self { Self::MIN }
+
+    /// The maximum relative block height.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MAX`].
+    pub fn max_value() -> Self { Self::MAX }
+
     /// Returns the inner `u16` value.
     #[inline]
     pub fn value(self) -> u16 {
@@ -232,6 +251,25 @@ impl fmt::Display for Height {
 pub struct Time(u16);
 
 impl Time {
+    /// Relative block time 0, can be included in any block.
+    pub const ZERO: Self = Time(0);
+
+    /// The minimum relative block time (0), can be included in any block.
+    pub const MIN: Self = Time::ZERO;
+
+    /// The maximum relative block time (33,554,432 seconds or approx 388 days).
+    pub const MAX: Self = Time(u16::max_value());
+
+    /// The minimum relative block time.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MIN`].
+    pub fn min_value() -> Self { Self::MIN }
+
+    /// The maximum relative block time.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MAX`].
+    pub fn max_value() -> Self { Self::MAX }
+
     /// Create a [`Time`] using time intervals where each interval is equivalent to 512 seconds.
     ///
     /// Encoding finer granularity of time for relative lock-times is not supported in Bitcoin.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -318,6 +318,11 @@ impl Sequence {
     /// BIP-68 relative lock time type flag mask.
     const LOCK_TYPE_MASK: u32 = 0x00400000;
 
+    /// The maximum allowable sequence number.
+    ///
+    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Sequence::MAX`].
+    pub fn max_value() -> Self { Self::MAX }
+
     /// Returns `true` if the sequence number enables absolute lock-time ([`Transaction::lock_time`]).
     #[inline]
     pub fn enables_absolute_lock_time(&self) -> bool {


### PR DESCRIPTION
Some of the lock time structs (`Height`, `Time` ect.) are missing standard constants for min, max ect.

Add standard constants taking into consideration the various locktime corner cases.

Add `max_value` and `min_value` to be consistent with Rust 1.41.1 (incl. `Sequence`).

Fix: #1451

This PR is not complex in itself but **locktimes are notoriously complex, please wait for 3 acks before merging** - and ack'ing makes no guarantee that reviewer got all corner cases :)

There is no rush on this one, apoelstra, Kixunil, sanket1729 please just review when your brain is fresh.