### PR TITLE
Remove FromStr impl from ScriptBuf

### DIFF
--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -62,7 +62,6 @@ use serde;
 use crate::blockdata::opcodes::{self, all::*};
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::hash_types::{ScriptHash, WScriptHash};
-use crate::hashes::hex;
 use crate::{io, OutPoint};
 use crate::prelude::*;
 
@@ -341,14 +340,6 @@ impl From<&ScriptBuf> for WScriptHash {
 impl From<&Script> for WScriptHash {
     fn from(script: &Script) -> WScriptHash {
         script.wscript_hash()
-    }
-}
-
-impl core::str::FromStr for ScriptBuf {
-    type Err = hex::Error;
-    #[inline]
-    fn from_str(s: &str) -> Result<Self, hex::Error> {
-        ScriptBuf::from_hex(s)
     }
 }
 


### PR DESCRIPTION
`FromStr` impls should roundtrip with `Display` imlps but currently our `ScriptBuf` displays using instructions but parses hex.

Looks like this slipped back in during a recent rebase fail by me.