### PR TITLE
Fix license on bip158 module

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -1,4 +1,4 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// Written in 2019 by Tammas Blummer.
 // SPDX-License-Identifier: CC0-1.0
 
 // This module was largely copied from https://github.com/rust-bitcoin/murmel/blob/master/src/blockfilter.rs


### PR DESCRIPTION
When we introduced the SPDX license blurb in [0] we incorrectly gave attribution to Andrew when the original file author had the attribution as "the rust-bitcoin developers". The original author [1] was Tamas Blummer and he copied this code from code he wrote and explicitly re-licenses it. In order to make the re-licensing comment a little clearer and fix the mis-attribution use Tamas' name in the attribution.

[0] commit: `91ff2f628ce7db732d234a812e29fa8508f501a1 Introduce SPDX license identifiers`
[1] commit: `c93a70487f81a93c7d479ae046c75590d9fb7733 Add client side block filter (BIP158) (#281)`