### PR TITLE
Remove `schemars` pin from manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,15 @@ For more information please see `./CONTRIBUTING.md`.
 
 This library should always compile with any combination of features on **Rust 1.48.0**.
 
-To build with the MSRV you will need to pin some dependencies:
+To build with the MSRV you will need to pin `serde` (if you have the feature enabled)
+
 ```
+# serde 1.0.157 uses syn 2.0 which requires edition 2021
 cargo update -p serde --precise 1.0.156
-cargo update -p syn --precise 1.0.107
 ```
+
+before building. (And if your code is a library, your downstream users will need to run these
+commands, and so on.)
 
 ## Installing Rust
 

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -27,8 +27,6 @@ fi
 if cargo --version | grep "1\.48"; then
     # 1.0.157 uses syn 2.0 which requires edition 2018
     cargo update -p serde --precise 1.0.156
-    # 1.0.108 uses `matches!` macro so does not work with Rust 1.41.1, bad `syn` no biscuit.
-    cargo update -p syn --precise 1.0.107
 fi
 
 # We should not have any duplicate dependencies. This catches mistakes made upgrading dependencies

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -16,7 +16,6 @@ exclude = ["tests", "contrib"]
 default = ["std"]
 std = ["alloc", "internals/std"]
 alloc = ["internals/alloc"]
-schemars = ["actual-schemars", "dyn-clone"]
 serde-std = ["serde/std"]
 
 [package.metadata.docs.rs]
@@ -27,13 +26,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 internals = { path = "../internals", package = "bitcoin-private", version = "0.1.0" }
 
 core2 = { version = "0.3.0", default_features = false, optional = true }
+schemars = { version = "0.8.3", optional = true }
 # Only enable this if you explicitly do not want to use "std", otherwise enable "serde-std".
 serde = { version = "1.0", default-features = false, optional = true }
-# Do NOT use this as a feature! Use the `schemars` feature instead. Can only be used with "std" enabled.
-actual-schemars = { package = "schemars", version = "<=0.8.3", optional = true }
-# Do NOT enable this dependency, this is just to pin dyn-clone (transitive dep from schemars)
-# because 1.0.8 does not build with Rust 1.41.1 (because of useage of `Arc::as_ptr`).
-dyn-clone = { version = "<=1.0.7", default_features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/hashes/README.md
+++ b/hashes/README.md
@@ -13,6 +13,18 @@ since these are needed to display hashes anway.
 
 This library should always compile with any combination of features on **Rust 1.48.0**.
 
+
+To build with the MSRV you will need to pin `serde` (if you have either the `serde` or the
+`schemars` feature enabled)
+
+```
+# serde 1.0.157 uses syn 2.0 which requires edition 2021
+cargo update -p serde --precise 1.0.156
+```
+
+before building. (And if your code is a library, your downstream users will need to run these
+commands, and so on.)
+
 ## Contributions
 
 Contributions are welcome, including additional hash function implementations.

--- a/hashes/extended_tests/schemars/Cargo.toml
+++ b/hashes/extended_tests/schemars/Cargo.toml
@@ -13,8 +13,8 @@ path = "../.."
 features = ['schemars', 'serde']
 
 [dependencies]
-jsonschema-valid = "^0.4.0"
+jsonschema-valid = "0.4.0"
 serde = { version = "1.0", default-features = false}
-schemars = { version = "<=0.8.3"}
+schemars = "0.8.3"
 serde_test = "1.0"
 serde_json = "1.0"

--- a/hashes/extended_tests/schemars/README.md
+++ b/hashes/extended_tests/schemars/README.md
@@ -1,0 +1,10 @@
+# Test crate for the schemars feature
+
+Run as usual with `cargo test`.
+
+## Minimum Supported Rust Version (MSRV)
+
+To run the tests with the MSRV you will need to pin some dependencies:
+
+- `cargo update -p serde --precise 1.0.156`
+- `cargo update -p syn --precise 1.0.107`

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -113,7 +113,7 @@ pub mod _export {
 }
 
 #[cfg(feature = "schemars")]
-extern crate actual_schemars as schemars;
+extern crate schemars;
 
 mod internal_macros;
 #[macro_use]

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -31,16 +31,17 @@ pub trait Tag {
 }
 
 /// Output of the SHA256t hash function.
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
-pub struct Hash<T: Tag>(
-    #[cfg_attr(
-        feature = "schemars",
-        schemars(schema_with = "crate::util::json_hex_string::len_32")
-    )]
-    [u8; 32],
-    #[cfg_attr(feature = "schemars", schemars(skip))] PhantomData<T>,
-);
+pub struct Hash<T: Tag>([u8; 32], PhantomData<T>);
+
+#[cfg(feature = "schemars")]
+impl<T: Tag> schemars::JsonSchema for Hash<T> {
+    fn schema_name() -> String { "Hash".to_owned() }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        crate::util::json_hex_string::len_32(gen)
+    }
+}
 
 impl<T: Tag> Hash<T> {
     fn internal_new(arr: [u8; 32]) -> Self { Hash(arr, Default::default()) }


### PR DESCRIPTION
This has grown due to now including pinning work also done in https://github.com/rust-bitcoin/rust-bitcoin/pull/1736, I decided to do this because the PRs conflict and doing it all here saves accidentally getting out of sync. And  https://github.com/rust-bitcoin/rust-bitcoin/pull/1764 requires this PR.

- Patch 1 is unchanged
- Patch 2 now fixes pinning in bitcoin and hashes CI scripts and in the docs of both as well as the manifest stuff relating to `schemars` - phew.


Fix: #1687 
