### PR TITLE
Rename TapSighashHash to TapSighash

### DIFF
--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -89,7 +89,7 @@ use bitcoin::schnorr::{self, TapTweak};
 use bitcoin::secp256k1::{Message, Secp256k1};
 use bitcoin::sighash::{self, SchnorrSighashType, SighashCache};
 use bitcoin::taproot::{
-    LeafVersion, TapLeafHash, TapSighashHash, TaprootBuilder, TaprootSpendInfo,
+    LeafVersion, TapLeafHash, TapSighash, TaprootBuilder, TaprootSpendInfo,
 };
 use bitcoin::{
     absolute, script, Address, Amount, Network, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Witness,
@@ -735,7 +735,7 @@ fn sign_psbt_schnorr(
     pubkey: XOnlyPublicKey,
     leaf_hash: Option<TapLeafHash>,
     psbt_input: &mut psbt::Input,
-    hash: TapSighashHash,
+    hash: TapSighash,
     hash_ty: SchnorrSighashType,
     secp: &Secp256k1<secp256k1::All>,
 ) {

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -19,7 +19,7 @@ use crate::consensus::{encode, Encodable};
 use crate::error::impl_std_error;
 use crate::hashes::{sha256, sha256d, Hash};
 use crate::prelude::*;
-use crate::taproot::{LeafVersion, TapLeafHash, TapSighashHash, TAPROOT_ANNEX_PREFIX};
+use crate::taproot::{LeafVersion, TapLeafHash, TapSighash, TAPROOT_ANNEX_PREFIX};
 
 /// Used for signature hash for invalid use of SIGHASH_SINGLE.
 #[rustfmt::skip]
@@ -626,8 +626,8 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
         annex: Option<Annex>,
         leaf_hash_code_separator: Option<(TapLeafHash, u32)>,
         sighash_type: SchnorrSighashType,
-    ) -> Result<TapSighashHash, Error> {
-        let mut enc = TapSighashHash::engine();
+    ) -> Result<TapSighash, Error> {
+        let mut enc = TapSighash::engine();
         self.taproot_encode_signing_data_to(
             &mut enc,
             input_index,
@@ -636,7 +636,7 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
             leaf_hash_code_separator,
             sighash_type,
         )?;
-        Ok(TapSighashHash::from_engine(enc))
+        Ok(TapSighash::from_engine(enc))
     }
 
     /// Computes the BIP341 sighash for a key spend.
@@ -645,8 +645,8 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
         input_index: usize,
         prevouts: &Prevouts<T>,
         sighash_type: SchnorrSighashType,
-    ) -> Result<TapSighashHash, Error> {
-        let mut enc = TapSighashHash::engine();
+    ) -> Result<TapSighash, Error> {
+        let mut enc = TapSighash::engine();
         self.taproot_encode_signing_data_to(
             &mut enc,
             input_index,
@@ -655,7 +655,7 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
             None,
             sighash_type,
         )?;
-        Ok(TapSighashHash::from_engine(enc))
+        Ok(TapSighash::from_engine(enc))
     }
 
     /// Computes the BIP341 sighash for a script spend.
@@ -668,8 +668,8 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
         prevouts: &Prevouts<T>,
         leaf_hash: S,
         sighash_type: SchnorrSighashType,
