### PR TITLE
ci: Check for remaining NEXT_RELEASE in the release script

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -9,6 +9,16 @@ main () {
     for crate in "internals" "hashes" "bitcoin"; do
         if release_changes $crate; then
             echo "$crate has changes implying this is a release PR, checking if we can publish ..."
+
+            # Check if there is any mention of NEXT_RELEASE which means the
+            # next version number should be filled in.
+            if grep -qr NEXT_RELEASE ./$crate; then
+                echo Version number needs to be filled in following places:
+                grep -r NEXT_RELEASE ./$crate
+                exit 1
+            fi
+
+            # Then try to dry-run cargo publish
             publish_dry_run $crate
         fi
     done


### PR DESCRIPTION

The intention here is that we can use the deprecation tag
`#[deprecated(since = "NEXT_RELEASE")]` and fill in the version number
at release time.

Not sure if there is a good place to mention this somewhere in developer docs. I looked into CONTRIBUTING.md but didn't really found a suitable section for this.