### PR TITLE
Reexport `Magic`

### DIFF
--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -33,3 +33,5 @@ pub mod message_filter;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod message_network;
+
+pub use self::constants::Magic;


### PR DESCRIPTION
Writing `network::Magic` is more natural and less annoying than `network::constants::Magic`, so this change reexports it.

Closes #1667