### PR TITLE
update rust-secp to 0.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For more information please see `./CONTRIBUTING.md`.
 This library should always compile with any combination of features (minus
 `no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
 
-To build with the MSRV you will need to pin some dependencies:
+To build with the MSRV you will need to pin some dependencies (also for `no-std`):
 ```
 cargo update -p serde --precise 1.0.156
 cargo update -p syn --precise 1.0.107

--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ For more information please see `./CONTRIBUTING.md`.
 This library should always compile with any combination of features (minus
 `no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
 
-To build with the MSRV you will need to pin some dependencies, currently this is
-only `syn`, and can be achieved using `cargo update -p syn --precise 1.0.107`.
+To build with the MSRV you will need to pin some dependencies:
+```
+cargo update -p serde --precise 1.0.156
+cargo update -p syn --precise 1.0.107
+```
 
 ## Installing Rust
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -37,7 +37,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitcoin-internals = { path = "../internals", package = "bitcoin-private", version = "0.1.0" }
 bech32 = { version = "0.9.0", default-features = false }
 bitcoin_hashes = { version = "0.12.0", default-features = false }
-secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", tag = "2023-03-05--fix-hashes", default-features = false, features = ["bitcoin_hashes"] }
+secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
 hex_lit = "0.1.1"
 
 base64 = { version = "0.13.0", optional = true }
@@ -50,7 +50,6 @@ actual-serde = { package = "serde", version = "1.0.103", default-features = fals
 serde_json = "1.0.0"
 serde_test = "1.0.19"
 serde_derive = "1.0.103"
-secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", tag = "2023-03-05--fix-hashes", features = ["recovery"] }
 bincode = "1.3.1"
 
 [target.'cfg(mutate)'.dev-dependencies]

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -31,6 +31,12 @@ if cargo --version | grep "1\.41"; then
     cargo update -p syn --precise 1.0.107
 fi
 
+# Pin dependencies as above (required for no-std tests that use Rust 1.47 toolchain).
+if cargo --version | grep "1\.47"; then
+    cargo update -p serde --precise 1.0.156
+    cargo update -p syn --precise 1.0.107
+fi
+
 # We should not have any duplicate dependencies. This catches mistakes made upgrading dependencies
 # in one crate and not in another (e.g. upgrade bitcoin_hashes in bitcoin but not in secp).
 duplicate_dependencies=$(

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -25,6 +25,8 @@ fi
 
 # Pin dependencies as required if we are using MSRV toolchain.
 if cargo --version | grep "1\.41"; then
+    # 1.0.157 uses syn 2.0 which requires edition 2018
+    cargo update -p serde --precise 1.0.156
     # 1.0.108 uses `matches!` macro so does not work with Rust 1.41.1, bad `syn` no biscuit.
     cargo update -p syn --precise 1.0.107
 fi

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -31,7 +31,14 @@ fi
 
 # We should not have any duplicate dependencies. This catches mistakes made upgrading dependencies
 # in one crate and not in another (e.g. upgrade bitcoin_hashes in bitcoin but not in secp).
-duplicate_dependencies=$(cargo tree  --target=all --all-features --duplicates | wc -l)
+duplicate_dependencies=$(
+    # Only show the actual duplicated deps, not their reverse tree, then
+    # whitelist the 'syn' crate which is duplicated but it's not our fault.
+    cargo tree  --target=all --all-features --duplicates \
+        | grep '^[0-9A-Za-z]' \
+        | grep -v 'syn' \
+        | wc -l
+)
 if [ "$duplicate_dependencies" -ne 0 ]; then
     echo "Dependency tree is broken, contains duplicates"
     cargo tree  --target=all --all-features --duplicates


### PR DESCRIPTION
Also remove the spurious dev-dependency copy of rust-secp, which should've been updated to remove the "recovery" feature in https://www.github.com/rust-bitcoin/rust-bitcoin/pull/545 and then been removed entirely in https://www.github.com/rust-bitcoin/rust-bitcoin/pull/1387