### PR TITLE
WIP: Split `ecdsa` types up

### DIFF
--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -14,7 +14,7 @@ use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::io::{self, Read, Write};
 use crate::prelude::*;
-use crate::sighash::EcdsaSighashType;
+use crate::sighash::SegwitV0SighashType;
 use crate::taproot::TAPROOT_ANNEX_PREFIX;
 use crate::{Script, VarInt};
 
@@ -255,7 +255,7 @@ impl Witness {
     pub fn push_bitcoin_signature(
         &mut self,
         signature: &ecdsa::SerializedSignature,
-        hash_type: EcdsaSighashType,
+        hash_type: SegwitV0SighashType,
     ) {
         // Note that a maximal length ECDSA signature is 72 bytes, plus the sighash type makes 73
         let mut sig = [0; 73];
@@ -551,7 +551,7 @@ mod test {
             hex!("304402207c800d698f4b0298c5aac830b822f011bb02df41eb114ade9a6702f364d5e39c0220366900d2a60cab903e77ef7dd415d46509b1f78ac78906e3296f495aa1b1b541");
         let sig = ecdsa::Signature::from_der(&sig_bytes).unwrap();
         let mut witness = Witness::default();
-        witness.push_bitcoin_signature(&sig.serialize_der(), EcdsaSighashType::All);
+        witness.push_bitcoin_signature(&sig.serialize_der(), SegwitV0SighashType::All);
         let expected_witness = vec![hex!(
             "304402207c800d698f4b0298c5aac830b822f011bb02df41eb114ade9a6702f364d5e39c0220366900d2a60cab903e77ef7dd415d46509b1f78ac78906e3296f495aa1b1b54101")
             ];

--- a/bitcoin/src/crypto/legacy.rs
+++ b/bitcoin/src/crypto/legacy.rs
@@ -1,0 +1,240 @@
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
+
+//! Legacy ECDSA Bitcoin signatures.
+//!
+//! This module provides ECDSA signatures, as used by legacy Bitcoin transactions, that can be
+//! roundtrip (de)serialized.
+
+use core::str::FromStr;
+use core::{fmt, iter};
+
+use bitcoin_internals::hex::display::DisplayHex;
+use bitcoin_internals::write_err;
+use hashes::hex::{self, FromHex};
+use secp256k1;
+
+use crate::prelude::*;
+use crate::script::PushBytes;
+use crate::sighash::{LegacySighashType, NonStandardSighashType};
+
+const MAX_SIG_LEN: usize = 73;
+
+/// An ECDSA signature with the corresponding hash type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Signature {
+    /// The underlying ECDSA Signature
+    pub sig: secp256k1::ecdsa::Signature,
+    /// The corresponding hash type
+    pub hash_ty: LegacySighashType,
+}
+
+#[allow(dead_code)] // While we have the ecdsa module still.
+impl Signature {
+    /// Constructs an ECDSA bitcoin signature for [`LegacySighashType::All`].
+    pub fn sighash_all(sig: secp256k1::ecdsa::Signature) -> Signature {
+        Signature { sig, hash_ty: LegacySighashType::All }
+    }
+
+    /// Deserializes from slice following the standardness rules for [`LegacySighashType`].
+    pub fn from_slice(sl: &[u8]) -> Result<Self, Error> {
+        let (hash_ty, sig) = sl.split_last().ok_or(Error::EmptySignature)?;
+        let hash_ty = LegacySighashType::from_standard(*hash_ty as u32)
+            .map_err(|_| Error::NonStandardSighashType(*hash_ty as u32))?;
+        let sig = secp256k1::ecdsa::Signature::from_der(sig).map_err(Error::Secp256k1)?;
+        Ok(Signature { sig, hash_ty })
+    }
+
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format).
+    ///
+    /// This does **not** perform extra heap allocation.
+    pub fn serialize(&self) -> SerializedSignature {
+        let mut buf = [0u8; MAX_SIG_LEN];
+        let signature = self.sig.serialize_der();
+        buf[..signature.len()].copy_from_slice(&signature);
+        buf[signature.len()] = self.hash_ty as u8;
+        SerializedSignature { data: buf, len: signature.len() + 1 }
+    }
+
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) into `Vec`.
+    ///
+    /// Note: this performs an extra heap allocation, you might prefer the
+    /// [`serialize`](Self::serialize) method instead.
+    pub fn to_vec(self) -> Vec<u8> {
+        // TODO: add support to serialize to a writer to SerializedSig
+        self.sig.serialize_der().iter().copied().chain(iter::once(self.hash_ty as u8)).collect()
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.sig.serialize_der().as_hex(), f)?;
+        fmt::LowerHex::fmt(&[self.hash_ty as u8].as_hex(), f)
+    }
+}
+
+impl FromStr for Signature {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = Vec::from_hex(s)?;
+        let (sighash_byte, signature) = bytes.split_last().ok_or(Error::EmptySignature)?;
+        Ok(Signature {
+            sig: secp256k1::ecdsa::Signature::from_der(signature)?,
+            hash_ty: LegacySighashType::from_standard(*sighash_byte as u32)?,
+        })
+    }
+}
+
+/// Holds signature serialized in-line (not in `Vec`).
+///
+/// This avoids allocation and allows proving maximum size of the signature (73 bytes).
+/// The type can be used largely as a byte slice. It implements all standard traits one would
+/// expect and has familiar methods.
+/// However, the usual use case is to push it into a script. This can be done directly passing it
+/// into [`push_slice`](crate::script::ScriptBuf::push_slice).
+#[derive(Copy, Clone)]
+pub struct SerializedSignature {
+    data: [u8; MAX_SIG_LEN],
+    len: usize,
+}
+
+impl SerializedSignature {
+    /// Returns an iterator over bytes of the signature.
+    #[inline]
+    pub fn iter(&self) -> core::slice::Iter<'_, u8> { self.into_iter() }
+}
+
+impl core::ops::Deref for SerializedSignature {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target { &self.data[..self.len] }
+}
+
+impl core::ops::DerefMut for SerializedSignature {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.data[..self.len] }
+}
+
+impl AsRef<[u8]> for SerializedSignature {
+    #[inline]
+    fn as_ref(&self) -> &[u8] { self }
+}
+
+impl AsMut<[u8]> for SerializedSignature {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] { self }
+}
+
+impl AsRef<PushBytes> for SerializedSignature {
+    #[inline]
+    fn as_ref(&self) -> &PushBytes { &<&PushBytes>::from(&self.data)[..self.len()] }
+}
+
+impl core::borrow::Borrow<[u8]> for SerializedSignature {
+    #[inline]
+    fn borrow(&self) -> &[u8] { self }
+}
+
+impl core::borrow::BorrowMut<[u8]> for SerializedSignature {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [u8] { self }
+}
+
+impl fmt::Debug for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self, f) }
+}
+
+impl fmt::Display for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
+}
+
+impl fmt::LowerHex for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&(**self).as_hex(), f)
+    }
+}
+
+impl fmt::UpperHex for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&(**self).as_hex(), f)
+    }
+}
+
+impl PartialEq for SerializedSignature {
+    #[inline]
+    fn eq(&self, other: &SerializedSignature) -> bool { **self == **other }
+}
+
+impl Eq for SerializedSignature {}
+
+impl core::hash::Hash for SerializedSignature {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) { core::hash::Hash::hash(&**self, state) }
+}
+
+impl<'a> IntoIterator for &'a SerializedSignature {
+    type IntoIter = core::slice::Iter<'a, u8>;
+    type Item = &'a u8;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { (*self).iter() }
+}
+
+/// A key-related error.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Hex encoding error
+    HexEncoding(hex::Error),
+    /// Base58 encoding error
+    NonStandardSighashType(u32),
+    /// Empty Signature
+    EmptySignature,
+    /// secp256k1-related error
+    Secp256k1(secp256k1::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HexEncoding(ref e) => write_err!(f, "Signature hex encoding error"; e),
+            Error::NonStandardSighashType(hash_ty) =>
+                write!(f, "Non standard signature hash type {}", hash_ty),
+            Error::EmptySignature => write!(f, "Empty ECDSA signature"),
+            Error::Secp256k1(ref e) => write_err!(f, "invalid ECDSA signature"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match self {
+            HexEncoding(e) => Some(e),
+            Secp256k1(e) => Some(e),
+            NonStandardSighashType(_) | EmptySignature => None,
+        }
+    }
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
+}
+
+impl From<NonStandardSighashType> for Error {
+    fn from(err: NonStandardSighashType) -> Self { Error::NonStandardSighashType(err.0) }
+}
+
+impl From<hex::Error> for Error {
+    fn from(err: hex::Error) -> Self { Error::HexEncoding(err) }
+}

