### PR TITLE
Implement unit-specific serde implementations for FeeRate

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -1257,10 +1257,9 @@ pub mod serde {
 
     use serde::{Deserializer, Serialize, Serializer};
 
+    use super::ParseAmountError;
     use crate::amount::{Amount, Denomination, SignedAmount};
     use crate::serde_utils::DelegatingOptionVisitor;
-
-    use super::ParseAmountError;
 
     /// A serde Visitor for visiting amounts expressed in satoshi.
     pub struct SatVisitor;
@@ -1336,8 +1335,7 @@ pub mod serde {
             Ok(SignedAmount::from_sat(v as i64))
         }
         fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
-            let sats = TryFrom::try_from(v)
-                .map_err(|_| E::custom(ParseAmountError::TooBig))?;
+            let sats = TryFrom::try_from(v).map_err(|_| E::custom(ParseAmountError::TooBig))?;
             Ok(SignedAmount::from_sat(sats))
         }
         fn visit_f32<E: serde::de::Error>(self, v: f32) -> Result<Self::Value, E> {
@@ -1358,41 +1356,49 @@ pub mod serde {
         }
         fn visit_i8<E: serde::de::Error>(self, v: i8) -> Result<Self::Value, E> {
             let pos = u64::try_from(v).map_err(|_| E::custom(ParseAmountError::Negative))?;
-            let sats = pos.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
+            let sats =
+                pos.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(Amount::from_sat(sats))
         }
         fn visit_i16<E: serde::de::Error>(self, v: i16) -> Result<Self::Value, E> {
             let pos = u64::try_from(v).map_err(|_| E::custom(ParseAmountError::Negative))?;
-            let sats = pos.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
+            let sats =
+                pos.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(Amount::from_sat(sats))
         }
         fn visit_i32<E: serde::de::Error>(self, v: i32) -> Result<Self::Value, E> {
             let pos = u64::try_from(v).map_err(|_| E::custom(ParseAmountError::Negative))?;
-            let sats = pos.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
+            let sats =
+                pos.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(Amount::from_sat(sats))
         }
         fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
             let pos = u64::try_from(v).map_err(|_| E::custom(ParseAmountError::Negative))?;
-            let sats = pos.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
+            let sats =
+                pos.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(Amount::from_sat(sats))
         }
         fn visit_u8<E: serde::de::Error>(self, v: u8) -> Result<Self::Value, E> {
-            let sats = (v as u64).checked_mul(100_000_000)
+            let sats = (v as u64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(Amount::from_sat(sats))
         }
         fn visit_u16<E: serde::de::Error>(self, v: u16) -> Result<Self::Value, E> {
-            let sats = (v as u64).checked_mul(100_000_000)
+            let sats = (v as u64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(Amount::from_sat(sats))
         }
         fn visit_u32<E: serde::de::Error>(self, v: u32) -> Result<Self::Value, E> {
-            let sats = (v as u64).checked_mul(100_000_000)
+            let sats = (v as u64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(Amount::from_sat(sats))
         }
         fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
-            let sats = v.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
+            let sats =
+                v.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(Amount::from_sat(sats))
         }
         fn visit_f32<E: serde::de::Error>(self, v: f32) -> Result<Self::Value, E> {
@@ -1412,37 +1418,43 @@ pub mod serde {
             write!(f, "a signed Bitcoin amount in Bitcoin")
         }
         fn visit_i8<E: serde::de::Error>(self, v: i8) -> Result<Self::Value, E> {
-            let sats = (v as i64).checked_mul(100_000_000)
+            let sats = (v as i64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(SignedAmount::from_sat(sats))
         }
         fn visit_i16<E: serde::de::Error>(self, v: i16) -> Result<Self::Value, E> {
-            let sats = (v as i64).checked_mul(100_000_000)
+            let sats = (v as i64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(SignedAmount::from_sat(sats))
         }
         fn visit_i32<E: serde::de::Error>(self, v: i32) -> Result<Self::Value, E> {
-            let sats = (v as i64).checked_mul(100_000_000)
+            let sats = (v as i64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(SignedAmount::from_sat(sats))
         }
         fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
-            let sats = v.checked_mul(100_000_000)
-                .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
+            let sats =
+                v.checked_mul(100_000_000).ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(SignedAmount::from_sat(sats))
         }
         fn visit_u8<E: serde::de::Error>(self, v: u8) -> Result<Self::Value, E> {
-            let sats = (v as i64).checked_mul(100_000_000)
+            let sats = (v as i64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(SignedAmount::from_sat(sats))
         }
         fn visit_u16<E: serde::de::Error>(self, v: u16) -> Result<Self::Value, E> {
-            let sats = (v as i64).checked_mul(100_000_000)
+            let sats = (v as i64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(SignedAmount::from_sat(sats))
         }
         fn visit_u32<E: serde::de::Error>(self, v: u32) -> Result<Self::Value, E> {
-            let sats = (v as i64).checked_mul(100_000_000)
+            let sats = (v as i64)
+                .checked_mul(100_000_000)
                 .ok_or_else(|| E::custom(ParseAmountError::TooBig))?;
             Ok(SignedAmount::from_sat(sats))
         }

--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -517,7 +517,7 @@ impl Amount {
     pub const fn from_sat(satoshi: u64) -> Amount { Amount(satoshi) }
 
     /// Gets the number of satoshis in this [`Amount`].
-    pub fn to_sat(self) -> u64 { self.0 }
+    pub const fn to_sat(self) -> u64 { self.0 }
 
     /// The maximum value of an [Amount].
     #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
@@ -662,19 +662,30 @@ impl Amount {
 
     /// Checked addition.
     /// Returns [None] if overflow occurred.
-    pub fn checked_add(self, rhs: Amount) -> Option<Amount> {
-        self.0.checked_add(rhs.0).map(Amount)
+    pub const fn checked_add(self, rhs: Amount) -> Option<Amount> {
+        match self.0.checked_add(rhs.0) {
+            Some(v) => Some(Amount(v)),
+            None => None,
+        }
     }
 
     /// Checked subtraction.
     /// Returns [None] if overflow occurred.
-    pub fn checked_sub(self, rhs: Amount) -> Option<Amount> {
-        self.0.checked_sub(rhs.0).map(Amount)
+    pub const fn checked_sub(self, rhs: Amount) -> Option<Amount> {
+        match self.0.checked_sub(rhs.0) {
+            Some(v) => Some(Amount(v)),
+            None => None,
+        }
     }
 
     /// Checked multiplication.
     /// Returns [None] if overflow occurred.
-    pub fn checked_mul(self, rhs: u64) -> Option<Amount> { self.0.checked_mul(rhs).map(Amount) }
+    pub const fn checked_mul(self, rhs: u64) -> Option<Amount> {
+        match self.0.checked_mul(rhs) {
+            Some(v) => Some(Amount(v)),
+            None => None,
+        }
+    }
 
     /// Checked integer division.
     /// Be aware that integer division loses the remainder if no exact division

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -24,9 +24,7 @@ where
         write!(f, "'")
     }
 
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(None)
-    }
+    fn visit_none<E>(self) -> Result<Self::Value, E> { Ok(None) }
 
     fn visit_some<D: serde::de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
         Ok(Some(d.deserialize_any(self.0)?))
@@ -99,7 +97,10 @@ where
     fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
         Ok(Some(V::visit_unit(self.0)?))
     }
-    fn visit_newtype_struct<D: serde::de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+    fn visit_newtype_struct<D: serde::de::Deserializer<'de>>(
+        self,
+        d: D,
+    ) -> Result<Self::Value, D::Error> {
         Ok(Some(V::visit_newtype_struct(self.0, d)?))
     }
     fn visit_seq<A: serde::de::SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -5,7 +5,7 @@
 //! This module is for special serde serializations.
 //!
 
-pub(crate) struct SerializeBytesAsHex<'a>(pub(crate) &'a [u8]);
+pub struct SerializeBytesAsHex<'a>(pub &'a [u8]);
 
 impl<'a> serde::Serialize for SerializeBytesAsHex<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -5,6 +5,114 @@
 //! This module is for special serde serializations.
 //!
 
+/// A serde Visitor for Option<T> by wrapping a Visitor for T.
+///
+/// It implements [visit_some] and [visit_none] to be used with
+/// [deserialize_option], but it also delegates all other visitor methods so
+/// that it can also be used directly with [deserialize_any].
+pub struct DelegatingOptionVisitor<V>(pub V);
+
+impl<'de, V, T> serde::de::Visitor<'de> for DelegatingOptionVisitor<V>
+where
+    V: serde::de::Visitor<'de, Value = T>,
+{
+    type Value = Option<T>;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "an optional '")?;
+        <V as serde::de::Visitor>::expecting(&self.0, f)?;
+        write!(f, "'")
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+
+    fn visit_some<D: serde::de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+        Ok(Some(d.deserialize_any(self.0)?))
+    }
+
+    // all other impls are just delegations with a Some wrapper
+
+    fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_bool(self.0, v)?))
+    }
+    fn visit_i8<E: serde::de::Error>(self, v: i8) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_i8(self.0, v)?))
+    }
+    fn visit_i16<E: serde::de::Error>(self, v: i16) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_i16(self.0, v)?))
+    }
+    fn visit_i32<E: serde::de::Error>(self, v: i32) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_i32(self.0, v)?))
+    }
+    fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_i64(self.0, v)?))
+    }
+    fn visit_i128<E: serde::de::Error>(self, v: i128) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_i128(self.0, v)?))
+    }
+    fn visit_u8<E: serde::de::Error>(self, v: u8) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_u8(self.0, v)?))
+    }
+    fn visit_u16<E: serde::de::Error>(self, v: u16) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_u16(self.0, v)?))
+    }
+    fn visit_u32<E: serde::de::Error>(self, v: u32) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_u32(self.0, v)?))
+    }
+    fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_u64(self.0, v)?))
+    }
+    fn visit_u128<E: serde::de::Error>(self, v: u128) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_u128(self.0, v)?))
+    }
+    fn visit_f32<E: serde::de::Error>(self, v: f32) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_f32(self.0, v)?))
+    }
+    fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_f64(self.0, v)?))
+    }
+    fn visit_char<E: serde::de::Error>(self, v: char) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_char(self.0, v)?))
+    }
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_str(self.0, v)?))
+    }
+    fn visit_borrowed_str<E: serde::de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_borrowed_str(self.0, v)?))
+    }
+    #[cfg(feature = "alloc")]
+    fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_string(self.0, v)?))
+    }
+    fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_bytes(self.0, v)?))
+    }
+    fn visit_borrowed_bytes<E: serde::de::Error>(self, v: &'de [u8]) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_borrowed_bytes(self.0, v)?))
+    }
+    #[cfg(feature = "alloc")]
+    fn visit_byte_buf<E: serde::de::Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_byte_buf(self.0, v)?))
+    }
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(Some(V::visit_unit(self.0)?))
+    }
+    fn visit_newtype_struct<D: serde::de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+        Ok(Some(V::visit_newtype_struct(self.0, d)?))
+    }
+    fn visit_seq<A: serde::de::SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {
+        Ok(Some(V::visit_seq(self.0, seq)?))
+    }
+    fn visit_map<A: serde::de::MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+        Ok(Some(V::visit_map(self.0, map)?))
+    }
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        Ok(Some(V::visit_enum(self.0, data)?))
+    }
+}
+
 pub struct SerializeBytesAsHex<'a>(pub &'a [u8]);
 
 impl<'a> serde::Serialize for SerializeBytesAsHex<'a> {


### PR DESCRIPTION
I had created a FeeRate type in bitcoincore_rpc already and was informed there was one here too. I did a small refactor to leverage more the `Amount` type we already have so that we don't need to keep track of units inside the impl. Some roundabout fiddling to keep const working..

Apart from the two requests for comment in my own inline comments, some considerations made:

- I only added the two representations that are used by bitcoin core in the RPC; if people have requests for others, feel free to request or add.
- The serialization is tailored to JSON. This is unfortunate, but I guess common in our codebase. Specifically I mean the assumption that all numbers will eventually be represented as floating point. On this point, I'd be very happy to change the names of the modules to explicitly mention this. This would mean a little bit annoyance the users, but it would allow for more accurate serializers for users that don't use JSON.

Closes #1786 