### PR TITLE
Add `Weight` and `FeeRate` newtypes

### DIFF
--- a/bitcoin/fuzz/fuzz_targets/deserialize_transaction.rs
+++ b/bitcoin/fuzz/fuzz_targets/deserialize_transaction.rs
@@ -8,7 +8,7 @@ fn do_test(data: &[u8]) {
             let ser = bitcoin::consensus::encode::serialize(&tx);
             assert_eq!(&ser[..], data);
             let len = ser.len();
-            let calculated_weight = tx.weight();
+            let calculated_weight = tx.weight().to_wu() as usize;
             for input in &mut tx.input {
                 input.witness = bitcoin::blockdata::witness::Witness::default();
             }

--- a/bitcoin/src/blockdata/fee_rate.rs
+++ b/bitcoin/src/blockdata/fee_rate.rs
@@ -1,0 +1,136 @@
+//! Implements `FeeRate` and assoctiated features.
+
+use core::fmt;
+use core::ops::{Mul, Div};
+use crate::Amount;
+use super::Weight;
+
+/// Represents fee rate.
+///
+/// This is an integer newtype representing fee rate in `sat/kwu`. It provides protection against mixing
+/// up the types as well as basic formatting features.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct FeeRate(u64);
+
+impl FeeRate {
+    /// 0 sat/kwu.
+    ///
+    /// Equivalent to [`MIN`](Self::MIN), may better express intent in some contexts.
+    pub const ZERO: FeeRate = FeeRate(0);
+
+    /// Minimum possible value (0 sat/kwu).
+    ///
+    /// Equivalent to [`ZERO`](Self::ZERO), may better express intent in some contexts.
+    pub const MIN: FeeRate = FeeRate(u64::min_value());
+
+    /// Maximum possible value.
+    pub const MAX: FeeRate = FeeRate(u64::max_value());
+
+    /// Minimum fee rate required to broadcast a transaction.
+    ///
+    /// The value matches the default Bitcoin Core policy at the time of library release.
+    pub const BROADCAST_MIN: FeeRate = FeeRate::from_sat_per_vb_unchecked(1);
+
+    /// Fee rate used to compute dust amount.
+    pub const DUST: FeeRate = FeeRate::from_sat_per_vb_unchecked(3);
+
+    /// Constructs `FeeRate` from satoshis per 1000 weight units.
+    pub const fn from_sat_per_kwu(sat_kwu: u64) -> Self {
+        FeeRate(sat_kwu)
+    }
+
+    /// Constructs `FeeRate` from satoshis per virtual bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` on arithmetic overflow.
+    pub fn from_sat_per_vb(sat_vb: u64) -> Option<Self> {
+        // 1 vb == 4 wu
+        // 1 sat/vb == 1/4 sat/wu
+        // sat_vb sat/vb * 1000 / 4 == sat/kwu
+        Some(FeeRate(sat_vb.checked_mul(1000 / 4)?))
+    }
+
+    /// Constructs `FeeRate` from satoshis per virtual bytes without overflow check.
+    pub const fn from_sat_per_vb_unchecked(sat_vb: u64) -> Self {
+        FeeRate(sat_vb * (1000 / 4))
+    }
+
+    /// Returns raw fee rate.
+    ///
+    /// Can be used instead of `into()` to avoid inference issues.
+    pub const fn to_sat_per_kwu(self) -> u64 {
+        self.0
+    }
+
+    /// Converts to sat/vB rounding down.
+    pub const fn to_sat_per_vb_floor(self) -> u64 {
+        self.0 / (1000 / 4)
+    }
+
+    /// Converts to sat/vB rounding up.
+    pub const fn to_sat_per_vb_ceil(self) -> u64 {
+        (self.0 + (1000 / 4 - 1)) / (1000 / 4)
+    }
+
+    /// Checked multiplication.
+    ///
+    /// Computes `self * rhs` returning `None` if overflow occurred.
+    pub fn checked_mul(self, rhs: u64) -> Option<Self> {
+        self.0.checked_mul(rhs).map(Self)
+    }
+
+    /// Checked division.
+    ///
+    /// Computes `self / rhs` returning `None` if `rhs == 0`.
+    pub fn checked_div(self, rhs: u64) -> Option<Self> {
+        self.0.checked_div(rhs).map(Self)
+    }
+}
+
+/// Alternative will display the unit.
+impl fmt::Display for FeeRate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "{} sat/kwu", self.0)
+        } else {
+            fmt::Display::fmt(&self.0, f)
+        }
+    }
+}
+
+impl From<FeeRate> for u64 {
+    fn from(value: FeeRate) -> Self {
+        value.to_sat_per_kwu()
+    }
+}
+
+/// Computes ceiling so that fee computation is conservative.
+impl Mul<FeeRate> for Weight {
+    type Output = Amount;
+
+    fn mul(self, rhs: FeeRate) -> Self::Output {
+        Amount::from_sat((rhs.to_sat_per_kwu() * self.to_wu() + 999) / 1000)
+    }
+}
+
+impl Mul<Weight> for FeeRate {
+    type Output = Amount;
+
+    fn mul(self, rhs: Weight) -> Self::Output {
+        rhs * self
+    }
+}
+
+impl Div<Weight> for Amount {
+    type Output = FeeRate;
+
+    fn div(self, rhs: Weight) -> Self::Output {
+        FeeRate(self.to_sat() * 1000 / rhs.to_wu())
+    }
+}
+
+crate::parse::impl_parse_str_through_int!(FeeRate);

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -14,3 +14,8 @@ pub mod script;
 pub mod transaction;
 pub mod block;
 pub mod witness;
