### PR TITLE
psbt: Remove reexport of Prevouts

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -20,7 +20,6 @@ use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::crypto::ecdsa;
 use crate::crypto::key::{PrivateKey, PublicKey};
 use crate::prelude::*;
-pub use crate::sighash::Prevouts;
 use crate::sighash::{self, EcdsaSighashType, SighashCache};
 use crate::Amount;
 


### PR DESCRIPTION
No idea why this re-export is here, the `Prevouts` type is not even used in the `psbt` module.

Remove the re-export of `crate::sighash::Prevouts` from `pstb`.

Fix: #1869