### PR TITLE
Allow parsing sub-sat denominations with decimal points 

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -1642,6 +1642,7 @@ mod tests {
         use super::ParseAmountError as E;
         let btc = Denomination::Bitcoin;
         let sat = Denomination::Satoshi;
+        let msat = Denomination::MilliSatoshi;
         let p = Amount::from_str_in;
         let sp = SignedAmount::from_str_in;
 
@@ -1654,6 +1655,15 @@ mod tests {
         let more_than_max = format!("1{}", Amount::max_value());
         assert_eq!(p(&more_than_max, btc), Err(E::TooBig));
         assert_eq!(p("0.000000042", btc), Err(E::TooPrecise));
+        assert_eq!(p("999.0000000", msat), Err(E::TooPrecise));
+        assert_eq!(p("1.0000000", msat), Err(E::TooPrecise));
+        assert_eq!(p("1.1", msat), Err(E::TooPrecise));
+        assert_eq!(p("1000.1", msat), Err(E::TooPrecise));
+        assert_eq!(p("1001.0000000", msat), Err(E::TooPrecise));
+        assert_eq!(p("1000.0000001", msat), Err(E::TooPrecise));
+        assert_eq!(p("1000.1000000", msat), Err(E::TooPrecise));
+        assert_eq!(p("1100.0000000", msat), Err(E::TooPrecise));
+        assert_eq!(p("10001.0000000", msat), Err(E::TooPrecise));
 
         assert_eq!(p("1", btc), Ok(Amount::from_sat(1_000_000_00)));
         assert_eq!(sp("-.5", btc), Ok(SignedAmount::from_sat(-500_000_00)));

--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -1684,6 +1684,8 @@ mod tests {
             p("12345678901.12345678", btc),
             Ok(Amount::from_sat(12_345_678_901__123_456_78))
         );
+        assert_eq!(p("1000.0", msat), Ok(Amount::from_sat(1)));
+        assert_eq!(p("1000.000000000000000000000000000", msat), Ok(Amount::from_sat(1)));
 
         // make sure satoshi > i64::max_value() is checked.
         let amount = Amount::from_sat(i64::max_value() as u64);


### PR DESCRIPTION
Numbers with only zeros after decimal points are valid if they are also
multiples of `10^precision` (e.g. 1000 for msats). These were
artificially disallowed as "too precise" which was at least misleading.

This change allows parsing such numbers.

And yes, I know this is not perfectly efficient (unless the compiler figures out some magic opts) but so isn't the rest of the code. TBH this parsing code drives me crazy and I'd love to rewrite it to be more efficient and readable.