### PR TITLE
Add per crate release notes link

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,11 @@ support only a single blockchain.
 
 ## Release Notes
 
-See [CHANGELOG.md](bitcoin/CHANGELOG.md).
+Release notes are done per crate, see:
+
+- [bitcoin CHANGELOG](bitcoin/CHANGELOG.md)
+- [hashes CHANGELOG](hashes/CHANGELOG.md)
+- [internals CHANGELOG](internals/CHANGELOG.md)
 
 
 ## Licensing


### PR DESCRIPTION
In #1759 we fixed the link to the bitcoin changelog, we can go one step further and add links for each of the crates.



