### PR TITLE
Take `Into<secp256k1::PublicKey>` in PublicKey constructors

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -92,19 +92,19 @@ pub struct PublicKey {
 
 impl PublicKey {
     /// Constructs compressed ECDSA public key from the provided generic Secp256k1 public key
-    pub fn new(key: secp256k1::PublicKey) -> PublicKey {
+    pub fn new(key: impl Into<secp256k1::PublicKey>) -> PublicKey {
         PublicKey {
             compressed: true,
-            inner: key,
+            inner: key.into(),
         }
     }
 
     /// Constructs uncompressed (legacy) ECDSA public key from the provided generic Secp256k1
     /// public key
-    pub fn new_uncompressed(key: secp256k1::PublicKey) -> PublicKey {
+    pub fn new_uncompressed(key: impl Into<secp256k1::PublicKey>) -> PublicKey {
         PublicKey {
             compressed: false,
-            inner: key,
+            inner: key.into(),
         }
     }
 
@@ -838,5 +838,17 @@ mod tests {
             vector.input.sort_by_cached_key(|k| PublicKey::to_sort_key(*k));
             assert_eq!(vector.input, vector.expect);
         }
+    }
+
+    #[test]
+    #[cfg(feature = "rand-std")]
+    fn public_key_constructors() {
+        use crate::secp256k1::rand;
+
+        let secp = Secp256k1::new();
+        let kp = KeyPair::new(&secp, &mut rand::thread_rng());
+
+        let _ = PublicKey::new(kp);
+        let _ = PublicKey::new_uncompressed(kp);
     }
 }

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -544,14 +544,17 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
 
 #[cfg(test)]
 mod tests {
-    use crate::io;
-    use super::{PrivateKey, PublicKey, SortKey};
-    use secp256k1::Secp256k1;
+    use super::*;
+
     use std::str::FromStr;
+
+    use secp256k1::Secp256k1;
+
+    use crate::address::Address;
     use crate::hashes::hex::FromHex;
+    use crate::io;
     use crate::network::constants::Network::Testnet;
     use crate::network::constants::Network::Bitcoin;
-    use crate::address::Address;
 
     #[test]
     fn test_key_derivation() {


### PR DESCRIPTION
We can make the API more ergonomic by taking a generic argument that implements `Into<secp256k1::PublicKey>` in the `bitcoin::PublicKey` constructors.
    
The only thing than this is useful for is passing in `KeyPair` and the `From` implementation already exists. Add a unit test to verify.
    
Fix: #1453

## Note

As per the discussion in #1453 I checked secp and bitcoin for all keys that can be converted using `From` and it turns out its only `KeyPair` which already has `From` impls - good rust-bitcoin devs :) 
