### PR TITLE
ci: fix -run syntax

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -53,8 +53,12 @@ hashes_sha1,
           override: true
           profile: minimal
       - name: fuzz
-        run: if [[ "${{ matrix.fuzz_target }}" =~ ^bitcoin ]]; then export RUSTFLAGS='--cfg=hashes_fuzz --cfg=secp256k1_fuzz'; fi
-        run: cd fuzz && ./fuzz.sh "${{ matrix.fuzz_target }}"
+        run: |
+          if [[ "${{ matrix.fuzz_target }}" =~ ^bitcoin ]]; then
+              export RUSTFLAGS='--cfg=hashes_fuzz --cfg=secp256k1_fuzz'
+          fi
+          echo "Using RUSTFLAGS $RUSTFLAGS"
+          cd fuzz && ./fuzz.sh "${{ matrix.fuzz_target }}"
       - run: echo "${{ matrix.fuzz_target }}" >executed_${{ matrix.fuzz_target }}
       - uses: actions/upload-artifact@v2
         with:

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -78,8 +78,12 @@ $(for name in $(listTargetNames); do echo "$name,"; done)
           override: true
           profile: minimal
       - name: fuzz
-        run: if [[ "\${{ matrix.fuzz_target }}" =~ ^bitcoin ]]; then export RUSTFLAGS='--cfg=hashes_fuzz --cfg=secp256k1_fuzz'; fi
-        run: cd fuzz && ./fuzz.sh "\${{ matrix.fuzz_target }}"
+        run: |
+          if [[ "\${{ matrix.fuzz_target }}" =~ ^bitcoin ]]; then
+              export RUSTFLAGS='--cfg=hashes_fuzz --cfg=secp256k1_fuzz'
+          fi
+          echo "Using RUSTFLAGS \$RUSTFLAGS"
+          cd fuzz && ./fuzz.sh "\${{ matrix.fuzz_target }}"
       - run: echo "\${{ matrix.fuzz_target }}" >executed_\${{ matrix.fuzz_target }}
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
I think our CI failures started with #1821 when we added an extra `run:` line to `fuzz.yml` without prefixing it with `-`.

Fix the syntax to use a multi-line `run` instead.