### PR TITLE
[Docs] Update internal project link to changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ support only a single blockchain.
 
 ## Release Notes
 
-See [CHANGELOG.md](CHANGELOG.md).
+See [CHANGELOG.md](bitcoin/CHANGELOG.md).
 
 
 ## Licensing


### PR DESCRIPTION
The changelog was moved in[1], but the link to it in README.md wasn't updated.  I don't see any other outdated links to it in this project via a quick git grep.

---Not your usual Harding

[1] https://github.com/rust-bitcoin/rust-bitcoin/pull/1284/commits/bae64e156ee21d7dd2fae12b77674d330419ed0d