### PR TITLE
script: Audit inlining

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -210,7 +210,6 @@ impl Script {
     }
 
     /// Returns the bytes of the (possibly invalid) public key if this script is P2PK.
-    #[inline]
     pub(in crate::blockdata::script) fn p2pk_pubkey_bytes(&self) -> Option<&[u8]> {
         match self.len() {
             67 if self.0[0] == OP_PUSHBYTES_65.to_u8() && self.0[66] == OP_CHECKSIG.to_u8() =>
@@ -274,7 +273,6 @@ impl Script {
     }
 
     /// Check if this is an OP_RETURN output.
-    #[inline]
     pub fn is_op_return(&self) -> bool {
         match self.0.first() {
             Some(b) => *b == OP_RETURN.to_u8(),
@@ -283,7 +281,6 @@ impl Script {
     }
 
     /// Checks whether a script can be proven to have no satisfying input.
-    #[inline]
     pub fn is_provably_unspendable(&self) -> bool {
         use crate::blockdata::opcodes::Class::{IllegalOp, ReturnOp};
 

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -119,15 +119,12 @@ impl Script {
     pub fn builder() -> Builder { Builder::new() }
 
     /// Returns 160-bit hash of the script.
-    #[inline]
     pub fn script_hash(&self) -> ScriptHash { ScriptHash::hash(self.as_bytes()) }
 
     /// Returns 256-bit hash of the script for P2WSH outputs.
-    #[inline]
     pub fn wscript_hash(&self) -> WScriptHash { WScriptHash::hash(self.as_bytes()) }
 
     /// Computes leaf hash of tapscript.
-    #[inline]
     pub fn tapscript_leaf_hash(&self) -> TapLeafHash {
         TapLeafHash::from_script(self, LeafVersion::TapScript)
     }
@@ -150,12 +147,10 @@ impl Script {
 
     /// Computes the P2WSH output corresponding to this witnessScript (aka the "witness redeem
     /// script").
-    #[inline]
     pub fn to_v0_p2wsh(&self) -> ScriptBuf { ScriptBuf::new_v0_p2wsh(&self.wscript_hash()) }
 
     /// Computes P2TR output with a given internal key and a single script spending path equal to
     /// the current script, assuming that the script is a Tapscript.
-    #[inline]
     pub fn to_v1_p2tr<C: Verification>(
         &self,
         secp: &Secp256k1<C>,
@@ -167,7 +162,6 @@ impl Script {
     }
 
     /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
-    #[inline]
     pub fn witness_version(&self) -> Option<WitnessVersion> {
         self.0.first().and_then(|opcode| WitnessVersion::try_from(opcodes::All::from(*opcode)).ok())
     }
@@ -196,7 +190,6 @@ impl Script {
     ///
     /// You can obtain the public key, if its valid,
     /// by calling [`p2pk_public_key()`](Self::p2pk_public_key)
-    #[inline]
     pub fn is_p2pk(&self) -> bool { self.p2pk_pubkey_bytes().is_some() }
 
     /// Returns the public key if this script is P2PK with a **valid** public key.
@@ -204,7 +197,6 @@ impl Script {
     /// This may return `None` even when [`is_p2pk()`](Self::is_p2pk) returns true.
     /// This happens when the public key is invalid (e.g. the point not being on the curve).
     /// It also implies the script is unspendable.
-    #[inline]
     pub fn p2pk_public_key(&self) -> Option<PublicKey> {
         PublicKey::from_slice(self.p2pk_pubkey_bytes()?).ok()
     }
@@ -221,7 +213,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
-    #[inline]
     pub fn is_witness_program(&self) -> bool {
         // A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
         // push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
@@ -241,7 +232,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2WSH output.
-    #[inline]
     pub fn is_v0_p2wsh(&self) -> bool {
         self.0.len() == 34
             && self.witness_version() == Some(WitnessVersion::V0)
@@ -249,7 +239,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2WPKH output.
-    #[inline]
     pub fn is_v0_p2wpkh(&self) -> bool {
         self.0.len() == 22
             && self.witness_version() == Some(WitnessVersion::V0)
@@ -265,7 +254,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2TR output.
-    #[inline]
     pub fn is_v1_p2tr(&self) -> bool {
         self.0.len() == 34
             && self.witness_version() == Some(WitnessVersion::V1)

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -25,9 +25,11 @@ impl Builder {
     pub fn new() -> Self { Builder(ScriptBuf::new(), None) }
 
     /// Returns the length in bytes of the script.
+    #[inline]
     pub fn len(&self) -> usize { self.0.len() }
 
     /// Checks whether the script is the empty script.
+    #[inline]
     pub fn is_empty(&self) -> bool { self.0.is_empty() }
 
     /// Adds instructions to push an integer onto the stack.
@@ -119,15 +121,19 @@ impl Builder {
     }
 
     /// Converts the `Builder` into `ScriptBuf`.
+    #[inline]
     pub fn into_script(self) -> ScriptBuf { self.0 }
 
     /// Converts the `Builder` into script bytes
+    #[inline]
     pub fn into_bytes(self) -> Vec<u8> { self.0.into() }
 
     /// Returns the internal script
+    #[inline]
     pub fn as_script(&self) -> &Script { &self.0 }
 
     /// Returns script bytes
+    #[inline]
     pub fn as_bytes(&self) -> &[u8] { self.0.as_bytes() }
 }
 

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -185,10 +185,10 @@ impl<'a> InstructionIndices<'a> {
     /// Views the remaining script as a slice.
     ///
     /// This is analogous to what [`core::str::Chars::as_str`] does.
-    #[inline]
     pub fn as_script(&self) -> &'a Script { self.instructions.as_script() }
 
     /// Creates `Self` setting `pos` to 0.
+    #[inline]
     pub(super) fn from_instructions(instructions: Instructions<'a>) -> Self {
         InstructionIndices { instructions, pos: 0 }
     }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -192,7 +192,6 @@ pub fn read_scriptbool(v: &[u8]) -> bool {
 ///
 /// Note that this does **not** return an error for `size` between `core::size_of::<usize>()`
 /// and `u16::max_value / 8` if there's no overflow.
-#[inline]
 #[deprecated(since = "0.30.0", note = "bitcoin integers are signed 32 bits, use read_scriptint")]
 pub fn read_uint(data: &[u8], size: usize) -> Result<usize, Error> {
     read_uint_iter(&mut data.iter(), size).map_err(Into::into)
@@ -296,10 +295,12 @@ impl<'a> From<&'a Script> for Rc<Script> {
 }
 
 impl From<Vec<u8>> for ScriptBuf {
+    #[inline]
     fn from(v: Vec<u8>) -> Self { ScriptBuf(v) }
 }
 
 impl From<ScriptBuf> for Vec<u8> {
+    #[inline]
     fn from(v: ScriptBuf) -> Self { v.0 }
 }
 
@@ -333,6 +334,7 @@ impl AsRef<Script> for Script {
 }
 
 impl AsRef<Script> for ScriptBuf {
+    #[inline]
     fn as_ref(&self) -> &Script { self }
 }
 
@@ -342,14 +344,17 @@ impl AsRef<[u8]> for Script {
 }
 
 impl AsRef<[u8]> for ScriptBuf {
+    #[inline]
     fn as_ref(&self) -> &[u8] { self.as_bytes() }
 }
 
 impl AsMut<Script> for Script {
+    #[inline]
     fn as_mut(&mut self) -> &mut Script { self }
 }
 
 impl AsMut<Script> for ScriptBuf {
+    #[inline]
     fn as_mut(&mut self) -> &mut Script { self }
 }
 
@@ -359,6 +364,7 @@ impl AsMut<[u8]> for Script {
 }
 
 impl AsMut<[u8]> for ScriptBuf {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
 }
 
@@ -375,12 +381,10 @@ impl fmt::Debug for ScriptBuf {
 }
 
 impl fmt::Display for Script {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.fmt_asm(f) }
 }
 
 impl fmt::Display for ScriptBuf {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self.as_script(), f) }
 }
 
@@ -391,7 +395,6 @@ impl fmt::LowerHex for Script {
 }
 
 impl fmt::LowerHex for ScriptBuf {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self.as_script(), f) }
 }
 
@@ -402,43 +405,50 @@ impl fmt::UpperHex for Script {
 }
 
 impl fmt::UpperHex for ScriptBuf {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(self.as_script(), f) }
 }
 
 impl Deref for ScriptBuf {
     type Target = Script;
 
+    #[inline]
     fn deref(&self) -> &Self::Target { Script::from_bytes(&self.0) }
 }
 
 impl DerefMut for ScriptBuf {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target { Script::from_bytes_mut(&mut self.0) }
 }
 
 impl Borrow<Script> for ScriptBuf {
+    #[inline]
     fn borrow(&self) -> &Script { self }
 }
 
 impl BorrowMut<Script> for ScriptBuf {
+    #[inline]
     fn borrow_mut(&mut self) -> &mut Script { self }
 }
 
 impl PartialEq<ScriptBuf> for Script {
+    #[inline]
     fn eq(&self, other: &ScriptBuf) -> bool { self.eq(other.as_script()) }
 }
 
 impl PartialEq<Script> for ScriptBuf {
+    #[inline]
     fn eq(&self, other: &Script) -> bool { self.as_script().eq(other) }
 }
 
 impl PartialOrd<Script> for ScriptBuf {
+    #[inline]
     fn partial_cmp(&self, other: &Script) -> Option<Ordering> {
         self.as_script().partial_cmp(other)
     }
 }
 
 impl PartialOrd<ScriptBuf> for Script {
+    #[inline]
     fn partial_cmp(&self, other: &ScriptBuf) -> Option<Ordering> {
         self.partial_cmp(other.as_script())
     }
@@ -566,21 +576,18 @@ impl<'de> serde::Deserialize<'de> for ScriptBuf {
 }
 
 impl Encodable for Script {
-    #[inline]
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         crate::consensus::encode::consensus_encode_with_size(&self.0, w)
     }
 }
 
 impl Encodable for ScriptBuf {
-    #[inline]
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         self.0.consensus_encode(w)
     }
 }
 
 impl Decodable for ScriptBuf {
-    #[inline]
     fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(
         r: &mut R,
     ) -> Result<Self, encode::Error> {
@@ -713,6 +720,7 @@ mod bitcoinconsensus_hack {
     // bitcoinconsensus::Error has no sources at this time
     impl std::error::Error for Error {}
 
+    #[inline]
     pub(crate) fn wrap_error(error: &bitcoinconsensus::Error) -> &Error {
         // Unfortunately, we cannot have the reference inside `Error` struct because of the 'static
         // bound on `source` return type, so we have to use unsafe to overcome the limitation.

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -173,7 +173,6 @@ pub fn read_scriptint(v: &[u8]) -> Result<i64, Error> {
 ///
 /// This is like "`read_scriptint` then map 0 to false and everything
 /// else as true", except that the overflow rules don't apply.
-#[inline]
 pub fn read_scriptbool(v: &[u8]) -> bool {
     match v.split_last() {
         Some((last, rest)) => !((last & !0x80 == 0x00) && rest.iter().all(|&b| b == 0)),

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -63,9 +63,11 @@ impl ScriptBuf {
     pub fn reserve_exact(&mut self, additional_len: usize) { self.0.reserve_exact(additional_len); }
 
     /// Returns a reference to unsized script.
+    #[inline]
     pub fn as_script(&self) -> &Script { Script::from_bytes(&self.0) }
 
     /// Returns a mutable reference to unsized script.
+    #[inline]
     pub fn as_mut_script(&mut self) -> &mut Script { Script::from_bytes_mut(&mut self.0) }
 
     /// Creates a new script builder
@@ -166,11 +168,13 @@ impl ScriptBuf {
     /// Converts byte vector into script.
     ///
     /// This method doesn't (re)allocate.
+    #[inline]
     pub fn from_bytes(bytes: Vec<u8>) -> Self { ScriptBuf(bytes) }
 
     /// Converts the script into a byte vector.
     ///
     /// This method doesn't (re)allocate.
+    #[inline]
     pub fn into_bytes(self) -> Vec<u8> { self.0 }
 
     /// Computes the P2SH output corresponding to this redeem script.

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -49,6 +49,7 @@ mod primitive {
         /// ## Safety
         ///
         /// The caller is responsible for checking that the length is less than the [`LIMIT`].
+        #[inline]
         unsafe fn from_slice_unchecked(bytes: &[u8]) -> &Self {
             &*(bytes as *const [u8] as *const PushBytes)
         }
@@ -58,20 +59,24 @@ mod primitive {
         /// ## Safety
         ///
         /// The caller is responsible for checking that the length is less than the [`LIMIT`].
+        #[inline]
         unsafe fn from_mut_slice_unchecked(bytes: &mut [u8]) -> &mut Self {
             &mut *(bytes as *mut [u8] as *mut PushBytes)
         }
 
         /// Creates an empty `PushBytes`.
+        #[inline]
         pub fn empty() -> &'static Self {
             // 0 < LIMIT
             unsafe { Self::from_slice_unchecked(&[]) }
         }
 
         /// Returns the underlying bytes.
+        #[inline]
         pub fn as_bytes(&self) -> &[u8] { &self.0 }
 
         /// Returns the underlying mutbale bytes.
+        #[inline]
         pub fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self.0 }
     }
 
@@ -232,6 +237,7 @@ mod primitive {
         }
 
         /// Remove the last byte from buffer if any.
+        #[inline]
         pub fn pop(&mut self) -> Option<u8> { self.0.pop() }
 
         /// Remove the byte at `index` and return it.
@@ -243,9 +249,11 @@ mod primitive {
         pub fn remove(&mut self, index: usize) -> u8 { self.0.remove(index) }
 
         /// Remove all bytes from buffer without affecting capacity.
+        #[inline]
         pub fn clear(&mut self) { self.0.clear() }
 
         /// Remove bytes from buffer past `len`.
+        #[inline]
         pub fn truncate(&mut self, len: usize) { self.0.truncate(len) }
 
         /// Extracts `PushBytes` slice
@@ -261,16 +269,19 @@ mod primitive {
         }
 
         /// Accesses inner `Vec` - provided for `super` to impl other methods.
+        #[inline]
         pub(super) fn inner(&self) -> &Vec<u8> { &self.0 }
     }
 
     impl From<PushBytesBuf> for Vec<u8> {
+        #[inline]
         fn from(value: PushBytesBuf) -> Self { value.0 }
     }
 
     impl TryFrom<Vec<u8>> for PushBytesBuf {
         type Error = PushBytesError;
 
+        #[inline]
         fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
             // check len
             let _: &PushBytes = vec.as_slice().try_into()?;
@@ -281,34 +292,42 @@ mod primitive {
     impl ToOwned for PushBytes {
         type Owned = PushBytesBuf;
 
+        #[inline]
         fn to_owned(&self) -> Self::Owned { PushBytesBuf(self.0.to_owned()) }
     }
 }
 
 impl PushBytes {
     /// Returns the number of bytes in buffer.
+    #[inline]
     pub fn len(&self) -> usize { self.as_bytes().len() }
 
     /// Returns true if the buffer contains zero bytes.
+    #[inline]
     pub fn is_empty(&self) -> bool { self.as_bytes().is_empty() }
 }
 
 impl PushBytesBuf {
     /// Returns the number of bytes in buffer.
+    #[inline]
     pub fn len(&self) -> usize { self.inner().len() }
 
     /// Returns the number of bytes the buffer can contain without reallocating.
+    #[inline]
     pub fn capacity(&self) -> usize { self.inner().capacity() }
 
     /// Returns true if the buffer contains zero bytes.
+    #[inline]
     pub fn is_empty(&self) -> bool { self.inner().is_empty() }
 }
 
 impl AsRef<[u8]> for PushBytes {
+    #[inline]
     fn as_ref(&self) -> &[u8] { self.as_bytes() }
 }
 
 impl AsMut<[u8]> for PushBytes {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
 }
 
@@ -323,10 +342,12 @@ impl DerefMut for PushBytesBuf {
 }
 
 impl AsRef<PushBytes> for PushBytes {
+    #[inline]
     fn as_ref(&self) -> &PushBytes { self }
 }
 
 impl AsMut<PushBytes> for PushBytes {
+    #[inline]
     fn as_mut(&mut self) -> &mut PushBytes { self }
 }
 


### PR DESCRIPTION
Audit the `script` module and improve inlining. While doing this I made an effort to understand and think a bit harder about inlining, I used godbolt.org to compile snippets.

This is non-urgent work, review will require some thought. I no doubt have more to learn yet. If I can please ask for the assistance of reviewers in improving my understanding here then doing the rest of the codebase should require much less review time.

Thanks