### PR TITLE
Avoid usage of atomic types if not supported by the target arch

### DIFF
--- a/bitcoin/build.rs
+++ b/bitcoin/build.rs
@@ -23,7 +23,7 @@ fn main() {
         .parse::<u64>()
         .expect("invalid Rust minor version");
 
-    for activate_version in &[46, 53] {
+    for activate_version in &[46, 53, 60] {
         if minor >= *activate_version {
             println!("cargo:rustc-cfg=rust_v_1_{}", activate_version);
         }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -49,6 +49,7 @@
 //! is minimal but we may extend it in the future if needed.
 
 use alloc::rc::Rc;
+#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
 use alloc::sync::Arc;
 
 use core::cmp::Ordering;
@@ -279,6 +280,9 @@ impl<'a> From<&'a Script> for Cow<'a, Script> {
     }
 }
 
+/// Note: This will fail to compile on old Rust for targets that don't support atomics
+#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+#[cfg_attr(docsrs, doc(cfg(target_has_atomic = "ptr")))]
 impl<'a> From<&'a Script> for Arc<Script> {
     fn from(value: &'a Script) -> Self {
         let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -720,6 +720,9 @@ impl<T: Encodable> Encodable for rc::Rc<T> {
     }
 }
 
+/// Note: This will fail to compile on old Rust for targets that don't support atomics
+#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+#[cfg_attr(docsrs, doc(cfg(target_has_atomic = "ptr")))]
 impl<T: Encodable> Encodable for sync::Arc<T> {
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         (**self).consensus_encode(w)

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -160,7 +160,10 @@ mod io_extras {
 #[rustfmt::skip]
 mod prelude {
     #[cfg(all(not(feature = "std"), not(test)))]
-    pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, Cow, ToOwned}, slice, rc, sync};
+    pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, Cow, ToOwned}, slice, rc};
+
+    #[cfg(all(not(feature = "std"), not(test), any(not(rust_v_1_60), target_has_atomic = "ptr")))]
+    pub use alloc::sync;
 
     #[cfg(any(feature = "std", test))]
     pub use std::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, Cow, ToOwned}, slice, rc, sync};


### PR DESCRIPTION
Hi! I'm still a beginner with both Rust and cross-compilation, so please take the rest with a few grains of salt!

I'm setting up a project targeting `riscv32i-unknown-none-elf`, which seems not to support atomic types. Even with `--no-default-features` and `no-std`, I would get this error:

```
error[E0432]: unresolved import `alloc::sync`
  --> rust-bitcoin/bitcoin/src/blockdata/script/mod.rs:52:12
   |
52 | use alloc::sync::Arc;
   |            ^^^^ could not find `sync` in `alloc`

error[E0432]: unresolved import `alloc::sync`
   --> rust-bitcoin/bitcoin/src/lib.rs:163:114
    |
163 |     pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, Cow, ToOwned}, slice, rc, sync};
    |                                                                                                                  ^^^^ no `sync` in the root
    |
    = help: consider importing one of these items instead:
            bitcoin_hashes::_export::_core::sync
            core::sync
```

This PR gates the usage of `Arc` so that it's only enabled with the `std` feature.