### PR TITLE
Set `rustv_1_53` in build script

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -21,7 +21,6 @@ serde = ["actual-serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
-rust_v_1_53 = []
 
 # At least one of std, no-std must be enabled.
 #

--- a/bitcoin/build.rs
+++ b/bitcoin/build.rs
@@ -23,7 +23,7 @@ fn main() {
         .parse::<u64>()
         .expect("invalid Rust minor version");
 
-    for activate_version in &[46] {
+    for activate_version in &[46, 53] {
         if minor >= *activate_version {
             println!("cargo:rustc-cfg=rust_v_1_{}", activate_version);
         }

--- a/bitcoin/src/blockdata/script.rs
+++ b/bitcoin/src/blockdata/script.rs
@@ -59,7 +59,7 @@ use core::convert::TryFrom;
 use core::borrow::{Borrow, BorrowMut};
 use core::{fmt, default::Default};
 use core::ops::{Deref, DerefMut, Index, Range, RangeFull, RangeFrom, RangeTo, RangeInclusive, RangeToInclusive};
-#[cfg(feature = "rust_v_1_53")]
+#[cfg(rust_v_1_53)]
 use core::ops::Bound;
 
 #[cfg(feature = "serde")] use serde;
@@ -615,8 +615,8 @@ macro_rules! delegate_index {
 }
 
 delegate_index!(Range<usize>, RangeFrom<usize>, RangeTo<usize>, RangeFull, RangeInclusive<usize>, RangeToInclusive<usize>);
-#[cfg(feature = "rust_v_1_53")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rust_v_1_53")))]
+#[cfg(rust_v_1_53)]
+#[cfg_attr(docsrs, doc(cfg(rust_v_1_53)))]
 delegate_index!((Bound<usize>, Bound<usize>));
 
 impl AsRef<Script> for Script {


### PR DESCRIPTION
The rust version is supposed to be set by the build script so that users automagically get features matching the toolchain in use. Currently we have a feature in the manifest for `rustv_1_53` instead setting a compiler conditional configuration option in the build script. This causes `cargo +1.41.1 --all-features check` to fail.

## Note

I don't see `rustv_1_46` used anywhere, do we need that still?