### PR TITLE
Mutate mul_u64 with mutagen

### DIFF
--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -402,7 +402,9 @@ impl U256 {
     ///
     /// The multiplication result along with a boolean indicating whether an arithmetic overflow
     /// occurred. If an overflow occurred then the wrapped value is returned.
-    // mutagen false positive: binop_bit, replace `|` with `^`
+    // mutagen false pos mul_u64: replace `|` with `^` (XOR is same as OR when combined with <<)
+    // mutagen false pos mul_u64: replace `|` with `^`
+    #[cfg_attr(all(test, mutate), mutate)]
     fn mul_u64(self, rhs: u64) -> (U256, bool) {
         let mut carry: u128 = 0;
         let mut split_le =


### PR DESCRIPTION
Add the `mutate` attribute to mutate `mul_u64`. Add non-doc comments listing the two false positives. These are identical but we list them twice so when devs grep for `mutagen false pos` the same number of lines for each function is displayed as is displayed by the `mutagen` run. This coding false positives thing is also introduced in PR #1655.