### PR TITLE
hashes: Use clippy::pedantic to improve the code

### DIFF
--- a/hashes/src/hex.rs
+++ b/hashes/src/hex.rs
@@ -95,8 +95,11 @@ fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, Error> {
     let hih = (hi as char).to_digit(16).ok_or(Error::InvalidChar(hi))?;
     let loh = (lo as char).to_digit(16).ok_or(Error::InvalidChar(lo))?;
 
+    assert!(hih < 16); // 4 bits
+    assert!(loh < 16);
+
     let ret = (hih << 4) + loh;
-    Ok(ret as u8)
+    Ok(ret as u8) // Cast is ok because two hex digits fit into a byte.
 }
 
 impl<'a> Iterator for HexIterator<'a> {

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -73,6 +73,7 @@ macro_rules! hash_trait_impls {
             ///
             /// This is mainly intended as an internal method and you shouldn't need it unless
             /// you're doing something special.
+            #[must_use = "use the returned object to display hex forwards eg., {:x}"]
             pub fn forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex {
                 internals::hex::display::DisplayHex::as_hex(&self.0)
             }
@@ -81,12 +82,14 @@ macro_rules! hash_trait_impls {
             ///
             /// This is mainly intended as an internal method and you shouldn't need it unless
             /// you're doing something special.
+            #[must_use = "use the returned object to display hex backwards eg., {:x}"]
             pub fn backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex {
                 internals::hex::display::DisplayArray::<_, [u8; $bits / 8 * 2]>::new(self.0.iter().rev())
             }
 
             /// Zero cost conversion between a fixed length byte array shared reference and
             /// a shared reference to this Hash type.
+            #[must_use = "returns the reference to converted type"]
             pub fn from_bytes_ref(bytes: &[u8; $bits / 8]) -> &Self {
                 // Safety: Sound because Self is #[repr(transparent)] containing [u8; $bits / 8]
                 unsafe { &*(bytes as *const _ as *const Self) }
@@ -94,6 +97,7 @@ macro_rules! hash_trait_impls {
 
             /// Zero cost conversion between a fixed length byte array exclusive reference and
             /// an exclusive reference to this Hash type.
+            #[must_use = "returns the reference to converted type"]
             pub fn from_bytes_mut(bytes: &mut [u8; $bits / 8]) -> &mut Self {
                 // Safety: Sound because Self is #[repr(transparent)] containing [u8; $bits / 8]
                 unsafe { &mut *(bytes as *mut _ as *mut Self) }

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -53,7 +53,7 @@
 //! ```
 //!
 //!
-//! Hashing content by [`std::io::Write`] on HashEngine:
+//! Hashing content by [`std::io::Write`] on `HashEngine`:
 //!
 //! ```rust
 //! use bitcoin_hashes::sha256;
@@ -106,7 +106,7 @@ extern crate test;
 
 #[doc(hidden)]
 pub mod _export {
-    /// A re-export of core::*
+    /// A re-export of `core::*`.
     pub mod _core {
         pub use core::*;
     }
@@ -153,10 +153,10 @@ pub trait HashEngine: Clone + Default {
     /// Length of the hash's internal block size, in bytes.
     const BLOCK_SIZE: usize;
 
-    /// Add data to the hash engine.
+    /// Adds data to the hash engine.
     fn input(&mut self, data: &[u8]);
 
-    /// Return the number of bytes already n_bytes_hashed(inputted).
+    /// Returns the number of bytes already inputted.
     fn n_bytes_hashed(&self) -> usize;
 }
 
@@ -188,6 +188,7 @@ pub trait Hash:
     type Bytes: hex::FromHex + Copy;
 
     /// Constructs a new engine.
+    #[must_use = "returns the new engine"]
     fn engine() -> Self::Engine { Self::Engine::default() }
 
     /// Produces a hash from the current state of a given engine.
@@ -197,9 +198,11 @@ pub trait Hash:
     const LEN: usize;
 
     /// Copies a byte slice into a hash object.
+    #[must_use = "returns the hash type"]
     fn from_slice(sl: &[u8]) -> Result<Self, Error>;
 
     /// Hashes some bytes.
+    #[must_use = "returns the hash type"]
     fn hash(data: &[u8]) -> Self {
         let mut engine = Self::engine();
         engine.input(data);

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -155,16 +155,17 @@ impl Midstate {
 
     /// Copies a byte slice into the [`Midstate`] object.
     pub fn from_slice(sl: &[u8]) -> Result<Midstate, Error> {
-        if sl.len() != Self::LEN {
-            Err(Error::InvalidLength(Self::LEN, sl.len()))
-        } else {
+        if sl.len() == Self::LEN {
             let mut ret = [0; 32];
             ret.copy_from_slice(sl);
             Ok(Midstate(ret))
+        } else {
+            Err(Error::InvalidLength(Self::LEN, sl.len()))
         }
     }
 
     /// Unwraps the [`Midstate`] and returns the underlying byte array.
+    #[must_use = "returns inner type without modifying self"]
     pub fn to_byte_array(self) -> [u8; 32] { self.0 }
 
     /// Creates midstate for tagged hashes.
@@ -173,6 +174,7 @@ impl Midstate {
     ///
     /// Computes non-finalized hash of `sha256(tag) || sha256(tag)` for use in
     /// [`sha256t`](super::sha256t). It's provided for use with [`sha256t`](crate::sha256t).
+    #[must_use]
     pub const fn hash_tag(tag: &[u8]) -> Self {
         let hash = Hash::const_hash(tag);
         let mut buf = [0u8; 64];
@@ -391,6 +393,7 @@ impl HashEngine {
     /// # Panics
     ///
     /// If `length` is not a multiple of the block size.
+    #[must_use = "returns the constructed type"]
     pub fn from_midstate(midstate: Midstate, length: usize) -> HashEngine {
         assert!(length % BLOCK_SIZE == 0, "length is no multiple of the block size");
 
@@ -672,7 +675,7 @@ mod tests {
                 156, 224, 228, 230, 124, 17, 108, 57, 56, 179, 202, 242, 195, 15, 80, 137, 211,
                 243, 147, 108, 71, 99, 110, 96, 125, 179, 62, 234, 221, 198, 240, 201,
             ])
-        )
+        );
     }
 
     #[cfg(feature = "serde")]

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -43,7 +43,7 @@ pub struct Hash<T: Tag>(
 );
 
 impl<T: Tag> Hash<T> {
-    fn internal_new(arr: [u8; 32]) -> Self { Hash(arr, Default::default()) }
+    fn internal_new(arr: [u8; 32]) -> Self { Hash(arr, PhantomData::default()) }
 
     fn internal_engine() -> HashEngine { T::engine() }
 }

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -17,7 +17,7 @@
 // was written entirely by Steven Roose, who is re-licensing its
 // contents here as CC0.
 
-//! SipHash 2-4 implementation.
+//! SipHash-2-4 implementation.
 //!
 
 use core::ops::Index;
@@ -29,7 +29,7 @@ use crate::{Error, Hash as _, HashEngine as _};
 crate::internal_macros::hash_type! {
     64,
     false,
-    "Output of the SipHash24 hash function.",
+    "Output of the SipHash-2-4 hash function.",
     "crate::util::json_hex_string::len_8"
 }
 
@@ -95,7 +95,7 @@ pub struct State {
     v3: u64,
 }
 
-/// Engine to compute the SipHash24 hash function.
+/// Engine to compute the SipHash-2-4 hash function.
 #[derive(Debug, Clone)]
 pub struct HashEngine {
     k0: u64,
@@ -107,7 +107,8 @@ pub struct HashEngine {
 }
 
 impl HashEngine {
-    /// Creates a new SipHash24 engine with keys.
+    /// Creates a new SipHash-2-4 engine with keys.
+    #[must_use = "returns the constructed type"]
     pub fn with_keys(k0: u64, k1: u64) -> HashEngine {
         HashEngine {
             k0,
@@ -124,10 +125,12 @@ impl HashEngine {
         }
     }
 
-    /// Creates a new SipHash24 engine.
+    /// Creates a new SipHash-2-4 engine.
+    #[must_use = "returns the constructed type"]
     pub fn new() -> HashEngine { HashEngine::with_keys(0, 0) }
 
     /// Retrieves the keys of this engine.
+    #[must_use = "returns the keys"]
     pub fn keys(&self) -> (u64, u64) { (self.k0, self.k1) }
 
     #[inline]
@@ -201,6 +204,7 @@ impl crate::HashEngine for HashEngine {
 
 impl Hash {
     /// Hashes the given data with an engine with the provided keys.
+    #[must_use = "use the returned hash"]
     pub fn hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> Hash {
         let mut engine = HashEngine::with_keys(k0, k1);
         engine.input(data);
@@ -208,6 +212,7 @@ impl Hash {
     }
 
     /// Hashes the given data directly to u64 with an engine with the provided keys.
+    #[must_use = "use the returned u64"]
     pub fn hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64 {
         let mut engine = HashEngine::with_keys(k0, k1);
         engine.input(data);
@@ -216,6 +221,7 @@ impl Hash {
 
     /// Produces a hash as `u64` from the current state of a given engine.
     #[inline]
+    #[must_use = "use the returned u64"]
     pub fn from_engine_to_u64(e: HashEngine) -> u64 {
         let mut state = e.state;
 
@@ -232,9 +238,11 @@ impl Hash {
     }
 
     /// Returns the (little endian) 64-bit integer representation of the hash value.
+    #[must_use = "use the returned u64"]
     pub fn as_u64(&self) -> u64 { u64::from_le_bytes(self.0) }
 
     /// Creates a hash from its (little endian) 64-bit integer representation.
+    #[must_use = "use the returned hash"]
     pub fn from_u64(hash: u64) -> Hash { Hash(hash.to_le_bytes()) }
 }
 
@@ -252,7 +260,7 @@ unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
     }
     if i + 1 < len {
         out |= u64::from(load_int_le!(buf, start + i, u16)) << (i * 8);
-        i += 2
+        i += 2;
     }
     if i < len {
         out |= u64::from(*buf.get_unchecked(start + i)) << (i * 8);

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -139,7 +139,7 @@ macro_rules! engine_input_impl(
 /// You can add arbitrary doc comments or other attributes to the struct or it's field. Note that
 /// the macro already derives [`Copy`], [`Clone`], [`Eq`], [`PartialEq`],
 /// [`Hash`](core::hash::Hash), [`Ord`], [`PartialOrd`]. With the `serde` feature on, this also adds
-/// [`Serialize`](serde::Serialize) and [`Deserialize](serde::Deserialize) implementations.
+/// [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) implementations.
 ///
 /// You can also define multiple newtypes within one macro call:
 ///
@@ -458,28 +458,28 @@ mod test {
     fn display() {
         let want = "0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{}", TestHash::all_zeros());
-        assert_eq!(got, want)
+        assert_eq!(got, want);
     }
 
     #[test]
     fn display_alternate() {
         let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{:#}", TestHash::all_zeros());
-        assert_eq!(got, want)
+        assert_eq!(got, want);
     }
 
     #[test]
     fn lower_hex() {
         let want = "0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{:x}", TestHash::all_zeros());
-        assert_eq!(got, want)
+        assert_eq!(got, want);
     }
 
     #[test]
     fn lower_hex_alternate() {
         let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{:#x}", TestHash::all_zeros());
-        assert_eq!(got, want)
+        assert_eq!(got, want);
     }
 
     #[test]


### PR DESCRIPTION
I thought I'd see what `clippy::pedantic` had to say about our code.

I'm abusing review time here a little by not breaking this up into a bunch of patches because I'm doing weekend hacking just for fun - sorry about that.

Also, this is just for `hashes` - if thees fixes are deemed valuable we could do the other crates.

A few comments:

- There are a million instances of long ints (eg. 0x12345678) that clippy wants to see written as `0x1234_5678` but this seems like churn to me.
- I created an issue for documenting error returns
- I didn't touch any of the unsafe code but clippy doesn't like the casts
- There are a bunch of other casts that clippy doesn't like either but they required too much thinking for me to fix right now