### PR TITLE
embedded: Document how to clean up linker flags

### DIFF
--- a/bitcoin/embedded/README.md
+++ b/bitcoin/embedded/README.md
@@ -23,3 +23,12 @@ Address: bc1qpx9t9pzzl4qsydmhyt6ctrxxjd4ep549np9993
 ```
 
 Note that this heap size is required because of the amount of stack used by libsecp256k1 when initializing a context.
+
+## Cleanup
+
+After sourcing `scripts/env.sh` and _before_ building again using another target
+you'll want to unset `RUSTFLAGS` otherwise you'll get linker errors.
+
+```shell
+unset RUSTFLAGS
+```


### PR DESCRIPTION
Our embedded crate includes instructions to source a shell script that sets the `RUSTFLAGS` env var. Having the env var set like this in ones environment breaks linkage when trying to do "regular" builds.

Document how to clean up.