### PR TITLE
transaction: Add doc alias is_coinbase to is_coin_base method

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -981,6 +981,7 @@ impl Transaction {
     /// transaction. It is impossible to check if the transaction is first in the block, so this
     /// function checks the structure of the transaction instead - the previous output must be
     /// all-zeros (creates satoshis "out of thin air").
+    #[doc(alias = "is_coinbase")]
     pub fn is_coin_base(&self) -> bool {
         self.input.len() == 1 && self.input[0].previous_output.is_null()
     }


### PR DESCRIPTION
It has officially been two times in two years that I remember thinking "heh, I really thought there was an is_coinbase method, but I guess I was wrong" to then later find it in the code.

This is just a doc alias so that searching for the method (and grepping the code!) will give you a result for is_coinbase.

Tbh, I'd be in favor of deprecating the method and renaming it as well, but well. I've never seen anyone write "coin base transaction" or "coin-base transaction", always just "coinbase transaction". But for the sake of stability, I like the doc alias.