### PR TITLE
Move and rename TxOut default trait to a const called NULL

### DIFF
--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -29,7 +29,7 @@ pub struct ScriptBuf(pub(in crate::blockdata::script) Vec<u8>);
 
 impl ScriptBuf {
     /// Creates a new empty script.
-    pub fn new() -> Self { ScriptBuf(Vec::new()) }
+    pub const fn new() -> Self { ScriptBuf(Vec::new()) }
 
     /// Creates a new empty script with pre-allocated capacity.
     pub fn with_capacity(capacity: usize) -> Self { ScriptBuf(Vec::with_capacity(capacity)) }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -484,6 +484,10 @@ pub struct TxOut {
 }
 
 impl TxOut {
+    /// This is used as a "null txout" in consensus signing code.
+    pub const NULL: Self =
+        TxOut { value: Amount::from_sat(0xffffffffffffffff), script_pubkey: ScriptBuf::new() };
+
     /// The weight of the txout in witness units
     ///
     /// Keep in mind that when adding a TxOut to a transaction, the total weight of the transaction
@@ -515,13 +519,6 @@ impl TxOut {
             value: Amount::from_sat(dust_amount + 1), // minimal non-dust amount is one higher than dust amount
             script_pubkey,
         }
-    }
-}
-
-// This is used as a "null txout" in consensus signing code.
-impl Default for TxOut {
-    fn default() -> TxOut {
-        TxOut { value: Amount::from_sat(0xffffffffffffffff), script_pubkey: ScriptBuf::new() }
     }
 }
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -929,15 +929,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                         .iter()
                         .take(input_index + 1) // sign all outputs up to and including this one, but erase
                         .enumerate() // all of them except for this one
-                        .map(
-                            |(n, out)| {
-                                if n == input_index {
-                                    out.clone()
-                                } else {
-                                    TxOut::default()
-                                }
-                            },
-                        );
+                        .map(|(n, out)| if n == input_index { out.clone() } else { TxOut::NULL });
                     output_iter.collect()
                 }
                 EcdsaSighashType::None => vec![],
@@ -1142,7 +1134,7 @@ mod tests {
             version: 1,
             lock_time: absolute::LockTime::ZERO,
             input: vec![TxIn::default(), TxIn::default()],
-            output: vec![TxOut::default()],
+            output: vec![TxOut::NULL],
         };
         let script = ScriptBuf::new();
         let cache = SighashCache::new(&tx);
@@ -1340,13 +1332,13 @@ mod tests {
             c.taproot_signature_hash(0, &empty_prevouts, None, None, TapSighashType::All),
             Err(Error::PrevoutsSize)
         );
-        let two = vec![TxOut::default(), TxOut::default()];
+        let two = vec![TxOut::NULL, TxOut::NULL];
         let too_many_prevouts = Prevouts::All(&two);
         assert_eq!(
             c.taproot_signature_hash(0, &too_many_prevouts, None, None, TapSighashType::All),
             Err(Error::PrevoutsSize)
         );
-        let tx_out = TxOut::default();
+        let tx_out = TxOut::NULL;
         let prevout = Prevouts::One(1, &tx_out);
         assert_eq!(
             c.taproot_signature_hash(0, &prevout, None, None, TapSighashType::All),

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1691,11 +1691,11 @@ mod tests {
                 output: vec![
                     TxOut {
                         value: output_0_val,
-                        ..Default::default()
+                        script_pubkey:  ScriptBuf::new()
                     },
                     TxOut {
                         value: output_1_val,
-                        ..Default::default()
+                        script_pubkey:  ScriptBuf::new()
                     },
                 ],
             },
@@ -1730,11 +1730,11 @@ mod tests {
                         output: vec![
                             TxOut {
                                 value: prev_output_val,
-                                ..Default::default()
+                                script_pubkey:  ScriptBuf::new()
                             },
                             TxOut {
                                 value: Amount::from_sat(190_303_501_938),
-                                ..Default::default()
+                                script_pubkey:  ScriptBuf::new()
                             },
                         ],
                     }),
@@ -1788,7 +1788,7 @@ mod tests {
             version: 2,
             lock_time: absolute::LockTime::ZERO,
             input: vec![TxIn::default(), TxIn::default()],
-            output: vec![TxOut::default()],
+            output: vec![TxOut::NULL],
         };
         let mut psbt = PartiallySignedTransaction::from_unsigned_tx(unsigned_tx).unwrap();
 


### PR DESCRIPTION
Create an associated constant `const TxOut::NULL` for consensus signing code and remove the default trait.  Note I tried to deprecate the `default()` fn instead of just removing it but it doesn't seem to be possible.  Also because `TxOut::NULL` is `const`, `ScriptBuf::new()` needed to be changed to `const fn`.