### PR TITLE
hashes: remove version pin on schemars.

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -30,7 +30,7 @@ core2 = { version = "0.3.0", default_features = false, optional = true }
 # Only enable this if you explicitly do not want to use "std", otherwise enable "serde-std".
 serde = { version = "1.0", default-features = false, optional = true }
 # Do NOT use this as a feature! Use the `schemars` feature instead. Can only be used with "std" enabled.
-actual-schemars = { package = "schemars", version = "<=0.8.3", optional = true }
+actual-schemars = { package = "schemars", version = "0.8.0", optional = true }
 # Do NOT enable this dependency, this is just to pin dyn-clone (transitive dep from schemars)
 # because 1.0.8 does not build with Rust 1.41.1 (because of useage of `Arc::as_ptr`).
 dyn-clone = { version = "<=1.0.7", default_features = false, optional = true }


### PR DESCRIPTION
This pin was implemented incorrectly, and anyway appears to be completely unnecessary on 1.41.

Fixes #1687 