### PR TITLE
hashes: Derive traits on the sha512::Hash type

### DIFF
--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -23,7 +23,7 @@
 use core::convert::TryInto;
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, hash, str};
+use core::{cmp, str};
 
 use crate::{Error, HashEngine as _};
 
@@ -80,6 +80,7 @@ impl crate::HashEngine for HashEngine {
 }
 
 /// Output of the SHA512 hash function.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
@@ -94,38 +95,6 @@ impl Hash {
     fn internal_new(arr: [u8; 64]) -> Self { Hash(arr) }
 
     fn internal_engine() -> HashEngine { Default::default() }
-}
-
-impl Copy for Hash {}
-
-impl Clone for Hash {
-    fn clone(&self) -> Hash {
-        let mut ret = [0; 64];
-        ret.copy_from_slice(&self.0);
-        Hash(ret)
-    }
-}
-
-impl PartialEq for Hash {
-    fn eq(&self, other: &Hash) -> bool { self.0[..] == other.0[..] }
-}
-
-impl Eq for Hash {}
-
-impl Default for Hash {
-    fn default() -> Hash { Hash([0; 64]) }
-}
-
-impl PartialOrd for Hash {
-    fn partial_cmp(&self, other: &Hash) -> Option<cmp::Ordering> { self.0.partial_cmp(&other.0) }
-}
-
-impl Ord for Hash {
-    fn cmp(&self, other: &Hash) -> cmp::Ordering { self.0.cmp(&other.0) }
-}
-
-impl hash::Hash for Hash {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) { self.0.hash(state) }
 }
 
 #[cfg(not(fuzzing))]


### PR DESCRIPTION
For all the other hash types we use derive, by way of the `hash_type!` macro, unless I'm missing something we can do the same for `sha512::Hash`.