### PR TITLE
CI: Prevent duplicate CI runs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,11 @@
 name: Fuzz
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'test-ci/**'
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'test-ci/**'
+  pull_request:
 
 name: Continuous integration
 


### PR DESCRIPTION
Closes #1726 

This will prevent duplicate CI runs when merging an internal branch into master.

You can opt-in to a non-master branch CI by using the prefix given.