### PR TITLE
Use shorter imports

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -34,6 +34,7 @@ use core::str::FromStr;
 
 use bech32;
 use bitcoin_internals::write_err;
+use hashes::{sha256, Hash, HashEngine};
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::base58;
@@ -49,7 +50,6 @@ use crate::blockdata::script::{
 use crate::crypto::key::{PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
 use crate::error::ParseIntError;
 use crate::hash_types::{PubkeyHash, ScriptHash};
-use crate::hashes::{sha256, Hash, HashEngine};
 use crate::network::constants::Network;
 use crate::prelude::*;
 use crate::taproot::TapNodeHash;

--- a/bitcoin/src/base58.rs
+++ b/bitcoin/src/base58.rs
@@ -10,7 +10,8 @@
 use core::convert::TryInto;
 use core::{fmt, iter, slice, str};
 
-use crate::hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash};
+
 use crate::prelude::*;
 
 static BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -11,9 +11,9 @@ use core::{convert, fmt, mem};
 use std::error;
 
 use bitcoin_internals::impl_array_newtype;
+use hashes::{sha256, siphash24, Hash};
 
 use crate::consensus::encode::{self, Decodable, Encodable, VarInt};
-use crate::hashes::{sha256, siphash24, Hash};
 use crate::internal_macros::{impl_bytes_newtype, impl_consensus_encoding};
 use crate::prelude::*;
 use crate::{block, io, Block, BlockHash, Transaction};
@@ -372,11 +372,12 @@ impl BlockTransactions {
 
 #[cfg(test)]
 mod test {
+    use hashes::hex::FromHex;
+
     use super::*;
     use crate::blockdata::locktime::absolute;
     use crate::consensus::encode::{deserialize, serialize};
     use crate::hash_types::TxMerkleNode;
-    use crate::hashes::hex::FromHex;
     use crate::{
         CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
     };

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -44,6 +44,7 @@ use core::convert::TryInto;
 use core::fmt::{self, Display, Formatter};
 
 use bitcoin_internals::write_err;
+use hashes::{siphash24, Hash};
 
 use crate::blockdata::block::Block;
 use crate::blockdata::script::Script;
@@ -51,7 +52,6 @@ use crate::blockdata::transaction::OutPoint;
 use crate::consensus::encode::VarInt;
 use crate::consensus::{Decodable, Encodable};
 use crate::hash_types::{BlockHash, FilterHash, FilterHeader};
-use crate::hashes::{siphash24, Hash};
 use crate::io;
 use crate::prelude::*;
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -14,6 +14,7 @@ use core::ops::Index;
 use core::str::FromStr;
 
 use bitcoin_internals::{impl_array_newtype, write_err};
+use hashes::{hex, sha512, Hash, HashEngine, Hmac, HmacEngine};
 use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 #[cfg(feature = "serde")]
 use serde;
@@ -21,7 +22,6 @@ use serde;
 use crate::base58;
 use crate::crypto::key::{self, KeyPair, PrivateKey, PublicKey};
 use crate::hash_types::XpubIdentifier;
-use crate::hashes::{hex, sha512, Hash, HashEngine, Hmac, HmacEngine};
 use crate::internal_macros::impl_bytes_newtype;
 use crate::io::Write;
 use crate::network::constants::Network;

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -69,9 +69,7 @@ impl Header {
     pub fn difficulty(&self) -> u128 { self.target().difficulty() }
 
     /// Computes the popular "difficulty" measure for mining and returns a float value of f64.
-    pub fn difficulty_float(&self) -> f64 {
-        self.target().difficulty_float()
-    }
+    pub fn difficulty_float(&self) -> f64 { self.target().difficulty_float() }
 
     /// Checks that the proof-of-work for the block is valid, returning the block hash.
     pub fn validate_pow(&self, required_target: Target) -> Result<BlockHash, Error> {

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -11,6 +11,8 @@
 
 use core::fmt;
 
+use hashes::{Hash, HashEngine};
+
 use super::Weight;
 use crate::blockdata::script;
 use crate::blockdata::transaction::Transaction;
@@ -18,7 +20,6 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::error::Error::{self, BlockBadProofOfWork, BlockBadTarget};
 pub use crate::hash_types::BlockHash;
 use crate::hash_types::{TxMerkleNode, WitnessCommitment, WitnessMerkleNode, Wtxid};
-use crate::hashes::{Hash, HashEngine};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::pow::{CompactTarget, Target, Work};
 use crate::prelude::*;
@@ -394,9 +395,10 @@ impl From<&Block> for BlockHash {
 
 #[cfg(test)]
 mod tests {
+    use hashes::hex::FromHex;
+
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::hashes::hex::FromHex;
     use crate::internal_macros::hex;
 
     #[test]

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -11,6 +11,7 @@
 use core::default::Default;
 
 use bitcoin_internals::impl_array_newtype;
+use hashes::{sha256d, Hash};
 use hex_lit::hex;
 
 use crate::blockdata::block::{self, Block};
@@ -19,7 +20,6 @@ use crate::blockdata::opcodes::all::*;
 use crate::blockdata::script;
 use crate::blockdata::transaction::{OutPoint, Sequence, Transaction, TxIn, TxOut};
 use crate::blockdata::witness::Witness;
-use crate::hashes::{sha256d, Hash};
 use crate::internal_macros::impl_bytes_newtype;
 use crate::network::constants::Network;
 use crate::pow::CompactTarget;
@@ -278,7 +278,7 @@ mod test {
     // The *_chain_hash tests are sanity/regression tests, they verify that the const byte array
     // representing the genesis block is the same as that created by hashing the genesis block.
     fn chain_hash_and_genesis_block(network: Network) {
-        use crate::hashes::sha256;
+        use hashes::sha256;
 
         // The genesis block hash is a double-sha256 and it is displayed backwards.
         let genesis_hash = genesis_block(network).block_hash();

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -7,6 +7,7 @@ use core::fmt;
 use core::ops::Bound;
 use core::ops::{Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
+use hashes::Hash;
 use secp256k1::{Secp256k1, Verification};
 
 use crate::address::WitnessVersion;
@@ -19,7 +20,6 @@ use crate::blockdata::script::{
 };
 use crate::consensus::Encodable;
 use crate::hash_types::{ScriptHash, WScriptHash};
-use crate::hashes::Hash;
 use crate::key::{PublicKey, UntweakedPublicKey};
 use crate::policy::DUST_RELAY_TX_FEE;
 use crate::prelude::*;

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -517,7 +517,7 @@ impl<'de> serde::Deserialize<'de> for ScriptBuf {
     {
         use core::fmt::Formatter;
 
-        use crate::hashes::hex::FromHex;
+        use hashes::hex::FromHex;
 
         if deserializer.is_human_readable() {
             struct Visitor;

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -4,6 +4,7 @@
 #[cfg(doc)]
 use core::ops::Deref;
 
+use hashes::hex;
 use secp256k1::{Secp256k1, Verification};
 
 use crate::address::{WitnessProgram, WitnessVersion};
@@ -11,7 +12,6 @@ use crate::blockdata::opcodes::all::*;
 use crate::blockdata::opcodes::{self};
 use crate::blockdata::script::{opcode_to_verify, Builder, Instruction, PushBytes, Script};
 use crate::hash_types::{PubkeyHash, ScriptHash, WPubkeyHash, WScriptHash};
-use crate::hashes::hex;
 use crate::key::{PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
 use crate::prelude::*;
 use crate::taproot::TapNodeHash;
@@ -157,7 +157,7 @@ impl ScriptBuf {
 
     /// Creates a [`ScriptBuf`] from a hex string.
     pub fn from_hex(s: &str) -> Result<Self, hex::Error> {
-        use crate::hashes::hex::FromHex;
+        use hashes::hex::FromHex;
 
         let v = Vec::from_hex(s)?;
         Ok(ScriptBuf::from_bytes(v))

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -1,5 +1,6 @@
 use core::str::FromStr;
 
+use hashes::Hash;
 use hex_lit::hex;
 
 use super::*;
@@ -7,7 +8,6 @@ use crate::blockdata::opcodes;
 use crate::consensus::encode::{deserialize, serialize};
 use crate::crypto::key::{PublicKey, XOnlyPublicKey};
 use crate::hash_types::{PubkeyHash, ScriptHash, WPubkeyHash, WScriptHash};
-use crate::hashes::Hash;
 use crate::psbt::serialize::Serialize;
 
 #[test]

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -17,6 +17,7 @@ use core::default::Default;
 use core::{cmp, fmt, str};
 
 use bitcoin_internals::write_err;
+use hashes::{self, sha256d, Hash};
 
 use super::Weight;
 use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
@@ -29,7 +30,6 @@ use crate::blockdata::witness::Witness;
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::crypto::sighash::LegacySighash;
 use crate::hash_types::{Txid, Wtxid};
-use crate::hashes::{self, sha256d, Hash};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::parse::impl_parse_str_from_int_infallible;
 use crate::prelude::*;
@@ -1428,12 +1428,13 @@ impl InputWeightPrediction {
 mod tests {
     use core::str::FromStr;
 
+    use hashes::hex::FromHex;
+
     use super::*;
     use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::script::ScriptBuf;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::hashes::hex::FromHex;
     use crate::internal_macros::hex;
     use crate::sighash::EcdsaSighashType;
 

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -399,10 +399,9 @@ impl<'de> serde::Deserialize<'de> for Witness {
                 self,
                 mut a: A,
             ) -> Result<Self::Value, A::Error> {
+                use hashes::hex::Error::*;
+                use hashes::hex::FromHex;
                 use serde::de::{self, Unexpected};
-
-                use crate::hashes::hex::Error::*;
-                use crate::hashes::hex::FromHex;
 
                 let mut ret = match a.size_hint() {
                     Some(len) => Vec::with_capacity(len),
@@ -461,10 +460,11 @@ impl From<Vec<&[u8]>> for Witness {
 
 #[cfg(test)]
 mod test {
+    use secp256k1::ecdsa;
+
     use super::*;
     use crate::consensus::{deserialize, serialize};
     use crate::internal_macros::hex;
-    use crate::secp256k1::ecdsa;
     use crate::Transaction;
 
     fn append_u32_vec(mut v: Vec<u8>, n: &[u32]) -> Vec<u8> {

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -20,11 +20,11 @@ use core::convert::From;
 use core::{fmt, mem, u32};
 
 use bitcoin_internals::write_err;
+use hashes::{sha256, sha256d, Hash};
 
 use crate::bip152::{PrefilledTransaction, ShortId};
 use crate::blockdata::transaction::{Transaction, TxIn, TxOut};
 use crate::hash_types::{BlockHash, FilterHash, FilterHeader, TxMerkleNode};
-use crate::hashes::{sha256, sha256d, Hash};
 use crate::io::{self, Cursor, Read};
 #[cfg(feature = "std")]
 use crate::network::{

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -10,9 +10,9 @@ use core::{fmt, iter};
 
 use bitcoin_internals::hex::display::DisplayHex;
 use bitcoin_internals::write_err;
+use hashes::hex::{self, FromHex};
 use secp256k1;
 
-use crate::hashes::hex::{self, FromHex};
 use crate::prelude::*;
 use crate::script::PushBytes;
 use crate::sighash::{EcdsaSighashType, NonStandardSighashType};

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -11,11 +11,11 @@ use core::ops;
 use core::str::FromStr;
 
 use bitcoin_internals::write_err;
+use hashes::hex::FromHex;
+use hashes::{hash160, hex, Hash};
 pub use secp256k1::{self, constants, KeyPair, Parity, Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::hash_types::{PubkeyHash, WPubkeyHash};
-use crate::hashes::hex::FromHex;
-use crate::hashes::{hash160, hex, Hash};
 use crate::network::constants::Network;
 use crate::prelude::*;
 use crate::taproot::{TapNodeHash, TapTweakHash};
@@ -716,11 +716,11 @@ impl From<TweakedKeyPair> for TweakedPublicKey {
 mod tests {
     use std::str::FromStr;
 
+    use hashes::hex::FromHex;
     use secp256k1::Secp256k1;
 
     use super::*;
     use crate::address::Address;
-    use crate::hashes::hex::FromHex;
     use crate::io;
     use crate::network::constants::Network::{Bitcoin, Testnet};
 
@@ -1032,7 +1032,7 @@ mod tests {
     #[test]
     #[cfg(feature = "rand-std")]
     fn public_key_constructors() {
-        use crate::secp256k1::rand;
+        use secp256k1::rand;
 
         let secp = Secp256k1::new();
         let kp = KeyPair::new(&secp, &mut rand::thread_rng());

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -14,11 +14,12 @@
 use core::borrow::{Borrow, BorrowMut};
 use core::{fmt, str};
 
+use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
+
 use crate::blockdata::transaction::EncodeSigningDataResult;
 use crate::blockdata::witness::Witness;
 use crate::consensus::{encode, Encodable};
 use crate::error::impl_std_error;
-use crate::hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
 use crate::prelude::*;
 use crate::taproot::{LeafVersion, TapLeafHash, TAPROOT_ANNEX_PREFIX};
 use crate::{io, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut};
@@ -1126,14 +1127,15 @@ fn is_invalid_use_of_sighash_single(sighash: u32, input_index: usize, output_len
 mod tests {
     use std::str::FromStr;
 
+    use hashes::hex::FromHex;
+    use hashes::HashEngine;
+
     use super::*;
     use crate::address::Address;
     use crate::blockdata::locktime::absolute;
     use crate::consensus::deserialize;
     use crate::crypto::key::PublicKey;
     use crate::crypto::sighash::{LegacySighash, TapSighash};
-    use crate::hashes::hex::FromHex;
-    use crate::hashes::HashEngine;
     use crate::internal_macros::hex;
     use crate::network::constants::Network;
     use crate::taproot::TapLeafHash;

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -53,7 +53,7 @@ pub use newtypes::*;
 
 #[rustfmt::skip]
 mod newtypes {
-    use crate::hashes::{sha256, sha256d, hash160, hash_newtype};
+    use hashes::{sha256, sha256d, hash160, hash_newtype};
 
     hash_newtype! {
         /// A bitcoin transaction hash/transaction ID.

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -41,13 +41,14 @@
 
 use core::fmt;
 
+use hashes::Hash;
+
 use self::MerkleBlockError::*;
 use crate::blockdata::block::{self, Block};
 use crate::blockdata::constants::{MAX_BLOCK_WEIGHT, MIN_TRANSACTION_WEIGHT};
 use crate::blockdata::transaction::Transaction;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::hash_types::{TxMerkleNode, Txid};
-use crate::hashes::Hash;
 use crate::io;
 use crate::prelude::*;
 
@@ -519,14 +520,14 @@ impl std::error::Error for MerkleBlockError {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "rand-std")]
+    use hashes::Hash;
+    #[cfg(feature = "rand-std")]
     use secp256k1::rand::prelude::*;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
     #[cfg(feature = "rand-std")]
     use crate::hash_types::TxMerkleNode;
-    #[cfg(feature = "rand-std")]
-    use crate::hashes::Hash;
     use crate::internal_macros::hex;
     use crate::{Block, Txid};
 
@@ -752,7 +753,7 @@ mod tests {
     /// Returns a real block (0000000000013b8ab2cd513b0261a14096412195a72a0c4827d229dcc7e0f7af)
     /// with 9 txs.
     fn get_block_13b8a() -> Block {
-        use crate::hashes::hex::FromHex;
+        use hashes::hex::FromHex;
         let block_hex = include_str!("../../tests/data/block_13b8a.hex");
         deserialize(&Vec::from_hex(block_hex).unwrap()).unwrap()
     }

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -20,9 +20,9 @@ use core::cmp::min;
 use core::iter;
 
 pub use block::{MerkleBlock, MerkleBlockError, PartialMerkleTree};
+use hashes::Hash;
 
 use crate::consensus::encode::Encodable;
-use crate::hashes::Hash;
 use crate::io;
 use crate::prelude::*;
 
@@ -110,10 +110,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use hashes::sha256d;
+
     use super::*;
     use crate::blockdata::block::Block;
     use crate::consensus::encode::deserialize;
-    use crate::hashes::sha256d;
 
     #[test]
     fn both_merkle_root_functions_return_the_same_result() {

--- a/bitcoin/src/network/address.rs
+++ b/bitcoin/src/network/address.rs
@@ -307,9 +307,10 @@ mod test {
     use core::str::FromStr;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
+    use hashes::hex::FromHex;
+
     use super::{AddrV2, AddrV2Message, Address};
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::hashes::hex::FromHex;
     use crate::internal_macros::hex;
     use crate::network::constants::ServiceFlags;
 

--- a/bitcoin/src/network/constants.rs
+++ b/bitcoin/src/network/constants.rs
@@ -33,13 +33,13 @@ use core::str::FromStr;
 use core::{fmt, ops};
 
 use bitcoin_internals::{debug_from_display, write_err};
+use hashes::hex::{Error, FromHex};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::constants::ChainHash;
 use crate::error::impl_std_error;
-use crate::hashes::hex::{Error, FromHex};
 use crate::io;
 use crate::prelude::{String, ToOwned};
 

--- a/bitcoin/src/network/message.rs
+++ b/bitcoin/src/network/message.rs
@@ -512,6 +512,9 @@ impl Decodable for RawNetworkMessage {
 mod test {
     use std::net::Ipv4Addr;
 
+    use hashes::sha256d::Hash;
+    use hashes::Hash as HashTrait;
+
     use super::message_network::{Reject, RejectReason, VersionMessage};
     use super::{CommandString, NetworkMessage, RawNetworkMessage, *};
     use crate::bip152::BlockTransactionsRequest;
@@ -519,8 +522,6 @@ mod test {
     use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::Transaction;
     use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
-    use crate::hashes::sha256d::Hash;
-    use crate::hashes::Hash as HashTrait;
     use crate::internal_macros::hex;
     use crate::network::address::{AddrV2, AddrV2Message, Address};
     use crate::network::constants::{Magic, Network, ServiceFlags};

--- a/bitcoin/src/network/message_blockdata.rs
+++ b/bitcoin/src/network/message_blockdata.rs
@@ -7,9 +7,10 @@
 //! Bitcoin data (blocks and transactions) around.
 //!
 
+use hashes::{sha256d, Hash as _};
+
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::hash_types::{BlockHash, Txid, Wtxid};
-use crate::hashes::{sha256d, Hash as _};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::io;
 use crate::network::constants;
@@ -127,9 +128,10 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {
+    use hashes::Hash;
+
     use super::{GetBlocksMessage, GetHeadersMessage, Vec};
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::hashes::Hash;
     use crate::internal_macros::hex;
 
     #[test]

--- a/bitcoin/src/network/message_network.rs
+++ b/bitcoin/src/network/message_network.rs
@@ -7,8 +7,9 @@
 //! capabilities.
 //!
 
+use hashes::sha256d;
+
 use crate::consensus::{encode, Decodable, Encodable, ReadExt};
-use crate::hashes::sha256d;
 use crate::internal_macros::impl_consensus_encoding;
 use crate::io;
 use crate::network::address::Address;
@@ -141,9 +142,10 @@ impl_consensus_encoding!(Reject, message, ccode, reason, hash);
 
 #[cfg(test)]
 mod tests {
+    use hashes::sha256d;
+
     use super::{Reject, RejectReason, VersionMessage};
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::hashes::sha256d;
     use crate::internal_macros::hex;
     use crate::network::constants::ServiceFlags;
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -190,7 +190,7 @@ impl Target {
     /// to the target.
     #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_met_by(&self, hash: BlockHash) -> bool {
-        use crate::hashes::Hash;
+        use hashes::Hash;
         let hash = U256::from_le_bytes(hash.to_byte_array());
         hash <= self.0
     }
@@ -813,7 +813,8 @@ impl<'de> crate::serde::Deserialize<'de> for U256 {
     fn deserialize<D: crate::serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         use core::convert::TryInto;
 
-        use crate::hashes::hex::FromHex;
+        use hashes::hex::FromHex;
+
         use crate::serde::de;
 
         if d.is_human_readable() {
@@ -1537,7 +1538,7 @@ mod tests {
     fn target_is_met_by_for_target_equals_hash() {
         use std::str::FromStr;
 
-        use crate::hashes::Hash;
+        use hashes::Hash;
 
         let hash =
             BlockHash::from_str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -4,6 +4,7 @@ use core::convert::TryFrom;
 use core::fmt;
 use core::str::FromStr;
 
+use hashes::{self, hash160, ripemd160, sha256, sha256d};
 use secp256k1::XOnlyPublicKey;
 
 use crate::bip32::KeySource;
@@ -12,7 +13,6 @@ use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::blockdata::witness::Witness;
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
-use crate::hashes::{self, hash160, ripemd160, sha256, sha256d};
 use crate::prelude::*;
 use crate::psbt::map::Map;
 use crate::psbt::serialize::Deserialize;

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -820,6 +820,7 @@ pub use self::display_from_str::PsbtParseError;
 mod tests {
     use std::collections::BTreeMap;
 
+    use hashes::{hash160, ripemd160, sha256, Hash};
     use secp256k1::{self, Secp256k1};
     #[cfg(feature = "rand-std")]
     use secp256k1::{All, SecretKey};
@@ -830,7 +831,6 @@ mod tests {
     use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::{OutPoint, Sequence, Transaction, TxIn, TxOut};
     use crate::blockdata::witness::Witness;
-    use crate::hashes::{hash160, ripemd160, sha256, Hash};
     use crate::internal_macros::hex;
     use crate::network::constants::Network::Bitcoin;
     use crate::psbt::map::{Input, Output};
@@ -979,7 +979,8 @@ mod tests {
     #[test]
     fn test_serde_psbt() {
         //! Create a full PSBT value with various fields filled and make sure it can be JSONized.
-        use crate::hashes::sha256d;
+        use hashes::sha256d;
+
         use crate::psbt::map::Input;
 
         // create some values to use in the PSBT

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -8,6 +8,7 @@
 
 use core::convert::{TryFrom, TryInto};
 
+use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use secp256k1::{self, XOnlyPublicKey};
 
 use super::map::{Input, Map, Output, PsbtSighashType};
@@ -19,7 +20,6 @@ use crate::blockdata::witness::Witness;
 use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
-use crate::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use crate::prelude::*;
 use crate::psbt::{Error, PartiallySignedTransaction};
 use crate::taproot::{

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -24,9 +24,9 @@ pub mod btreemap_byte_values {
 
     // NOTE: This module can be exactly copied to use with HashMap.
 
+    use hashes::hex::FromHex;
     use serde;
 
-    use crate::hashes::hex::FromHex;
     use crate::prelude::*;
 
     pub fn serialize<S, T>(v: &BTreeMap<T, Vec<u8>>, s: S) -> Result<S::Ok, S::Error>
@@ -248,9 +248,8 @@ pub mod hex_bytes {
     //! Module for serialization of byte arrays as hex strings.
     #![allow(missing_docs)]
 
+    use hashes::hex::FromHex;
     use serde;
-
-    use crate::hashes::hex::FromHex;
 
     pub fn serialize<T, S>(bytes: &T, s: S) -> Result<S::Ok, S::Error>
     where

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -7,11 +7,12 @@
 //! library is used with the `secp-recovery` feature.
 //!
 
+use hashes::{sha256d, Hash, HashEngine};
+
 #[cfg(feature = "secp-recovery")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
 pub use self::message_signing::{MessageSignature, MessageSignatureError};
 use crate::consensus::{encode, Encodable};
-use crate::hashes::{sha256d, Hash, HashEngine};
 
 /// The prefix for signed messages using Bitcoin's message signing protocol.
 pub const BITCOIN_SIGNED_MSG_PREFIX: &[u8] = b"\x18Bitcoin Signed Message:\n";
@@ -21,12 +22,12 @@ mod message_signing {
     use core::fmt;
 
     use bitcoin_internals::write_err;
+    use hashes::sha256d;
     use secp256k1;
     use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 
     use crate::address::{Address, AddressType};
     use crate::crypto::key::PublicKey;
-    use crate::hashes::sha256d;
     #[cfg(feature = "base64")]
     use crate::prelude::*;
 

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -11,13 +11,13 @@ use core::fmt;
 use core::iter::FusedIterator;
 
 use bitcoin_internals::write_err;
+use hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use secp256k1::{self, Scalar, Secp256k1};
 
 use crate::consensus::Encodable;
 use crate::crypto::key::{TapTweak, TweakedPublicKey, UntweakedPublicKey, XOnlyPublicKey};
 // Re-export these so downstream only has to use one `taproot` module.
 pub use crate::crypto::taproot::{Error, Signature};
-use crate::hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use crate::prelude::*;
 use crate::{io, Script, ScriptBuf};
 
@@ -1576,12 +1576,12 @@ impl std::error::Error for TaprootError {
 mod test {
     use core::str::FromStr;
 
+    use hashes::hex::FromHex;
+    use hashes::sha256t::Tag;
+    use hashes::{sha256, Hash, HashEngine};
     use secp256k1::{VerifyOnly, XOnlyPublicKey};
 
     use super::*;
-    use crate::hashes::hex::FromHex;
-    use crate::hashes::sha256t::Tag;
-    use crate::hashes::{sha256, Hash, HashEngine};
     use crate::sighash::{TapSighash, TapSighashTag};
     use crate::{Address, Network};
     extern crate serde_json;


### PR DESCRIPTION
Just patch 2, patch 1 is #1728  

From the commit log of patch 2

    Use shorter import statements
    
    As per discussion [0] use the shorter form for importing crates that we
    re-export (`hashes` and `secp256k1`).
    
    [0] https://github.com/rust-bitcoin/rust-bitcoin/discussions/1661
