### PR TITLE
Draft: Add transaction fee calculation

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -19,6 +19,7 @@ use hashes::{self, sha256d, Hash};
 use internals::write_err;
 
 use super::Weight;
+use crate::FeeRate;
 use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
 use crate::blockdata::locktime::absolute::{self, Height, Time};
 use crate::blockdata::locktime::relative;
@@ -36,6 +37,7 @@ use crate::prelude::*;
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::string::FromHexStr;
 use crate::{io, Amount, VarInt};
+
 
 /// A reference to a transaction output.
 ///
@@ -784,6 +786,13 @@ impl Transaction {
                 },
             },
         }
+    }
+
+    /// Computes the Transaction fee.
+    ///
+    /// fee_rate * size.
+    pub fn fee(self, f: FeeRate) -> Amount {
+        f * self.weight()
     }
 
     /// Computes a signature hash for a given input index with a given sighash flag.


### PR DESCRIPTION
Thoughts on adding a fee calculation function to `Transaction`?

Also, I think if we add this calculation, it would be best to make the mul trait `checked_mul` [here](https://github.com/rust-bitcoin/rust-bitcoin/blob/4fc6a6a145cab29c6c973bcce569fef2f06b46f6/bitcoin/src/blockdata/fee_rate.rs#L104).  I'm not if there's a reason this was left as unchecked.