### PR TITLE
Improve to/from_consensus

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -128,12 +128,33 @@ impl Version {
     /// Creates a [`Version`] from a signed 32 bit integer value.
     ///
     /// This is the data type used in consensus code in Bitcoin Core.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::block::Version;
+    /// // Roundtrips with `Version::to_consensus_i32()`.
+    /// assert_eq!(Version::from_consensus(1).to_consensus_i32(), 1)
+    /// ```
+    #[inline]
     pub fn from_consensus(v: i32) -> Self { Version(v) }
 
-    /// Returns the inner `i32` value.
+    /// Returns the inner `i32` consensus encoded value.
     ///
-    /// This is the data type used in consensus code in Bitcoin Core.
-    pub fn to_consensus(self) -> i32 { self.0 }
+    /// # Examples
+    /// ```
+    /// # use bitcoin::block::Version;
+    /// // Roundtrips with `Version::from_consensus()`.
+    /// let v = Version::ONE;
+    /// assert_eq!(Version::from_consensus(v.to_consensus_i32()), v)
+    /// ```
+    #[inline]
+    pub fn to_consensus_i32(self) -> i32 { self.0 }
+
+    /// Returns the inner `i32` consensus encoded value.
+    ///
+    /// Equivalent to [`Self::to_consensus_i32`] and `i32::from()`.
+    #[inline]
+    pub fn to_i32(self) -> i32 { self.to_consensus_i32() }
 
     /// Checks whether the version number is signalling a soft fork at the given bit.
     ///
@@ -157,6 +178,11 @@ impl Version {
 
 impl Default for Version {
     fn default() -> Version { Self::NO_SOFT_FORK_SIGNALLING }
+}
+
+impl From<Version> for i32 {
+    #[inline]
+    fn from(v: Version) -> Self { v.to_consensus_i32() }
 }
 
 impl Encodable for Version {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -399,13 +399,40 @@ impl Sequence {
         }
     }
 
-    /// Creates a sequence from a u32 value.
+    /// Creates a sequence from a `u32` value.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::transaction::Sequence;
+    /// # let bits = 0x40FFFF;
+    /// // Roundtrips with `Sequence::to_consensus()`.
+    /// assert_eq!(Sequence::from_consensus(bits).to_consensus_u32(), bits)
+    /// ```
     #[inline]
     pub fn from_consensus(n: u32) -> Self { Sequence(n) }
 
-    /// Returns the inner 32bit integer value of Sequence.
+    /// Returns the inner `u32` consensus encoded value.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::transaction::Sequence;
+    /// // Roundtrips with `Sequence::from_consensus()`.
+    /// let n = Sequence::from(0x40FFFF);
+    /// assert_eq!(Sequence::from_consensus(n.to_consensus_u32()), n)
+    /// ```
     #[inline]
     pub fn to_consensus_u32(self) -> u32 { self.0 }
+
+    /// Returns the inner `u32` consensus encoded value.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::transaction::Sequence;
+    /// let n = Sequence::from_consensus(0x40FFFF);
+    /// assert_eq!(n.to_u32(), n.to_consensus_u32());
+    /// ```
+    #[inline]
+    pub fn to_u32(self) -> u32 { self.to_consensus_u32() }
 
     /// Creates a [`relative::LockTime`] from this [`Sequence`] number.
     #[inline]
@@ -445,8 +472,14 @@ impl Default for Sequence {
     fn default() -> Self { Sequence::MAX }
 }
 
+impl From<u32> for Sequence {
+    #[inline]
+    fn from(x: u32) -> Self { Sequence::from_consensus(x) }
+}
+
 impl From<Sequence> for u32 {
-    fn from(sequence: Sequence) -> u32 { sequence.0 }
+    #[inline]
+    fn from(n: Sequence) -> Self { Sequence::to_consensus_u32(n) }
 }
 
 impl fmt::Display for Sequence {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -331,7 +331,7 @@ impl<'s> ScriptPath<'s> {
         let mut enc = TapLeafHash::engine();
 
         self.leaf_version
-            .to_consensus()
+            .to_consensus_u8()
             .consensus_encode(&mut enc)
             .expect("Writing to hash enging should never fail");
         self.script.consensus_encode(&mut enc).expect("Writing to hash enging should never fail");

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -252,14 +252,48 @@ pub struct CompactTarget(u32);
 
 impl CompactTarget {
     /// Creates a [`CompactTarget`] from a consensus encoded `u32`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::pow::CompactTarget;
+    /// # let bits = 0x1d00ffff;
+    /// // Roundtrips with `CompactTarget::to_consensus_u32()`.
+    /// assert_eq!(CompactTarget::from_consensus(bits).to_consensus_u32(), bits)
+    /// ```
+    #[inline]
     pub fn from_consensus(bits: u32) -> Self { Self(bits) }
 
     /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
-    pub fn to_consensus(self) -> u32 { self.0 }
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::pow::CompactTarget;
+    /// // Roundtrips with `CompactTarget::from_consensus()`.
+    /// let c = CompactTarget::from_consensus(0x1d00ffff);
+    /// assert_eq!(CompactTarget::from_consensus(c.to_consensus_u32()), c)
+    /// ```
+    #[inline]
+    pub fn to_consensus_u32(self) -> u32 { self.0 }
+
+    /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
+    ///
+    /// # Examples
+    /// ```
+    /// # use bitcoin::pow::CompactTarget;
+    /// // Equivalent to `Self::to_consensus_u32()` and `u32::from()`.
+    /// let c = CompactTarget::from_consensus(0x1d00ffff);
+    /// assert_eq!(c.to_u32(), c.to_consensus_u32());
+    /// ```
+    #[inline]
+    pub fn to_u32(self) -> u32 { self.to_consensus_u32() }
 }
 
 impl From<CompactTarget> for Target {
     fn from(c: CompactTarget) -> Self { Target::from_compact(c) }
+}
+
+impl From<CompactTarget> for u32 {
+    fn from(c: CompactTarget) -> Self { c.to_consensus_u32() }
 }
 
 impl FromHexStr for CompactTarget {
@@ -1582,7 +1616,7 @@ mod tests {
         let back = t.to_compact_lossy();
         assert_eq!(back, compact); // From/Into sanity check.
 
-        assert_eq!(back.to_consensus(), consensus);
+        assert_eq!(back.to_consensus_u32(), consensus);
     }
 
     #[test]

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -302,7 +302,7 @@ impl Serialize for (ScriptBuf, LeafVersion) {
     fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.0.len() + 1);
         buf.extend(self.0.as_bytes());
-        buf.push(self.1.to_consensus());
+        buf.push(self.1.to_consensus_u8());
         buf
     }
 }
@@ -355,7 +355,7 @@ impl Serialize for TapTree {
             // TaprootMerkleBranch can only have len atmost 128(TAPROOT_CONTROL_MAX_NODE_COUNT).
             // safe to cast from usize to u8
             buf.push(leaf_info.merkle_branch().len() as u8);
-            buf.push(leaf_info.version().to_consensus());
+            buf.push(leaf_info.version().to_consensus_u8());
             leaf_info.script().consensus_encode(&mut buf).expect("Vecs dont err");
         }
         buf


### PR DESCRIPTION
We have many types that convert to/from consensus encode integers. We would like to provide an API that is:

- Intuitive (i.e., uniform method names)
- Ergonomic for hardcore Bitcoin/Rust devs
- Safe and clear without forcing policy on downstream devs

Attempt to achieve the above by adding additional methods to various types. Also add examples to help document the methods and as rustdoc tests (found we were lacking in this department using `cargo mutants`).

With this applied all relevant types have, (or should have assuming I haven't missed any):
    
- `from_consensus`
- `From<type>` or `TryFrom<type>`
- `to_consensus_<type>`
- `to_<type>`
    
Some have `u8` and `u32` for `<type>`


### Note

Includes the changes in #1303 (so fixes #1302)

FTR this leaves the types in `taproot` without rustdoc tests, I'm not as familiar with that `module` so I elected to leave it as is - can do if/when this merges.