### PR TITLE
Add KeyPair import to rustdoc example

### DIFF
--- a/bitcoin/src/crypto/schnorr.rs
+++ b/bitcoin/src/crypto/schnorr.rs
@@ -48,7 +48,7 @@ pub type UntweakedKeyPair = KeyPair;
 /// # Examples
 /// ```
 /// # #[cfg(feature = "rand-std")] {
-/// # use bitcoin::schnorr::{TweakedKeyPair, TweakedPublicKey};
+/// # use bitcoin::schnorr::{KeyPair, TweakedKeyPair, TweakedPublicKey};
 /// # use bitcoin::secp256k1::{rand, Secp256k1};
 /// # let secp = Secp256k1::new();
 /// # let keypair = TweakedKeyPair::dangerous_assume_tweaked(KeyPair::new(&secp, &mut rand::thread_rng()));


### PR DESCRIPTION
Recently, and bizarrely, a PR merged that broke `cargo test --doc`.

Add an import for `KeyPair` to the `schnorr` rustdoc example.