### PR TITLE
Clarify the intention of strange condition

### DIFF
--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -435,6 +435,8 @@ mod error {
     }
 }
 
+// we have 64 bits in mind, but even for esoteric sizes, this code is correct, since it's the
+// conservative one that checks for errors
 #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
 mod error {
     use core::fmt;


### PR DESCRIPTION
It may not be obvious why the condition in `push_bytes` module checks for negation of 16 and 32 bit architectures rather than 64 bit. This adds a comment about it being conservative.

Addresses https://github.com/rust-bitcoin/rust-bitcoin/pull/1190#discussion_r1111342671