### PR TITLE
Add new Weight type

### DIFF
--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -13,4 +13,5 @@ pub mod opcodes;
 pub mod script;
 pub mod transaction;
 pub mod block;
+pub mod weight;
 pub mod witness;

--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -48,7 +48,8 @@
 //! At the time of writing there's only one operation using the cache - `push_verify`, so the cache
 //! is minimal but we may extend it in the future if needed.
 
-use crate::prelude::*;
+use crate::{prelude::*, VarInt};
+use crate::weight::ComputeSize;
 
 use alloc::rc::Rc;
 use alloc::sync::Arc;
@@ -518,6 +519,15 @@ impl Script {
         // layout).
         let inner = unsafe { Box::from_raw(rw) };
         ScriptBuf(Vec::from(inner))
+    }
+}
+
+impl ComputeSize for Script {
+    /// Blocksize of a script.
+    fn encoded_size(&self) -> usize {
+        let script_len = self.len();
+        // script varint len + script push in vbytes
+        VarInt(script_len as u64).len() + script_len
     }
 }
 

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Weight
+//!
+//! This module contains the [`Weight`] struct and related methods to operate on it
+//! Block weight represents virtual size (vsize) of a transaction measured in virtual bytes (vbytes).
+
+// ensure explicit constructor
+use std::ops::{Add, Sub, AddAssign, SubAssign, Mul};
+
+/// Represents virtual transaction size
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub struct Weight(usize);
+
+impl Weight {
+    pub(crate) const ZERO: Weight = Weight(0);
+
+    pub(crate) fn from_witness_data_size(size: usize) -> Self {
+        Weight(size)
+    }
+
+    pub(crate) fn from_non_witness_data_size(size: usize) -> Self {
+        Weight(size * 4)
+    }
+}
+
+impl From<Weight> for usize {
+    fn from(value: Weight) -> Self {
+        value.0
+    }
+}
+
+impl Add for Weight {
+    type Output = Weight;
+
+    fn add(self, rhs: Weight) -> Self::Output {
+        Weight(self.0 + rhs.0)
+    }
+}
+
+impl Sub for Weight {
+    type Output = Weight;
+
+    fn sub(self, rhs: Weight) -> Self::Output {
+        Weight(self.0 - rhs.0)
+    }
+}
+
+impl AddAssign for Weight {
+    fn add_assign(&mut self, rhs: Weight) {
+        self.0 += rhs.0
+    }
+}
+
+impl SubAssign for Weight {
+    fn sub_assign(&mut self, rhs: Weight) {
+        self.0 -= rhs.0
+    }
+}
+
+impl Mul<usize> for Weight {
+    type Output = Weight;
+
+    fn mul(self, rhs: usize) -> Self::Output {
+        Weight(self.0 * rhs)
+    }
+}
+
+pub(crate) trait ComputeWeight {
+    fn weight(&self) -> Weight;
+}
+pub(crate) trait ComputeSize {
+    fn encoded_size(&self) -> usize;
+}

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -10,11 +10,13 @@ use core::ops::Index;
 
 use secp256k1::ecdsa;
 
+use crate::blockdata::weight::Weight;
 use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::sighash::EcdsaSighashType;
 use crate::io::{self, Read, Write};
 use crate::prelude::*;
+use crate::weight::ComputeWeight;
 use crate::{Script, VarInt};
 use crate::taproot::TAPROOT_ANNEX_PREFIX;
 
@@ -339,6 +341,15 @@ impl Witness {
                 self.nth(len - script_pos_from_last)
             })
             .map(Script::from_bytes)
+    }
+}
+
+impl ComputeWeight for Witness {
+    fn weight(&self) -> Weight {
+        if self.is_empty() {
+            return Weight::ZERO;
+        }
+        Weight::from_witness_data_size(self.serialized_len())
     }
 }
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -131,6 +131,7 @@ pub use crate::blockdata::block::{self, Block};
 pub use crate::blockdata::locktime::{self, absolute, relative};
 pub use crate::blockdata::script::{self, Script, ScriptBuf};
 pub use crate::blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut};
+pub use crate::blockdata::weight::{self, Weight};
 pub use crate::blockdata::witness::{self, Witness};
 pub use crate::blockdata::{constants, opcodes};
 pub use crate::consensus::encode::VarInt;


### PR DESCRIPTION
This work intends to addresses part of @Kixunil's #630 by introducing a Weight type by adding:

- An extension trait `ComputeWeight` for weight calculation so that one may for instance predict how much transaction fee will change (would use inherent methods here). Implemented on
  - [x] TxOut
  - [ ] TxIn; need to merge legacy_weight and segwit_weight
  - [x] OutPoint
  - [x] Witness
- An extension trait `ComputeSize` for size calculation on Script
- Weight data type - newtype around ~~u64~~ usize for transaction weight, returned by weight-computing functions. usize was already being used for weight so it seemed more appropriate than u64

This implementation differs from that in the payjoin crate because it exposes the type as public. That other version forces the use of the constructor on an inner module, but I felt we should expose weight since that was the purpose of #1411, & #1467. This is also still missing the FeeRate type.

I'm seeking feedback as to whether the design with extension traits makes sense and as to the location of the additions on this early draft, please.