### PR TITLE
Add `ChainHash::from_genesis_block_hash`

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -185,6 +185,11 @@ impl ChainHash {
         let hashes = [Self::BITCOIN, Self::TESTNET, Self::SIGNET, Self::REGTEST];
         hashes[network as usize]
     }
+
+    /// Converts genesis block hash into `ChainHash`.
+    pub fn from_genesis_block_hash(block_hash: crate::BlockHash) -> Self {
+        ChainHash(block_hash.to_byte_array())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This improves readability of converting `BlockHash` into `ChainHash`. It's useful in e.g. Electrum protocol which sends `BlockHash` (serialized backward).

Closes #1751