### PR TITLE
Mark `Denomination` as `non_exhaustive`

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -31,6 +31,7 @@ use crate::prelude::*;
 /// assert_eq!(Amount::from_str("1000 msats").unwrap(), Amount::from_sat(1));
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub enum Denomination {
     /// BTC
     Bitcoin,


### PR DESCRIPTION
It is possible that we will add new variants to `Denomination` in the future so making it `non_exhaustive` is better for forward compatibility.