### PR TITLE
embedded: Remove error handler

### DIFF
--- a/bitcoin/embedded/src/main.rs
+++ b/bitcoin/embedded/src/main.rs
@@ -8,7 +8,6 @@ extern crate bitcoin;
 
 use alloc::string::ToString;
 use alloc::vec;
-use core::alloc::Layout;
 use core::panic::PanicInfo;
 
 use alloc_cortex_m::CortexMHeap;
@@ -17,7 +16,6 @@ use bitcoin::{Address, Network, PrivateKey};
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
 
-use cortex_m::asm;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
 
@@ -53,16 +51,6 @@ fn main() -> ! {
     // exit QEMU
     // NOTE do not run this on hardware; it can corrupt OpenOCD state
     debug::exit(debug::EXIT_SUCCESS);
-
-    loop {}
-}
-
-// define what happens in an Out Of Memory (OOM) condition
-#[alloc_error_handler]
-fn alloc_error(_layout: Layout) -> ! {
-    hprintln!("alloc error").unwrap();
-    debug::exit(debug::EXIT_FAILURE);
-    asm::bkpt();
 
     loop {}
 }

--- a/hashes/embedded/src/main.rs
+++ b/hashes/embedded/src/main.rs
@@ -7,8 +7,6 @@ extern crate bitcoin_hashes;
 
 #[cfg(feature = "alloc")] extern crate alloc;
 #[cfg(feature = "alloc")] use alloc_cortex_m::CortexMHeap;
-#[cfg(feature = "alloc")] use core::alloc::Layout;
-#[cfg(feature = "alloc")] use cortex_m::asm;
 #[cfg(feature = "alloc")] use alloc::string::ToString;
 
 use bitcoin_hashes::{sha256, Hash, HashEngine};
@@ -62,13 +60,4 @@ fn check_result(engine: sha256::HashEngine) {
     if hash.to_string() != hash_check.to_string() {
         debug::exit(debug::EXIT_FAILURE);
     }
-}
-
-// define what happens in an Out Of Memory (OOM) condition
-#[cfg(feature = "alloc")]
-#[alloc_error_handler]
-fn alloc_error(_layout: Layout) -> ! {
-    asm::bkpt();
-
-    loop {}
 }


### PR DESCRIPTION
Seems we no longer need an explicit error handler, remove it.

I did not grok the reason (long thread link below) but just removed it and checked that the embedded crates still ran correctly.

https://github.com/rust-lang/rust/issues/51540

Fix: #1813