### PR TITLE
Update `secp256k1` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["bitcoin", "hashes", "internals"]
 
-[patch.crates-io.bitcoin_hashes]
-path = "hashes"
+[patch.crates-io]
+# Arbitrary commit during dev of v0.12.0 (and rust-bitcoin v0.30.0)
+bitcoin_hashes = { git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "f90338021bda8be8c648cdd0e9276ccad54eef9a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = ["bitcoin", "hashes", "internals"]
 [patch.crates-io]
 # Arbitrary commit during dev of v0.12.0 (and rust-bitcoin v0.30.0)
 bitcoin_hashes = { git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "f90338021bda8be8c648cdd0e9276ccad54eef9a" }
+secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", rev = "" }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitcoin-internals = { path = "../internals" }
 bech32 = { version = "0.9.0", default-features = false }
 bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { version = "0.25.0", default-features = false, features = ["bitcoin_hashes"] }
+secp256k1 = { version = "0.26.0", default-features = false, features = ["bitcoin_hashes"] }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 
 base64 = { version = "0.13.0", optional = true }
@@ -51,7 +51,7 @@ actual-serde = { package = "serde", version = "1.0.103", default-features = fals
 serde_json = "1.0.0"
 serde_test = "1.0.19"
 serde_derive = "1.0.103"
-secp256k1 = { version = "0.25.0", features = ["recovery"] }
+secp256k1 = { version = "0.26.0", features = ["recovery"] }
 bincode = "1.3.1"
 
 [target.'cfg(mutate)'.dev-dependencies]


### PR DESCRIPTION
Draft because builds on https://github.com/rust-bitcoin/rust-bitcoin/pull/1598 and requires https://github.com/rust-bitcoin/rust-secp256k1/pull/575 to merge first.

From the final patch (the only one that is part of this PR)

    We just merged into `secp256k1` a change to make secp depend on a
    git/ref version of `hashes`. This was aimed at resolving the dependency
    hole issue we currently have, we can now use the new version of secp.
    This completes the dependency hole fix.

    FTR with this merged the merge workflow for making breaking changes to
    `hashes` can be:

    1. Patch `hashes`
    2. Wait for merge of 1, then patch secp (incl. update of git/rev dep)
    3. Wait for merge of 2, then patch bitcoin (incl. update of git/rev dep)

    One dev workflow can be:
    0. Patch hashes and secp dependencies to use path
    1. Make the changes everywhere
    2. Make three separate commits that will make up the steps 1-3 above

Note, we need to fill the `rev` in this PR from the revision made by merging https://github.com/rust-bitcoin/rust-secp256k1/pull/575