+pub mod weight;
+pub mod fee_rate;
+
+pub use weight::Weight;
+pub use fee_rate::FeeRate;

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -1,0 +1,198 @@
+//! Implements `Weight` and associated features.
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign};
+
+/// Represents block weight - the weight of a transaction or block.
+///
+/// This is an integer newtype representing weigth in `wu`. It provides protection against mixing
+/// up the types as well as basic formatting features.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Weight(u64);
+
+impl Weight {
+    /// 0 wu.
+    ///
+    /// Equivalent to [`MIN`](Self::MIN), may better express intent in some contexts.
+    pub const ZERO: Weight = Weight(0);
+
+    /// Minimum possible value (0 wu).
+    ///
+    /// Equivalent to [`ZERO`](Self::ZERO), may better express intent in some contexts.
+    pub const MIN: Weight = Weight(u64::min_value());
+
+    /// Maximum possible value.
+    pub const MAX: Weight = Weight(u64::max_value());
+
+    /// Directly constructs `Weight` from weight units.
+    pub const fn from_wu(wu: u64) -> Self {
+        Weight(wu)
+    }
+
+    /// Constructs `Weight` from virtual bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` on overflow.
+    pub fn from_vb(vb: u64) -> Option<Self> {
+        vb.checked_mul(4).map(Weight::from_wu)
+    }
+
+    /// Constructs `Weight` from virtual bytes without overflow check.
+    pub const fn from_vb_unchecked(vb: u64) -> Self {
+        Weight::from_wu(vb * 4)
+    }
+
+    /// Constructs `Weight` from witness size.
+    pub const fn from_witness_data_size(witness_size: u64) -> Self {
+        Weight(witness_size)
+    }
+
+    /// Constructs `Weight` from non-witness size.
+    pub const fn from_non_witness_data_size(non_witness_size: u64) -> Self {
+        Weight(non_witness_size * 4)
+    }
+
+    /// Returns raw weight units.
+    ///
+    /// Can be used instead of `into()` to avoid inference issues.
+    pub const fn to_wu(self) -> u64 {
+        self.0
+    }
+
+    /// Converts to vB rounding down.
+    pub const fn to_vbytes_floor(self) -> u64 {
+        self.0 / 4
+    }
+
+    /// Converts to vB rounding up.
+    pub const fn to_vbytes_ceil(self) -> u64 {
+        (self.0 + 3) / 4
+    }
+
+    /// Checked addition.
+    ///
+    /// Computes `self + rhs` returning `None` if overflow occurred.
+    pub fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.0.checked_add(rhs.0).map(Self)
+    }
+
+    /// Checked subtraction.
+    ///
+    /// Computes `self - rhs` returning `None` if overflow occurred.
+    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.0.checked_add(rhs.0).map(Self)
+    }
+
+    /// Checked multiplication.
+    ///
+    /// Computes `self * rhs` returning `None` if overflow occurred.
+    pub fn checked_mul(self, rhs: u64) -> Option<Self> {
+        self.0.checked_mul(rhs).map(Self)
+    }
+
+    /// Checked division.
+    ///
+    /// Computes `self / rhs` returning `None` if `rhs == 0`.
+    pub fn checked_div(self, rhs: u64) -> Option<Self> {
+        self.0.checked_div(rhs).map(Self)
+    }
+}
+
+/// Alternative will display the unit.
+impl fmt::Display for Weight {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "{} wu", self.0)
+        } else {
+            fmt::Display::fmt(&self.0, f)
+        }
+    }
+}
+
+impl From<Weight> for u64 {
+    fn from(value: Weight) -> Self {
+        value.to_wu()
+    }
+}
+
+impl Add for Weight {
+    type Output = Weight;
+
+    fn add(self, rhs: Weight) -> Self::Output {
+        Weight(self.0 + rhs.0)
+    }
+}
+
+impl AddAssign for Weight {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0
+    }
+}
+
+impl Sub for Weight {
+    type Output = Weight;
+
+    fn sub(self, rhs: Weight) -> Self::Output {
+        Weight(self.0 - rhs.0)
+    }
+}
+
+impl SubAssign for Weight {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0
+    }
+}
+
+impl Mul<u64> for Weight {
+    type Output = Weight;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        Weight(self.0 * rhs)
+    }
+}
+
+impl Mul<Weight> for u64 {
+    type Output = Weight;
+
+    fn mul(self, rhs: Weight) -> Self::Output {
+        Weight(self * rhs.0)
+    }
+}
+
+impl MulAssign<u64> for Weight {
+    fn mul_assign(&mut self, rhs: u64) {
+        self.0 *= rhs
+    }
+}
+
+impl Div<u64> for Weight {
+    type Output = Weight;
+
+    fn div(self, rhs: u64) -> Self::Output {
+        Weight(self.0 / rhs)
+    }
+}
+
+impl DivAssign<u64> for Weight {
+    fn div_assign(&mut self, rhs: u64) {
+        self.0 /= rhs
+    }
+}
+
+impl core::iter::Sum for Weight {
+    fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
+        Weight(iter.map(Weight::to_wu).sum())
+    }
+}
+
+impl<'a> core::iter::Sum<&'a Weight> for Weight {
+    fn sum<I>(iter: I) -> Self where I: Iterator<Item = &'a Weight> {
+        iter.cloned().sum()
+    }
+}
+
+crate::parse::impl_parse_str_through_int!(Weight);

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -116,7 +116,7 @@ pub(crate) use impl_tryfrom_str_through_int_single;
 /// The `Error` type is `ParseIntError`
 macro_rules! impl_parse_str_through_int {
     ($to:ident $(, $fn:ident)?) => {
-        $crate::parse::impl_tryfrom_str_through_int_single!(&str, $to $(, $fn)?; String, $to $(, $fn)?; Box<str>, $to $(, $fn)?);
+        $crate::parse::impl_tryfrom_str_through_int_single!(&str, $to $(, $fn)?; alloc::string::String, $to $(, $fn)?; alloc::boxed::Box<str>, $to $(, $fn)?);
 
         impl core::str::FromStr for $to {
             type Err = $crate::error::ParseIntError;


### PR DESCRIPTION
Use of general-purpose integers is often error-prone and annoying. We're working towards improving it by introducing newtypes.

This adds newtypes for weight and fee rate to make fee computation easier and more readable. Note however that this dosn't change the type for individual parts of the transaction since computing the total weight is not as simple as summing them up and we want to avoid such confusion.

Part of #630
Replaces #1607 (I want to get this in quickly and don't want to be blocked on DanGould's availability.)