-    ) -> Result<TapSighashHash, Error> {
-        let mut enc = TapSighashHash::engine();
+    ) -> Result<TapSighash, Error> {
+        let mut enc = TapSighash::engine();
         self.taproot_encode_signing_data_to(
             &mut enc,
             input_index,
@@ -678,7 +678,7 @@ impl<R: Deref<Target = Transaction>> SighashCache<R> {
             Some((leaf_hash.into(), 0xFFFFFFFF)),
             sighash_type,
         )?;
-        Ok(TapSighashHash::from_engine(enc))
+        Ok(TapSighash::from_engine(enc))
     }
 
     /// Encodes the BIP143 signing data for any flag type into a given object implementing a
@@ -1059,7 +1059,7 @@ mod tests {
     use crate::hashes::{Hash, HashEngine};
     use crate::internal_macros::hex;
     use crate::network::constants::Network;
-    use crate::taproot::{TapLeafHash, TapSighashHash};
+    use crate::taproot::{TapLeafHash, TapSighash};
 
     extern crate serde_json;
 
@@ -1130,9 +1130,9 @@ mod tests {
         let bytes = hex!("00011b96877db45ffa23b307e9f0ac87b80ef9a80b4c5f0db3fbe734422453e83cc5576f3d542c5d4898fb2b696c15d43332534a7c1d1255fda38993545882df92c3e353ff6d36fbfadc4d168452afd8467f02fe53d71714fcea5dfe2ea759bd00185c4cb02bc76d42620393ca358a1a713f4997f9fc222911890afb3fe56c6a19b202df7bffdcfad08003821294279043746631b00e2dc5e52a111e213bbfe6ef09a19428d418dab0d50000000000");
         let expected =
             hex!("04e808aad07a40b3767a1442fead79af6ef7e7c9316d82dec409bb31e77699b0");
-        let mut enc = TapSighashHash::engine();
+        let mut enc = TapSighash::engine();
         enc.input(&bytes);
-        let hash = TapSighashHash::from_engine(enc);
+        let hash = TapSighash::from_engine(enc);
         assert_eq!(expected, hash.into_inner());
     }
 
@@ -1442,7 +1442,7 @@ mod tests {
             tweaked_privkey: SecretKey,
             sig_msg: String,
             //precomputed_used: Vec<String>, // unused
-            sig_hash: TapSighashHash,
+            sig_hash: TapSighash,
         }
 
         #[derive(serde::Deserialize)]

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -39,7 +39,7 @@ const MIDSTATE_TAPTWEAK: [u8; 32] = [
 ];
 // d129a2f3701c655d6583b6c3b941972795f4e23294fd54f4a2ae8d8547ca590b
 
-/// The SHA-256 midstate value for the [`TapSighashHash`].
+/// The SHA-256 midstate value for the [`TapSighash`].
 const MIDSTATE_TAPSIGHASH: [u8; 32] = [
     245, 4, 164, 37, 215, 248, 120, 59, 19, 99, 134, 138, 227, 229, 86, 88, 110, 238, 148, 93, 188,
     120, 136, 221, 2, 166, 226, 195, 24, 115, 254, 159,
@@ -63,13 +63,13 @@ sha256t_hash_newtype!(TapTweakHash, TapTweakTag, MIDSTATE_TAPTWEAK, 64,
     This hash type is used while computing the tweaked public key", false
 );
 #[rustfmt::skip]
-sha256t_hash_newtype!(TapSighashHash, TapSighashTag, MIDSTATE_TAPSIGHASH, 64,
+sha256t_hash_newtype!(TapSighash, TapSighashTag, MIDSTATE_TAPSIGHASH, 64,
     doc="Taproot-tagged hash with tag \"TapSighash\".
 
 This hash type is used for computing taproot signature hash.", false
 );
 
-impl secp256k1::ThirtyTwoByteHash for TapSighashHash {
+impl secp256k1::ThirtyTwoByteHash for TapSighash {
     fn into_32(self) -> [u8; 32] { self.into_inner() }
 }
 
@@ -1147,7 +1147,7 @@ mod test {
         assert_eq!(empty_hash("TapLeaf"), TapLeafHash::hash(&[]).into_inner());
         assert_eq!(empty_hash("TapBranch"), TapNodeHash::hash(&[]).into_inner());
         assert_eq!(empty_hash("TapTweak"), TapTweakHash::hash(&[]).into_inner());
-        assert_eq!(empty_hash("TapSighash"), TapSighashHash::hash(&[]).into_inner());
+        assert_eq!(empty_hash("TapSighash"), TapSighash::hash(&[]).into_inner());
     }
 
     #[test]
@@ -1170,7 +1170,7 @@ mod test {
             "8aa4229474ab0100b2d6f0687f031d1fc9d8eef92a042ad97d279bff456b15e4"
         );
         assert_eq!(
-            TapSighashHash::from_engine(TapSighashTag::engine()).to_string(),
+            TapSighash::from_engine(TapSighashTag::engine()).to_string(),
             "dabc11914abcd8072900042a2681e52f8dba99ce82e224f97b5fdb7cd4b9c803"
         );
 
@@ -1192,7 +1192,7 @@ mod test {
             "cd8737b5e6047fc3f16f03e8b9959e3440e1bdf6dd02f7bb899c352ad490ea1e"
         );
         assert_eq!(
-            TapSighashHash::hash(&[0]).to_string(),
+            TapSighash::hash(&[0]).to_string(),
             "c2fd0de003889a09c4afcf676656a0d8a1fb706313ff7d509afb00c323c010cd"
         );
     }


### PR DESCRIPTION
The `TapSighash` is the taproot sighash, it is a little misnamed as it is. Change the name to `TapSighash`.

Leave the definition in the `taproot` module. This is a little incongruent to its non-taproot counterpart `hash_types::Sighash`. I have no better idea for where to put these currently.

Fix: #1550