### PR TITLE
Add changelo entry for removal of FromHex

### DIFF
--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -57,6 +57,8 @@ This release is big, to help users upgrade we wrote a blog post, please see http
      contains a `LockTime` but is `Ord`, we have manually sorted the locktimes based on
      their consensus encoding. This ordering is somewhat arbitrary -- there is no total
      ordering on locktimes since they may be measured in either blocks or seconds.
+  - [Removed `FromHex` implementation](https://github.com/rust-bitcoin/rust-bitcoin/pull/1565) from
+    all types except `Vec` and arrays, replace where appropriate with `FromStr`.
 
 - Performance improvements:
   - [Remove needless allocation from BIP-158 encoding](https://github.com/rust-bitcoin/rust-bitcoin/pull/1146)

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -6,6 +6,8 @@ began the process of replacing the hex functionality in this crate with a more
 performant, dedicated crate, and otherwise cleaning up the API as we look forward
 to 1.0.
 
+* [Remove `FromHex` implementation](https://github.com/rust-bitcoin/rust-bitcoin/pull/1565/commits/a308e1e2ea5c6ae419d961b8da71cc8a35a92715)
+from all hashes and implement `FromStr` instead.
 * Move crate from [original repo](https://github.com/rust-bitcoin/bitcoin_hashes) to the
 `rust-bitcoin` repository. Commit history was lost during move, for commit history see the original
 repository. Tip of bitcoin_hashes:master at time of import: 54c16249e06cc6b7870c7fc07d90f489d82647c7


### PR DESCRIPTION
During the last round of releases (bitcoin 0.30, hashes 0.12) we removed the `FromHex` implementation from all types except vecs and arrays. We added `FromStr` impls for types that roundtrip with `Display`.

We never added a changelog mention to either `bitcoin` or `hashes`, lets retroactively add an entry.

Fix: #1747