### PR TITLE
Include address in Error::NetworkValidation

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -92,7 +92,9 @@ pub enum Error {
         /// Network that was required.
         required: Network,
         /// Network on which the address was found to be valid.
-        found: Network
+        found: Network,
+        /// The address itself
+        address: Address<NetworkUnchecked>
     }
 }
 
@@ -112,7 +114,11 @@ impl fmt::Display for Error {
             Error::ExcessiveScriptSize => write!(f, "script size exceed 520 bytes"),
             Error::UnrecognizedScript => write!(f, "script is not a p2pkh, p2sh or witness program"),
             Error::UnknownAddressType(ref s) => write!(f, "unknown address type: '{}' is either invalid or not supported in rust-bitcoin", s),
-	    Error::NetworkValidation { required, found } => write!(f, "address's network {} is different from required {}", found, required),
+            Error::NetworkValidation { required, found, ref address } => {
+                write!(f, "address ")?;
+                address.fmt_internal(f)?; // Using fmt_internal in order to remove the "Address<NetworkUnchecked>(..)" wrapper
+                write!(f, " belongs to network {} which is different from required {}", found, required)
+            }
         }
     }
 }
@@ -1003,7 +1009,7 @@ impl Address<NetworkUnchecked> {
         if self.is_valid_for_network(required) {
             Ok(self.assume_checked())
         } else {
-            Err(Error::NetworkValidation { found: self.network, required })
+            Err(Error::NetworkValidation { found: self.network, required, address: self })
         }
     }
 


### PR DESCRIPTION
Fixes: #1677

## Change
In `bitcoin/src/address.rs`, a new field `address` is added to the enum variant `Error::NetworkValidation`. Also, the implementation of `Display` trait for `Error` is updated to print the `address` field.

However, to print the `address` through `Display`, either the reference is needed or `Address` and `Payload` both need to derive the `Copy` trait. Since I am little new to both the rust-bitcoin codebase and rust itself, I am confused about choosing between the two and have moved with the first one. Would appreciate any feedback on this.