### PR TITLE
Patch the bitcoin_hashes dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["bitcoin", "hashes", "internals"]
 
-[patch.crates-io.bitcoin_hashes]
-path = "hashes"
+[patch.crates-io]
+# Arbitrary commit during dev of v0.12.0 (and rust-bitcoin v0.30.0)
+bitcoin_hashes = { git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "f90338021bda8be8c648cdd0e9276ccad54eef9a" }


### PR DESCRIPTION
Currently we have a hole in our dependency graph that is making it impossible to patch `bitcoin_hashes` with breaking changes.

  bitcoin -> secp -> hashes
  bitcoin -> hashes

We tried to fix this by using a `path` dependency for `hashes` but this does not work.

Use a git/rev dependency for `hashes` that makes `bitcoin` depend on a recent commit on the master branch.

With this applied we will be able to make breaking changes to `hashes` and still build `bitcoin`.