### PR TITLE
Associate io, encode errors with psbt::Error

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1732,15 +1732,24 @@ mod tests {
         // no previous output
         let mut t2 = t.clone();
         t2.inputs[0].non_witness_utxo = None;
-        assert_eq!(t2.fee(), Err(Error::MissingUtxo));
+        match t2.fee().unwrap_err() {
+            Error::MissingUtxo => {},
+            e => panic!("unexpected error: {:?}", e)
+        }
         //  negative fee
         let mut t3 = t.clone();
         t3.unsigned_tx.output[0].value = prev_output_val;
-        assert_eq!(t3.fee(), Err(Error::NegativeFee));
+        match t3.fee().unwrap_err() {
+            Error::NegativeFee => {},
+            e => panic!("unexpected error: {:?}", e)
+        }
         // overflow
         t.unsigned_tx.output[0].value = u64::max_value();
         t.unsigned_tx.output[1].value = u64::max_value();
-        assert_eq!(t.fee(), Err(Error::FeeOverflow));
+        match t.fee().unwrap_err() {
+            Error::FeeOverflow => {},
+            e => panic!("unexpected error: {:?}", e)
+        }
     }
 
     #[test]

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -225,7 +225,7 @@ impl Serialize for KeySource {
 impl Deserialize for KeySource {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() < 4 {
-            return Err(encode::Error::from(io::Error::from(io::ErrorKind::UnexpectedEof)).into())
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())
         }
 
         let fprint: Fingerprint = bytes[0..4].try_into().expect("4 is the fingerprint length");
@@ -319,7 +319,7 @@ impl Serialize for (XOnlyPublicKey, TapLeafHash) {
 impl Deserialize for (XOnlyPublicKey, TapLeafHash) {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() < 32 {
-            return Err(encode::Error::from(io::Error::from(io::ErrorKind::UnexpectedEof)).into())
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())
         }
         let a: XOnlyPublicKey = Deserialize::deserialize(&bytes[..32])?;
         let b: TapLeafHash = Deserialize::deserialize(&bytes[32..])?;
@@ -353,7 +353,7 @@ impl Serialize for (ScriptBuf, LeafVersion) {
 impl Deserialize for (ScriptBuf, LeafVersion) {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.is_empty() {
-            return Err(encode::Error::from(io::Error::from(io::ErrorKind::UnexpectedEof)).into())
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())
         }
         // The last byte is LeafVersion.
         let script = ScriptBuf::deserialize(&bytes[..bytes.len() - 1])?;


### PR DESCRIPTION
- patch 1 fix #1590 
- patch 2 addresses [this related comment](https://github.com/rust-bitcoin/rust-bitcoin/pull/1532/files#r1067812911) about associated `encode::Error` 

EDIT (by Tobin): fix #1548

I believe this closes out PSBT refactoring and makes way for PSBTv2 in the epic 😎

patch 1 uses match to check the error type in tests. If msrv were 1.42 we could use assert!(matches!(...)); one liners instead.