### PR TITLE
Fix associated constants of `InputWeightPrediction`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1329,7 +1329,8 @@ pub const fn predict_weight_from_slices(
 /// Weight prediction of an individual input.
 ///
 /// This helper type collects information about an input to be used in [`predict_weight`] function.
-/// It can only be created using the [`new`](InputWeightPrediction::new) function.
+/// It can only be created using the [`new`](InputWeightPrediction::new) function or using other
+/// associated constants/methods.
 #[derive(Copy, Clone, Debug)]
 pub struct InputWeightPrediction {
     script_size: usize,


### PR DESCRIPTION
These constants had an error that they had `script_size` set to 0 which
was incorrect because it's not length of the script but serialized size.
Rather than just bumping the value this uses the `from_slice` method
which is less error-prone.

Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/1834