### PR TITLE
CI: Only run release job for release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ on:
 name: Release
 
 jobs:
-  bitcoin:
-    name: Release - bitcoin
+  release:
+    name: Release - dry-run
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
@@ -19,24 +19,4 @@ jobs:
       - name: Checkout Toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: run cargo
-        run: cargo publish -p bitcoin --dry-run
-  private:
-    name: Release - private
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Crate
-        uses: actions/checkout@v3
-      - name: Checkout Toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: run cargo
-        run: cargo publish -p bitcoin-private --dry-run
-  hashes:
-    name: Release - bitcoin_hashes
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Crate
-        uses: actions/checkout@v3
-      - name: Checkout Toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: run cargo
-        run: cargo publish -p bitcoin_hashes --dry-run
+        run: contrib/release.sh

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Check that we can publish crates in their current form if there are changes on top of the tip of
+# master that imply that we are about to do a release.
+
+set -ex
+
+main () {
+    for crate in "internals" "hashes" "bitcoin"; do
+        if release_changes $crate; then
+            echo "$crate has changes implying this is a release PR, checking if we can publish ..."
+            publish_dry_run $crate
+        fi
+    done
+}
+
+# Returns 0 if crate ($1) contains changes since tip of master that imply this patch set is done in
+# preparation for releasing the crate.
+release_changes() {
+    local crate=$1
+    git log --patch --reverse master.. -- $crate/Cargo.toml | grep version
+}
+
+# Do a dry run publish to crates.io using the correct package name for crate ($1).
+# We use `set -e` so this will fail the script if the dry-run fails.
+publish_dry_run() {
+    local crate=$1
+    if [ "$crate" == "hashes" ]; then
+        cargo publish -p "bitcoin_hashes" --dry-run
+    elif [ "$crate" == "internals" ]; then
+        cargo publish -p "bitcoin-private" --dry-run
+    elif [ "$crate" == "bitcoin" ]; then
+        cargo publish -p "bitcoin" --dry-run
+    fi
+}
+
+#
+# Main script.
+#
+main $@


### PR DESCRIPTION
Currently we run the release jobs for all PRs, this leads to red CI runs any time we have unreleased changes in one crate used by another i.e., basically days after a release comes out.

Add a `release.sh` script that has more smarts to try and figure out if the patch series currently ontop of tip of mater contains changes that imply its a release PR. To do so we check for changes to the version field in the manifest of each crate.