### PR TITLE
Add from_int_btc method to Amount

### DIFF
--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -49,7 +49,7 @@ const UTXO_1: P2trUtxo = P2trUtxo {
     script_pubkey: UTXO_SCRIPT_PUBKEY,
     pubkey: UTXO_PUBKEY,
     master_fingerprint: UTXO_MASTER_FINGERPRINT,
-    amount_in_sats: Amount::from_sat(50 * 100_000_000), // 50 BTC
+    amount_in_sats: Amount::from_int_btc(50),
     derivation_path: BIP86_DERIVATION_PATH,
 };
 
@@ -60,7 +60,7 @@ const UTXO_2: P2trUtxo = P2trUtxo {
     script_pubkey: UTXO_SCRIPT_PUBKEY,
     pubkey: UTXO_PUBKEY,
     master_fingerprint: UTXO_MASTER_FINGERPRINT,
-    amount_in_sats: Amount::from_sat(50 * 100_000_000), // 50 BTC
+    amount_in_sats: Amount::from_int_btc(50),
     derivation_path: BIP86_DERIVATION_PATH,
 };
 
@@ -71,7 +71,7 @@ const UTXO_3: P2trUtxo = P2trUtxo {
     script_pubkey: UTXO_SCRIPT_PUBKEY,
     pubkey: UTXO_PUBKEY,
     master_fingerprint: UTXO_MASTER_FINGERPRINT,
-    amount_in_sats: Amount::from_sat(50 * 100_000_000), // 50 BTC
+    amount_in_sats: Amount::from_int_btc(50),
     derivation_path: BIP86_DERIVATION_PATH,
 };
 

--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -502,9 +502,9 @@ impl Amount {
     /// Exactly one satoshi.
     pub const ONE_SAT: Amount = Amount(1);
     /// Exactly one bitcoin.
-    pub const ONE_BTC: Amount = Amount(100_000_000);
+    pub const ONE_BTC: Amount = Self::from_int_btc(1);
     /// The maximum value allowed as an amount. Useful for sanity checking.
-    pub const MAX_MONEY: Amount = Amount(21_000_000 * 100_000_000);
+    pub const MAX_MONEY: Amount = Self::from_int_btc(21_000_000);
     /// The minimum value of an amount.
     pub const MIN: Amount = Amount::ZERO;
     /// The maximum value of an amount.


### PR DESCRIPTION
Followup PR from https://github.com/rust-bitcoin/rust-bitcoin/pull/1811

Added a `const` associated function `from_int_btc()` for Amount.  `panic()` in const context is only available after 1.57+ so a work around is provided. 