### PR TITLE
Remove no-std feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,20 +73,6 @@ jobs:
       - name: Running test script
         env:
           DO_FEATURE_MATRIX: true
-        run: ./contrib/test.sh
-
-  NoStd:
-    name: Test - 1.47 toolchain
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout Crate
-        uses: actions/checkout@v3
-      - name: Checkout Toolchain
-        uses: dtolnay/rust-toolchain@1.47
-      - name: Running test script
-        env:
           DO_NO_STD: true
         run: ./contrib/test.sh
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,9 @@ For more information please see `./CONTRIBUTING.md`.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features (minus
-`no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
+This library should always compile with any combination of features on **Rust 1.48**.
 
-To build with the MSRV you will need to pin some dependencies (also for `no-std`):
+To build with the MSRV you will need to pin some dependencies:
 ```
 cargo update -p serde --precise 1.0.156
 cargo update -p syn --precise 1.0.107
@@ -96,11 +95,7 @@ versions than the current stable one (see MSRV section).
 
 ## Building
 
-The cargo feature `std` is enabled by default. At least one of the features `std` or `no-std` or both must be enabled.
-
-Enabling the `no-std` feature does not disable `std`. To disable the `std` feature you must disable default features. The `no-std` feature only enables additional features required for this crate to be usable without `std`. Both can be enabled without conflict.
-
-The library can be built and tested using [`cargo`](https://github.com/rust-lang/cargo/):
+The cargo feature `std` is enabled by default. The library can be built and tested using [`cargo`](https://github.com/rust-lang/cargo/):
 
 ```
 git clone git@github.com:rust-bitcoin/rust-bitcoin.git

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -14,20 +14,13 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = [ "std", "secp-recovery" ]
+std = ["secp256k1/std", "core2/std", "bitcoin_hashes/std", "bech32/std", "bitcoin-internals/std"]
 rand-std = ["secp256k1/rand-std"]
 rand = ["secp256k1/rand"]
 serde = ["actual-serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
-
-# At least one of std, no-std must be enabled.
-#
-# The no-std feature doesn't disable std - you need to turn off the std feature for that by disabling default.
-# Instead no-std enables additional features required for this crate to be usable without std.
-# As a result, both can be enabled without conflict.
-std = ["secp256k1/std", "bitcoin_hashes/std", "bech32/std", "bitcoin-internals/std"]
-no-std = ["core2", "bitcoin_hashes/alloc", "bitcoin_hashes/core2", "secp256k1/alloc"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -36,13 +29,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitcoin-internals = { path = "../internals", package = "bitcoin-private", version = "0.1.0" }
 bech32 = { version = "0.9.0", default-features = false }
-bitcoin_hashes = { version = "0.12.0", default-features = false }
-secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
+bitcoin_hashes = { version = "0.12.0", default-features = false, features = ["alloc", "core2"] }
+core2 = { version = "0.3.0", default-features = false, features = ["alloc"] }
+secp256k1 = { version = "0.27.0", default-features = false, features = ["alloc", "bitcoin_hashes"] }
 hex_lit = "0.1.1"
 
 base64 = { version = "0.13.0", optional = true }
 bitcoinconsensus = { version = "0.20.2-0.5.0", default-features = false, optional = true }
-core2 = { version = "0.3.0", default-features = false, features = ["alloc"], optional = true }
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
 

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -4,6 +4,9 @@ set -ex
 
 FEATURES="base64 bitcoinconsensus serde rand secp-recovery"
 
+# Make all cargo invocations verbose
+export CARGO_TERM_VERBOSE=true
+
 if [ "$DO_COV" = true ]
 then
     export RUSTFLAGS="-C link-dead-code"
@@ -23,17 +26,12 @@ if cargo --version | grep beta; then
     STABLE=false
 fi
 
+# TODO: Check we need this pin for 1.48
 # Pin dependencies as required if we are using MSRV toolchain.
-if cargo --version | grep "1\.41"; then
+if cargo --version | grep "1\.48"; then
     # 1.0.157 uses syn 2.0 which requires edition 2018
     cargo update -p serde --precise 1.0.156
     # 1.0.108 uses `matches!` macro so does not work with Rust 1.41.1, bad `syn` no biscuit.
-    cargo update -p syn --precise 1.0.107
-fi
-
-# Pin dependencies as above (required for no-std tests that use Rust 1.47 toolchain).
-if cargo --version | grep "1\.47"; then
-    cargo update -p serde --precise 1.0.156
     cargo update -p syn --precise 1.0.107
 fi
 
@@ -53,6 +51,10 @@ if [ "$duplicate_dependencies" -ne 0 ]; then
     exit 1
 fi
 
+# Defaults / sanity checks
+cargo build
+cargo test
+
 if [ "$DO_LINT" = true ]
 then
     cargo clippy --all-features --all-targets -- -D warnings
@@ -62,48 +64,51 @@ then
     cargo clippy --example taproot-psbt --features=rand-std,bitcoinconsensus -- -D warnings
 fi
 
-echo "********* Testing std *************"
-# Test without any features other than std first
-cargo test --verbose --no-default-features --features="std"
+# Tests features with "std" enabled.
+if [ "$DO_FEATURE_MATRIX" = true ]; then
+    cargo build
+    cargo test
 
-echo "********* Testing default *************"
-# Then test with the default features
-cargo test --verbose
+    # All features
+    cargo build --features="$FEATURES"
+    cargo test --features="$FEATURES"
+    # Single features
+    for feature in ${FEATURES}
+    do
+        cargo build --features="$feature"
+        cargo test --features="$feature"
+		# All combos of two features
+		for featuretwo in ${FEATURES}; do
+			cargo build --features="$feature $featuretwo"
+			cargo test --features="$feature $featuretwo"
+		done
+    done
 
+    cargo run --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+    cargo run --example ecdsa-psbt --features=bitcoinconsensus
+    cargo run --example taproot-psbt --features=rand-std,bitcoinconsensus
+fi
+
+# Runs tests without "std" enabled i.e., with no default features.
 if [ "$DO_NO_STD" = true ]
 then
-    echo "********* Testing no-std build *************"
-    # Build no_std, to make sure that cfg(test) doesn't hide any issues
-    cargo build --verbose --features="no-std" --no-default-features
+    # Build non-std, to make sure that cfg(test) doesn't hide any issues
+    cargo build --verbose --no-default-features
 
-    # Build std + no_std, to make sure they are not incompatible
-    cargo build --verbose --features="no-std"
-
-    # Test no_std
-    cargo test --verbose --features="no-std" --no-default-features
+    # Test non-std
+    cargo test --verbose --no-default-features
 
     # Build all features
-    cargo build --verbose --features="no-std $FEATURES" --no-default-features
+    cargo build --verbose --features="$FEATURES" --no-default-features
 
     # Build specific features
     for feature in ${FEATURES}
     do
-        cargo build --verbose --features="no-std $feature" --no-default-features
+        cargo build --verbose --features="$feature" --no-default-features
     done
 
-    cargo run --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
-    cargo run --no-default-features --features no-std --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+    cargo run --no-default-features --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
 fi
-
-# Test each feature
-for feature in ${FEATURES}
-do
-    echo "********* Testing $feature *************"
-    cargo test --verbose --features="$feature"
-done
-
-cargo run --example ecdsa-psbt --features=bitcoinconsensus
-cargo run --example taproot-psbt --features=rand-std,bitcoinconsensus
 
 # Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCSRS" = true ]; then

--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -15,7 +15,7 @@ cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 alloc-cortex-m = "0.4.1"
-bitcoin = { path="../", default-features = false, features = ["no-std", "secp-lowmemory"] }
+bitcoin = { path="../", default-features = false, features = ["secp-lowmemory"] }
 
 
 [[bin]]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -23,8 +23,6 @@
 //! * `serde` - (dependency), implements `serde`-based serialization and
 //!                 deserialization.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
-//! * `no-std` - enables additional features required for this crate to be usable
-//!              without std. Does **not** disable `std`. Depends on `core2`.
 //! * `bitcoinconsensus-std` - enables `std` in `bitcoinconsensus` and communicates it
 //!                            to this crate so it knows how to implement
 //!                            `std::error::Error`. At this time there's a hack to
@@ -39,9 +37,6 @@
 #![warn(missing_docs)]
 // Instead of littering the codebase for non-fuzzing code just globally allow.
 #![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
-
-#[cfg(not(any(feature = "std", feature = "no-std")))]
-compile_error!("at least one of the `std` or `no-std` features must be enabled");
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]

--- a/internals/src/error.rs
+++ b/internals/src/error.rs
@@ -10,7 +10,7 @@
 ///
 /// If `std` feature is OFF appends error source (delimited by `: `). We do this because
 /// `e.source()` is only available in std builds, without this macro the error source is lost for
-/// no-std builds.
+/// non-std builds.
 #[macro_export]
 macro_rules! write_err {
     ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {


### PR DESCRIPTION
(For consideration post 0.30.0 release, post MSRV bump (because core2 requires 1.47))

A few observations:

- `rust-bitcoin` requires an allocator, it is not an optional feature.

- We have a requirement that users pick either "std" or "no-std" (or both) to build however there is no obvious reason why we should not be able to build with `cargo check --no-default-features` other than the requirement to configure the allocator.

- `core2` re-exports stdlib if the "std" feature is enabled.

With the above observations we can add "core2" as a non-optional dependency (with "alloc" feature). We can then enable "core2/std" if our "std" feature is enabled. This allows us to remove the "no-std" feature all together.

Props to @LLFourn for prompting me to look at this.

EDIT: This PR puts us at the mercy of `core2`, if they raise the MSRV.