### PR TITLE
Add README docs for proper use of std and no-std features

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ versions than the current stable one (see MSRV section).
 
 ## Building
 
+The cargo feature `std` is enabled by default. At least one of the features `std` or `no-std` or both must be enabled.
+
+Enabling the `no-std` feature does not disable `std`. To disable the `std` feature you must disable default features. The `no-std` feature only enables additional features required for this crate to be usable without `std`. Both can be enabled without conflict.
+
 The library can be built and tested using [`cargo`](https://github.com/rust-lang/cargo/):
 
 ```


### PR DESCRIPTION
Building this crate requires the `std` and/or `no-std` features be enabled. This PR documents this build constraint in the README ~~and gives an error is anyone tries to build without enabling one or both of these features~~.

See discussion in rust-bitcoin/rust-miniscript#533.