### PR TITLE
Remove the rustfmt required_version config option

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -76,7 +76,6 @@ use_field_init_shorthand = false
 force_explicit_abi = true
 condense_wildcard_suffixes = false
 color = "Auto"
-required_version = "1.5.1"
 unstable_features = false
 disable_all_formatting = false
 skip_children = false


### PR DESCRIPTION
The `rustfmt` config option `required_version` causes grief in CI because everytime `rustfmt` is update our `nightly` job fails. Since we require nightly anyways to run `rustfmt` the config option is basically redundant.

