### PR TITLE
Remove unnecessary lifetime

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -419,9 +419,9 @@ impl GcsFilter {
     fn new(k0: u64, k1: u64, p: u8) -> GcsFilter { GcsFilter { k0, k1, p } }
 
     /// Golomb-Rice encodes a number `n` to a bit stream (parameter 2^k).
-    fn golomb_rice_encode<'a, W>(
+    fn golomb_rice_encode<W>(
         &self,
-        writer: &mut BitStreamWriter<'a, W>,
+        writer: &mut BitStreamWriter<W>,
         n: u64,
     ) -> Result<usize, io::Error>
     where


### PR DESCRIPTION
Clippy emits:

  warning: the following explicit lifetimes could be elided: 'a

As suggested, remove the unnecessary lifetime.