### PR TITLE
Simplify per-file license comments

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin addresses.

--- a/bitcoin/src/base58.rs
+++ b/bitcoin/src/base58.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Base58 encoder and decoder.

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Tammas Blummer.
 // SPDX-License-Identifier: CC0-1.0
 
 // This module was largely copied from https://github.com/rust-bitcoin/murmel/blob/master/src/blockfilter.rs

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! BIP32 implementation.

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin blocks.

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Blockdata constants.

--- a/bitcoin/src/blockdata/fee_rate.rs
+++ b/bitcoin/src/blockdata/fee_rate.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Implements `FeeRate` and assoctiated features.
 
 use core::fmt;

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -1,4 +1,3 @@
-// Rust Bitcoin Library - Written by the rust-bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
 //! Provides type [`LockTime`] that implements the logic around nLockTime/OP_CHECKLOCKTIMEVERIFY.

--- a/bitcoin/src/blockdata/locktime/mod.rs
+++ b/bitcoin/src/blockdata/locktime/mod.rs
@@ -1,4 +1,3 @@
-// Rust Bitcoin Library - Written by the rust-bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
 //! Provides absolute and relative locktimes.

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -1,4 +1,3 @@
-// Rust Bitcoin Library - Written by the rust-bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
 //! Provides type [`LockTime`] that implements the logic around nSequence/OP_CHECKSEQUENCEVERIFY.

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin block data.

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin script opcodes.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 use core::convert::{TryFrom, TryInto};

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 #[cfg(feature = "bitcoinconsensus")]

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 use core::convert::TryInto;

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin scripts.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 #[cfg(doc)]

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Contains `PushBytes` & co
 
 use core::borrow::{Borrow, BorrowMut};

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 use core::str::FromStr;
 
 use hashes::Hash;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin transactions.

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Implements `Weight` and associated features.
 
 use core::fmt;

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin consensus-encodable types.

--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin consensus parameters.

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Serde serialization via consensus encoding
 //!
 //! This provides functions for (de)serializing any type as consensus-encoded bytes.

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! ECDSA Bitcoin signatures.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin keys.

--- a/bitcoin/src/crypto/mod.rs
+++ b/bitcoin/src/crypto/mod.rs
@@ -1,4 +1,3 @@
-// Rust Bitcoin Library - Written by the rust-bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
 //! Cryptography

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin taproot keys.

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Contains error types and other error handling tools.
 
 use core::fmt;

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin hash types.

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Internal macros.

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Rust Bitcoin Library

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -1,4 +1,3 @@
-// Written by John L. Jegutanis
 // SPDX-License-Identifier: CC0-1.0
 //
 // This code was translated from merkleblock.h, merkleblock.cpp and pmt_tests.cpp

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin merkle tree functions.

--- a/bitcoin/src/network/address.rs
+++ b/bitcoin/src/network/address.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network addresses.

--- a/bitcoin/src/network/constants.rs
+++ b/bitcoin/src/network/constants.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network constants.

--- a/bitcoin/src/network/message.rs
+++ b/bitcoin/src/network/message.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network messages.

--- a/bitcoin/src/network/message_blockdata.rs
+++ b/bitcoin/src/network/message_blockdata.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin blockdata network messages.

--- a/bitcoin/src/network/message_compact_blocks.rs
+++ b/bitcoin/src/network/message_compact_blocks.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //!
 //! BIP152  Compact Blocks network messages
 //!

--- a/bitcoin/src/network/message_network.rs
+++ b/bitcoin/src/network/message_network.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network-related network messages.

--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin network support.

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 use core::convert::TryFrom;
 use core::fmt;
 use core::str::FromStr;

--- a/bitcoin/src/policy.rs
+++ b/bitcoin/src/policy.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin policy.

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1,4 +1,3 @@
-// Rust Bitcoin Library - Written by the rust-bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
 //! Proof-of-work related integer types.

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Signature

--- a/bitcoin/src/test_macros.rs
+++ b/bitcoin/src/test_macros.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Bitcoin serde macros.

--- a/bitcoin/src/util/mod.rs
+++ b/bitcoin/src/util/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2014 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Utility functions.

--- a/hashes/src/cmp.rs
+++ b/hashes/src/cmp.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Useful comparison functions.
 
 /// Compare two slices for equality in fixed time. Panics if the slices are of non-equal length.

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Crate error type.
 //!

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -1,17 +1,5 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 //
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
-
 // This module is largely copied from the rust-crypto ripemd.rs file;
 // while rust-crypto is licensed under Apache, that file specifically
 // was written entirely by Andrew Poelstra, who is re-licensing its

