### PR TITLE
Overflow check for feerate traits

### DIFF
--- a/bitcoin/src/blockdata/fee_rate.rs
+++ b/bitcoin/src/blockdata/fee_rate.rs
@@ -105,12 +105,6 @@ impl Mul<FeeRate> for Weight {
     }
 }
 
-impl Mul<Weight> for FeeRate {
-    type Output = Amount;
-
-    fn mul(self, rhs: Weight) -> Self::Output { rhs * self }
-}
-
 impl Div<Weight> for Amount {
     type Output = Option<FeeRate>;
 


### PR DESCRIPTION
Add checks for overflow for fee_rate div and mul traits.  Also I'm not 100% but I think there is a trait that isn't useful so I've removed it in a separate commit.