### PR TITLE
Pin syn dependency for MSRV toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ For more information please see `./CONTRIBUTING.md`.
 This library should always compile with any combination of features (minus
 `no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
 
+To build with the MSRV you will need to pin some dependencies, currently this is
+only `syn`, and can be achieved using `cargo update -p syn --precise 1.0.107`.
+
 ## Installing Rust
 
 Rust can be installed using your package manager of choice or

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -18,6 +18,12 @@ if cargo --version | grep nightly; then
     NIGHTLY=true
 fi
 
+# Pin dependencies as required if we are using MSRV toolchain.
+if cargo --version | grep "1\.41"; then
+    # 1.0.108 uses `matches!` macro so does not work with Rust 1.41.1, bad `syn` no biscuit.
+    cargo update -p syn --precise 1.0.107
+fi
+
 # We should not have any duplicate dependencies. This catches mistakes made upgrading dependencies
 # in one crate and not in another (e.g. upgrade bitcoin_hashes in bitcoin but not in secp).
 duplicate_dependencies=$(cargo tree  --target=all --all-features --duplicates | wc -l)


### PR DESCRIPTION
CI change only, can this merge without 2 acks?

The recent 1.0.108 `syn` update violated our MSRV, pin `syn` in the CI script.