--- a/bitcoin/src/crypto/mod.rs
+++ b/bitcoin/src/crypto/mod.rs
@@ -6,8 +6,10 @@
 //! Cryptography related functionality: keys and signatures.
 //!
 
-pub mod ecdsa;
+pub mod ecdsa; // Should only be used by the PSBT code.
 pub mod key;
+pub mod legacy;
+pub mod segwit_v0;
 pub mod sighash;
 // Contents re-exported in `bitcoin::taproot`.
 pub(crate) mod taproot;

--- a/bitcoin/src/crypto/segwit_v0.rs
+++ b/bitcoin/src/crypto/segwit_v0.rs
@@ -1,0 +1,240 @@
+// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
+
+//! ECDSA Bitcoin signatures.
+//!
+//! This module provides ECDSA signatures, as used by segwit V0 Bitcoin transactions, that can be
+//! roundtrip (de)serialized.
+
+use core::str::FromStr;
+use core::{fmt, iter};
+
+use bitcoin_internals::hex::display::DisplayHex;
+use bitcoin_internals::write_err;
+use hashes::hex::{self, FromHex};
+use secp256k1;
+
+use crate::prelude::*;
+use crate::script::PushBytes;
+use crate::sighash::{NonStandardSighashType, SegwitV0SighashType};
+
+const MAX_SIG_LEN: usize = 73;
+
+/// An ECDSA signature with the corresponding hash type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Signature {
+    /// The underlying ECDSA Signature
+    pub sig: secp256k1::ecdsa::Signature,
+    /// The corresponding hash type
+    pub hash_ty: SegwitV0SighashType,
+}
+
+#[allow(dead_code)] // While we have the ecdsa module still.
+impl Signature {
+    /// Constructs an ECDSA bitcoin signature for [`SegwitV0SighashType::All`].
+    pub fn sighash_all(sig: secp256k1::ecdsa::Signature) -> Signature {
+        Signature { sig, hash_ty: SegwitV0SighashType::All }
+    }
+
+    /// Deserializes from slice following the standardness rules for [`SegwitV0SighashType`].
+    pub fn from_slice(sl: &[u8]) -> Result<Self, Error> {
+        let (hash_ty, sig) = sl.split_last().ok_or(Error::EmptySignature)?;
+        let hash_ty = SegwitV0SighashType::from_standard(*hash_ty as u32)
+            .map_err(|_| Error::NonStandardSighashType(*hash_ty as u32))?;
+        let sig = secp256k1::ecdsa::Signature::from_der(sig).map_err(Error::Secp256k1)?;
+        Ok(Signature { sig, hash_ty })
+    }
+
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format).
+    ///
+    /// This does **not** perform extra heap allocation.
+    pub fn serialize(&self) -> SerializedSignature {
+        let mut buf = [0u8; MAX_SIG_LEN];
+        let signature = self.sig.serialize_der();
+        buf[..signature.len()].copy_from_slice(&signature);
+        buf[signature.len()] = self.hash_ty as u8;
+        SerializedSignature { data: buf, len: signature.len() + 1 }
+    }
+
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) into `Vec`.
+    ///
+    /// Note: this performs an extra heap allocation, you might prefer the
+    /// [`serialize`](Self::serialize) method instead.
+    pub fn to_vec(self) -> Vec<u8> {
+        // TODO: add support to serialize to a writer to SerializedSig
+        self.sig.serialize_der().iter().copied().chain(iter::once(self.hash_ty as u8)).collect()
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.sig.serialize_der().as_hex(), f)?;
+        fmt::LowerHex::fmt(&[self.hash_ty as u8].as_hex(), f)
+    }
+}
+
+impl FromStr for Signature {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = Vec::from_hex(s)?;
+        let (sighash_byte, signature) = bytes.split_last().ok_or(Error::EmptySignature)?;
+        Ok(Signature {
+            sig: secp256k1::ecdsa::Signature::from_der(signature)?,
+            hash_ty: SegwitV0SighashType::from_standard(*sighash_byte as u32)?,
+        })
+    }
+}
+
+/// Holds signature serialized in-line (not in `Vec`).
+///
+/// This avoids allocation and allows proving maximum size of the signature (73 bytes).
+/// The type can be used largely as a byte slice. It implements all standard traits one would
+/// expect and has familiar methods.
+/// However, the usual use case is to push it into a script. This can be done directly passing it
+/// into [`push_slice`](crate::script::ScriptBuf::push_slice).
+#[derive(Copy, Clone)]
+pub struct SerializedSignature {
+    data: [u8; MAX_SIG_LEN],
+    len: usize,
+}
+
+impl SerializedSignature {
+    /// Returns an iterator over bytes of the signature.
+    #[inline]
+    pub fn iter(&self) -> core::slice::Iter<'_, u8> { self.into_iter() }
+}
+
+impl core::ops::Deref for SerializedSignature {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target { &self.data[..self.len] }
+}
+
+impl core::ops::DerefMut for SerializedSignature {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.data[..self.len] }
+}
+
+impl AsRef<[u8]> for SerializedSignature {
+    #[inline]
+    fn as_ref(&self) -> &[u8] { self }
+}
+
+impl AsMut<[u8]> for SerializedSignature {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] { self }
+}
+
+impl AsRef<PushBytes> for SerializedSignature {
+    #[inline]
+    fn as_ref(&self) -> &PushBytes { &<&PushBytes>::from(&self.data)[..self.len()] }
+}
+
+impl core::borrow::Borrow<[u8]> for SerializedSignature {
+    #[inline]
+    fn borrow(&self) -> &[u8] { self }
+}
+
+impl core::borrow::BorrowMut<[u8]> for SerializedSignature {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [u8] { self }
+}
+
+impl fmt::Debug for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self, f) }
+}
+
+impl fmt::Display for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
+}
+
+impl fmt::LowerHex for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&(**self).as_hex(), f)
+    }
+}
+
+impl fmt::UpperHex for SerializedSignature {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&(**self).as_hex(), f)
+    }
+}
+
+impl PartialEq for SerializedSignature {
+    #[inline]
+    fn eq(&self, other: &SerializedSignature) -> bool { **self == **other }
+}
+
+impl Eq for SerializedSignature {}
+
+impl core::hash::Hash for SerializedSignature {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) { core::hash::Hash::hash(&**self, state) }
+}
+
+impl<'a> IntoIterator for &'a SerializedSignature {
+    type IntoIter = core::slice::Iter<'a, u8>;
+    type Item = &'a u8;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { (*self).iter() }
+}
+
+/// A key-related error.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Hex encoding error
+    HexEncoding(hex::Error),
+    /// Base58 encoding error
+    NonStandardSighashType(u32),
+    /// Empty Signature
+    EmptySignature,
+    /// secp256k1-related error
+    Secp256k1(secp256k1::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HexEncoding(ref e) => write_err!(f, "Signature hex encoding error"; e),
+            Error::NonStandardSighashType(hash_ty) =>
+                write!(f, "Non standard signature hash type {}", hash_ty),
+            Error::EmptySignature => write!(f, "Empty ECDSA signature"),
+            Error::Secp256k1(ref e) => write_err!(f, "invalid ECDSA signature"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match self {
+            HexEncoding(e) => Some(e),
+            Secp256k1(e) => Some(e),
+            NonStandardSighashType(_) | EmptySignature => None,
+        }
+    }
+}
+
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
+}
+
+impl From<NonStandardSighashType> for Error {
+    fn from(err: NonStandardSighashType) -> Self { Error::NonStandardSighashType(err.0) }
+}
+
+impl From<hex::Error> for Error {
+    fn from(err: hex::Error) -> Self { Error::HexEncoding(err) }
+}

