### PR TITLE
Add '_ back into the BitStreamWriter

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -421,7 +421,7 @@ impl GcsFilter {
     /// Golomb-Rice encodes a number `n` to a bit stream (parameter 2^k).
     fn golomb_rice_encode<W>(
         &self,
-        writer: &mut BitStreamWriter<W>,
+        writer: &mut BitStreamWriter<'_, W>,
         n: u64,
     ) -> Result<usize, io::Error>
     where


### PR DESCRIPTION
Recently we merged `commit 53d4fe66b57c255086def2b5e47afaddee776b75` to fix CI even though a better approach is to use `'_` because it assists reading the code (shows that the bit stream writer is not writing from a reference since its writing a `Copy` type `n`).

Add back in the `'_` (I forget what its called).