### PR TITLE
docs: Add doc comments for external crates

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -56,11 +56,21 @@ extern crate test;
 extern crate alloc;
 
 #[cfg(feature = "base64")]
+/// Encodes and decodes base64 as bytes or utf8.
 pub extern crate base64;
+
+/// Encodes and decodes the Bech32 forrmat.
 pub extern crate bech32;
+
 #[cfg(feature = "bitcoinconsensus")]
+/// Bitcoin's libbitcoinconsensus with Rust binding.
 pub extern crate bitcoinconsensus;
+
+/// Rust implementation of cryptographic hash function algorithems.
 pub extern crate hashes;
+
+/// Rust wrapper library for Pieter Wuille's libsecp256k1.  Implements ECDSA and BIP 340 signatures
+/// for the SECG elliptic curve group secp256k1 and related utilities.
 pub extern crate secp256k1;
 
 #[cfg(feature = "serde")]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -85,8 +85,11 @@ extern crate alloc;
 extern crate core;
 #[cfg(feature = "core2")]
 extern crate core2;
+
 #[cfg(feature = "serde")]
+/// A generic serialization/deserialization framework.
 pub extern crate serde;
+
 #[cfg(all(test, feature = "serde"))]
 extern crate serde_test;
 #[cfg(bench)]


### PR DESCRIPTION
A new version of rust nightly is causing a test failure for external crates that are not documented.  This is currently causing a failure on my branch here: https://github.com/rust-bitcoin/rust-bitcoin/pull/1838

As a side note, it feels like this should be locked to a specific version of nightly in the CI tests and then updated as a choir instead of having it create a new problem in a branch that's not related.