### PR TITLE
Use doc_auto_cfg

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -126,7 +126,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -181,7 +181,6 @@ impl fmt::Display for ParseAmountError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for ParseAmountError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::ParseAmountError::*;
@@ -1160,7 +1159,6 @@ mod private {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde {
     // methods are implementation of a standardized serde-specific signature
     #![allow(missing_docs)]

--- a/bitcoin/src/base58.rs
+++ b/bitcoin/src/base58.rs
@@ -255,7 +255,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -38,7 +38,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -79,7 +79,6 @@ impl Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -211,7 +211,6 @@ impl FromStr for ChildNumber {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for ChildNumber {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -222,7 +221,6 @@ impl<'de> serde::Deserialize<'de> for ChildNumber {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl serde::Serialize for ChildNumber {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -482,7 +480,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -366,7 +366,6 @@ impl fmt::Display for Bip34Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Bip34Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Bip34Error::*;

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -569,7 +569,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -621,7 +620,6 @@ impl fmt::Display for ConversionError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for ConversionError {}
 
 /// Describes the two types of locking, lock-by-blockheight and lock-by-blocktime.
@@ -664,7 +662,6 @@ impl fmt::Display for OperationError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for OperationError {}
 
 #[cfg(test)]

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -325,7 +325,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -422,7 +422,6 @@ impl From<u8> for All {
 debug_from_display!(All);
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl serde::Serialize for All {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -368,7 +368,6 @@ impl Script {
     ///  * `amount` - The amount this script guards.
     ///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
     #[cfg(feature = "bitcoinconsensus")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
     pub fn verify(
         &self,
         index: usize,
@@ -386,7 +385,6 @@ impl Script {
     ///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
     ///  * `flags` - Verification flags, see [`bitcoinconsensus::VERIFY_ALL`] and similar.
     #[cfg(feature = "bitcoinconsensus")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
     pub fn verify_with_flags<F: Into<u32>>(
         &self,
         index: usize,
@@ -502,5 +500,4 @@ delegate_index!(
     RangeToInclusive<usize>
 );
 #[cfg(rust_v_1_53)]
-#[cfg_attr(docsrs, doc(cfg(rust_v_1_53)))]
 delegate_index!((Bound<usize>, Bound<usize>));

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -273,7 +273,6 @@ impl<'a> From<&'a Script> for Cow<'a, Script> {
 
 /// Note: This will fail to compile on old Rust for targets that don't support atomics
 #[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
-#[cfg_attr(docsrs, doc(cfg(target_has_atomic = "ptr")))]
 impl<'a> From<&'a Script> for Arc<Script> {
     fn from(value: &'a Script) -> Self {
         let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));
@@ -446,7 +445,6 @@ impl PartialOrd<ScriptBuf> for Script {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl serde::Serialize for Script {
     /// User-facing serialization for `Script`.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -463,7 +461,6 @@ impl serde::Serialize for Script {
 
 /// Can only deserialize borrowed bytes.
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for &'de Script {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -497,7 +494,6 @@ impl<'de> serde::Deserialize<'de> for &'de Script {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl serde::Serialize for ScriptBuf {
     /// User-facing serialization for `Script`.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -509,7 +505,6 @@ impl serde::Serialize for ScriptBuf {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for ScriptBuf {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -686,7 +681,6 @@ pub enum Error {
     NumericOverflow,
     /// Error validating the script with bitcoinconsensus library.
     #[cfg(feature = "bitcoinconsensus")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
     BitcoinConsensus(bitcoinconsensus::Error),
     /// Can not find the spent output.
     UnknownSpentOutput(OutPoint),
@@ -753,7 +747,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -122,7 +122,6 @@ impl fmt::Display for ParseOutPointError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for ParseOutPointError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::ParseOutPointError::*;
@@ -943,7 +942,6 @@ impl Transaction {
 
     /// Shorthand for [`Self::verify_with_flags`] with flag [`bitcoinconsensus::VERIFY_ALL`].
     #[cfg(feature = "bitcoinconsensus")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
     pub fn verify<S>(&self, spent: S) -> Result<(), script::Error>
     where
         S: FnMut(&OutPoint) -> Option<TxOut>,
@@ -955,7 +953,6 @@ impl Transaction {
     ///
     /// The `spent` closure should not return the same [`TxOut`] twice!
     #[cfg(feature = "bitcoinconsensus")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
     pub fn verify_with_flags<S, F>(&self, mut spent: S, flags: F) -> Result<(), script::Error>
     where
         S: FnMut(&OutPoint) -> Option<TxOut>,

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -79,7 +79,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -733,7 +732,6 @@ impl<T: Encodable> Encodable for rc::Rc<T> {
 
 /// Note: This will fail to compile on old Rust for targets that don't support atomics
 #[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
-#[cfg_attr(docsrs, doc(cfg(target_has_atomic = "ptr")))]
 impl<T: Encodable> Encodable for sync::Arc<T> {
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         (**self).consensus_encode(w)

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -15,5 +15,4 @@ pub use self::encode::{
 pub use self::params::Params;
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde;

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -212,7 +212,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -51,7 +51,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -401,7 +400,6 @@ impl ops::Index<ops::RangeFull> for PrivateKey {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl serde::Serialize for PrivateKey {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.collect_str(self)
@@ -409,7 +407,6 @@ impl serde::Serialize for PrivateKey {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for PrivateKey {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<PrivateKey, D::Error> {
         struct WifVisitor;
@@ -445,7 +442,6 @@ impl<'de> serde::Deserialize<'de> for PrivateKey {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 #[allow(clippy::collapsible_else_if)] // Aids readability.
 impl serde::Serialize for PublicKey {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
@@ -458,7 +454,6 @@ impl serde::Serialize for PublicKey {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for PublicKey {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<PublicKey, D::Error> {
         if d.is_human_readable() {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -268,7 +268,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use Error::*;

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -85,7 +85,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -31,7 +31,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -54,13 +53,11 @@ macro_rules! impl_std_error {
     // No source available
     ($type:ty) => {
         #[cfg(feature = "std")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
         impl std::error::Error for $type {}
     };
     // Struct with $field as source
     ($type:ty, $field:ident) => {
         #[cfg(feature = "std")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
         impl std::error::Error for $type {
             fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.$field) }
         }

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -135,7 +135,6 @@ macro_rules! impl_bytes_newtype {
         }
 
         #[cfg(feature = "serde")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl $crate::serde::Serialize for $t {
             fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 if s.is_human_readable() {
@@ -147,7 +146,6 @@ macro_rules! impl_bytes_newtype {
         }
 
         #[cfg(feature = "serde")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl<'de> $crate::serde::Deserialize<'de> for $t {
             fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> Result<$t, D::Error> {
                 if d.is_human_readable() {

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -34,7 +34,7 @@
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.
 #![cfg_attr(bench, feature(test))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions
 #![warn(missing_docs)]
 // Instead of littering the codebase for non-fuzzing code just globally allow.
@@ -57,12 +57,10 @@ extern crate test;
 extern crate alloc;
 
 #[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 pub extern crate base64;
 pub extern crate bech32;
 pub extern crate bitcoin_hashes as hashes;
 #[cfg(feature = "bitcoinconsensus")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
 pub extern crate bitcoinconsensus;
 pub extern crate secp256k1;
 

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -504,7 +504,6 @@ impl fmt::Display for MerkleBlockError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for MerkleBlockError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::MerkleBlockError::*;

--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -10,28 +10,20 @@
 pub mod constants;
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod address;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use self::address::Address;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod message;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod message_blockdata;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod message_bloom;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod message_compact_blocks;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod message_filter;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod message_network;
 
 pub use self::constants::Magic;

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -91,7 +91,6 @@ impl Work {
     /// used mainly for informative and displaying purposes, similarly to Bitcoin Core's
     /// `log2_work` output in its logs.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn log2(self) -> f64 { self.0.to_f64().log2() }
 }
 do_impl!(Work);
@@ -702,7 +701,6 @@ impl fmt::Display for TryFromError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for TryFromError {}
 
 impl Add for U256 {
@@ -785,7 +783,6 @@ impl_hex!(LowerHex, bitcoin_internals::hex::Case::Lower);
 impl_hex!(UpperHex, bitcoin_internals::hex::Case::Upper);
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl crate::serde::Serialize for U256 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -808,7 +805,6 @@ impl crate::serde::Serialize for U256 {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> crate::serde::Deserialize<'de> for U256 {
     fn deserialize<D: crate::serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         use core::convert::TryInto;

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -162,7 +162,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -601,7 +601,6 @@ impl fmt::Display for GetKeyError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for GetKeyError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetKeyError::*;
@@ -722,7 +721,6 @@ impl fmt::Display for SignError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for SignError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::SignError::*;
@@ -762,7 +760,6 @@ mod display_from_str {
 
     /// Error encountered during PSBT decoding from Base64 string.
     #[derive(Debug)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
     #[non_exhaustive]
     pub enum PsbtParseError {
         /// Error in internal PSBT data structure.
@@ -783,7 +780,6 @@ mod display_from_str {
     }
 
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     impl std::error::Error for PsbtParseError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             use self::PsbtParseError::*;
@@ -795,14 +791,12 @@ mod display_from_str {
         }
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
     impl Display for PartiallySignedTransaction {
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
             write!(f, "{}", Base64Display::with_config(&self.serialize(), base64::STANDARD))
         }
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
     impl FromStr for PartiallySignedTransaction {
         type Err = PsbtParseError;
 
@@ -813,7 +807,6 @@ mod display_from_str {
     }
 }
 #[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 pub use self::display_from_str::PsbtParseError;
 
 #[cfg(test)]

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -10,7 +10,6 @@
 use hashes::{sha256d, Hash, HashEngine};
 
 #[cfg(feature = "secp-recovery")]
-#[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
 pub use self::message_signing::{MessageSignature, MessageSignatureError};
 use crate::consensus::{encode, Encodable};
 
@@ -32,7 +31,6 @@ mod message_signing {
     use crate::prelude::*;
 
     /// An error used for dealing with Bitcoin Signed Messages.
-    #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
     #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum MessageSignatureError {
@@ -60,7 +58,6 @@ mod message_signing {
     }
 
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     impl std::error::Error for MessageSignatureError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             use self::MessageSignatureError::*;
@@ -85,7 +82,6 @@ mod message_signing {
     /// `fmt::Display` and `str::FromStr` implementations, the `base64` feature
     /// must be enabled.
     #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "secp-recovery")))]
     pub struct MessageSignature {
         /// The inner recoverable signature.
         pub signature: RecoverableSignature,
@@ -165,7 +161,6 @@ mod message_signing {
 
         /// Convert a signature from base64 encoding.
         #[cfg(feature = "base64")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
         pub fn from_base64(s: &str) -> Result<MessageSignature, MessageSignatureError> {
             let bytes = base64::decode(s).map_err(|_| MessageSignatureError::InvalidBase64)?;
             MessageSignature::from_slice(&bytes)
@@ -173,12 +168,10 @@ mod message_signing {
 
         /// Convert to base64 encoding.
         #[cfg(feature = "base64")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
         pub fn to_base64(self) -> String { base64::encode(&self.serialize()[..]) }
     }
 
     #[cfg(feature = "base64")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
     impl fmt::Display for MessageSignature {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let bytes = self.serialize();
@@ -192,7 +185,6 @@ mod message_signing {
     }
 
     #[cfg(feature = "base64")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
     impl core::str::FromStr for MessageSignature {
         type Err = MessageSignatureError;
         fn from_str(s: &str) -> Result<MessageSignature, MessageSignatureError> {

--- a/bitcoin/src/string.rs
+++ b/bitcoin/src/string.rs
@@ -60,7 +60,6 @@ impl<E: fmt::Display> fmt::Display for FromHexError<E> {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<E> std::error::Error for FromHexError<E>
 where
     E: std::error::Error + 'static,

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -612,7 +612,6 @@ impl core::fmt::Display for IncompleteBuilder {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for IncompleteBuilder {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::IncompleteBuilder::*;
@@ -651,7 +650,6 @@ impl core::fmt::Display for HiddenNodes {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for HiddenNodes {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::HiddenNodes::*;
@@ -851,7 +849,6 @@ impl TryFrom<TaprootBuilder> for NodeInfo {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl serde::Serialize for NodeInfo {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -868,7 +865,6 @@ impl serde::Serialize for NodeInfo {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for NodeInfo {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1398,7 +1394,6 @@ impl fmt::UpperHex for LeafVersion {
 
 /// Serializes [`LeafVersion`] as a `u8` using consensus encoding.
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl serde::Serialize for LeafVersion {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1410,7 +1405,6 @@ impl serde::Serialize for LeafVersion {
 
 /// Deserializes [`LeafVersion`] as a `u8` using consensus encoding.
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for LeafVersion {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1492,7 +1486,6 @@ impl fmt::Display for TaprootBuilderError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for TaprootBuilderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::TaprootBuilderError::*;
@@ -1555,7 +1548,6 @@ impl fmt::Display for TaprootError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for TaprootError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::TaprootError::*;

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -36,7 +36,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/hashes/src/hex.rs
+++ b/hashes/src/hex.rs
@@ -48,7 +48,6 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -116,7 +115,6 @@ impl<'a> Iterator for HexIterator<'a> {
 }
 
 #[cfg(any(feature = "std", feature = "core2"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "core2"))))]
 impl<'a> io::Read for HexIterator<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut bytes_read = 0usize;
@@ -144,7 +142,6 @@ impl<'a> DoubleEndedIterator for HexIterator<'a> {
 impl<'a> ExactSizeIterator for HexIterator<'a> {}
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
 impl FromHex for Vec<u8> {
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
     where

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -184,7 +184,6 @@ impl<T: Hash> Hash for Hmac<T> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<T: Hash + Serialize> Serialize for Hmac<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         Serialize::serialize(&self.0, s)
@@ -192,7 +191,6 @@ impl<T: Hash + Serialize> Serialize for Hmac<T> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, T: Hash + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Hmac<T>, D::Error> {
         let bytes = Deserialize::deserialize(d)?;

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -80,7 +80,7 @@
 // Coding conventions
 #![warn(missing_docs)]
 // Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(bench, feature(test))]
 // In general, rust is absolutely horrid at supporting users doing things like,
 // for example, compiling Rust code for real environments. Disable useless lints

--- a/hashes/src/serde_macros.rs
+++ b/hashes/src/serde_macros.rs
@@ -17,7 +17,6 @@
 
 /// Functions used by serde impls of all hashes.
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde_details {
     use core::marker::PhantomData;
     use core::str::FromStr;
@@ -121,7 +120,6 @@ pub mod serde_details {
 /// represents a newtype over a byte-slice over length `$len`.
 #[macro_export]
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 macro_rules! serde_impl(
     ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => (
         impl<$($gen: $gent),*> $crate::serde_macros::serde_details::SerdeHash for $t<$($gen),*> {

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -399,7 +399,6 @@ macro_rules! hash_newtype_known_attrs {
 }
 
 #[cfg(feature = "schemars")]
-#[cfg_attr(docsrs, doc(cfg(feature = "schemars")))]
 pub mod json_hex_string {
     use schemars::gen::SchemaGenerator;
     use schemars::schema::{Schema, SchemaObject};

--- a/internals/src/hex/display.rs
+++ b/internals/src/hex/display.rs
@@ -35,7 +35,6 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     ///
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_lower_hex_string(self) -> String { self.to_hex_string(Case::Lower) }
 
     /// Create an upper-hex-encoded string.
@@ -44,14 +43,12 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     ///
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_upper_hex_string(self) -> String { self.to_hex_string(Case::Upper) }
 
     /// Create a hex-encoded string.
     ///
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn to_hex_string(self, case: Case) -> String {
         let mut string = String::new();
         self.append_hex_to_string(case, &mut string);
@@ -63,7 +60,6 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     /// This may be faster than `write!(string, "{:x}", self.display_hex())` because it uses
     /// `reserve_sugggestion`.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn append_hex_to_string(self, case: Case, string: &mut String) {
         use fmt::Write;
 
@@ -112,7 +108,6 @@ impl<'a> DisplayHex for &'a [u8] {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl<'a> DisplayHex for &'a alloc::vec::Vec<u8> {
     type Display = DisplayByteSlice<'a>;
 

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -9,7 +9,7 @@
 
 #![no_std]
 // Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions
 #![warn(missing_docs)]
 


### PR DESCRIPTION
If we use `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` instead of `#![cfg_attr(docsrs, feature(doc_cfg))]` we no longer need to manually mark types with `#[cfg_attr(docsrs, doc(cfg(feature = "std")))]`.

Sweeeeeet.

Props to pezcore for the lesson :)