### PR TITLE
Instruct devs to use nightly for embedded

### DIFF
--- a/bitcoin/embedded/README.md
+++ b/bitcoin/embedded/README.md
@@ -4,13 +4,13 @@ To run the embedded test, first prepare your environment:
 
 ```shell
 sudo ./scripts/install-deps
-rustup target add thumbv7m-none-eabi
+rustup +nightly target add thumbv7m-none-eabi
 ```
 
 Then:
 
 ```shell
-source ./scripts/env.sh && cargo run --target thumbv7m-none-eabi
+source ./scripts/env.sh && cargo +nightly run --target thumbv7m-none-eabi
 ```
 
 Output should be something like:


### PR DESCRIPTION
The embedded test crate requires usage of the nightly toolchain, fix the docs to show this.