### PR TITLE
bitcoin: Fix path to the readme

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/bitcoin/"
 description = "General purpose library for using and interoperating with Bitcoin."
 categories = ["cryptography::cryptocurrencies"]
 keywords = [ "crypto", "bitcoin" ]
-readme = "README.md"
+readme = "../README.md"
 edition = "2018"
 exclude = ["tests", "contrib"]
 


### PR DESCRIPTION
We moved to a submodule and didn't fix the readme path in the `bitcoin` manifest.