### PR TITLE
ci: Remove stal DO_ALLOC_TESTS variable

### DIFF
--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -2,11 +2,7 @@
 
 set -ex
 
-FEATURES="serde serde-std std core2"
-
-if [ "$DO_ALLOC_TESTS" = true ]; then
-	FEATURES="$FEATURES alloc"
-fi
+FEATURES="serde serde-std std core2 alloc"
 
 cargo --version
 rustc --version


### PR DESCRIPTION
We never enable the `DO_ALLOC_TESTS` variable, and hence never test the "alloc" feature in `hashes`.

Remove the `DO_ALLOC_TESTS` variable and add "alloc" to the `FEATURES` array.