### PR TITLE
hashes: Remove stale status badge

### DIFF
--- a/hashes/README.md
+++ b/hashes/README.md
@@ -1,5 +1,3 @@
-[![Status](https://travis-ci.org/rust-bitcoin/bitcoin_hashes.png?branch=master)](https://travis-ci.org/rust-bitcoin/bitcoin_hashes)
-
 # Bitcoin Hashes Library
 
 This is a simple, no-dependency library which implements the hash functions


### PR DESCRIPTION
We do not use travis in our CI pipeline anymore, remove the stale badge.