### PR TITLE
Use ignore to stop rustdoc code from being built

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -637,7 +637,7 @@ impl NetworkValidation for NetworkUnchecked {}
 /// assert_eq!(address.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
 /// ```
 ///
-/// ```compile_fail
+/// ```ignore
 /// # use std::str::FromStr;
 /// # use bitcoin::address::{Address, NetworkChecked};
 /// let address: Address<NetworkUnchecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")


### PR DESCRIPTION
Currently we have an attempted tag ```compile_fail that seems to be aiming at allowing code that does not build to exist in rustdoc. This is causing an error when running tests.

No clue how this made it through CI.

Use ```ignore to prevent rustdoc code from being built.