### PR TITLE
Implement serde::Serialize for Address

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -616,7 +616,7 @@ mod sealed {
 
 /// Marker of status of address's network validation. See section [*Parsing addresses*](Address#parsing-addresses)
 /// on [`Address`] for details.
-pub trait NetworkValidation: sealed::NetworkValidation {
+pub trait NetworkValidation: sealed::NetworkValidation + Sync + Send + Sized + Unpin {
     /// Indicates whether this `NetworkValidation` is `NetworkChecked` or not.
     const IS_CHECKED: bool;
 }

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -748,21 +748,18 @@ where
     V: NetworkValidation;
 
 #[cfg(feature = "serde")]
-struct DisplayUnchecked<'a>(&'a Address<NetworkUnchecked>);
+struct DisplayUnchecked<'a, N: NetworkValidation>(&'a Address<N>);
 
 #[cfg(feature = "serde")]
-impl fmt::Display for DisplayUnchecked<'_> {
+impl<N: NetworkValidation> fmt::Display for DisplayUnchecked<'_, N> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result { self.0.fmt_internal(fmt) }
 }
-
-#[cfg(feature = "serde")]
-crate::serde_utils::serde_string_serialize_impl!(Address, "a Bitcoin address");
 
 #[cfg(feature = "serde")]
 crate::serde_utils::serde_string_deserialize_impl!(Address<NetworkUnchecked>, "a Bitcoin address");
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for Address<NetworkUnchecked> {
+impl<N: NetworkValidation> serde::Serialize for Address<N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,


### PR DESCRIPTION
With the new rewrite of Address, `serde::Serialize` is only implemented on `Address<bitcoin::address::NetworkChecked>` and `Address<bitcoin::address::NetworkUnchecked>`. But the compiler has no way of knowing that that are all the possible versions of `Address`, so the generic `Address<impl bitcoin::address::NetworkValidation>` doesn't implement `serde::Serialize`.