--- a/bitcoin/src/crypto/sighash/ecdsa.rs
+++ b/bitcoin/src/crypto/sighash/ecdsa.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Sighash type for ECDSA (legacy and segwit v0) signatures.
+
+use core::{fmt, str};
+
+use super::{NonStandardSighashType, SighashTypeParseError};
+use crate::prelude::*;
+
+/// Hashtype of an input's signature, encoded in the last byte of the signature.
+///
+/// Fixed values so they can be cast as integer types for encoding (see also
+/// [`TapSighashType`]).
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
+pub enum EcdsaSighashType {
+    /// 0x1: Sign all outputs.
+    All = 0x01,
+    /// 0x2: Sign no outputs --- anyone can choose the destination.
+    None = 0x02,
+    /// 0x3: Sign the output whose index matches this input's index. If none exists,
+    /// sign the hash `0000000000000000000000000000000000000000000000000000000000000001`.
+    /// (This rule is probably an unintentional C++ism, but it's consensus so we have
+    /// to follow it.)
+    Single = 0x03,
+    /// 0x81: Sign all outputs but only this input.
+    AllPlusAnyoneCanPay = 0x81,
+    /// 0x82: Sign no outputs and only this input.
+    NonePlusAnyoneCanPay = 0x82,
+    /// 0x83: Sign one output and only this input (see `Single` for what "one output" means).
+    SinglePlusAnyoneCanPay = 0x83,
+}
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_impl!(EcdsaSighashType, "a EcdsaSighashType data");
+
+impl EcdsaSighashType {
+    /// Splits the sighash flag into the "real" sighash flag and the ANYONECANPAY boolean.
+    pub(crate) fn split_anyonecanpay_flag(self) -> (EcdsaSighashType, bool) {
+        use EcdsaSighashType::*;
+
+        match self {
+            All => (All, false),
+            None => (None, false),
+            Single => (Single, false),
+            AllPlusAnyoneCanPay => (All, true),
+            NonePlusAnyoneCanPay => (None, true),
+            SinglePlusAnyoneCanPay => (Single, true),
+        }
+    }
+
+    /// Creates a [`EcdsaSighashType`] from a raw `u32`.
+    ///
+    /// **Note**: this replicates consensus behaviour, for current standardness rules correctness
+    /// you probably want [`Self::from_standard`].
+    ///
+    /// This might cause unexpected behavior because it does not roundtrip. That is,
+    /// `EcdsaSighashType::from_consensus(n) as u32 != n` for non-standard values of `n`. While
+    /// verifying signatures, the user should retain the `n` and use it compute the signature hash
+    /// message.
+    pub fn from_consensus(n: u32) -> EcdsaSighashType {
+        use EcdsaSighashType::*;
+
+        // In Bitcoin Core, the SignatureHash function will mask the (int32) value with
+        // 0x1f to (apparently) deactivate ACP when checking for SINGLE and NONE bits.
+        // We however want to be matching also against on ACP-masked ALL, SINGLE, and NONE.
+        // So here we re-activate ACP.
+        let mask = 0x1f | 0x80;
+        match n & mask {
+            // "real" sighashes
+            0x01 => All,
+            0x02 => None,
+            0x03 => Single,
+            0x81 => AllPlusAnyoneCanPay,
+            0x82 => NonePlusAnyoneCanPay,
+            0x83 => SinglePlusAnyoneCanPay,
+            // catchalls
+            x if x & 0x80 == 0x80 => AllPlusAnyoneCanPay,
+            _ => All,
+        }
+    }
+
+    /// Creates a [`EcdsaSighashType`] from a raw `u32`.
+    ///
+    /// # Errors
+    ///
+    /// If `n` is a non-standard sighash value.
+    pub fn from_standard(n: u32) -> Result<EcdsaSighashType, NonStandardSighashType> {
+        use EcdsaSighashType::*;
+
+        match n {
+            // Standard sighashes, see https://github.com/bitcoin/bitcoin/blob/b805dbb0b9c90dadef0424e5b3bf86ac308e103e/src/script/interpreter.cpp#L189-L198
+            0x01 => Ok(All),
+            0x02 => Ok(None),
+            0x03 => Ok(Single),
+            0x81 => Ok(AllPlusAnyoneCanPay),
+            0x82 => Ok(NonePlusAnyoneCanPay),
+            0x83 => Ok(SinglePlusAnyoneCanPay),
+            non_standard => Err(NonStandardSighashType(non_standard)),
+        }
+    }
+
+    /// Converts [`EcdsaSighashType`] to a `u32` sighash flag.
+    ///
+    /// The returned value is guaranteed to be a valid according to standardness rules.
+    pub fn to_u32(self) -> u32 { self as u32 }
+}
+
+impl fmt::Display for EcdsaSighashType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use EcdsaSighashType::*;
+
+        let s = match self {
+            All => "SIGHASH_ALL",
+            None => "SIGHASH_NONE",
+            Single => "SIGHASH_SINGLE",
+            AllPlusAnyoneCanPay => "SIGHASH_ALL|SIGHASH_ANYONECANPAY",
+            NonePlusAnyoneCanPay => "SIGHASH_NONE|SIGHASH_ANYONECANPAY",
+            SinglePlusAnyoneCanPay => "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY",
+        };
+        f.write_str(s)
+    }
+}
+
+impl str::FromStr for EcdsaSighashType {
+    type Err = SighashTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use EcdsaSighashType::*;
+
+        match s {
+            "SIGHASH_ALL" => Ok(All),
+            "SIGHASH_NONE" => Ok(None),
+            "SIGHASH_SINGLE" => Ok(Single),
+            "SIGHASH_ALL|SIGHASH_ANYONECANPAY" => Ok(AllPlusAnyoneCanPay),
+            "SIGHASH_NONE|SIGHASH_ANYONECANPAY" => Ok(NonePlusAnyoneCanPay),
+            "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY" => Ok(SinglePlusAnyoneCanPay),
+            _ => Err(SighashTypeParseError { unrecognized: s.to_owned() }),
+        }
+    }
+}

