### PR TITLE
script: Mutate and improve unit testing

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -8,6 +8,8 @@ use core::ops::Bound;
 use core::ops::{Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 use hashes::Hash;
+#[cfg(all(test, mutate))]
+use mutagen::mutate;
 use secp256k1::{Secp256k1, Verification};
 
 use crate::address::WitnessVersion;
@@ -211,6 +213,7 @@ impl Script {
 
     /// Returns the bytes of the (possibly invalid) public key if this script is P2PK.
     #[inline]
+    #[cfg_attr(all(test, mutate), mutate)]
     pub(in crate::blockdata::script) fn p2pk_pubkey_bytes(&self) -> Option<&[u8]> {
         match self.len() {
             67 if self.0[0] == OP_PUSHBYTES_65.to_u8() && self.0[66] == OP_CHECKSIG.to_u8() =>


### PR DESCRIPTION
Use `mutagen` to mutate functions and methods in the `script` module. Add more unit tests as needed to ensure mutants are killed.

Note please: Includes logic changes to `read_uint_iter()` - this function is private and the logic changes make it more fit for purpose, done with the assistance of `mutagen`.

### False positives

This PR introduces a way to handle `mutagen` false positives. We add a non-doc comment starting with the prefix `// mutagen false pos <function name>` and then after running `mutagen` one can grep the code base to see false positives (note the function name in the `git grep` output and the `mutagen` output.
```
$ RUSTFLAGS='--cfg=mutate' cargo +nightly mutagen

...

SURVIVED
    bitcoin/src/blockdata/locktime/absolute.rs
            all 13 mutants killed
    bitcoin/src/blockdata/locktime/relative.rs
            all 16 mutants killed
    bitcoin/src/blockdata/script/borrowed.rs
            all 20 mutants killed
    bitcoin/src/blockdata/script/mod.rs
            6/107(5.61%) mutants survived
        53: replace `0` with `1` at 104:19-104:20(fn write_scriptint)
        54: replace `<` with `<=` at 104:17-104:18(fn write_scriptint)
        58: replace `255` with `254` at 107:17-107:21(fn write_scriptint)
        61: replace `>` with `>=` at 107:15-107:16(fn write_scriptint)
        101: replace `1` with `0` at 169:23-169:24(fn read_scriptint)
        102: replace `<=` with `<` at 169:20-169:22(fn read_scriptint)
    bitcoin/src/pow.rs
            all 128 mutants killed

284 generated mutants
278(97.89%) mutants killed, 1(0.35%) by timeout
6(2.11%) mutants SURVIVED, 0(0.00%) NOT COVERED
Total time: 1m 35s

$ git grep 'mutagen false pos '
bitcoin/src/blockdata/script/mod.rs:94:// mutagen false pos write_scriptint: replace `0` with `1` (on line: let neg = n < 0;)
bitcoin/src/blockdata/script/mod.rs:95:// mutagen false pos write_scriptint: replace `<` with `<=` (on line: let neg = n < 0;)
bitcoin/src/blockdata/script/mod.rs:96:// mutagen false pos write_scriptint: replace `255` with `254` (on line: while abs > 0xFF {)
bitcoin/src/blockdata/script/mod.rs:97:// mutagen false pos write_scriptint: replace `>` with `>=` (on line: while abs > 0xFF {)
bitcoin/src/blockdata/script/mod.rs:147:// mutagen false pos read_scriptint: replace `1` with `0`  (on line: if v.len() <= 1 || (v[v.len() - 2] & 0x80) == 0 {)
bitcoin/src/blockdata/script/mod.rs:148:// mutagen false pos read_scriptint: replace `<=` with `<` (on line: if v.len() <= 1 || (v[v.len() - 2] & 0x80) == 0 {)
```
