### PR TITLE
Add methods for pushing locktimes

### DIFF
--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,8 +7,10 @@ use core::fmt;
 
 use secp256k1::XOnlyPublicKey;
 
+use crate::blockdata::locktime::absolute;
 use crate::blockdata::opcodes::{self, all::*};
 use crate::blockdata::script::{write_scriptint, opcode_to_verify, Script, ScriptBuf};
+use crate::blockdata::transaction::Sequence;
 use crate::key::PublicKey;
 use crate::prelude::*;
 
@@ -104,6 +106,16 @@ impl Builder {
             },
             None => self.push_opcode(OP_VERIFY),
         }
+    }
+
+    /// Adds instructions to push an absolute lock time onto the stack.
+    pub fn push_lock_time(self, lock_time: absolute::LockTime) -> Builder {
+        self.push_int(lock_time.to_consensus_u32().into())
+    }
+
+    /// Adds instructions to push a sequence number onto the stack.
+    pub fn push_sequence(self, sequence: Sequence) -> Builder  {
+        self.push_int(sequence.to_consensus_u32().into())
     }
 
     /// Converts the `Builder` into `ScriptBuf`.


### PR DESCRIPTION
Lock times are `u32` and can require encoding using 5 bytes. 
    
Add methods `push_lock_time` and `push_sequence` for pushing absolute lock times and sequence numbers. We do not push relative locktimes because they are only 16 bits from the original sequence number.
 

