### PR TITLE
 Implement from arrays for `TaprootMerkleBranch`

### DIFF
--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -727,6 +727,23 @@ impl_try_from!(&[TapNodeHash]);
 impl_try_from!(Vec<TapNodeHash>);
 impl_try_from!(Box<[TapNodeHash]>);
 
+macro_rules! impl_try_from_array {
+    ($($len:expr),* $(,)?) => {
+        $(
+            impl From<[TapNodeHash; $len]> for TaprootMerkleBranch {
+                fn from(a: [TapNodeHash; $len]) -> Self {
+                    Self(a.to_vec())
+                }
+            }
+        )*
+    }
+}
+// Implement for all values [0, 128] inclusive.
+//
+// The reason zero is included is that `TaprootMerkleBranch` doesn't contain the hash of the node
+// that's being proven - it's not needed because the script is already right before control block.
+impl_try_from_array!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128);
+
 /// Control block data structure used in Tapscript satisfaction.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
The `TaprootMerkleBranch` contains a vector of `TapNodeHash`s, as such it can trivially be constructed from an array of the same type.

Implement `From` for all array sizes 1 - 128 inclusive.


Fix: #1469 