### PR TITLE
Improve `sighash` module documentation

### DIFF
--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Generalized, efficient, signature hash implementation.
+//! Signature hash implementation (used in transaction signing).
 //!
-//! Implementation of the algorithm to compute the message to be signed according to
+//! Efficient implementation of the algorithm to compute the message to be signed according to
 //! [Bip341](https://github.com/bitcoin/bips/blob/150ab6f5c3aca9da05fccc5b435e9667853407f4/bip-0341.mediawiki),
 //! [Bip143](https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0143.mediawiki)
 //! and legacy (before Bip143).
 //!
+//! Computing signature hashes is required to sign a transaction and this module is designed to
+//! handle its complexity efficiently. Computing these hashes is as simple as creating
+//! [`SighashCache`] and calling its methods.
 
 use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};


### PR DESCRIPTION
"Sighash" is a technical term that newbies in Bitcoin may not know and could get lost when trying to find how to sign a transaction. This change attempts to make it more obvious that this module is needed for signing.

Closes #1463