### PR TITLE
Bump MSRV to 1.48.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
         run: ./contrib/test.sh
 
   MSRV:
-    name: Test - 1.41.1 toolchain
+    name: Test - 1.48.0 toolchain
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -74,24 +74,10 @@ jobs:
       - name: Checkout Crate
         uses: actions/checkout@v3
       - name: Checkout Toolchain
-        uses: dtolnay/rust-toolchain@1.41.1
+        uses: dtolnay/rust-toolchain@1.48.0
       - name: Running test script
         env:
           DO_FEATURE_MATRIX: true
-        run: ./contrib/test.sh
-
-  NoStd:
-    name: Test - 1.47 toolchain
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout Crate
-        uses: actions/checkout@v3
-      - name: Checkout Toolchain
-        uses: dtolnay/rust-toolchain@1.47
-      - name: Running test script
-        env:
           DO_NO_STD: true
         run: ./contrib/test.sh
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <a href="https://github.com/rust-bitcoin/rust-bitcoin/blob/master/LICENSE"><img alt="CC0 1.0 Universal Licensed" src="https://img.shields.io/badge/license-CC0--1.0-blue.svg"/></a>
     <a href="https://github.com/rust-bitcoin/rust-bitcoin/actions?query=workflow%3AContinuous%20integration"><img alt="CI Status" src="https://github.com/rust-bitcoin/rust-bitcoin/workflows/Continuous%20integration/badge.svg"></a>
     <a href="https://docs.rs/bitcoin"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bitcoin-green"/></a>
-    <a href="https://blog.rust-lang.org/2020/02/27/Rust-1.41.1.html"><img alt="Rustc Version 1.41.1+" src="https://img.shields.io/badge/rustc-1.41.1%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2020/02/27/Rust-1.48.0.html"><img alt="Rustc Version 1.48.0+" src="https://img.shields.io/badge/rustc-1.48.0%2B-lightgrey.svg"/></a>
     <a href="https://gnusha.org/bitcoin-rust/"><img alt="Chat on IRC" src="https://img.shields.io/badge/irc-%23bitcoin--rust%20on%20libera.chat-blue"></a>
     <a href="https://github.com/model-checking/kani"><imp alt="kani" src="https://github.com/rust-bitcoin/rust-bitcoin/actions/workflows/kani.yaml/badge.svg"></a>
     <img alt="Lines of code" src="https://img.shields.io/tokei/lines/github/rust-bitcoin/rust-bitcoin">
