### PR TITLE
`psbt` cleanup

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -647,8 +647,6 @@ pub enum SigningAlgorithm {
 /// Errors encountered while calculating the sighash message.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum SignError {
-    /// An ECDSA key-related error occurred.
-    EcdsaSig(ecdsa::Error),
     /// Input index out of bounds (actual index, maximum index allowed).
     IndexOutOfBounds(usize, usize),
     /// Invalid Sighash type.
@@ -696,7 +694,6 @@ impl fmt::Display for SignError {
             NotEcdsa => write!(f, "attempted to ECDSA sign an non-ECDSA input"),
             NotWpkh => write!(f, "the scriptPubkey is not a P2WPKH script"),
             SighashComputation(e) => write!(f, "sighash: {}", e),
-            EcdsaSig(ref e) => write_err!(f, "ecdsa signature"; e),
             UnknownOutputType => write!(f, "unable to determine the output type"),
             KeyNotFound => write!(f, "unable to find key"),
             WrongSigningAlgorithm => write!(f, "attempt to sign an input with the wrong signing algorithm"),
@@ -725,7 +722,6 @@ impl std::error::Error for SignError {
                 | KeyNotFound
                 | WrongSigningAlgorithm
                 | Unsupported => None,
-            EcdsaSig(ref e) => Some(e),
             SighashComputation(ref e) => Some(e),
         }
     }
@@ -734,12 +730,6 @@ impl std::error::Error for SignError {
 impl From<sighash::Error> for SignError {
     fn from(e: sighash::Error) -> Self {
         SignError::SighashComputation(e)
-    }
-}
-
-impl From<ecdsa::Error> for SignError {
-    fn from(e: ecdsa::Error) -> Self {
-        SignError::EcdsaSig(e)
     }
 }
 


### PR DESCRIPTION
Remove an unused error variant for PSBT code (API breaking because the error type is public).

Woops, somehow I managed to get what was patch 1 of this series merged yesterday, I thought I left it out. Anyways, this is just the remove unused error variant now. No changes to that patch from previous versions of the PR.