### PR TITLE
release bitcoin_hashes 0.12

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -36,8 +36,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitcoin-internals = { path = "../internals" }
 bech32 = { version = "0.9.0", default-features = false }
-bitcoin_hashes = { version = "0.11.0", default-features = false }
-secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", tag = "2023-02-01--fix-hashes", default-features = false, features = ["bitcoin_hashes"] }
+bitcoin_hashes = { version = "0.12.0", default-features = false }
+secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", tag = "2023-03-05--fix-hashes", default-features = false, features = ["bitcoin_hashes"] }
 hex_lit = "0.1.1"
 
 base64 = { version = "0.13.0", optional = true }
@@ -50,7 +50,7 @@ actual-serde = { package = "serde", version = "1.0.103", default-features = fals
 serde_json = "1.0.0"
 serde_test = "1.0.19"
 serde_derive = "1.0.103"
-secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", tag = "2023-02-01--fix-hashes", features = ["recovery"] }
+secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", tag = "2023-03-05--fix-hashes", features = ["recovery"] }
 bincode = "1.3.1"
 
 [target.'cfg(mutate)'.dev-dependencies]

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -1,8 +1,22 @@
-# Unreleased (0.12.0)
+# 0.12.0 - 2023-03-05
 
-Move crate from [original repo](https://github.com/rust-bitcoin/bitcoin_hashes) to the
+0.12 is a significant release. We pulled the repository into the rust-bitcoin
+repo to improve our integration testing and to get more eyes on this crate. We
+began the process of replacing the hex functionality in this crate with a more
+performant, dedicated crate, and otherwise cleaning up the API as we look forward
+to 1.0.
+
+* Move crate from [original repo](https://github.com/rust-bitcoin/bitcoin_hashes) to the
 `rust-bitcoin` repository. Commit history was lost during move, for commit history see the original
 repository. Tip of bitcoin_hashes:master at time of import: 54c16249e06cc6b7870c7fc07d90f489d82647c7
+* [Remove `Deref` impls for all hashes](https://github.com/rust-bitcoin/rust-bitcoin/pull/1450)
+* [Add `AsRef` impls for all hashes from fixed-size arrays](https://github.com/rust-bitcoin/rust-bitcoin/pull/1593)
+* [Add the `sha512_256` hash](https://github.com/rust-bitcoin/rust-bitcoin/pull/1413)
+* [Remove the `ToHex` trait in favor of `DisplayHex` and `fmt::Display`](https://github.com/rust-bitcoin/rust-bitcoin/pull/1531)
+* [Remove the now-unused `HexWriter` object](https://github.com/rust-bitcoin/rust-bitcoin/pull/1572)
+* [nostd: `alloc` feature no longer enables `core2`](https://github.com/rust-bitcoin/rust-bitcoin/pull/1612)
+* [Rewrite `hash_newtype` macro with new syntax](https://github.com/rust-bitcoin/rust-bitcoin/pull/1659)
+* [Rename `Hash::Inner` to `Hash::Bytes`, 'Hash::*_inner` and several related conversion methods](https://github.com/rust-bitcoin/rust-bitcoin/pull/1577)
 
 
 # 0.11.0 - 2022-06-25

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/bitcoin_hashes/"


### PR DESCRIPTION
It was a little tricky to bump the version number because of https://github.com/rust-bitcoin/rust-bitcoin/issues/1553. There are a couple other things I considered trying, which maybe we'll do for future releases, but I believe this works for now.

Maybe should wait for #1111.