--- a/bitcoin/src/crypto/sighash/legacy.rs
+++ b/bitcoin/src/crypto/sighash/legacy.rs
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Sighash type for ECDSA (legacy and segwit v0) signatures.
+//! Sighash type for legacy (ECDSA) signatures.
 
 use core::{fmt, str};
 
 use super::{NonStandardSighashType, SighashTypeParseError};
-use crate::prelude::*;
 
 /// Hashtype of an input's signature, encoded in the last byte of the signature.
 ///
 /// Fixed values so they can be cast as integer types for encoding (see also
 /// [`TapSighashType`]).
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
-pub enum EcdsaSighashType {
+pub enum LegacySighashType {
     /// 0x1: Sign all outputs.
     All = 0x01,
     /// 0x2: Sign no outputs --- anyone can choose the destination.
@@ -30,20 +29,34 @@ pub enum EcdsaSighashType {
     SinglePlusAnyoneCanPay = 0x83,
 }
 #[cfg(feature = "serde")]
-crate::serde_utils::serde_string_impl!(EcdsaSighashType, "a EcdsaSighashType data");
+crate::serde_utils::serde_string_impl!(LegacySighashType, "a LegacySighashType data");
 
-impl EcdsaSighashType {
-    /// Creates a [`EcdsaSighashType`] from a raw `u32`.
+impl LegacySighashType {
+    /// Splits the sighash flag into the "real" sighash flag and the ANYONECANPAY boolean.
+    pub(crate) fn split_anyonecanpay_flag(self) -> (LegacySighashType, bool) {
+        use LegacySighashType::*;
+
+        match self {
+            All => (All, false),
+            None => (None, false),
+            Single => (Single, false),
+            AllPlusAnyoneCanPay => (All, true),
+            NonePlusAnyoneCanPay => (None, true),
+            SinglePlusAnyoneCanPay => (Single, true),
+        }
+    }
+
+    /// Creates a [`LegacySighashType`] from a raw `u32`.
     ///
     /// **Note**: this replicates consensus behaviour, for current standardness rules correctness
     /// you probably want [`Self::from_standard`].
     ///
     /// This might cause unexpected behavior because it does not roundtrip. That is,
-    /// `EcdsaSighashType::from_consensus(n) as u32 != n` for non-standard values of `n`. While
+    /// `LegacySighashType::from_consensus(n) as u32 != n` for non-standard values of `n`. While
     /// verifying signatures, the user should retain the `n` and use it compute the signature hash
     /// message.
-    pub fn from_consensus(n: u32) -> EcdsaSighashType {
-        use EcdsaSighashType::*;
+    pub fn from_consensus(n: u32) -> LegacySighashType {
+        use LegacySighashType::*;
 
         // In Bitcoin Core, the SignatureHash function will mask the (int32) value with
         // 0x1f to (apparently) deactivate ACP when checking for SINGLE and NONE bits.
@@ -64,13 +77,13 @@ impl EcdsaSighashType {
         }
     }
 
-    /// Creates a [`EcdsaSighashType`] from a raw `u32`.
+    /// Creates a [`LegacySighashType`] from a raw `u32`.
     ///
     /// # Errors
     ///
     /// If `n` is a non-standard sighash value.
-    pub fn from_standard(n: u32) -> Result<EcdsaSighashType, NonStandardSighashType> {
-        use EcdsaSighashType::*;
+    pub fn from_standard(n: u32) -> Result<LegacySighashType, NonStandardSighashType> {
+        use LegacySighashType::*;
 
         match n {
             // Standard sighashes, see https://github.com/bitcoin/bitcoin/blob/b805dbb0b9c90dadef0424e5b3bf86ac308e103e/src/script/interpreter.cpp#L189-L198
@@ -84,15 +97,15 @@ impl EcdsaSighashType {
         }
     }
 
-    /// Converts [`EcdsaSighashType`] to a `u32` sighash flag.
+    /// Converts [`LegacySighashType`] to a `u32` sighash flag.
     ///
     /// The returned value is guaranteed to be a valid according to standardness rules.
     pub fn to_u32(self) -> u32 { self as u32 }
 }
 
-impl fmt::Display for EcdsaSighashType {
+impl fmt::Display for LegacySighashType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use EcdsaSighashType::*;
+        use LegacySighashType::*;
 
         let s = match self {
             All => "SIGHASH_ALL",
@@ -106,11 +119,11 @@ impl fmt::Display for EcdsaSighashType {
     }
 }
 
-impl str::FromStr for EcdsaSighashType {
+impl str::FromStr for LegacySighashType {
     type Err = SighashTypeParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use EcdsaSighashType::*;
+        use LegacySighashType::*;
 
         match s {
             "SIGHASH_ALL" => Ok(All),

--- a/bitcoin/src/crypto/sighash/mod.rs
+++ b/bitcoin/src/crypto/sighash/mod.rs
@@ -21,11 +21,15 @@ use crate::prelude::*;
 
 mod cache;
 mod ecdsa;
+mod legacy;
+mod segwit_v0;
 mod taproot;
 
 pub use self::cache::{Annex, Prevouts, ScriptPath, SighashCache};
-pub use self::ecdsa::EcdsaSighashType;
-pub use self::taproot::TapSighashType;
+pub use self::ecdsa::EcdsaSighashType; // Should only be used by the PSBT code.
+pub use self::legacy::LegacySighashType;
+pub use self::segwit_v0::SegwitV0SighashType;
+pub use self::taproot::TapSighashType; // FIXME: Should this be TaprootSighashType?
 
 /// Used for signature hash for invalid use of SIGHASH_SINGLE.
 #[rustfmt::skip]
@@ -77,9 +81,84 @@ This hash type is used for computing taproot signature hash.",
 
 impl_thirty_two_byte_hash!(TapSighash);
 
-impl From<EcdsaSighashType> for TapSighashType {
-    fn from(s: EcdsaSighashType) -> Self {
+impl From<SegwitV0SighashType> for TapSighashType {
+    fn from(s: SegwitV0SighashType) -> Self {
         use TapSighashType::*;
+
+        match s {
+            SegwitV0SighashType::All => All,
+            SegwitV0SighashType::None => None,
+            SegwitV0SighashType::Single => Single,
+            SegwitV0SighashType::AllPlusAnyoneCanPay => AllPlusAnyoneCanPay,
+            SegwitV0SighashType::NonePlusAnyoneCanPay => NonePlusAnyoneCanPay,
+            SegwitV0SighashType::SinglePlusAnyoneCanPay => SinglePlusAnyoneCanPay,
+        }
+    }
+}
+
+impl From<LegacySighashType> for TapSighashType {
+    fn from(s: LegacySighashType) -> Self {
+        use TapSighashType::*;
+
+        match s {
+            LegacySighashType::All => All,
+            LegacySighashType::None => None,
+            LegacySighashType::Single => Single,
+            LegacySighashType::AllPlusAnyoneCanPay => AllPlusAnyoneCanPay,
+            LegacySighashType::NonePlusAnyoneCanPay => NonePlusAnyoneCanPay,
+            LegacySighashType::SinglePlusAnyoneCanPay => SinglePlusAnyoneCanPay,
+        }
+    }
+}
+
+impl From<LegacySighashType> for EcdsaSighashType {
+    fn from(s: LegacySighashType) -> Self {
+        use EcdsaSighashType::*;
+
+        match s {
+            LegacySighashType::All => All,
+            LegacySighashType::None => None,
+            LegacySighashType::Single => Single,
+            LegacySighashType::AllPlusAnyoneCanPay => AllPlusAnyoneCanPay,
+            LegacySighashType::NonePlusAnyoneCanPay => NonePlusAnyoneCanPay,
+            LegacySighashType::SinglePlusAnyoneCanPay => SinglePlusAnyoneCanPay,
+        }
+    }
+}
+
+impl From<SegwitV0SighashType> for EcdsaSighashType {
+    fn from(s: SegwitV0SighashType) -> Self {
+        use EcdsaSighashType::*;
+
+        match s {
+            SegwitV0SighashType::All => All,
+            SegwitV0SighashType::None => None,
+            SegwitV0SighashType::Single => Single,
+            SegwitV0SighashType::AllPlusAnyoneCanPay => AllPlusAnyoneCanPay,
+            SegwitV0SighashType::NonePlusAnyoneCanPay => NonePlusAnyoneCanPay,
+            SegwitV0SighashType::SinglePlusAnyoneCanPay => SinglePlusAnyoneCanPay,
+        }
+    }
+}
+
+impl From<EcdsaSighashType> for LegacySighashType {
+    fn from(s: EcdsaSighashType) -> Self {
+        use LegacySighashType::*;
+
+        match s {
+            EcdsaSighashType::All => All,
+            EcdsaSighashType::None => None,
+            EcdsaSighashType::Single => Single,
+            EcdsaSighashType::AllPlusAnyoneCanPay => AllPlusAnyoneCanPay,
+            EcdsaSighashType::NonePlusAnyoneCanPay => NonePlusAnyoneCanPay,
+            EcdsaSighashType::SinglePlusAnyoneCanPay => SinglePlusAnyoneCanPay,
+        }
+    }
+}
+
+impl From<EcdsaSighashType> for SegwitV0SighashType {
+    fn from(s: EcdsaSighashType) -> Self {
+        use SegwitV0SighashType::*;
 
         match s {
             EcdsaSighashType::All => All,

--- a/bitcoin/src/crypto/sighash/mod.rs
+++ b/bitcoin/src/crypto/sighash/mod.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Signature hash implementation (used in transaction signing).
+//!
+//! Efficient implementation of the algorithm to compute the message to be signed according to
+//! [Bip341](https://github.com/bitcoin/bips/blob/150ab6f5c3aca9da05fccc5b435e9667853407f4/bip-0341.mediawiki),
+//! [Bip143](https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0143.mediawiki)
+//! and legacy (before Bip143).
+//!
+//! Computing signature hashes is required to sign a transaction and this module is designed to
+//! handle its complexity efficiently. Computing these hashes is as simple as creating
+//! [`SighashCache`] and calling its methods.
+
+use core::{fmt, str};
+
+use hashes::{hash_newtype, sha256d, sha256t_hash_newtype, Hash};
+
+use crate::error::impl_std_error;
+use crate::io;
+use crate::prelude::*;
+
+mod cache;
+mod ecdsa;
+mod taproot;
+
+pub use self::cache::{Annex, Prevouts, ScriptPath, SighashCache};
+pub use self::ecdsa::EcdsaSighashType;
+pub use self::taproot::TapSighashType;
+
+/// Used for signature hash for invalid use of SIGHASH_SINGLE.
+#[rustfmt::skip]
+pub(crate) const UINT256_ONE: [u8; 32] = [
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+];
+
+/// The SHA-256 midstate value for the [`TapSighash`].
+pub(crate) const MIDSTATE_TAPSIGHASH: [u8; 32] = [
+    245, 4, 164, 37, 215, 248, 120, 59, 19, 99, 134, 138, 227, 229, 86, 88, 110, 238, 148, 93, 188,
+    120, 136, 221, 2, 166, 226, 195, 24, 115, 254, 159,
+];
+// f504a425d7f8783b1363868ae3e556586eee945dbc7888dd02a6e2c31873fe9f
+
+macro_rules! impl_thirty_two_byte_hash {
+    ($ty:ident) => {
+        impl secp256k1::ThirtyTwoByteHash for $ty {
+            fn into_32(self) -> [u8; 32] { self.to_byte_array() }
+        }
+    };
+}
+
+hash_newtype! {
+    /// Hash of a transaction according to the legacy signature algorithm.
+    #[hash_newtype(forward)]
+    pub struct LegacySighash(sha256d::Hash);
+
+    /// Hash of a transaction according to the segwit version 0 signature algorithm.
+    #[hash_newtype(forward)]
+    pub struct SegwitV0Sighash(sha256d::Hash);
+}
+
+impl_thirty_two_byte_hash!(LegacySighash);
+impl_thirty_two_byte_hash!(SegwitV0Sighash);
+
+sha256t_hash_newtype!(
+    TapSighash,
+    TapSighashTag,
+    MIDSTATE_TAPSIGHASH,
+    64,
+    doc = "Taproot-tagged hash with tag \"TapSighash\".
+
+This hash type is used for computing taproot signature hash.",
+    forward
+);
+
+impl_thirty_two_byte_hash!(TapSighash);
+
+impl From<EcdsaSighashType> for TapSighashType {
+    fn from(s: EcdsaSighashType) -> Self {
+        use TapSighashType::*;
+
+        match s {
+            EcdsaSighashType::All => All,
+            EcdsaSighashType::None => None,
+            EcdsaSighashType::Single => Single,
+            EcdsaSighashType::AllPlusAnyoneCanPay => AllPlusAnyoneCanPay,
+            EcdsaSighashType::NonePlusAnyoneCanPay => NonePlusAnyoneCanPay,
+            EcdsaSighashType::SinglePlusAnyoneCanPay => SinglePlusAnyoneCanPay,
+        }
+    }
+}
+
+/// Possible errors in computing the signature message.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Could happen only by using `*_encode_signing_*` methods with custom writers, engines writers
+    /// like the ones used in methods `*_signature_hash` do not error.
+    Io(io::ErrorKind),
+
+    /// Requested index is greater or equal than the number of inputs in the transaction.
+    IndexOutOfInputsBounds {
+        /// Requested index.
+        index: usize,
+        /// Number of transaction inputs.
+        inputs_size: usize,
+    },
+
+    /// Using `SIGHASH_SINGLE` without a "corresponding output" (an output with the same index as
+    /// the input being verified) is a validation failure.
+    SingleWithoutCorrespondingOutput {
+        /// Requested index.
+        index: usize,
+        /// Number of transaction outputs.
+        outputs_size: usize,
+    },
+
+    /// There are mismatches in the number of prevouts provided compared to the number of inputs in
+    /// the transaction.
+    PrevoutsSize,
+
+    /// Requested a prevout index which is greater than the number of prevouts provided or a
+    /// [`Prevouts::One`] with different index.
+    PrevoutIndex,
+
+    /// A single prevout has been provided but all prevouts are needed unless using
+    /// `SIGHASH_ANYONECANPAY`.
+    PrevoutKind,
+
+    /// Annex must be at least one byte long and the first bytes must be `0x50`.
+    WrongAnnex,
+
+    /// Invalid Sighash type.
+    InvalidSighashType(u32),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Error::*;
+
+        match self {
+            Io(error_kind) => write!(f, "writer errored: {:?}", error_kind),
+            IndexOutOfInputsBounds { index, inputs_size } => write!(f, "Requested index ({}) is greater or equal than the number of transaction inputs ({})", index, inputs_size),
+            SingleWithoutCorrespondingOutput { index, outputs_size } => write!(f, "SIGHASH_SINGLE for input ({}) haven't a corresponding output (#outputs:{})", index, outputs_size),
+            PrevoutsSize => write!(f, "Number of supplied prevouts differs from the number of inputs in transaction"),
+            PrevoutIndex => write!(f, "The index requested is greater than available prevouts or different from the provided [Provided::Anyone] index"),
+            PrevoutKind => write!(f, "A single prevout has been provided but all prevouts are needed without `ANYONECANPAY`"),
+            WrongAnnex => write!(f, "Annex must be at least one byte long and the first bytes must be `0x50`"),
+            InvalidSighashType(hash_ty) => write!(f, "Invalid taproot signature hash type : {} ", hash_ty),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match self {
+            Io(_)
+            | IndexOutOfInputsBounds { .. }
+            | SingleWithoutCorrespondingOutput { .. }
+            | PrevoutsSize
+            | PrevoutIndex
+            | PrevoutKind
+            | WrongAnnex
+            | InvalidSighashType(_) => None,
+        }
+    }
+}
+
+/// This type is consensus valid but an input including it would prevent the transaction from
+/// being relayed on today's Bitcoin network.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NonStandardSighashType(pub u32);
+
+impl fmt::Display for NonStandardSighashType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Non standard sighash type {}", self.0)
+    }
+}
+
+impl_std_error!(NonStandardSighashType);
+
+/// Error returned for failure during parsing one of the sighash types.
+///
+/// This is currently returned for unrecognized sighash strings.
+#[derive(Debug, Clone)]
+pub struct SighashTypeParseError {
+    /// The unrecognized string we attempted to parse.
+    pub unrecognized: String,
+}
+
+impl fmt::Display for SighashTypeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Unrecognized SIGHASH string '{}'", self.unrecognized)
+    }
+}
+
+impl_std_error!(SighashTypeParseError);
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self { Error::Io(e.kind()) }
+}

--- a/bitcoin/src/crypto/sighash/taproot.rs
+++ b/bitcoin/src/crypto/sighash/taproot.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Sighash type for Taproot (Segwit V1) signatures.
+
+use core::{fmt, str};
+
+use super::{Error, SighashTypeParseError};
+use crate::prelude::*;
+
+/// Hashtype of an input's signature, encoded in the last byte of the signature.
+/// Fixed values so they can be cast as integer types for encoding.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum TapSighashType {
+    /// 0x0: Used when not explicitly specified, defaults to [`TapSighashType::All`]
+    Default = 0x00,
+    /// 0x1: Sign all outputs.
+    All = 0x01,
+    /// 0x2: Sign no outputs --- anyone can choose the destination.
+    None = 0x02,
+    /// 0x3: Sign the output whose index matches this input's index. If none exists,
+    /// sign the hash `0000000000000000000000000000000000000000000000000000000000000001`.
+    /// (This rule is probably an unintentional C++ism, but it's consensus so we have
+    /// to follow it.)
+    Single = 0x03,
+    /// 0x81: Sign all outputs but only this input.
+    AllPlusAnyoneCanPay = 0x81,
+    /// 0x82: Sign no outputs and only this input.
+    NonePlusAnyoneCanPay = 0x82,
+    /// 0x83: Sign one output and only this input (see `Single` for what "one output" means).
+    SinglePlusAnyoneCanPay = 0x83,
+}
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_impl!(TapSighashType, "a TapSighashType data");
+
+impl TapSighashType {
+    /// Breaks the sighash flag into the "real" sighash flag and the `SIGHASH_ANYONECANPAY` boolean.
+    pub(crate) fn split_anyonecanpay_flag(self) -> (TapSighashType, bool) {
+        use TapSighashType::*;
+
+        match self {
+            Default => (Default, false),
+            All => (All, false),
+            None => (None, false),
+            Single => (Single, false),
+            AllPlusAnyoneCanPay => (All, true),
+            NonePlusAnyoneCanPay => (None, true),
+            SinglePlusAnyoneCanPay => (Single, true),
+        }
+    }
+
+    /// Constructs a [`TapSighashType`] from a raw `u8`.
+    pub fn from_consensus_u8(hash_ty: u8) -> Result<Self, Error> {
+        use TapSighashType::*;
+
+        Ok(match hash_ty {
+            0x00 => Default,
+            0x01 => All,
+            0x02 => None,
+            0x03 => Single,
+            0x81 => AllPlusAnyoneCanPay,
+            0x82 => NonePlusAnyoneCanPay,
+            0x83 => SinglePlusAnyoneCanPay,
+            x => return Err(Error::InvalidSighashType(x as u32)),
+        })
+    }
+}
+
+impl fmt::Display for TapSighashType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use TapSighashType::*;
+
+        let s = match self {
+            Default => "SIGHASH_DEFAULT",
+            All => "SIGHASH_ALL",
+            None => "SIGHASH_NONE",
+            Single => "SIGHASH_SINGLE",
+            AllPlusAnyoneCanPay => "SIGHASH_ALL|SIGHASH_ANYONECANPAY",
+            NonePlusAnyoneCanPay => "SIGHASH_NONE|SIGHASH_ANYONECANPAY",
+            SinglePlusAnyoneCanPay => "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY",
+        };
+        f.write_str(s)
+    }
+}
+
+impl str::FromStr for TapSighashType {
+    type Err = SighashTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use TapSighashType::*;
+
+        match s {
+            "SIGHASH_DEFAULT" => Ok(Default),
+            "SIGHASH_ALL" => Ok(All),
+            "SIGHASH_NONE" => Ok(None),
+            "SIGHASH_SINGLE" => Ok(Single),
+            "SIGHASH_ALL|SIGHASH_ANYONECANPAY" => Ok(AllPlusAnyoneCanPay),
+            "SIGHASH_NONE|SIGHASH_ANYONECANPAY" => Ok(NonePlusAnyoneCanPay),
+            "SIGHASH_SINGLE|SIGHASH_ANYONECANPAY" => Ok(SinglePlusAnyoneCanPay),
+            _ => Err(SighashTypeParseError { unrecognized: s.to_owned() }),
+        }
+    }
+}

--- a/bitcoin/src/crypto/sighash/taproot.rs
+++ b/bitcoin/src/crypto/sighash/taproot.rs
@@ -8,6 +8,7 @@ use super::{Error, SighashTypeParseError};
 use crate::prelude::*;
 
 /// Hashtype of an input's signature, encoded in the last byte of the signature.
+///
 /// Fixed values so they can be cast as integer types for encoding.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum TapSighashType {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -341,8 +341,12 @@ impl PartiallySignedTransaction {
             }
             Wpkh => {
                 let script_code = ScriptBuf::p2wpkh_script_code(spk).ok_or(SignError::NotWpkh)?;
-                let sighash =
-                    cache.segwit_signature_hash(input_index, &script_code, utxo.value, hash_ty)?;
+                let sighash = cache.segwit_signature_hash(
+                    input_index,
+                    &script_code,
+                    utxo.value,
+                    hash_ty.into(),
+                )?;
                 Ok((Message::from(sighash), hash_ty))
             }
             ShWpkh => {
@@ -350,15 +354,23 @@ impl PartiallySignedTransaction {
                     input.redeem_script.as_ref().expect("checked above"),
                 )
                 .ok_or(SignError::NotWpkh)?;
-                let sighash =
-                    cache.segwit_signature_hash(input_index, &script_code, utxo.value, hash_ty)?;
+                let sighash = cache.segwit_signature_hash(
+                    input_index,
+                    &script_code,
+                    utxo.value,
+                    hash_ty.into(),
+                )?;
                 Ok((Message::from(sighash), hash_ty))
             }
             Wsh | ShWsh => {
                 let script_code =
                     input.witness_script.as_ref().ok_or(SignError::MissingWitnessScript)?;
-                let sighash =
-                    cache.segwit_signature_hash(input_index, script_code, utxo.value, hash_ty)?;
+                let sighash = cache.segwit_signature_hash(
+                    input_index,
+                    script_code,
+                    utxo.value,
+                    hash_ty.into(),
+                )?;
                 Ok((Message::from(sighash), hash_ty))
             }
             Tr => {


### PR DESCRIPTION
Make another attempt at splitting the `ecdsa` types (sighash type and signatures) up into `legacy` and `native` (I posted #1762, and from @apoelstra comment probably need to change "native" back to "segwit_v0" here, will leave as is for now because its a minor thing to change).
    
This is a bit curly because of PSBT's classifying things as either taproot or non-taproot - and we currently use `ecdsa` types for that - as such this PR _duplicates_ the ecdsa stuff without removing it.
    

