### PR TITLE
Delegate debug for ScriptBuf to Script

### DIFF
--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -137,7 +137,7 @@ pub struct Script([u8]);
 /// that all the safety/validity restrictions that apply to [`Script`] apply to `ScriptBuf` as well.
 ///
 /// [deref coercions]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion
-#[derive(Default, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct ScriptBuf(Vec<u8>);
 
 impl ToOwned for Script {
@@ -1312,6 +1312,12 @@ impl ScriptBuf {
         // Copied from PathBuf::into_boxed_path
         let rw = Box::into_raw(self.0.into_boxed_slice()) as *mut Script;
         unsafe { Box::from_raw(rw) }
+    }
+}
+
+impl fmt::Debug for ScriptBuf {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self.as_script(), f)
     }
 }
 


### PR DESCRIPTION
Currently the derived implementation of `Debug` for `ScriptBuf` prints the inner vector of u8s as integers, this is ugly and hard to read. The `Script` implementation of `Debug` prints the script opcodes and data as hex, we can just delegate to it.

With this applied we get debug output of form:

    Script(OP_DUP OP_HASH160 OP_PUSHBYTES_20 3bde42dbee7e4dbe6a21b2d50ce2f0167faa8159 OP_EQUALVERIFY OP_CHECKSIG)

Fix: #1516