### PR TITLE
Add newline in rustdoc

### DIFF
--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -50,7 +50,8 @@ const MIDSTATE_TAPSIGHASH: [u8; 32] = [
 #[rustfmt::skip]
 sha256t_hash_newtype!(TapLeafHash, TapLeafTag, MIDSTATE_TAPLEAF, 64,
     doc="Taproot-tagged hash with tag \"TapLeaf\".
-    This is used for computing tapscript script spend hash.", false
+
+This is used for computing tapscript script spend hash.", false
 );
 #[rustfmt::skip]
 sha256t_hash_newtype!(TapNodeHash, TapBranchTag, MIDSTATE_TAPBRANCH, 64,
@@ -64,7 +65,8 @@ sha256t_hash_newtype!(TapTweakHash, TapTweakTag, MIDSTATE_TAPTWEAK, 64,
 #[rustfmt::skip]
 sha256t_hash_newtype!(TapSighashHash, TapSighashTag, MIDSTATE_TAPSIGHASH, 64,
     doc="Taproot-tagged hash with tag \"TapSighash\".
-    This hash type is used for computing taproot signature hash.", false
+
+This hash type is used for computing taproot signature hash.", false
 );
 
 impl secp256k1::ThirtyTwoByteHash for TapSighashHash {


### PR DESCRIPTION
Docs created with the `sha256t_hash_newtype` macro are missing a newline between the doc heading and doc main section.

Note that the strings used span multiple lines and therefor the subsequent lines must be aligned with the start of the line (not indented).

Fix: #1540