### PR TITLE
Accept borrowed values in InputWeightPrediction::new()

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1278,11 +1278,12 @@ pub struct InputWeightPrediction {
 
 impl InputWeightPrediction {
     /// Computes the prediction for a single input.
-    pub fn new<I>(input_script_len: usize, witness_element_lengths: I) -> Self
-        where I: IntoIterator<Item = usize>,
+    pub fn new<T>(input_script_len: usize, witness_element_lengths: T) -> Self
+        where T :IntoIterator, T::Item:Borrow<usize>,
     {
         let (count, total_size) = witness_element_lengths.into_iter()
             .fold((0, 0), |(count, total_size), elem_len| {
+                let elem_len = *elem_len.borrow();
                 let elem_size = elem_len + VarInt(elem_len as u64).len();
                 (count + 1, total_size + elem_size)
             });


### PR DESCRIPTION
The updated implementation accepts borrowed values and now it is convenient to use with slices.


closes #1669 