### PR TITLE
Fix docs for UnknownMagic to be accurate

### DIFF
--- a/bitcoin/src/network/constants.rs
+++ b/bitcoin/src/network/constants.rs
@@ -239,7 +239,7 @@ impl From<Network> for Magic {
     }
 }
 
-/// Error in parsing magic from string.
+/// Error in creating a Network from Magic bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnknownMagic(Magic);
 


### PR DESCRIPTION
I assume the old docs are a copy-paste error, strings are not involved when this error is encountered.