@@ -76,10 +76,9 @@ For more information please see `./CONTRIBUTING.md`.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features (minus
-`no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
+This library should always compile with any combination of features on **Rust 1.48.0**.
 
-To build with the MSRV you will need to pin some dependencies (also for `no-std`):
+To build with the MSRV you will need to pin some dependencies:
 ```
 cargo update -p serde --precise 1.0.156
 cargo update -p syn --precise 1.0.107

--- a/bitcoin/build.rs
+++ b/bitcoin/build.rs
@@ -23,7 +23,7 @@ fn main() {
         .parse::<u64>()
         .expect("invalid Rust minor version");
 
-    for activate_version in &[46, 53, 60] {
+    for activate_version in &[53, 60] {
         if minor >= *activate_version {
             println!("cargo:rustc-cfg=rust_v_1_{}", activate_version);
         }

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -24,16 +24,10 @@ if cargo --version | grep beta; then
 fi
 
 # Pin dependencies as required if we are using MSRV toolchain.
-if cargo --version | grep "1\.41"; then
+if cargo --version | grep "1\.48"; then
     # 1.0.157 uses syn 2.0 which requires edition 2018
     cargo update -p serde --precise 1.0.156
     # 1.0.108 uses `matches!` macro so does not work with Rust 1.41.1, bad `syn` no biscuit.
-    cargo update -p syn --precise 1.0.107
-fi
-
-# Pin dependencies as above (required for no-std tests that use Rust 1.47 toolchain).
-if cargo --version | grep "1\.47"; then
-    cargo update -p serde --precise 1.0.156
     cargo update -p syn --precise 1.0.107
 fi
 

--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -1953,13 +1953,13 @@ mod tests {
         assert_eq!(Amount::from_str("5BTC BTC"), Err(E::InvalidCharacter('B')));
         assert_eq!(Amount::from_str("5 5 BTC"), Err(E::UnknownDenomination("5 BTC".into())));
 
-        #[cfg_attr(rust_v_1_46, track_caller)]
+        #[track_caller]
         fn case(s: &str, expected: Result<Amount, ParseAmountError>) {
             assert_eq!(Amount::from_str(s), expected);
             assert_eq!(Amount::from_str(&s.replace(' ', "")), expected);
         }
 
-        #[cfg_attr(rust_v_1_46, track_caller)]
+        #[track_caller]
         fn scase(s: &str, expected: Result<SignedAmount, ParseAmountError>) {
             assert_eq!(SignedAmount::from_str(s), expected);
             assert_eq!(SignedAmount::from_str(&s.replace(' ', "")), expected);

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -83,7 +83,7 @@ mod primitive {
                     type Output = Self;
 
                     #[inline]
-                    #[cfg_attr(rust_v_1_46, track_caller)]
+                    #[track_caller]
                     fn index(&self, index: $type) -> &Self::Output {
                         // Slicing can not make slices longer
                         unsafe {
@@ -111,7 +111,7 @@ mod primitive {
         type Output = u8;
 
         #[inline]
-        #[cfg_attr(rust_v_1_46, track_caller)]
+        #[track_caller]
         fn index(&self, index: usize) -> &Self::Output { &self.0[index] }
     }
 
@@ -239,7 +239,7 @@ mod primitive {
         /// ## Panics
         ///
         /// This method panics if `index` is out of bounds.
-        #[cfg_attr(rust_v_1_46, track_caller)]
+        #[track_caller]
         pub fn remove(&mut self, index: usize) -> u8 { self.0.remove(index) }
 
         /// Remove all bytes from buffer without affecting capacity.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1245,26 +1245,30 @@ where
     )
 }
 
-crate::internal_macros::maybe_const_fn! {
-    fn predict_weight_internal(input_count: usize, partial_input_weight: usize, inputs_with_witnesses: usize, output_count: usize, output_scripts_size: usize) -> Weight {
-        let input_weight = partial_input_weight + input_count * 4 * (32 + 4 + 4);
-        let output_size = 8 * output_count + output_scripts_size;
-        let non_input_size =
-            // version:
-            4 +
-            // count varints:
-            VarInt(input_count as u64).len() +
-            VarInt(output_count as u64).len() +
-            output_size +
-            // lock_time
-            4;
-        let weight = if inputs_with_witnesses == 0 {
-            non_input_size * 4 + input_weight
-        } else {
-            non_input_size * 4 + input_weight + input_count - inputs_with_witnesses + 2
-        };
-        Weight::from_wu(weight as u64)
-    }
+const fn predict_weight_internal(
+    input_count: usize,
+    partial_input_weight: usize,
+    inputs_with_witnesses: usize,
+    output_count: usize,
+    output_scripts_size: usize,
+) -> Weight {
+    let input_weight = partial_input_weight + input_count * 4 * (32 + 4 + 4);
+    let output_size = 8 * output_count + output_scripts_size;
+    let non_input_size =
+    // version:
+        4 +
+    // count varints:
+        VarInt(input_count as u64).len() +
+        VarInt(output_count as u64).len() +
+        output_size +
+    // lock_time
+        4;
+    let weight = if inputs_with_witnesses == 0 {
+        non_input_size * 4 + input_weight
+    } else {
+        non_input_size * 4 + input_weight + input_count - inputs_with_witnesses + 2
+    };
+    Weight::from_wu(weight as u64)
 }
 
 /// Predicts the weight of a to-be-constructed transaction in const context.
@@ -1276,7 +1280,6 @@ crate::internal_macros::maybe_const_fn! {
 /// `predict_weight` and thus is intended to be only used in `const` context.
 ///
 /// Please see the documentation of `predict_weight` to learn more about this function.
-#[cfg(rust_v_1_46)]
 pub const fn predict_weight_from_slices(
     inputs: &[InputWeightPrediction],
     output_script_lens: &[usize],
@@ -1402,7 +1405,6 @@ impl InputWeightPrediction {
     /// This is a `const` version of [`new`](Self::new) which only allows slices due to current Rust
     /// limitations around `const fn`. Because of these limitations it may be less efficient than
     /// `new` and thus is intended to be only used in `const` context.
-    #[cfg(rust_v_1_46)]
     pub const fn from_slice(input_script_len: usize, witness_element_lengths: &[usize]) -> Self {
         let mut i = 0;
         let mut total_size = 0;

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -365,21 +365,19 @@ impl_int_encodable!(i64, read_i64, emit_i64);
 
 #[allow(clippy::len_without_is_empty)] // VarInt has on concept of 'is_empty'.
 impl VarInt {
-    crate::internal_macros::maybe_const_fn! {
-        /// Gets the length of this VarInt when encoded.
-        ///
-        /// *Important: this method is only `const` in Rust 1.46 or higher!*
-        ///
-        /// Returns 1 for 0..=0xFC, 3 for 0xFD..=(2^16-1), 5 for 0x10000..=(2^32-1),
-        /// and 9 otherwise.
-        #[inline]
-        pub fn len(&self) -> usize {
-            match self.0 {
-                0..=0xFC             => { 1 }
-                0xFD..=0xFFFF        => { 3 }
-                0x10000..=0xFFFFFFFF => { 5 }
-                _                    => { 9 }
-            }
+    /// Gets the length of this VarInt when encoded.
+    ///
+    /// *Important: this method is only `const` in Rust 1.46 or higher!*
+    ///
+    /// Returns 1 for 0..=0xFC, 3 for 0xFD..=(2^16-1), 5 for 0x10000..=(2^32-1),
+    /// and 9 otherwise.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        match self.0 {
+            0..=0xFC => 1,
+            0xFD..=0xFFFF => 3,
+            0x10000..=0xFFFFFFFF => 5,
+            _ => 9,
         }
     }
 }

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -213,7 +213,7 @@ impl<W: fmt::Write> ErrorTrackingWriter<W> {
         }
     }
 
-    #[cfg_attr(rust_v_1_46, track_caller)]
+    #[track_caller]
     fn assert_no_error(&self, fun: &str) {
         #[cfg(debug_assertions)]
         {

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -45,20 +45,6 @@ macro_rules! impl_consensus_encoding {
     );
 }
 pub(crate) use impl_consensus_encoding;
-
-/// Marks the function const in Rust 1.46.0
-macro_rules! maybe_const_fn {
-    ($(#[$attr:meta])* $vis:vis fn $name:ident($($args:tt)*) -> $ret:ty $body:block) => {
-        #[cfg(rust_v_1_46)]
-        $(#[$attr])*
-        $vis const fn $name($($args)*) -> $ret $body
-
-        #[cfg(not(rust_v_1_46))]
-        $(#[$attr])*
-        $vis fn $name($($args)*) -> $ret $body
-    }
-}
-pub(crate) use maybe_const_fn;
 // We use test_macros module to keep things organised, re-export everything for ease of use.
 #[cfg(test)]
 pub(crate) use test_macros::*;

--- a/hashes/README.md
+++ b/hashes/README.md
@@ -11,7 +11,7 @@ since these are needed to display hashes anway.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features on **Rust 1.41.1**.
+This library should always compile with any combination of features on **Rust 1.48.0**.
 
 ## Contributions
 

--- a/internals/src/hex/buf_encoder.rs
+++ b/internals/src/hex/buf_encoder.rs
@@ -68,7 +68,7 @@ mod out_bytes {
         /// ## Panics
         ///
         /// The method panics if `len` is out of bounds.
-        #[cfg_attr(rust_v_1_46, track_caller)]
+        #[track_caller]
         pub(crate) fn assume_init(&self, len: usize) -> &[u8] { &self.0[..len] }
 
         /// Writes given bytes into the buffer.
@@ -76,7 +76,7 @@ mod out_bytes {
         /// ## Panics
         ///
         /// The method panics if pos is out of bounds or `bytes` don't fit into the buffer.
-        #[cfg_attr(rust_v_1_46, track_caller)]
+        #[track_caller]
         pub(crate) fn write(&mut self, pos: usize, bytes: &[u8]) {
             self.0[pos..(pos + bytes.len())].copy_from_slice(bytes);
         }
@@ -193,7 +193,7 @@ impl<T: AsOutBytes> BufEncoder<T> {
     ///
     /// The method panics if the buffer is full.
     #[inline]
-    #[cfg_attr(rust_v_1_46, track_caller)]
+    #[track_caller]
     pub fn put_byte(&mut self, byte: u8, case: Case) {
         self.buf.as_mut_out_bytes().write(self.pos, &super::byte_to_hex(byte, case.table()));
         self.pos += 2;
@@ -205,7 +205,7 @@ impl<T: AsOutBytes> BufEncoder<T> {
     ///
     /// The method panics if the bytes wouldn't fit the buffer.
     #[inline]
-    #[cfg_attr(rust_v_1_46, track_caller)]
+    #[track_caller]
     pub fn put_bytes<I>(&mut self, bytes: I, case: Case)
     where
         I: IntoIterator,
@@ -215,7 +215,7 @@ impl<T: AsOutBytes> BufEncoder<T> {
     }
 
     #[inline]
-    #[cfg_attr(rust_v_1_46, track_caller)]
+    #[track_caller]
     fn put_bytes_inner<I>(&mut self, bytes: I, case: Case)
     where
         I: Iterator,
@@ -236,7 +236,7 @@ impl<T: AsOutBytes> BufEncoder<T> {
     /// bytes. The method returns an empty slice if all bytes were written
     #[must_use = "this may write only part of the input buffer"]
     #[inline]
-    #[cfg_attr(rust_v_1_46, track_caller)]
+    #[track_caller]
     pub fn put_bytes_min<'a>(&mut self, bytes: &'a [u8], case: Case) -> &'a [u8] {
         let to_write = self.space_remaining().min(bytes.len());
         self.put_bytes(&bytes[..to_write], case);


### PR DESCRIPTION
Just patch 2, patch 1 is #1728  

From the commit log of patch 2

    Bump MSRV to 1.48.1
    
    As per discussion [0] bump our MSRV for all crates in `rust-bitcoin`
    repo to 1.48.1 [1].
    
    [0] https://github.com/rust-bitcoin/rust-bitcoin/discussions/1329
    [1] https://blog.rust-lang.org/2020/11/19/Rust-1.48.html
 