--- a/hashes/src/hex.rs
+++ b/hashes/src/hex.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Hex encoding and decoding.
 //!

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 // This module is largely copied from the rust-crypto ripemd.rs file;
 // while rust-crypto is licensed under Apache, that file specifically

--- a/hashes/src/impls.rs
+++ b/hashes/src/impls.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2019 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! `std` / `core2` Impls.
 //!

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Non-public macros
 
 macro_rules! arr_newtype_fmt_impl {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Rust hashes library.
 //!

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -1,21 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
-
-// This module is largely copied from the rust-crypto ripemd.rs file;
-// while rust-crypto is licensed under Apache, that file specifically
-// was written entirely by Andrew Poelstra, who is re-licensing its
-// contents here as CC0.
+// SPDX-License-Identifier: CC0-1.0
 
 //! RIPEMD160 implementation.
 //!

--- a/hashes/src/serde_macros.rs
+++ b/hashes/src/serde_macros.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Macros for serde trait implementations, and supporting code.
 //!

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! SHA1 implementation.
 //!

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! SHA256 implementation.
 //!

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! SHA256d implementation (double SHA256).
 //!

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2019 by
-//   The rust-bitcoin developers.
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! SHA256t implementation (tagged SHA256).
 //!

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -1,21 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
-
-// This module is largely copied from the rust-crypto ripemd.rs file;
-// while rust-crypto is licensed under Apache, that file specifically
-// was written entirely by Andrew Poelstra, who is re-licensing its
-// contents here as CC0.
+// SPDX-License-Identifier: CC0-1.0
 
 //! SHA512 implementation.
 //!

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -1,21 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2022 by
-//   The rust-bitcoin developers.
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
-
-// This module is largely copied from the rust-crypto ripemd.rs file;
-// while rust-crypto is licensed under Apache, that file specifically
-// was written entirely by Andrew Poelstra, who is re-licensing its
-// contents here as CC0.
+// SPDX-License-Identifier: CC0-1.0
 
 //! SHA512_256 implementation.
 //!

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -1,21 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2019 by
-//   The rust-bitcoin developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
-
-// This module is largely copied from the rust-siphash sip.rs file;
-// while rust-siphash is licensed under Apache, that file specifically
-// was written entirely by Steven Roose, who is re-licensing its
-// contents here as CC0.
+// SPDX-License-Identifier: CC0-1.0
 
 //! SipHash 2-4 implementation.
 //!

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -1,16 +1,4 @@
-// Bitcoin Hashes Library
-// Written in 2018 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 #[macro_export]
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.

--- a/internals/src/error.rs
+++ b/internals/src/error.rs
@@ -1,4 +1,3 @@
-// Written by the Rust Bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Error

--- a/internals/src/hex/buf_encoder.rs
+++ b/internals/src/hex/buf_encoder.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Implements a buffered encoder.
 //!
 //! The main type of this module is [`BufEncoder`] which provides buffered hex encoding. Such is

--- a/internals/src/hex/display.rs
+++ b/internals/src/hex/display.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Helpers for displaying bytes as hex strings.
 //!
 //! This module provides a trait for displaying things as hex as well as an implementation for

--- a/internals/src/hex/mod.rs
+++ b/internals/src/hex/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Helpers for encoding bytes as hex strings.
 
 pub mod buf_encoder;

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -1,4 +1,3 @@
-// Written by the Rust Bitcoin developers.
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Rust Bitcoin Internal

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Various macros used by the Rust Bitcoin ecosystem.
 //!
 


### PR DESCRIPTION
Please note, whether or not we need a per-file license comment is out of scope for this PR. This PR leaves us with the most simple per-file solution possible and leaves the merit of per-file license comment to be discussed on another day.

Simplify the per-file license stuff by doing:

- Remove the attribution line from each file. 

    Currently we have a mishmash of attribution lines accompanying the SPDX identifier. These lines are basically meaningless because:
    
    - The date is often wrong
    - The original author attributed is not the only contributor to a file
    - The term "rust bitcoin developers" is basically just noise

- Introduce SPDX license identifiers into `hashes` and remove attribution line (ie, make `hashes` uniform with `bitcoin`)


Required before merge please:

- [x] ack from apoelstra because as the library original author many of the changes in this PR remove his name
- [x] ack from Kixunil because he had some concerns in the issue descussion

Fix: #1816