### PR TITLE
Remove Into requirement from FromHexStr

### DIFF
--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -327,7 +327,7 @@ impl FromHexStr for LockTime {
     type Error = Error;
 
     #[inline]
-    fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
+    fn from_hex_str_no_prefix<S: AsRef<str>>(s: S) -> Result<Self, Self::Error> {
         let packed_lock_time = crate::parse::hex_u32(s)?;
         Ok(Self::from_consensus(packed_lock_time))
     }
@@ -461,7 +461,7 @@ impl FromHexStr for Height {
     type Error = Error;
 
     #[inline]
-    fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
+    fn from_hex_str_no_prefix<S: AsRef<str>>(s: S) -> Result<Self, Self::Error> {
         let height = crate::parse::hex_u32(s)?;
         Self::from_consensus(height)
     }
@@ -574,7 +574,7 @@ impl FromHexStr for Time {
     type Error = Error;
 
     #[inline]
-    fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
+    fn from_hex_str_no_prefix<S: AsRef<str>>(s: S) -> Result<Self, Self::Error> {
         let time = crate::parse::hex_u32(s)?;
         Time::from_consensus(time)
     }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -461,7 +461,7 @@ impl Sequence {
 impl FromHexStr for Sequence {
     type Error = crate::parse::ParseIntError;
 
-    fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
+    fn from_hex_str_no_prefix<S: AsRef<str>>(s: S) -> Result<Self, Self::Error> {
         let sequence = crate::parse::hex_u32(s)?;
         Ok(Self::from_consensus(sequence))
     }

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -70,10 +70,10 @@ impl_integer!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128);
 ///
 /// If the caller owns `String` or `Box<str>` which is not used later it's better to pass it as
 /// owned since it avoids allocation in error case.
-pub(crate) fn int<T: Integer, S: AsRef<str> + Into<String>>(s: S) -> Result<T, ParseIntError> {
+pub(crate) fn int<T: Integer, S: AsRef<str>>(s: S) -> Result<T, ParseIntError> {
     s.as_ref().parse().map_err(|error| {
         ParseIntError {
-            input: s.into(),
+            input: s.as_ref().to_owned(),
             bits: u8::try_from(core::mem::size_of::<T>() * 8).expect("max is 128 bits for u128"),
             // We detect if the type is signed by checking if -1 can be represented by it
             // this way we don't have to implement special traits and optimizer will get rid of the
@@ -84,9 +84,9 @@ pub(crate) fn int<T: Integer, S: AsRef<str> + Into<String>>(s: S) -> Result<T, P
     })
 }
 
-pub(crate) fn hex_u32<S: AsRef<str> + Into<String>>(s: S) -> Result<u32, ParseIntError> {
+pub(crate) fn hex_u32<S: AsRef<str>>(s: S) -> Result<u32, ParseIntError> {
     u32::from_str_radix(s.as_ref(), 16).map_err(|error| ParseIntError {
-        input: s.into(),
+        input: s.as_ref().to_owned(),
         bits: u8::try_from(core::mem::size_of::<u32>() * 8).expect("max is 32 bits for u32"),
         is_signed: u32::try_from(-1i8).is_ok(),
         source: error,

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -18,7 +18,6 @@ use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::consensus::Params;
 use crate::hash_types::BlockHash;
 use crate::io::{self, Read, Write};
-use crate::prelude::String;
 use crate::string::FromHexStr;
 
 /// Implements $int * $ty. Requires `u64::from($int)`.
@@ -293,7 +292,7 @@ impl From<CompactTarget> for Target {
 impl FromHexStr for CompactTarget {
     type Error = crate::parse::ParseIntError;
 
-    fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
+    fn from_hex_str_no_prefix<S: AsRef<str>>(s: S) -> Result<Self, Self::Error> {
         let compact_target = crate::parse::hex_u32(s)?;
         Ok(Self::from_consensus(compact_target))
     }

--- a/bitcoin/src/string.rs
+++ b/bitcoin/src/string.rs
@@ -9,7 +9,7 @@ use core::fmt;
 
 use bitcoin_internals::write_err;
 
-use crate::prelude::String;
+use crate::prelude::*;
 
 /// Trait that allows types to be initialized from hex strings
 pub trait FromHexStr: Sized {
@@ -19,9 +19,9 @@ pub trait FromHexStr: Sized {
     /// Parses provided string as hex requiring 0x prefix.
     ///
     /// This is intended for user-supplied inputs or already-existing protocols in which 0x prefix is used.
-    fn from_hex_str<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, FromHexError<Self::Error>> {
+    fn from_hex_str<S: AsRef<str>>(s: S) -> Result<Self, FromHexError<Self::Error>> {
         if !s.as_ref().starts_with("0x") {
-            Err(FromHexError::MissingPrefix(s.into()))
+            Err(FromHexError::MissingPrefix(s.as_ref().to_owned()))
         } else {
             Ok(Self::from_hex_str_no_prefix(s.as_ref().trim_start_matches("0x"))?)
         }
@@ -31,7 +31,7 @@ pub trait FromHexStr: Sized {
     ///
     /// This is **not** recommended for user-supplied inputs because of possible confusion with decimals.
     /// It should be only used for existing protocols which always encode values as hex without 0x prefix.
-    fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error>;
+    fn from_hex_str_no_prefix<S: AsRef<str>>(s: S) -> Result<Self, Self::Error>;
 }
 
 /// Hex parsing error


### PR DESCRIPTION
`ToOwned` is already implemented for `str` and expresses the intent of owning the string for error reporting purpose.

IMO a lifetime would be much better to avoid resource exhaustion attacks (but it depends if the user of the API allows unstrusted input anyway) and to be `alloc`-less friendly, but lifetimes and `Error`s don't scale that well.

I'm also thinking of renaming the module to `str` as the `FromHexStr` tries to mimic `FromStr` but for hex only strings.