### PR TITLE
extended_tests: Remove stale docs

### DIFF
--- a/hashes/extended_tests/schemars/README.md
+++ b/hashes/extended_tests/schemars/README.md
@@ -4,7 +4,6 @@ Run as usual with `cargo test`.
 
 ## Minimum Supported Rust Version (MSRV)
 
-To run the tests with the MSRV you will need to pin some dependencies:
+To run the tests with the MSRV you will need to pin `serde`:
 
 - `cargo update -p serde --precise 1.0.156`
-- `cargo update -p syn --precise 1.0.107`


### PR DESCRIPTION
We no longer need to pin `syn`; remove stale docs.

This is a follow up to #1696 