### PR TITLE
Print tool versions in ci

### DIFF
--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -9,15 +9,6 @@ then
     export RUSTFLAGS="-C link-dead-code"
 fi
 
-cargo --version
-rustc --version
-
-# Work out if we are using a nightly toolchain.
-NIGHTLY=false
-if cargo --version | grep nightly; then
-    NIGHTLY=true
-fi
-
 # Pin dependencies as required if we are using MSRV toolchain.
 if cargo --version | grep "1\.41"; then
     # 1.0.108 uses `matches!` macro so does not work with Rust 1.41.1, bad `syn` no biscuit.

--- a/bitcoin/fuzz/travis-fuzz.sh
+++ b/bitcoin/fuzz/travis-fuzz.sh
@@ -14,9 +14,6 @@ else
 	TARGETS=fuzz_targets/"$1".rs
 fi
 
-cargo --version
-rustc --version
-
 # Testing
 cargo install --force honggfuzz --no-default-features
 for TARGET in $TARGETS; do

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,6 +2,13 @@
 
 set -ex
 
+# Work out if we are using a nightly toolchain.
+if cargo +nightly --version >/dev/null 2>&1; then
+  NIGHTLY=true
+else
+  NIGHTLY=false
+fi
+
 # Print the versions of Rust and Cargo
 echo "Rust version:"
 if $NIGHTLY; then
@@ -11,18 +18,10 @@ else
 fi
 
 echo "Cargo version:"
-if cargo +nightly --version >/dev/null 2>&1; then
-  NIGHTLY=true
+if $NIGHTLY; then
+  cargo +nightly --version --verbose
 else
-  NIGHTLY=false
-fi
-
-
-# Work out if we are using a nightly toolchain.
-if cargo +nightly --version >/dev/null 2>&1; then
-  NIGHTLY=true
-else
-  NIGHTLY=false
+  cargo --version --verbose
 fi
 
 # Print clippy version if available

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,6 +2,41 @@
 
 set -ex
 
+# Print the versions of Rust and Cargo
+echo "Rust version:"
+if $NIGHTLY; then
+  rustc +nightly --version --verbose
+else
+  rustc --version --verbose
+fi
+
+echo "Cargo version:"
+if cargo +nightly --version >/dev/null 2>&1; then
+  NIGHTLY=true
+else
+  NIGHTLY=false
+fi
+
+
+# Work out if we are using a nightly toolchain.
+if cargo +nightly --version >/dev/null 2>&1; then
+  NIGHTLY=true
+else
+  NIGHTLY=false
+fi
+
+# Print clippy version if available
+if command -v cargo-clippy &> /dev/null; then
+  echo "Clippy version:"
+  cargo clippy --version --verbose
+fi
+
+# Print fmt version if available
+if command -v cargo-fmt &> /dev/null; then
+  echo "Fmt version:"
+  cargo fmt --version --verbose
+fi
+
 CRATES="bitcoin hashes internals"
 
 for crate in ${CRATES}


### PR DESCRIPTION
Add commands to (verbosely) print out versions of Rust, Clippy, Cargo before each run in CI. Fixes #1124. 