### PR TITLE
Make max/min_value functions const

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -521,10 +521,10 @@ impl Amount {
     pub fn to_sat(self) -> u64 { self.0 }
 
     /// The maximum value of an [Amount].
-    pub fn max_value() -> Amount { Amount(u64::max_value()) }
+    pub const fn max_value() -> Amount { Amount(u64::max_value()) }
 
     /// The minimum value of an [Amount].
-    pub fn min_value() -> Amount { Amount(u64::min_value()) }
+    pub const fn min_value() -> Amount { Amount(u64::min_value()) }
 
     /// Convert from a value expressing bitcoins to an [Amount].
     pub fn from_btc(btc: f64) -> Result<Amount, ParseAmountError> {
@@ -856,10 +856,10 @@ impl SignedAmount {
     pub fn to_sat(self) -> i64 { self.0 }
 
     /// The maximum value of an [SignedAmount].
-    pub fn max_value() -> SignedAmount { SignedAmount(i64::max_value()) }
+    pub const fn max_value() -> SignedAmount { SignedAmount(i64::max_value()) }
 
     /// The minimum value of an [SignedAmount].
-    pub fn min_value() -> SignedAmount { SignedAmount(i64::min_value()) }
+    pub const fn min_value() -> SignedAmount { SignedAmount(i64::min_value()) }
 
     /// Convert from a value expressing bitcoins to an [SignedAmount].
     pub fn from_btc(btc: f64) -> Result<SignedAmount, ParseAmountError> {

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -405,12 +405,12 @@ impl Height {
     /// The minimum absolute block height (0), the genesis block.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MIN`].
-    pub fn min_value() -> Self { Self::MIN }
+    pub const fn min_value() -> Self { Self::MIN }
 
     /// The maximum absolute block height.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MAX`].
-    pub fn max_value() -> Self { Self::MAX }
+    pub const fn max_value() -> Self { Self::MAX }
 
     /// Constructs a new block height.
     ///
@@ -518,12 +518,12 @@ impl Time {
     /// The minimum absolute block time.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MIN`].
-    pub fn min_value() -> Self { Self::MIN }
+    pub const fn min_value() -> Self { Self::MIN }
 
     /// The maximum absolute block time.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MAX`].
-    pub fn max_value() -> Self { Self::MAX }
+    pub const fn max_value() -> Self { Self::MAX }
 
     /// Constructs a new block time.
     ///

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -215,12 +215,12 @@ impl Height {
     /// The minimum relative block height (0), can be included in any block.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MIN`].
-    pub fn min_value() -> Self { Self::MIN }
+    pub const fn min_value() -> Self { Self::MIN }
 
     /// The maximum relative block height.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MAX`].
-    pub fn max_value() -> Self { Self::MAX }
+    pub const fn max_value() -> Self { Self::MAX }
 
     /// Returns the inner `u16` value.
     #[inline]
@@ -263,12 +263,12 @@ impl Time {
     /// The minimum relative block time.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MIN`].
-    pub fn min_value() -> Self { Self::MIN }
+    pub const fn min_value() -> Self { Self::MIN }
 
     /// The maximum relative block time.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MAX`].
-    pub fn max_value() -> Self { Self::MAX }
+    pub const fn max_value() -> Self { Self::MAX }
 
     /// Create a [`Time`] using time intervals where each interval is equivalent to 512 seconds.
     ///

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -321,7 +321,7 @@ impl Sequence {
     /// The maximum allowable sequence number.
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Sequence::MAX`].
-    pub fn max_value() -> Self { Self::MAX }
+    pub const fn max_value() -> Self { Self::MAX }
 
     /// Returns `true` if the sequence number enables absolute lock-time ([`Transaction::lock_time`]).
     #[inline]

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -171,7 +171,7 @@ impl Target {
     /// The maximum possible target (see [`Target::MAX`]).
     ///
     /// This is provided for consistency with Rust 1.41.1, newer code should use [`Target::MAX`].
-    pub fn max_value() -> Self { Target::MAX }
+    pub const fn max_value() -> Self { Target::MAX }
 
     /// Computes the [`Target`] value from a compact representation.
     ///


### PR DESCRIPTION
The `max_value` and `min_value` functions only exist to be compatible/uniform with Rust 1.41.1 they will never change and they just return a constant value. They can therefore be made const functions.