### PR TITLE
bitcoin: Export all hashtypes

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -126,9 +126,7 @@ pub use crate::consensus::encode::VarInt;
 pub use crate::crypto::key::{self, PrivateKey, PublicKey};
 pub use crate::crypto::{ecdsa, sighash};
 pub use crate::error::Error;
-pub use crate::hash_types::{
-    BlockHash, PubkeyHash, ScriptHash, Txid, WPubkeyHash, WScriptHash, Wtxid,
-};
+pub use crate::hash_types::*;
 pub use crate::merkle_tree::MerkleBlock;
 pub use crate::network::constants::Network;
 pub use crate::pow::{CompactTarget, Target, Work};


### PR DESCRIPTION
Maybe this is just a small piece of a larger effort. But I think almost all types should be re-exported unless there is a clear reason not to. I believe most of the old `util::xx` modules were self-contained and should not be reexported, but all the types used in the basic primitives (i.e. blockdata) should be.

I just spend 5 minutes checking if I was somehow on an unexpected version of the library because I couldn't import `TxMerkleNode` which is used in the block header.