### PR TITLE
Changing docs and examples to use correct function signature

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -52,7 +52,7 @@ fn main() {
     // generate first receiving address at m/0/0
     // manually creating indexes this time
     let zero = ChildNumber::from_normal_idx(0).unwrap();
-    let public_key = xpub.derive_pub(&secp, &vec![zero, zero]).unwrap().public_key;
+    let public_key = xpub.derive_pub(&secp, &[zero, zero]).unwrap().public_key;
     let address = Address::p2wpkh(&PublicKey::new(public_key), network).unwrap();
     println!("First receiving address: {}", address);
 }

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -265,7 +265,7 @@ impl WatchOnly {
         &self,
         secp: &Secp256k1<C>,
     ) -> Result<(PublicKey, Address, DerivationPath)> {
-        let path = vec![ChildNumber::from_normal_idx(1)?, ChildNumber::from_normal_idx(0)?];
+        let path = [ChildNumber::from_normal_idx(1)?, ChildNumber::from_normal_idx(0)?];
         let derived = self.account_0_xpub.derive_pub(secp, &path)?;
 
         let pk = derived.to_pub();

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -683,7 +683,7 @@ impl ExtendedPubKey {
 
     /// Attempts to derive an extended public key from a path.
     ///
-    /// The `path` argument can be both of type `DerivationPath` or `AsRef<ChildNumber>`.
+    /// The `path` argument can be any type implementing `AsRef<ChildNumber>`, such as `DerivationPath`, for instance.
     pub fn derive_pub<C: secp256k1::Verification, P: AsRef<[ChildNumber]>>(
         &self,
         secp: &Secp256k1<C>,

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -683,7 +683,7 @@ impl ExtendedPubKey {
 
     /// Attempts to derive an extended public key from a path.
     ///
-    /// The `path` argument can be both of type `DerivationPath` or `Vec<ChildNumber>`.
+    /// The `path` argument can be both of type `DerivationPath` or `AsRef<ChildNumber>`.
     pub fn derive_pub<C: secp256k1::Verification, P: AsRef<[ChildNumber]>>(
         &self,
         secp: &Secp256k1<C>,


### PR DESCRIPTION
`P: AsRef<[ChildNumber]>` means that path can be borrowed as a reference to a slice of `ChildNumber`.

While it does work with `Vec`, the documentation and examples mislead the user into thinking that he/she has to use a vec, which is not true. A simple reference to a slice of `ChildNumber` also works and does not consume heap