### PR TITLE
Move weight constants in the `Weight` type

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -32,10 +32,15 @@ pub const TARGET_BLOCK_SPACING: u32 = 600;
 pub const DIFFCHANGE_INTERVAL: u32 = 2016;
 /// How much time on average should occur between diffchanges.
 pub const DIFFCHANGE_TIMESPAN: u32 = 14 * 24 * 3600;
+
+#[deprecated(since = "0.31.0", note = "Use Weight::MAX_BLOCK instead")]
 /// The maximum allowed weight for a block, see BIP 141 (network rule).
 pub const MAX_BLOCK_WEIGHT: u32 = 4_000_000;
+
+#[deprecated(since = "0.31.0", note = "Use Weight::MIN_TRANSACTION instead")]
 /// The minimum transaction weight for a valid serialized transaction.
 pub const MIN_TRANSACTION_WEIGHT: u32 = 4 * 60;
+
 /// The factor that non-witness serialization data is multiplied by during weight calculation.
 pub const WITNESS_SCALE_FACTOR: usize = 4;
 /// The maximum allowed number of signature check operations in a block.

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -29,6 +29,12 @@ impl Weight {
     /// Maximum possible value.
     pub const MAX: Weight = Weight(u64::max_value());
 
+    /// The maximum allowed weight for a block, see BIP 141 (network rule).
+    pub const MAX_BLOCK: Weight = Weight(4_000_000);
+
+    /// The minimum transaction weight for a valid serialized transaction.
+    pub const MIN_TRANSACTION: Weight = Weight(4 * 60);
+
     /// Directly constructs `Weight` from weight units.
     pub const fn from_wu(wu: u64) -> Self { Weight(wu) }
 
@@ -247,6 +253,12 @@ impl Div<u64> for Weight {
     type Output = Weight;
 
     fn div(self, rhs: u64) -> Self::Output { Weight(self.0 / rhs) }
+}
+
+impl Div<Weight> for Weight {
+    type Output = u64;
+
+    fn div(self, rhs: Weight) -> Self::Output { self.to_wu() / rhs.to_wu() }
 }
 
 impl DivAssign<u64> for Weight {

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -45,8 +45,8 @@ use hashes::Hash;
 
 use self::MerkleBlockError::*;
 use crate::blockdata::block::{self, Block};
-use crate::blockdata::constants::{MAX_BLOCK_WEIGHT, MIN_TRANSACTION_WEIGHT};
 use crate::blockdata::transaction::Transaction;
+use crate::blockdata::weight::Weight;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::hash_types::{TxMerkleNode, Txid};
 use crate::io;
@@ -276,7 +276,7 @@ impl PartialMerkleTree {
             return Err(NoTransactions);
         };
         // check for excessively high numbers of transactions
-        if self.num_transactions > MAX_BLOCK_WEIGHT / MIN_TRANSACTION_WEIGHT {
+        if self.num_transactions as u64 > Weight::MAX_BLOCK / Weight::MIN_TRANSACTION {
             return Err(TooManyTransactions);
         }
         // there can never be more hashes provided than one for every txid


### PR DESCRIPTION
deprecate constants::MAX_BLOCK_WEIGHT and constants::MIN_TRANSACTION_WEIGHT to nicely redirect users to the constants in the Weight type