### PR TITLE
bip158: Replace usage of HashSet with BTreeSet

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,7 +29,7 @@ rust_v_1_53 = []
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
 std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std", "bitcoin-internals/std"]
-no-std = ["hashbrown", "core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
+no-std = ["core2/alloc", "bitcoin_hashes/alloc", "secp256k1/alloc"]
 
 [package.metadata.docs.rs]
 features = [ "std", "secp-recovery", "base64", "rand", "serde", "bitcoinconsensus" ]
@@ -46,7 +46,6 @@ base64 = { version = "0.13.0", optional = true }
 bitcoinconsensus = { version = "0.20.2-0.5.0", optional = true, default-features = false }
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
-hashbrown = { version = "0.8", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -363,14 +363,14 @@ fn map_to_range(hash: u64, nm: u64) -> u64 { ((hash as u128 * nm as u128) >> 64)
 pub struct GcsFilterWriter<'a, W> {
     filter: GcsFilter,
     writer: &'a mut W,
-    elements: HashSet<Vec<u8>>,
+    elements: BTreeSet<Vec<u8>>,
     m: u64,
 }
 
 impl<'a, W: io::Write> GcsFilterWriter<'a, W> {
     /// Creates a new [`GcsFilterWriter`] wrapping a generic writer, with specific seed to siphash.
     pub fn new(writer: &'a mut W, k0: u64, k1: u64, m: u64, p: u8) -> GcsFilterWriter<'a, W> {
-        GcsFilterWriter { filter: GcsFilter::new(k0, k1, p), writer, elements: HashSet::new(), m }
+        GcsFilterWriter { filter: GcsFilter::new(k0, k1, p), writer, elements: BTreeSet::new(), m }
     }
 
     /// Adds data to the filter.
@@ -634,7 +634,7 @@ mod test {
 
     #[test]
     fn test_filter() {
-        let mut patterns = HashSet::new();
+        let mut patterns = BTreeSet::new();
 
         patterns.insert(hex!("000000"));
         patterns.insert(hex!("111111"));

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -24,8 +24,7 @@
 //!                 deserialization.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
 //! * `no-std` - enables additional features required for this crate to be usable
-//!              without std. Does **not** disable `std`. Depends on `hashbrown`
-//!              and `core2`.
+//!              without std. Does **not** disable `std`. Depends on `core2`.
 //! * `bitcoinconsensus-std` - enables `std` in `bitcoinconsensus` and communicates it
 //!                            to this crate so it knows how to implement
 //!                            `std::error::Error`. At this time there's a hack to
@@ -181,12 +180,6 @@ mod prelude {
 
     #[cfg(not(feature = "std"))]
     pub use crate::io_extras::sink;
-
-    #[cfg(feature = "hashbrown")]
-    pub use hashbrown::HashSet;
-
-    #[cfg(not(feature = "hashbrown"))]
-    pub use std::collections::HashSet;
 
     pub use bitcoin_internals::hex::display::DisplayHex;
 }


### PR DESCRIPTION
The `bip158` module uses a `HashSet` and in order to do so requires the `hashbrown` dependency for "no-std" builds.

We can replace the usage of `HashSet` with a `BTreeSet` in `bip158` and remove the `hashbrown` dependency entirely.

This patch makes no claims about performance cost or benefit of this change. The patch also makes no claims about the validity of the current `HashSet` usage.

The `hashbrown` dependency and `HashSet` usage can be trivially added back in if someone comes up with perf data to back it up.