### PR TITLE
Improve `SighashCache` API

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -11,7 +11,6 @@
 use std::collections::{HashMap, HashSet};
 
 use core::{fmt, cmp};
-use core::ops::Deref;
 
 use secp256k1::{Message, Secp256k1, Signing};
 use bitcoin_internals::write_err;
@@ -266,7 +265,7 @@ impl PartiallySignedTransaction {
     ) -> Result<Vec<PublicKey>, SignError>
     where
         C: Signing,
-        T: Deref<Target=Transaction>,
+        T: Borrow<Transaction>,
         K: GetKey,
     {
         let msg_sighash_ty_res = self.sighash_ecdsa(input_index, cache);
@@ -309,7 +308,7 @@ impl PartiallySignedTransaction {
     /// Uses the [`EcdsaSighashType`] from this input if one is specified. If no sighash type is
     /// specified uses [`EcdsaSighashType::All`]. This function does not support scripts that
     /// contain `OP_CODESEPARATOR`.
-    pub fn sighash_ecdsa<T: Deref<Target=Transaction>>(
+    pub fn sighash_ecdsa<T: Borrow<Transaction>>(
         &self,
         input_index: usize,
         cache: &mut SighashCache<T>,

--- a/bitcoin/src/sighash.rs
+++ b/bitcoin/src/sighash.rs
@@ -499,6 +499,16 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         SighashCache { tx, common_cache: None, taproot_cache: None, segwit_cache: None }
     }
 
+    /// Returns the reference to the cached transaction.
+    pub fn transaction(&self) -> &Transaction {
+        self.tx.borrow()
+    }
+
+    /// Destroys the cache and recovers the stored transaction.
+    pub fn into_transaction(self) -> R {
+        self.tx
+    }
+
     /// Encodes the BIP341 signing data for any flag type into a given object implementing a
     /// [`io::Write`] trait.
     pub fn taproot_encode_signing_data_to<Write: io::Write, T: Borrow<TxOut>>(


### PR DESCRIPTION
This changes the bound from `Deref<Target = Transaction>` to `Borrow<Transaction>` (with respective `mut` changes) and adds accessors.

Closes #1423 (PSBT stuff will be separate issue).