### PR TITLE
Improve string parsing

### DIFF
--- a/bitcoin/src/blockdata/fee_rate.rs
+++ b/bitcoin/src/blockdata/fee_rate.rs
@@ -2,6 +2,8 @@
 
 use core::fmt;
 use core::ops::{Mul, Div};
+
+use crate::prelude::*;
 use crate::Amount;
 use super::Weight;
 
@@ -133,4 +135,4 @@ impl Div<Weight> for Amount {
     }
 }
 
-crate::parse::impl_parse_str_through_int!(FeeRate);
+crate::parse::impl_parse_str_from_int_infallible!(FeeRate, u64, from_sat_per_kwu);

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -9,8 +9,6 @@
 
 use core::{mem, fmt};
 use core::cmp::{PartialOrd, Ordering};
-use core::convert::TryFrom;
-use core::str::FromStr;
 
 use bitcoin_internals::write_err;
 
@@ -20,8 +18,8 @@ use mutagen::mutate;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::error::ParseIntError;
 use crate::io::{self, Read, Write};
+use crate::parse::{impl_parse_str_from_int_infallible, impl_parse_str_from_int_fallible};
 use crate::prelude::*;
-use crate::parse::{self, impl_parse_str_through_int};
 use crate::string::FromHexStr;
 
 #[cfg(doc)]
@@ -276,7 +274,7 @@ impl LockTime {
     }
 }
 
-impl_parse_str_through_int!(LockTime, from_consensus);
+impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
 
 impl From<Height> for LockTime {
     #[inline]
@@ -451,6 +449,8 @@ impl Height {
     }
 }
 
+impl_parse_str_from_int_fallible!(Height, u32, from_consensus, Error);
+
 impl fmt::Display for Height {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
@@ -464,37 +464,6 @@ impl FromHexStr for Height {
     fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
         let height = crate::parse::hex_u32(s)?;
         Self::from_consensus(height)
-    }
-}
-
-
-impl FromStr for Height {
-    type Err = Error;
-
-    #[inline]
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let n = parse::int(s)?;
-        Height::from_consensus(n)
-    }
-}
-
-impl TryFrom<&str> for Height {
-    type Error = Error;
-
-    #[inline]
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        let n = parse::int(s)?;
-        Height::from_consensus(n)
-    }
-}
-
-impl TryFrom<String> for Height {
-    type Error = Error;
-
-    #[inline]
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        let n = parse::int(s)?;
-        Height::from_consensus(n)
     }
 }
 
@@ -564,6 +533,8 @@ impl Time {
     }
 }
 
+impl_parse_str_from_int_fallible!(Time, u32, from_consensus, Error);
+
 impl fmt::Display for Time {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
@@ -577,36 +548,6 @@ impl FromHexStr for Time {
     fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
         let time = crate::parse::hex_u32(s)?;
         Time::from_consensus(time)
-    }
-}
-
-impl FromStr for Time {
-    type Err = Error;
-
-    #[inline]
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let n = parse::int(s)?;
-        Time::from_consensus(n)
-    }
-}
-
-impl TryFrom<&str> for Time {
-    type Error = Error;
-
-    #[inline]
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        let n = parse::int(s)?;
-        Time::from_consensus(n)
-    }
-}
-
-impl TryFrom<String> for Time {
-    type Error = Error;
-
-    #[inline]
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        let n = parse::int(s)?;
-        Time::from_consensus(n)
     }
 }
 

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -13,6 +13,9 @@ use core::convert::TryFrom;
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
 
+use crate::parse::impl_parse_str_from_int_infallible;
+use crate::prelude::*;
+
 #[cfg(doc)]
 use crate::relative;
 
@@ -236,6 +239,8 @@ impl From<u16> for Height {
     }
 }
 
+impl_parse_str_from_int_infallible!(Height, u16, from);
+
 impl fmt::Display for Height {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
@@ -299,6 +304,8 @@ impl Time {
         self.0
     }
 }
+
+impl_parse_str_from_int_infallible!(Time, u16, from_512_second_intervals);
 
 impl fmt::Display for Time {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -33,7 +33,7 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::hash_types::{Sighash, Txid, Wtxid};
 use crate::VarInt;
 use crate::internal_macros::impl_consensus_encoding;
-use crate::parse::impl_parse_str_through_int;
+use crate::parse::impl_parse_str_from_int_infallible;
 use super::Weight;
 
 #[cfg(doc)]
@@ -499,7 +499,7 @@ impl fmt::UpperHex for Sequence {
     }
 }
 
-impl_parse_str_through_int!(Sequence);
+impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
 
 /// Bitcoin transaction output.
 ///

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -3,6 +3,8 @@
 use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign};
 
+use crate::prelude::*;
+
 /// Represents block weight - the weight of a transaction or block.
 ///
 /// This is an integer newtype representing weigth in `wu`. It provides protection against mixing
@@ -195,4 +197,4 @@ impl<'a> core::iter::Sum<&'a Weight> for Weight {
     }
 }
 
-crate::parse::impl_parse_str_through_int!(Weight);
+crate::parse::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);


### PR DESCRIPTION
Currently we implement string parsing for height/time from the `absolute` module but not the `relative` module.

Improve the macros used to implement string parsing and use the new versions to implement string parsing for the height and time types in `relative`.

Done while reviewing data structures in relation to `serde`.