### PR TITLE
Do not use colon

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -5,7 +5,7 @@
 //!
 //! Support for ordinary base58 Bitcoin addresses and private keys.
 //!
-//! # Example: creating a new address from a randomly-generated key pair
+//! # Example creating a new address from a randomly-generated key pair
 //!
 //! ```rust
 //! # #[cfg(feature = "rand-std")] {


### PR DESCRIPTION
Idiomatic headers do not use colons.

### Note

Done while describing open source contribitions at BBB.

co-developed-by: The bitcoin bush bash attendees