### PR TITLE
Remove extern crate hashbrown

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -64,9 +64,6 @@ pub extern crate bitcoin_hashes as hashes;
 #[cfg(feature = "bitcoinconsensus")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
 pub extern crate bitcoinconsensus;
-#[cfg(feature = "hashbrown")]
-#[cfg_attr(docsrs, doc(cfg(feature = "hashbrown")))]
-pub extern crate hashbrown;
 pub extern crate secp256k1;
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
(Merge candidate only after release of 0.30.0)

We no longer have a "hashbrown" feature, the feature gated `pub extern crate hashbrown` should have been removed when we removed the feature.