### PR TITLE
Fix conditional configuration options usage

### DIFF
--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -14,7 +14,7 @@ use crate::prelude::*;
 /// break invariants. Therefore auditing this module should be sufficient.
 mod primitive {
     use core::convert::{TryFrom, TryInto};
-    #[cfg(feature = "rust_v_1_53")]
+    #[cfg(rust_v_1_53)]
     use core::ops::Bound;
     use core::ops::{
         Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
@@ -105,7 +105,7 @@ mod primitive {
         RangeInclusive<usize>,
         RangeToInclusive<usize>
     );
-    #[cfg(feature = "rust_v_1_53")]
+    #[cfg(rust_v_1_53)]
     delegate_index!((Bound<usize>, Bound<usize>));
 
     impl Index<usize> for PushBytes {

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -106,7 +106,6 @@ mod primitive {
         RangeToInclusive<usize>
     );
     #[cfg(feature = "rust_v_1_53")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rust_v_1_53")))]
     delegate_index!((Bound<usize>, Bound<usize>));
 
     impl Index<usize> for PushBytes {


### PR DESCRIPTION
These build cfg options are not features, fix broken usage. And remove stale docsrs attribute while we are at it. Bad rust-bitcoin devs.

Found while reviewing #1870