### PR TITLE
Check for changes to the public API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -174,3 +174,18 @@ jobs:
         uses: model-checking/kani-github-action@v1.1
         with:
           args: '--only-codegen'
+
+  API:
+    name: Check for changes to the public API
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-public-api
+        run: cargo install --locked cargo-public-api
+      - name: Running API checker script
+        run: ./contrib/check-for-api-changes.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,11 @@ Use of `unsafe` code is prohibited unless there is a unanimous decision among
 library maintainers on the exclusion from this rule. In such cases there is a
 requirement to test unsafe code with sanitizers including Miri.
 
+### API changes
+
+All PRs that change the public API of `rust-bitcoin` must include a patch to
+the `api/` text files. This should be a separate, final patch to the PR
+that is the diff created by running `./contrib/check-for-api-changes.sh`.
 
 ### Policy
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,11 @@
+API text files
+==============
+
+Each file here lists the public API when built with some set of features
+enabled. To create these files run `../contrib/check-for-api-changes.sh`:
+
+Requires `cargo-public-api`, install with:
+
+    `cargo +stable install cargo-public-api --locked`.
+
+ref: https://github.com/enselic/cargo-public-api

--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -1,0 +1,10283 @@
+#[non_exhaustive] pub enum bitcoin::AddressType
+#[non_exhaustive] pub enum bitcoin::KnownHrp
+#[non_exhaustive] pub enum bitcoin::Network
+#[non_exhaustive] pub enum bitcoin::absolute::Error
+#[non_exhaustive] pub enum bitcoin::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::address::AddressType
+#[non_exhaustive] pub enum bitcoin::address::Error
+#[non_exhaustive] pub enum bitcoin::address::KnownHrp
+#[non_exhaustive] pub enum bitcoin::address::ParseError
+#[non_exhaustive] pub enum bitcoin::address::error::Error
+#[non_exhaustive] pub enum bitcoin::address::error::ParseError
+#[non_exhaustive] pub enum bitcoin::base58::Error
+#[non_exhaustive] pub enum bitcoin::bip152::Error
+#[non_exhaustive] pub enum bitcoin::bip158::Error
+#[non_exhaustive] pub enum bitcoin::bip32::Error
+#[non_exhaustive] pub enum bitcoin::block::Bip34Error
+#[non_exhaustive] pub enum bitcoin::block::ValidationError
+#[non_exhaustive] pub enum bitcoin::blockdata::block::Bip34Error
+#[non_exhaustive] pub enum bitcoin::blockdata::block::ValidationError
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::absolute::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::relative::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_version::TryFromInstructionError
+#[non_exhaustive] pub enum bitcoin::blockdata::transaction::ParseOutPointError
+#[non_exhaustive] pub enum bitcoin::blockdata::transaction::TxVerifyError
+#[non_exhaustive] pub enum bitcoin::consensus::encode::Error
+#[non_exhaustive] pub enum bitcoin::consensus::validation::TxVerifyError
+#[non_exhaustive] pub enum bitcoin::ecdsa::Error
+#[non_exhaustive] pub enum bitcoin::key::Error
+#[non_exhaustive] pub enum bitcoin::locktime::absolute::Error
+#[non_exhaustive] pub enum bitcoin::locktime::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::locktime::relative::Error
+#[non_exhaustive] pub enum bitcoin::merkle_tree::MerkleBlockError
+#[non_exhaustive] pub enum bitcoin::network::Network
+#[non_exhaustive] pub enum bitcoin::psbt::Error
+#[non_exhaustive] pub enum bitcoin::psbt::ExtractTxError
+#[non_exhaustive] pub enum bitcoin::psbt::GetKeyError
+#[non_exhaustive] pub enum bitcoin::psbt::IndexOutOfBoundsError
+#[non_exhaustive] pub enum bitcoin::psbt::KeyRequest
+#[non_exhaustive] pub enum bitcoin::psbt::OutputType
+#[non_exhaustive] pub enum bitcoin::psbt::PsbtParseError
+#[non_exhaustive] pub enum bitcoin::psbt::SignError
+#[non_exhaustive] pub enum bitcoin::relative::Error
+#[non_exhaustive] pub enum bitcoin::script::Error
+#[non_exhaustive] pub enum bitcoin::script::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::script::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::script::witness_version::TryFromInstructionError
+#[non_exhaustive] pub enum bitcoin::sighash::AnnexError
+#[non_exhaustive] pub enum bitcoin::sighash::P2wpkhError
+#[non_exhaustive] pub enum bitcoin::sighash::PrevoutsIndexError
+#[non_exhaustive] pub enum bitcoin::sighash::TaprootError
+#[non_exhaustive] pub enum bitcoin::sign_message::MessageSignatureError
+#[non_exhaustive] pub enum bitcoin::string::FromHexError<E>
+#[non_exhaustive] pub enum bitcoin::taproot::HiddenNodesError
+#[non_exhaustive] pub enum bitcoin::taproot::IncompleteBuilderError
+#[non_exhaustive] pub enum bitcoin::taproot::SigFromSliceError
+#[non_exhaustive] pub enum bitcoin::taproot::TaprootBuilderError
+#[non_exhaustive] pub enum bitcoin::taproot::TaprootError
+#[non_exhaustive] pub enum bitcoin::transaction::ParseOutPointError
+#[non_exhaustive] pub enum bitcoin::transaction::TxVerifyError
+#[non_exhaustive] pub enum bitcoin::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::witness_version::TryFromInstructionError
+#[non_exhaustive] pub struct bitcoin::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::address::UnknownAddressTypeError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::UnknownHrpError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::error::UnknownAddressTypeError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::error::UnknownHrpError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::bip152::TxIndexOutOfRangeError(_)
+#[non_exhaustive] pub struct bitcoin::blockdata::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::blockdata::script::witness_version::TryFromError
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::IndexOutOfBoundsError
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::InputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::OutputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::consensus::Params
+#[non_exhaustive] pub struct bitcoin::consensus::params::Params
+#[non_exhaustive] pub struct bitcoin::consensus::validation::BitcoinconsensusError(_)
+#[non_exhaustive] pub struct bitcoin::error::ParseIntError
+#[non_exhaustive] pub struct bitcoin::key::UncompressedPubkeyError
+#[non_exhaustive] pub struct bitcoin::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::network::ParseNetworkError(_)
+#[non_exhaustive] pub struct bitcoin::network::UnknownChainHashError(_)
+#[non_exhaustive] pub struct bitcoin::p2p::ParseMagicError
+#[non_exhaustive] pub struct bitcoin::p2p::UnknownMagicError(_)
+#[non_exhaustive] pub struct bitcoin::p2p::message::CommandStringError
+#[non_exhaustive] pub struct bitcoin::pow::TryFromError(_)
+#[non_exhaustive] pub struct bitcoin::script::witness_version::TryFromError
+#[non_exhaustive] pub struct bitcoin::sighash::InvalidSighashTypeError(pub u32)
+#[non_exhaustive] pub struct bitcoin::sighash::NonStandardSighashTypeError(pub u32)
+#[non_exhaustive] pub struct bitcoin::sighash::PrevoutsKindError
+#[non_exhaustive] pub struct bitcoin::sighash::PrevoutsSizeError
+#[non_exhaustive] pub struct bitcoin::sighash::SighashTypeParseError
+#[non_exhaustive] pub struct bitcoin::sighash::SingleMissingOutputError
+#[non_exhaustive] pub struct bitcoin::transaction::IndexOutOfBoundsError
+#[non_exhaustive] pub struct bitcoin::transaction::InputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::transaction::OutputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::witness_version::TryFromError
+#[repr(transparent)] pub struct bitcoin::Address<V> where V: bitcoin::address::NetworkValidation(_, _)
+#[repr(transparent)] pub struct bitcoin::Script(_)
+#[repr(transparent)] pub struct bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation(_, _)
+#[repr(transparent)] pub struct bitcoin::blockdata::script::PushBytes(_)
+#[repr(transparent)] pub struct bitcoin::blockdata::script::Script(_)
+#[repr(transparent)] pub struct bitcoin::script::PushBytes(_)
+#[repr(transparent)] pub struct bitcoin::script::Script(_)
+#[repr(u8)] pub enum bitcoin::WitnessVersion
+#[repr(u8)] pub enum bitcoin::blockdata::script::witness_version::WitnessVersion
+#[repr(u8)] pub enum bitcoin::script::witness_version::WitnessVersion
+#[repr(u8)] pub enum bitcoin::witness_version::WitnessVersion
+impl !core::marker::Sized for bitcoin::blockdata::script::PushBytes
+impl !core::marker::Sized for bitcoin::blockdata::script::Script
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::PsbtParseError
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::PsbtParseError
+impl alloc::borrow::ToOwned for bitcoin::blockdata::script::PushBytes
+impl alloc::borrow::ToOwned for bitcoin::blockdata::script::Script
+impl bitcoin::CompressedPublicKey
+impl bitcoin::EcdsaSighashType
+impl bitcoin::LegacySighash
+impl bitcoin::MerkleBlock
+impl bitcoin::PrivateKey
+impl bitcoin::PubkeyHash
+impl bitcoin::PublicKey
+impl bitcoin::SegwitV0Sighash
+impl bitcoin::TapSighash
+impl bitcoin::TapSighashType
+impl bitcoin::WPubkeyHash
+impl bitcoin::address::Address
+impl bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+impl bitcoin::address::NetworkValidation for bitcoin::address::NetworkChecked
+impl bitcoin::address::NetworkValidation for bitcoin::address::NetworkUnchecked
+impl bitcoin::bip152::BlockTransactions
+impl bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::bip152::ShortId
+impl bitcoin::bip158::BlockFilter
+impl bitcoin::bip158::BlockFilterReader
+impl bitcoin::bip158::FilterHash
+impl bitcoin::bip158::FilterHeader
+impl bitcoin::bip158::GcsFilterReader
+impl bitcoin::bip32::ChainCode
+impl bitcoin::bip32::ChildNumber
+impl bitcoin::bip32::DerivationPath
+impl bitcoin::bip32::Fingerprint
+impl bitcoin::bip32::IntoDerivationPath for alloc::string::String
+impl bitcoin::bip32::XKeyIdentifier
+impl bitcoin::bip32::Xpriv
+impl bitcoin::bip32::Xpub
+impl bitcoin::blockdata::block::Block
+impl bitcoin::blockdata::block::BlockHash
+impl bitcoin::blockdata::block::Header
+impl bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::blockdata::block::Version
+impl bitcoin::blockdata::block::WitnessCommitment
+impl bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::blockdata::constants::ChainHash
+impl bitcoin::blockdata::fee_rate::FeeRate
+impl bitcoin::blockdata::locktime::absolute::Height
+impl bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::blockdata::locktime::absolute::Time
+impl bitcoin::blockdata::locktime::relative::Height
+impl bitcoin::blockdata::locktime::relative::LockTime
+impl bitcoin::blockdata::locktime::relative::Time
+impl bitcoin::blockdata::opcodes::Opcode
+impl bitcoin::blockdata::script::Builder
+impl bitcoin::blockdata::script::PushBytes
+impl bitcoin::blockdata::script::PushBytesBuf
+impl bitcoin::blockdata::script::PushBytesErrorReport for bitcoin::blockdata::script::PushBytesError
+impl bitcoin::blockdata::script::PushBytesErrorReport for core::convert::Infallible
+impl bitcoin::blockdata::script::Script
+impl bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::blockdata::script::ScriptHash
+impl bitcoin::blockdata::script::WScriptHash
+impl bitcoin::blockdata::script::witness_program::WitnessProgram
+impl bitcoin::blockdata::script::witness_version::WitnessVersion
+impl bitcoin::blockdata::transaction::InputWeightPrediction
+impl bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::blockdata::transaction::Sequence
+impl bitcoin::blockdata::transaction::Transaction
+impl bitcoin::blockdata::transaction::TxIn
+impl bitcoin::blockdata::transaction::TxOut
+impl bitcoin::blockdata::transaction::Txid
+impl bitcoin::blockdata::transaction::Version
+impl bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::blockdata::weight::Weight
+impl bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Decodable for [u16; 8]
+impl bitcoin::consensus::encode::Decodable for [u8; 10]
+impl bitcoin::consensus::encode::Decodable for [u8; 12]
+impl bitcoin::consensus::encode::Decodable for [u8; 16]
+impl bitcoin::consensus::encode::Decodable for [u8; 2]
+impl bitcoin::consensus::encode::Decodable for [u8; 32]
+impl bitcoin::consensus::encode::Decodable for [u8; 33]
+impl bitcoin::consensus::encode::Decodable for [u8; 4]
+impl bitcoin::consensus::encode::Decodable for [u8; 6]
+impl bitcoin::consensus::encode::Decodable for [u8; 8]
+impl bitcoin::consensus::encode::Decodable for alloc::borrow::Cow<'static, str>
+impl bitcoin::consensus::encode::Decodable for alloc::boxed::Box<[u8]>
+impl bitcoin::consensus::encode::Decodable for alloc::string::String
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<alloc::vec::Vec<u8>>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip152::ShortId>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip158::FilterHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip158::FilterHeader>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::Header>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::consensus::encode::VarInt>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::taproot::TapLeafHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<u64>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<u8>
+impl bitcoin::consensus::encode::Decodable for bitcoin::MerkleBlock
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::BlockTransactions
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::BlockTransactionsRequest
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::PrefilledTransaction
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::ShortId
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip158::FilterHash
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip158::FilterHeader
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Block
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::BlockHash
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Header
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Version
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Transaction
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::TxIn
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::TxOut
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Txid
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Version
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::Decodable for bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Decodable for bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::encode::Decodable for bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::Magic
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::ServiceFlags
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::address::AddrV2
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::address::AddrV2Message
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::address::Address
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message::CommandString
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message::RawNetworkMessage
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_blockdata::Inventory
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_bloom::BloomFlags
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_bloom::FilterAdd
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_bloom::FilterLoad
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::CFCheckpt
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::CFHeaders
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::CFilter
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::GetCFCheckpt
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::GetCFHeaders
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::GetCFilters
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_network::Reject
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_network::RejectReason
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_network::VersionMessage
+impl bitcoin::consensus::encode::Decodable for bitcoin::pow::CompactTarget
+impl bitcoin::consensus::encode::Decodable for bitcoin::taproot::TapLeafHash
+impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256::Hash
+impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256d::Hash
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Decodable for bool
+impl bitcoin::consensus::encode::Decodable for i16
+impl bitcoin::consensus::encode::Decodable for i32
+impl bitcoin::consensus::encode::Decodable for i64
+impl bitcoin::consensus::encode::Decodable for i8
+impl bitcoin::consensus::encode::Decodable for u16
+impl bitcoin::consensus::encode::Decodable for u32
+impl bitcoin::consensus::encode::Decodable for u64
+impl bitcoin::consensus::encode::Decodable for u8
+impl bitcoin::consensus::encode::Encodable for [u16; 8]
+impl bitcoin::consensus::encode::Encodable for [u8; 10]
+impl bitcoin::consensus::encode::Encodable for [u8; 12]
+impl bitcoin::consensus::encode::Encodable for [u8; 16]
+impl bitcoin::consensus::encode::Encodable for [u8; 2]
+impl bitcoin::consensus::encode::Encodable for [u8; 32]
+impl bitcoin::consensus::encode::Encodable for [u8; 33]
+impl bitcoin::consensus::encode::Encodable for [u8; 4]
+impl bitcoin::consensus::encode::Encodable for [u8; 6]
+impl bitcoin::consensus::encode::Encodable for [u8; 8]
+impl bitcoin::consensus::encode::Encodable for alloc::borrow::Cow<'static, str>
+impl bitcoin::consensus::encode::Encodable for alloc::boxed::Box<[u8]>
+impl bitcoin::consensus::encode::Encodable for alloc::string::String
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<alloc::vec::Vec<u8>>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip152::ShortId>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip158::FilterHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip158::FilterHeader>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::Header>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::consensus::encode::VarInt>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::taproot::TapLeafHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<u64>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<u8>
+impl bitcoin::consensus::encode::Encodable for bitcoin::MerkleBlock
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::BlockTransactions
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::BlockTransactionsRequest
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::PrefilledTransaction
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::ShortId
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip158::FilterHash
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip158::FilterHeader
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Block
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::BlockHash
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Header
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Version
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::script::Script
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Transaction
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::TxIn
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::TxOut
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Txid
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Version
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::Encodable for bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Encodable for bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::encode::Encodable for bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::Magic
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::ServiceFlags
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::address::AddrV2
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::address::AddrV2Message
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::address::Address
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message::CommandString
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message::NetworkMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message::RawNetworkMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_blockdata::Inventory
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_bloom::BloomFlags
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_bloom::FilterAdd
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_bloom::FilterLoad
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::CFCheckpt
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::CFHeaders
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::CFilter
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::GetCFCheckpt
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::GetCFHeaders
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::GetCFilters
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_network::Reject
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_network::RejectReason
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_network::VersionMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::pow::CompactTarget
+impl bitcoin::consensus::encode::Encodable for bitcoin::taproot::TapLeafHash
+impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256::Hash
+impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256d::Hash
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Encodable for bool
+impl bitcoin::consensus::encode::Encodable for i16
+impl bitcoin::consensus::encode::Encodable for i32
+impl bitcoin::consensus::encode::Encodable for i64
+impl bitcoin::consensus::encode::Encodable for i8
+impl bitcoin::consensus::encode::Encodable for u16
+impl bitcoin::consensus::encode::Encodable for u32
+impl bitcoin::consensus::encode::Encodable for u64
+impl bitcoin::consensus::encode::Encodable for u8
+impl bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::params::Params
+impl bitcoin::consensus::serde::IntoDeError for bitcoin::consensus::serde::hex::DecodeError
+impl bitcoin::consensus::serde::IntoDeError for bitcoin::consensus::serde::hex::DecodeInitError
+impl bitcoin::ecdsa::SerializedSignature
+impl bitcoin::ecdsa::Signature
+impl bitcoin::error::ParseIntError
+impl bitcoin::key::TapTweak for bitcoin::key::UntweakedKeypair
+impl bitcoin::key::TapTweak for bitcoin::key::UntweakedPublicKey
+impl bitcoin::key::TweakedKeypair
+impl bitcoin::key::TweakedPublicKey
+impl bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::network::Network
+impl bitcoin::network::NetworkKind
+impl bitcoin::p2p::Magic
+impl bitcoin::p2p::ServiceFlags
+impl bitcoin::p2p::address::AddrV2Message
+impl bitcoin::p2p::address::Address
+impl bitcoin::p2p::message::CommandString
+impl bitcoin::p2p::message::NetworkMessage
+impl bitcoin::p2p::message::RawNetworkMessage
+impl bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl bitcoin::p2p::message_blockdata::Inventory
+impl bitcoin::p2p::message_network::VersionMessage
+impl bitcoin::pow::CompactTarget
+impl bitcoin::pow::Target
+impl bitcoin::pow::Work
+impl bitcoin::psbt::GetKey for alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>
+impl bitcoin::psbt::GetKey for alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>
+impl bitcoin::psbt::GetKey for bitcoin::bip32::Xpriv
+impl bitcoin::psbt::GetKey for std::collections::hash::map::HashMap<bitcoin::PublicKey, bitcoin::PrivateKey>
+impl bitcoin::psbt::GetKey for std::collections::hash::set::HashSet<bitcoin::bip32::Xpriv>
+impl bitcoin::psbt::Input
+impl bitcoin::psbt::Output
+impl bitcoin::psbt::OutputType
+impl bitcoin::psbt::Psbt
+impl bitcoin::psbt::PsbtSighashType
+impl bitcoin::sign_message::MessageSignature
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::Height
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::Time
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::string::FromHexStr for bitcoin::pow::CompactTarget
+impl bitcoin::taproot::ControlBlock
+impl bitcoin::taproot::FutureLeafVersion
+impl bitcoin::taproot::HiddenNodesError
+impl bitcoin::taproot::IncompleteBuilderError
+impl bitcoin::taproot::LeafNode
+impl bitcoin::taproot::LeafVersion
+impl bitcoin::taproot::NodeInfo
+impl bitcoin::taproot::Signature
+impl bitcoin::taproot::TapLeaf
+impl bitcoin::taproot::TapLeafHash
+impl bitcoin::taproot::TapNodeHash
+impl bitcoin::taproot::TapTree
+impl bitcoin::taproot::TapTweakHash
+impl bitcoin::taproot::TaprootBuilder
+impl bitcoin::taproot::TaprootSpendInfo
+impl bitcoin::taproot::merkle_branch::IntoIter
+impl bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl bitcoin::taproot::serialized_signature::IntoIter
+impl bitcoin::taproot::serialized_signature::SerializedSignature
+impl bitcoin_hashes::Hash for bitcoin::LegacySighash
+impl bitcoin_hashes::Hash for bitcoin::PubkeyHash
+impl bitcoin_hashes::Hash for bitcoin::SegwitV0Sighash
+impl bitcoin_hashes::Hash for bitcoin::TapSighash
+impl bitcoin_hashes::Hash for bitcoin::WPubkeyHash
+impl bitcoin_hashes::Hash for bitcoin::bip158::FilterHash
+impl bitcoin_hashes::Hash for bitcoin::bip158::FilterHeader
+impl bitcoin_hashes::Hash for bitcoin::bip32::XKeyIdentifier
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin::blockdata::script::ScriptHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::script::WScriptHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapLeafHash
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapNodeHash
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapTweakHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::LegacySighash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::PubkeyHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::SegwitV0Sighash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::TapSighash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::WPubkeyHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::bip158::FilterHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::bip158::FilterHeader
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::bip32::XKeyIdentifier
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::blockdata::block::BlockHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::blockdata::block::WitnessCommitment
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::blockdata::script::ScriptHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::blockdata::script::WScriptHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::blockdata::transaction::Txid
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::taproot::TapLeafHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::taproot::TapNodeHash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin::taproot::TapTweakHash
+impl bitcoin_hashes::sha256t::Tag for bitcoin::TapSighashTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapBranchTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapLeafTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapTweakTag
+impl core::borrow::Borrow<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::borrow::Borrow<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::Borrow<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::borrow::Borrow<[u8; 4]> for bitcoin::p2p::Magic
+impl core::borrow::Borrow<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::borrow::Borrow<[u8]> for bitcoin::LegacySighash
+impl core::borrow::Borrow<[u8]> for bitcoin::PubkeyHash
+impl core::borrow::Borrow<[u8]> for bitcoin::SegwitV0Sighash
+impl core::borrow::Borrow<[u8]> for bitcoin::TapSighash
+impl core::borrow::Borrow<[u8]> for bitcoin::WPubkeyHash
+impl core::borrow::Borrow<[u8]> for bitcoin::bip152::ShortId
+impl core::borrow::Borrow<[u8]> for bitcoin::bip158::FilterHash
+impl core::borrow::Borrow<[u8]> for bitcoin::bip158::FilterHeader
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::ChainCode
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::Fingerprint
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::XKeyIdentifier
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::script::ScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::script::WScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::borrow::Borrow<[u8]> for bitcoin::p2p::Magic
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::borrow::Borrow<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::borrow::Borrow<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::borrow::BorrowMut<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::borrow::BorrowMut<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::borrow::BorrowMut<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::BorrowMut<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::borrow::BorrowMut<[u8; 4]> for bitcoin::p2p::Magic
+impl core::borrow::BorrowMut<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip152::ShortId
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip32::ChainCode
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip32::Fingerprint
+impl core::borrow::BorrowMut<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::BorrowMut<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::borrow::BorrowMut<[u8]> for bitcoin::p2p::Magic
+impl core::borrow::BorrowMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::borrow::BorrowMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::clone::Clone for bitcoin::CompressedPublicKey
+impl core::clone::Clone for bitcoin::EcdsaSighashType
+impl core::clone::Clone for bitcoin::LegacySighash
+impl core::clone::Clone for bitcoin::MerkleBlock
+impl core::clone::Clone for bitcoin::PrivateKey
+impl core::clone::Clone for bitcoin::PubkeyHash
+impl core::clone::Clone for bitcoin::PublicKey
+impl core::clone::Clone for bitcoin::SegwitV0Sighash
+impl core::clone::Clone for bitcoin::TapSighash
+impl core::clone::Clone for bitcoin::TapSighashTag
+impl core::clone::Clone for bitcoin::TapSighashType
+impl core::clone::Clone for bitcoin::WPubkeyHash
+impl core::clone::Clone for bitcoin::address::AddressType
+impl core::clone::Clone for bitcoin::address::KnownHrp
+impl core::clone::Clone for bitcoin::address::NetworkChecked
+impl core::clone::Clone for bitcoin::address::NetworkUnchecked
+impl core::clone::Clone for bitcoin::address::error::Error
+impl core::clone::Clone for bitcoin::address::error::ParseError
+impl core::clone::Clone for bitcoin::address::error::UnknownAddressTypeError
+impl core::clone::Clone for bitcoin::address::error::UnknownHrpError
+impl core::clone::Clone for bitcoin::base58::Error
+impl core::clone::Clone for bitcoin::bip152::BlockTransactions
+impl core::clone::Clone for bitcoin::bip152::BlockTransactionsRequest
+impl core::clone::Clone for bitcoin::bip152::Error
+impl core::clone::Clone for bitcoin::bip152::HeaderAndShortIds
+impl core::clone::Clone for bitcoin::bip152::PrefilledTransaction
+impl core::clone::Clone for bitcoin::bip152::ShortId
+impl core::clone::Clone for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::clone::Clone for bitcoin::bip158::BlockFilter
+impl core::clone::Clone for bitcoin::bip158::FilterHash
+impl core::clone::Clone for bitcoin::bip158::FilterHeader
+impl core::clone::Clone for bitcoin::bip32::ChainCode
+impl core::clone::Clone for bitcoin::bip32::ChildNumber
+impl core::clone::Clone for bitcoin::bip32::DerivationPath
+impl core::clone::Clone for bitcoin::bip32::Error
+impl core::clone::Clone for bitcoin::bip32::Fingerprint
+impl core::clone::Clone for bitcoin::bip32::XKeyIdentifier
+impl core::clone::Clone for bitcoin::bip32::Xpriv
+impl core::clone::Clone for bitcoin::bip32::Xpub
+impl core::clone::Clone for bitcoin::blockdata::block::Bip34Error
+impl core::clone::Clone for bitcoin::blockdata::block::Block
+impl core::clone::Clone for bitcoin::blockdata::block::BlockHash
+impl core::clone::Clone for bitcoin::blockdata::block::Header
+impl core::clone::Clone for bitcoin::blockdata::block::TxMerkleNode
+impl core::clone::Clone for bitcoin::blockdata::block::ValidationError
+impl core::clone::Clone for bitcoin::blockdata::block::Version
+impl core::clone::Clone for bitcoin::blockdata::block::WitnessCommitment
+impl core::clone::Clone for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::clone::Clone for bitcoin::blockdata::constants::ChainHash
+impl core::clone::Clone for bitcoin::blockdata::fee_rate::FeeRate
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Error
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Height
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Time
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Error
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Height
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::LockTime
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Time
+impl core::clone::Clone for bitcoin::blockdata::opcodes::Class
+impl core::clone::Clone for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::clone::Clone for bitcoin::blockdata::opcodes::Opcode
+impl core::clone::Clone for bitcoin::blockdata::script::Builder
+impl core::clone::Clone for bitcoin::blockdata::script::Error
+impl core::clone::Clone for bitcoin::blockdata::script::PushBytesBuf
+impl core::clone::Clone for bitcoin::blockdata::script::PushBytesError
+impl core::clone::Clone for bitcoin::blockdata::script::ScriptBuf
+impl core::clone::Clone for bitcoin::blockdata::script::ScriptHash
+impl core::clone::Clone for bitcoin::blockdata::script::WScriptHash
+impl core::clone::Clone for bitcoin::blockdata::script::witness_program::Error
+impl core::clone::Clone for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::clone::Clone for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::clone::Clone for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::clone::Clone for bitcoin::blockdata::transaction::InputsIndexError
+impl core::clone::Clone for bitcoin::blockdata::transaction::OutPoint
+impl core::clone::Clone for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::clone::Clone for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::clone::Clone for bitcoin::blockdata::transaction::Sequence
+impl core::clone::Clone for bitcoin::blockdata::transaction::Transaction
+impl core::clone::Clone for bitcoin::blockdata::transaction::TxIn
+impl core::clone::Clone for bitcoin::blockdata::transaction::TxOut
+impl core::clone::Clone for bitcoin::blockdata::transaction::Txid
+impl core::clone::Clone for bitcoin::blockdata::transaction::Version
+impl core::clone::Clone for bitcoin::blockdata::transaction::Wtxid
+impl core::clone::Clone for bitcoin::blockdata::weight::Weight
+impl core::clone::Clone for bitcoin::blockdata::witness::Witness
+impl core::clone::Clone for bitcoin::consensus::encode::CheckedData
+impl core::clone::Clone for bitcoin::consensus::encode::VarInt
+impl core::clone::Clone for bitcoin::consensus::params::Params
+impl core::clone::Clone for bitcoin::consensus::serde::hex::DecodeError
+impl core::clone::Clone for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::clone::Clone for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::clone::Clone for bitcoin::consensus::validation::TxVerifyError
+impl core::clone::Clone for bitcoin::ecdsa::Error
+impl core::clone::Clone for bitcoin::ecdsa::SerializedSignature
+impl core::clone::Clone for bitcoin::ecdsa::Signature
+impl core::clone::Clone for bitcoin::error::ParseIntError
+impl core::clone::Clone for bitcoin::key::Error
+impl core::clone::Clone for bitcoin::key::SortKey
+impl core::clone::Clone for bitcoin::key::TweakedKeypair
+impl core::clone::Clone for bitcoin::key::TweakedPublicKey
+impl core::clone::Clone for bitcoin::key::UncompressedPubkeyError
+impl core::clone::Clone for bitcoin::merkle_tree::MerkleBlockError
+impl core::clone::Clone for bitcoin::merkle_tree::PartialMerkleTree
+impl core::clone::Clone for bitcoin::network::Network
+impl core::clone::Clone for bitcoin::network::NetworkKind
+impl core::clone::Clone for bitcoin::network::ParseNetworkError
+impl core::clone::Clone for bitcoin::network::UnknownChainHashError
+impl core::clone::Clone for bitcoin::p2p::Magic
+impl core::clone::Clone for bitcoin::p2p::ParseMagicError
+impl core::clone::Clone for bitcoin::p2p::ServiceFlags
+impl core::clone::Clone for bitcoin::p2p::UnknownMagicError
+impl core::clone::Clone for bitcoin::p2p::address::AddrV2
+impl core::clone::Clone for bitcoin::p2p::address::AddrV2Message
+impl core::clone::Clone for bitcoin::p2p::address::Address
+impl core::clone::Clone for bitcoin::p2p::message::CommandString
+impl core::clone::Clone for bitcoin::p2p::message::CommandStringError
+impl core::clone::Clone for bitcoin::p2p::message::NetworkMessage
+impl core::clone::Clone for bitcoin::p2p::message::RawNetworkMessage
+impl core::clone::Clone for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::clone::Clone for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::clone::Clone for bitcoin::p2p::message_blockdata::Inventory
+impl core::clone::Clone for bitcoin::p2p::message_bloom::BloomFlags
+impl core::clone::Clone for bitcoin::p2p::message_bloom::FilterAdd
+impl core::clone::Clone for bitcoin::p2p::message_bloom::FilterLoad
+impl core::clone::Clone for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::clone::Clone for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::clone::Clone for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::clone::Clone for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::clone::Clone for bitcoin::p2p::message_filter::CFCheckpt
+impl core::clone::Clone for bitcoin::p2p::message_filter::CFHeaders
+impl core::clone::Clone for bitcoin::p2p::message_filter::CFilter
+impl core::clone::Clone for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::clone::Clone for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::clone::Clone for bitcoin::p2p::message_filter::GetCFilters
+impl core::clone::Clone for bitcoin::p2p::message_network::Reject
+impl core::clone::Clone for bitcoin::p2p::message_network::RejectReason
+impl core::clone::Clone for bitcoin::p2p::message_network::VersionMessage
+impl core::clone::Clone for bitcoin::pow::CompactTarget
+impl core::clone::Clone for bitcoin::pow::Target
+impl core::clone::Clone for bitcoin::pow::TryFromError
+impl core::clone::Clone for bitcoin::pow::Work
+impl core::clone::Clone for bitcoin::psbt::ExtractTxError
+impl core::clone::Clone for bitcoin::psbt::GetKeyError
+impl core::clone::Clone for bitcoin::psbt::IndexOutOfBoundsError
+impl core::clone::Clone for bitcoin::psbt::Input
+impl core::clone::Clone for bitcoin::psbt::KeyRequest
+impl core::clone::Clone for bitcoin::psbt::Output
+impl core::clone::Clone for bitcoin::psbt::OutputType
+impl core::clone::Clone for bitcoin::psbt::Psbt
+impl core::clone::Clone for bitcoin::psbt::PsbtSighashType
+impl core::clone::Clone for bitcoin::psbt::SignError
+impl core::clone::Clone for bitcoin::psbt::SigningAlgorithm
+impl core::clone::Clone for bitcoin::psbt::raw::Key
+impl core::clone::Clone for bitcoin::sighash::AnnexError
+impl core::clone::Clone for bitcoin::sighash::InvalidSighashTypeError
+impl core::clone::Clone for bitcoin::sighash::NonStandardSighashTypeError
+impl core::clone::Clone for bitcoin::sighash::P2wpkhError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsIndexError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsKindError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsSizeError
+impl core::clone::Clone for bitcoin::sighash::SighashTypeParseError
+impl core::clone::Clone for bitcoin::sighash::SingleMissingOutputError
+impl core::clone::Clone for bitcoin::sighash::TaprootError
+impl core::clone::Clone for bitcoin::sign_message::MessageSignature
+impl core::clone::Clone for bitcoin::sign_message::MessageSignatureError
+impl core::clone::Clone for bitcoin::taproot::ControlBlock
+impl core::clone::Clone for bitcoin::taproot::FutureLeafVersion
+impl core::clone::Clone for bitcoin::taproot::HiddenNodesError
+impl core::clone::Clone for bitcoin::taproot::IncompleteBuilderError
+impl core::clone::Clone for bitcoin::taproot::LeafNode
+impl core::clone::Clone for bitcoin::taproot::LeafVersion
+impl core::clone::Clone for bitcoin::taproot::NodeInfo
+impl core::clone::Clone for bitcoin::taproot::SigFromSliceError
+impl core::clone::Clone for bitcoin::taproot::Signature
+impl core::clone::Clone for bitcoin::taproot::TapBranchTag
+impl core::clone::Clone for bitcoin::taproot::TapLeaf
+impl core::clone::Clone for bitcoin::taproot::TapLeafHash
+impl core::clone::Clone for bitcoin::taproot::TapLeafTag
+impl core::clone::Clone for bitcoin::taproot::TapNodeHash
+impl core::clone::Clone for bitcoin::taproot::TapTree
+impl core::clone::Clone for bitcoin::taproot::TapTweakHash
+impl core::clone::Clone for bitcoin::taproot::TapTweakTag
+impl core::clone::Clone for bitcoin::taproot::TaprootBuilder
+impl core::clone::Clone for bitcoin::taproot::TaprootBuilderError
+impl core::clone::Clone for bitcoin::taproot::TaprootError
+impl core::clone::Clone for bitcoin::taproot::TaprootSpendInfo
+impl core::clone::Clone for bitcoin::taproot::merkle_branch::IntoIter
+impl core::clone::Clone for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::clone::Clone for bitcoin::taproot::serialized_signature::IntoIter
+impl core::clone::Clone for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::Eq for bitcoin::CompressedPublicKey
+impl core::cmp::Eq for bitcoin::EcdsaSighashType
+impl core::cmp::Eq for bitcoin::LegacySighash
+impl core::cmp::Eq for bitcoin::MerkleBlock
+impl core::cmp::Eq for bitcoin::PrivateKey
+impl core::cmp::Eq for bitcoin::PubkeyHash
+impl core::cmp::Eq for bitcoin::PublicKey
+impl core::cmp::Eq for bitcoin::SegwitV0Sighash
+impl core::cmp::Eq for bitcoin::TapSighash
+impl core::cmp::Eq for bitcoin::TapSighashTag
+impl core::cmp::Eq for bitcoin::TapSighashType
+impl core::cmp::Eq for bitcoin::WPubkeyHash
+impl core::cmp::Eq for bitcoin::address::AddressType
+impl core::cmp::Eq for bitcoin::address::KnownHrp
+impl core::cmp::Eq for bitcoin::address::NetworkChecked
+impl core::cmp::Eq for bitcoin::address::NetworkUnchecked
+impl core::cmp::Eq for bitcoin::address::error::Error
+impl core::cmp::Eq for bitcoin::address::error::ParseError
+impl core::cmp::Eq for bitcoin::address::error::UnknownAddressTypeError
+impl core::cmp::Eq for bitcoin::address::error::UnknownHrpError
+impl core::cmp::Eq for bitcoin::base58::Error
+impl core::cmp::Eq for bitcoin::bip152::BlockTransactions
+impl core::cmp::Eq for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::Eq for bitcoin::bip152::Error
+impl core::cmp::Eq for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::Eq for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::Eq for bitcoin::bip152::ShortId
+impl core::cmp::Eq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::cmp::Eq for bitcoin::bip158::BlockFilter
+impl core::cmp::Eq for bitcoin::bip158::FilterHash
+impl core::cmp::Eq for bitcoin::bip158::FilterHeader
+impl core::cmp::Eq for bitcoin::bip32::ChainCode
+impl core::cmp::Eq for bitcoin::bip32::ChildNumber
+impl core::cmp::Eq for bitcoin::bip32::DerivationPath
+impl core::cmp::Eq for bitcoin::bip32::Error
+impl core::cmp::Eq for bitcoin::bip32::Fingerprint
+impl core::cmp::Eq for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::Eq for bitcoin::bip32::Xpriv
+impl core::cmp::Eq for bitcoin::bip32::Xpub
+impl core::cmp::Eq for bitcoin::blockdata::block::Bip34Error
+impl core::cmp::Eq for bitcoin::blockdata::block::Block
+impl core::cmp::Eq for bitcoin::blockdata::block::BlockHash
+impl core::cmp::Eq for bitcoin::blockdata::block::Header
+impl core::cmp::Eq for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::Eq for bitcoin::blockdata::block::ValidationError
+impl core::cmp::Eq for bitcoin::blockdata::block::Version
+impl core::cmp::Eq for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::Eq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Error
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Error
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::Class
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::Opcode
+impl core::cmp::Eq for bitcoin::blockdata::script::Builder
+impl core::cmp::Eq for bitcoin::blockdata::script::Error
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytes
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytesError
+impl core::cmp::Eq for bitcoin::blockdata::script::Script
+impl core::cmp::Eq for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::Eq for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::Eq for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_program::Error
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::Eq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::Eq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::Eq for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::Eq for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Txid
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Version
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::Eq for bitcoin::blockdata::weight::Weight
+impl core::cmp::Eq for bitcoin::blockdata::witness::Witness
+impl core::cmp::Eq for bitcoin::consensus::encode::CheckedData
+impl core::cmp::Eq for bitcoin::consensus::encode::VarInt
+impl core::cmp::Eq for bitcoin::consensus::serde::hex::DecodeError
+impl core::cmp::Eq for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::cmp::Eq for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::cmp::Eq for bitcoin::consensus::validation::TxVerifyError
+impl core::cmp::Eq for bitcoin::ecdsa::Error
+impl core::cmp::Eq for bitcoin::ecdsa::SerializedSignature
+impl core::cmp::Eq for bitcoin::ecdsa::Signature
+impl core::cmp::Eq for bitcoin::error::ParseIntError
+impl core::cmp::Eq for bitcoin::key::Error
+impl core::cmp::Eq for bitcoin::key::SortKey
+impl core::cmp::Eq for bitcoin::key::TweakedKeypair
+impl core::cmp::Eq for bitcoin::key::TweakedPublicKey
+impl core::cmp::Eq for bitcoin::key::UncompressedPubkeyError
+impl core::cmp::Eq for bitcoin::merkle_tree::MerkleBlockError
+impl core::cmp::Eq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::cmp::Eq for bitcoin::network::Network
+impl core::cmp::Eq for bitcoin::network::NetworkKind
+impl core::cmp::Eq for bitcoin::network::ParseNetworkError
+impl core::cmp::Eq for bitcoin::network::UnknownChainHashError
+impl core::cmp::Eq for bitcoin::p2p::Magic
+impl core::cmp::Eq for bitcoin::p2p::ParseMagicError
+impl core::cmp::Eq for bitcoin::p2p::ServiceFlags
+impl core::cmp::Eq for bitcoin::p2p::UnknownMagicError
+impl core::cmp::Eq for bitcoin::p2p::address::AddrV2
+impl core::cmp::Eq for bitcoin::p2p::address::AddrV2Message
+impl core::cmp::Eq for bitcoin::p2p::address::Address
+impl core::cmp::Eq for bitcoin::p2p::message::CommandString
+impl core::cmp::Eq for bitcoin::p2p::message::CommandStringError
+impl core::cmp::Eq for bitcoin::p2p::message::NetworkMessage
+impl core::cmp::Eq for bitcoin::p2p::message::RawNetworkMessage
+impl core::cmp::Eq for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::cmp::Eq for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::cmp::Eq for bitcoin::p2p::message_blockdata::Inventory
+impl core::cmp::Eq for bitcoin::p2p::message_bloom::BloomFlags
+impl core::cmp::Eq for bitcoin::p2p::message_bloom::FilterAdd
+impl core::cmp::Eq for bitcoin::p2p::message_bloom::FilterLoad
+impl core::cmp::Eq for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::cmp::Eq for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::cmp::Eq for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::cmp::Eq for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::cmp::Eq for bitcoin::p2p::message_filter::CFCheckpt
+impl core::cmp::Eq for bitcoin::p2p::message_filter::CFHeaders
+impl core::cmp::Eq for bitcoin::p2p::message_filter::CFilter
+impl core::cmp::Eq for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::cmp::Eq for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::cmp::Eq for bitcoin::p2p::message_filter::GetCFilters
+impl core::cmp::Eq for bitcoin::p2p::message_network::Reject
+impl core::cmp::Eq for bitcoin::p2p::message_network::RejectReason
+impl core::cmp::Eq for bitcoin::p2p::message_network::VersionMessage
+impl core::cmp::Eq for bitcoin::pow::CompactTarget
+impl core::cmp::Eq for bitcoin::pow::Target
+impl core::cmp::Eq for bitcoin::pow::TryFromError
+impl core::cmp::Eq for bitcoin::pow::Work
+impl core::cmp::Eq for bitcoin::psbt::ExtractTxError
+impl core::cmp::Eq for bitcoin::psbt::GetKeyError
+impl core::cmp::Eq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::cmp::Eq for bitcoin::psbt::Input
+impl core::cmp::Eq for bitcoin::psbt::KeyRequest
+impl core::cmp::Eq for bitcoin::psbt::Output
+impl core::cmp::Eq for bitcoin::psbt::OutputType
+impl core::cmp::Eq for bitcoin::psbt::Psbt
+impl core::cmp::Eq for bitcoin::psbt::PsbtSighashType
+impl core::cmp::Eq for bitcoin::psbt::SignError
+impl core::cmp::Eq for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::Eq for bitcoin::psbt::raw::Key
+impl core::cmp::Eq for bitcoin::psbt::raw::Pair
+impl core::cmp::Eq for bitcoin::sighash::AnnexError
+impl core::cmp::Eq for bitcoin::sighash::InvalidSighashTypeError
+impl core::cmp::Eq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::cmp::Eq for bitcoin::sighash::P2wpkhError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsIndexError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsKindError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsSizeError
+impl core::cmp::Eq for bitcoin::sighash::SighashTypeParseError
+impl core::cmp::Eq for bitcoin::sighash::SingleMissingOutputError
+impl core::cmp::Eq for bitcoin::sighash::TaprootError
+impl core::cmp::Eq for bitcoin::sign_message::MessageSignature
+impl core::cmp::Eq for bitcoin::sign_message::MessageSignatureError
+impl core::cmp::Eq for bitcoin::taproot::ControlBlock
+impl core::cmp::Eq for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::Eq for bitcoin::taproot::HiddenNodesError
+impl core::cmp::Eq for bitcoin::taproot::IncompleteBuilderError
+impl core::cmp::Eq for bitcoin::taproot::LeafNode
+impl core::cmp::Eq for bitcoin::taproot::LeafVersion
+impl core::cmp::Eq for bitcoin::taproot::NodeInfo
+impl core::cmp::Eq for bitcoin::taproot::SigFromSliceError
+impl core::cmp::Eq for bitcoin::taproot::Signature
+impl core::cmp::Eq for bitcoin::taproot::TapBranchTag
+impl core::cmp::Eq for bitcoin::taproot::TapLeaf
+impl core::cmp::Eq for bitcoin::taproot::TapLeafHash
+impl core::cmp::Eq for bitcoin::taproot::TapLeafTag
+impl core::cmp::Eq for bitcoin::taproot::TapNodeHash
+impl core::cmp::Eq for bitcoin::taproot::TapTree
+impl core::cmp::Eq for bitcoin::taproot::TapTweakHash
+impl core::cmp::Eq for bitcoin::taproot::TapTweakTag
+impl core::cmp::Eq for bitcoin::taproot::TaprootBuilder
+impl core::cmp::Eq for bitcoin::taproot::TaprootBuilderError
+impl core::cmp::Eq for bitcoin::taproot::TaprootError
+impl core::cmp::Eq for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::Eq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::Eq for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::Ord for bitcoin::CompressedPublicKey
+impl core::cmp::Ord for bitcoin::LegacySighash
+impl core::cmp::Ord for bitcoin::PubkeyHash
+impl core::cmp::Ord for bitcoin::PublicKey
+impl core::cmp::Ord for bitcoin::SegwitV0Sighash
+impl core::cmp::Ord for bitcoin::TapSighash
+impl core::cmp::Ord for bitcoin::TapSighashTag
+impl core::cmp::Ord for bitcoin::TapSighashType
+impl core::cmp::Ord for bitcoin::WPubkeyHash
+impl core::cmp::Ord for bitcoin::address::AddressType
+impl core::cmp::Ord for bitcoin::address::KnownHrp
+impl core::cmp::Ord for bitcoin::address::NetworkChecked
+impl core::cmp::Ord for bitcoin::address::NetworkUnchecked
+impl core::cmp::Ord for bitcoin::bip152::BlockTransactions
+impl core::cmp::Ord for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::Ord for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::Ord for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::Ord for bitcoin::bip152::ShortId
+impl core::cmp::Ord for bitcoin::bip158::FilterHash
+impl core::cmp::Ord for bitcoin::bip158::FilterHeader
+impl core::cmp::Ord for bitcoin::bip32::ChainCode
+impl core::cmp::Ord for bitcoin::bip32::ChildNumber
+impl core::cmp::Ord for bitcoin::bip32::DerivationPath
+impl core::cmp::Ord for bitcoin::bip32::Fingerprint
+impl core::cmp::Ord for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::Ord for bitcoin::bip32::Xpub
+impl core::cmp::Ord for bitcoin::blockdata::block::BlockHash
+impl core::cmp::Ord for bitcoin::blockdata::block::Header
+impl core::cmp::Ord for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::Ord for bitcoin::blockdata::block::Version
+impl core::cmp::Ord for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::Ord for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::Ord for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::Ord for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::Ord for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::Ord for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::Ord for bitcoin::blockdata::script::PushBytes
+impl core::cmp::Ord for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::Ord for bitcoin::blockdata::script::Script
+impl core::cmp::Ord for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::Ord for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::Ord for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::Ord for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::Ord for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::Ord for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::Ord for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::Ord for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Txid
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Version
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::Ord for bitcoin::blockdata::weight::Weight
+impl core::cmp::Ord for bitcoin::blockdata::witness::Witness
+impl core::cmp::Ord for bitcoin::consensus::encode::VarInt
+impl core::cmp::Ord for bitcoin::key::SortKey
+impl core::cmp::Ord for bitcoin::key::TweakedKeypair
+impl core::cmp::Ord for bitcoin::key::TweakedPublicKey
+impl core::cmp::Ord for bitcoin::network::Network
+impl core::cmp::Ord for bitcoin::network::NetworkKind
+impl core::cmp::Ord for bitcoin::p2p::Magic
+impl core::cmp::Ord for bitcoin::p2p::ServiceFlags
+impl core::cmp::Ord for bitcoin::p2p::message_blockdata::Inventory
+impl core::cmp::Ord for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::cmp::Ord for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::cmp::Ord for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::cmp::Ord for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::cmp::Ord for bitcoin::pow::CompactTarget
+impl core::cmp::Ord for bitcoin::pow::Target
+impl core::cmp::Ord for bitcoin::pow::Work
+impl core::cmp::Ord for bitcoin::psbt::OutputType
+impl core::cmp::Ord for bitcoin::psbt::PsbtSighashType
+impl core::cmp::Ord for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::Ord for bitcoin::psbt::raw::Key
+impl core::cmp::Ord for bitcoin::taproot::ControlBlock
+impl core::cmp::Ord for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::Ord for bitcoin::taproot::LeafNode
+impl core::cmp::Ord for bitcoin::taproot::LeafVersion
+impl core::cmp::Ord for bitcoin::taproot::NodeInfo
+impl core::cmp::Ord for bitcoin::taproot::Signature
+impl core::cmp::Ord for bitcoin::taproot::TapBranchTag
+impl core::cmp::Ord for bitcoin::taproot::TapLeaf
+impl core::cmp::Ord for bitcoin::taproot::TapLeafHash
+impl core::cmp::Ord for bitcoin::taproot::TapLeafTag
+impl core::cmp::Ord for bitcoin::taproot::TapNodeHash
+impl core::cmp::Ord for bitcoin::taproot::TapTweakHash
+impl core::cmp::Ord for bitcoin::taproot::TapTweakTag
+impl core::cmp::Ord for bitcoin::taproot::TaprootBuilder
+impl core::cmp::Ord for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::Ord for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::Ord for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq for bitcoin::CompressedPublicKey
+impl core::cmp::PartialEq for bitcoin::EcdsaSighashType
+impl core::cmp::PartialEq for bitcoin::LegacySighash
+impl core::cmp::PartialEq for bitcoin::MerkleBlock
+impl core::cmp::PartialEq for bitcoin::PrivateKey
+impl core::cmp::PartialEq for bitcoin::PubkeyHash
+impl core::cmp::PartialEq for bitcoin::PublicKey
+impl core::cmp::PartialEq for bitcoin::SegwitV0Sighash
+impl core::cmp::PartialEq for bitcoin::TapSighash
+impl core::cmp::PartialEq for bitcoin::TapSighashTag
+impl core::cmp::PartialEq for bitcoin::TapSighashType
+impl core::cmp::PartialEq for bitcoin::WPubkeyHash
+impl core::cmp::PartialEq for bitcoin::address::AddressType
+impl core::cmp::PartialEq for bitcoin::address::KnownHrp
+impl core::cmp::PartialEq for bitcoin::address::NetworkChecked
+impl core::cmp::PartialEq for bitcoin::address::NetworkUnchecked
+impl core::cmp::PartialEq for bitcoin::address::error::Error
+impl core::cmp::PartialEq for bitcoin::address::error::ParseError
+impl core::cmp::PartialEq for bitcoin::address::error::UnknownAddressTypeError
+impl core::cmp::PartialEq for bitcoin::address::error::UnknownHrpError
+impl core::cmp::PartialEq for bitcoin::base58::Error
+impl core::cmp::PartialEq for bitcoin::bip152::BlockTransactions
+impl core::cmp::PartialEq for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::PartialEq for bitcoin::bip152::Error
+impl core::cmp::PartialEq for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::PartialEq for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::PartialEq for bitcoin::bip152::ShortId
+impl core::cmp::PartialEq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::cmp::PartialEq for bitcoin::bip158::BlockFilter
+impl core::cmp::PartialEq for bitcoin::bip158::FilterHash
+impl core::cmp::PartialEq for bitcoin::bip158::FilterHeader
+impl core::cmp::PartialEq for bitcoin::bip32::ChainCode
+impl core::cmp::PartialEq for bitcoin::bip32::ChildNumber
+impl core::cmp::PartialEq for bitcoin::bip32::DerivationPath
+impl core::cmp::PartialEq for bitcoin::bip32::Error
+impl core::cmp::PartialEq for bitcoin::bip32::Fingerprint
+impl core::cmp::PartialEq for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::PartialEq for bitcoin::bip32::Xpriv
+impl core::cmp::PartialEq for bitcoin::bip32::Xpub
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Bip34Error
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Block
+impl core::cmp::PartialEq for bitcoin::blockdata::block::BlockHash
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Header
+impl core::cmp::PartialEq for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin::blockdata::block::ValidationError
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Version
+impl core::cmp::PartialEq for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::PartialEq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::Class
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::Opcode
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Builder
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytes
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytesError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Script
+impl core::cmp::PartialEq for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialEq for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::PartialEq for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_program::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Txid
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Version
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin::blockdata::weight::Weight
+impl core::cmp::PartialEq for bitcoin::blockdata::witness::Witness
+impl core::cmp::PartialEq for bitcoin::consensus::encode::CheckedData
+impl core::cmp::PartialEq for bitcoin::consensus::encode::VarInt
+impl core::cmp::PartialEq for bitcoin::consensus::serde::hex::DecodeError
+impl core::cmp::PartialEq for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::cmp::PartialEq for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::cmp::PartialEq for bitcoin::consensus::validation::TxVerifyError
+impl core::cmp::PartialEq for bitcoin::ecdsa::Error
+impl core::cmp::PartialEq for bitcoin::ecdsa::SerializedSignature
+impl core::cmp::PartialEq for bitcoin::ecdsa::Signature
+impl core::cmp::PartialEq for bitcoin::error::ParseIntError
+impl core::cmp::PartialEq for bitcoin::key::Error
+impl core::cmp::PartialEq for bitcoin::key::SortKey
+impl core::cmp::PartialEq for bitcoin::key::TweakedKeypair
+impl core::cmp::PartialEq for bitcoin::key::TweakedPublicKey
+impl core::cmp::PartialEq for bitcoin::key::UncompressedPubkeyError
+impl core::cmp::PartialEq for bitcoin::merkle_tree::MerkleBlockError
+impl core::cmp::PartialEq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::cmp::PartialEq for bitcoin::network::Network
+impl core::cmp::PartialEq for bitcoin::network::NetworkKind
+impl core::cmp::PartialEq for bitcoin::network::ParseNetworkError
+impl core::cmp::PartialEq for bitcoin::network::UnknownChainHashError
+impl core::cmp::PartialEq for bitcoin::p2p::Magic
+impl core::cmp::PartialEq for bitcoin::p2p::ParseMagicError
+impl core::cmp::PartialEq for bitcoin::p2p::ServiceFlags
+impl core::cmp::PartialEq for bitcoin::p2p::UnknownMagicError
+impl core::cmp::PartialEq for bitcoin::p2p::address::AddrV2
+impl core::cmp::PartialEq for bitcoin::p2p::address::AddrV2Message
+impl core::cmp::PartialEq for bitcoin::p2p::address::Address
+impl core::cmp::PartialEq for bitcoin::p2p::message::CommandString
+impl core::cmp::PartialEq for bitcoin::p2p::message::CommandStringError
+impl core::cmp::PartialEq for bitcoin::p2p::message::NetworkMessage
+impl core::cmp::PartialEq for bitcoin::p2p::message::RawNetworkMessage
+impl core::cmp::PartialEq for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::cmp::PartialEq for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::cmp::PartialEq for bitcoin::p2p::message_blockdata::Inventory
+impl core::cmp::PartialEq for bitcoin::p2p::message_bloom::BloomFlags
+impl core::cmp::PartialEq for bitcoin::p2p::message_bloom::FilterAdd
+impl core::cmp::PartialEq for bitcoin::p2p::message_bloom::FilterLoad
+impl core::cmp::PartialEq for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::cmp::PartialEq for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::cmp::PartialEq for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::cmp::PartialEq for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::CFCheckpt
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::CFHeaders
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::CFilter
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::GetCFilters
+impl core::cmp::PartialEq for bitcoin::p2p::message_network::Reject
+impl core::cmp::PartialEq for bitcoin::p2p::message_network::RejectReason
+impl core::cmp::PartialEq for bitcoin::p2p::message_network::VersionMessage
+impl core::cmp::PartialEq for bitcoin::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin::pow::Target
+impl core::cmp::PartialEq for bitcoin::pow::TryFromError
+impl core::cmp::PartialEq for bitcoin::pow::Work
+impl core::cmp::PartialEq for bitcoin::psbt::ExtractTxError
+impl core::cmp::PartialEq for bitcoin::psbt::GetKeyError
+impl core::cmp::PartialEq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::cmp::PartialEq for bitcoin::psbt::Input
+impl core::cmp::PartialEq for bitcoin::psbt::KeyRequest
+impl core::cmp::PartialEq for bitcoin::psbt::Output
+impl core::cmp::PartialEq for bitcoin::psbt::OutputType
+impl core::cmp::PartialEq for bitcoin::psbt::Psbt
+impl core::cmp::PartialEq for bitcoin::psbt::PsbtSighashType
+impl core::cmp::PartialEq for bitcoin::psbt::SignError
+impl core::cmp::PartialEq for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::PartialEq for bitcoin::psbt::raw::Key
+impl core::cmp::PartialEq for bitcoin::psbt::raw::Pair
+impl core::cmp::PartialEq for bitcoin::sighash::AnnexError
+impl core::cmp::PartialEq for bitcoin::sighash::InvalidSighashTypeError
+impl core::cmp::PartialEq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::cmp::PartialEq for bitcoin::sighash::P2wpkhError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsIndexError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsKindError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsSizeError
+impl core::cmp::PartialEq for bitcoin::sighash::SighashTypeParseError
+impl core::cmp::PartialEq for bitcoin::sighash::SingleMissingOutputError
+impl core::cmp::PartialEq for bitcoin::sighash::TaprootError
+impl core::cmp::PartialEq for bitcoin::sign_message::MessageSignature
+impl core::cmp::PartialEq for bitcoin::sign_message::MessageSignatureError
+impl core::cmp::PartialEq for bitcoin::taproot::ControlBlock
+impl core::cmp::PartialEq for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::PartialEq for bitcoin::taproot::HiddenNodesError
+impl core::cmp::PartialEq for bitcoin::taproot::IncompleteBuilderError
+impl core::cmp::PartialEq for bitcoin::taproot::LeafNode
+impl core::cmp::PartialEq for bitcoin::taproot::LeafVersion
+impl core::cmp::PartialEq for bitcoin::taproot::NodeInfo
+impl core::cmp::PartialEq for bitcoin::taproot::SigFromSliceError
+impl core::cmp::PartialEq for bitcoin::taproot::Signature
+impl core::cmp::PartialEq for bitcoin::taproot::TapBranchTag
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeaf
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeafHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeafTag
+impl core::cmp::PartialEq for bitcoin::taproot::TapNodeHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapTree
+impl core::cmp::PartialEq for bitcoin::taproot::TapTweakHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapTweakTag
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootBuilder
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootBuilderError
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootError
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::PartialEq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::PartialEq for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialEq<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::Script
+impl core::cmp::PartialEq<bitcoin::taproot::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialOrd for bitcoin::CompressedPublicKey
+impl core::cmp::PartialOrd for bitcoin::LegacySighash
+impl core::cmp::PartialOrd for bitcoin::PubkeyHash
+impl core::cmp::PartialOrd for bitcoin::PublicKey
+impl core::cmp::PartialOrd for bitcoin::SegwitV0Sighash
+impl core::cmp::PartialOrd for bitcoin::TapSighash
+impl core::cmp::PartialOrd for bitcoin::TapSighashTag
+impl core::cmp::PartialOrd for bitcoin::TapSighashType
+impl core::cmp::PartialOrd for bitcoin::WPubkeyHash
+impl core::cmp::PartialOrd for bitcoin::address::AddressType
+impl core::cmp::PartialOrd for bitcoin::address::KnownHrp
+impl core::cmp::PartialOrd for bitcoin::address::NetworkChecked
+impl core::cmp::PartialOrd for bitcoin::address::NetworkUnchecked
+impl core::cmp::PartialOrd for bitcoin::bip152::BlockTransactions
+impl core::cmp::PartialOrd for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::PartialOrd for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::PartialOrd for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::PartialOrd for bitcoin::bip152::ShortId
+impl core::cmp::PartialOrd for bitcoin::bip158::FilterHash
+impl core::cmp::PartialOrd for bitcoin::bip158::FilterHeader
+impl core::cmp::PartialOrd for bitcoin::bip32::ChainCode
+impl core::cmp::PartialOrd for bitcoin::bip32::ChildNumber
+impl core::cmp::PartialOrd for bitcoin::bip32::DerivationPath
+impl core::cmp::PartialOrd for bitcoin::bip32::Fingerprint
+impl core::cmp::PartialOrd for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::PartialOrd for bitcoin::bip32::Xpub
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::Header
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::Version
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::PartialOrd for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::PushBytes
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::Script
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Version
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin::blockdata::weight::Weight
+impl core::cmp::PartialOrd for bitcoin::blockdata::witness::Witness
+impl core::cmp::PartialOrd for bitcoin::consensus::encode::VarInt
+impl core::cmp::PartialOrd for bitcoin::key::SortKey
+impl core::cmp::PartialOrd for bitcoin::key::TweakedKeypair
+impl core::cmp::PartialOrd for bitcoin::key::TweakedPublicKey
+impl core::cmp::PartialOrd for bitcoin::network::Network
+impl core::cmp::PartialOrd for bitcoin::network::NetworkKind
+impl core::cmp::PartialOrd for bitcoin::p2p::Magic
+impl core::cmp::PartialOrd for bitcoin::p2p::ServiceFlags
+impl core::cmp::PartialOrd for bitcoin::p2p::message_blockdata::Inventory
+impl core::cmp::PartialOrd for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::cmp::PartialOrd for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::cmp::PartialOrd for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::cmp::PartialOrd for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::cmp::PartialOrd for bitcoin::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin::pow::Target
+impl core::cmp::PartialOrd for bitcoin::pow::Work
+impl core::cmp::PartialOrd for bitcoin::psbt::OutputType
+impl core::cmp::PartialOrd for bitcoin::psbt::PsbtSighashType
+impl core::cmp::PartialOrd for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::PartialOrd for bitcoin::psbt::raw::Key
+impl core::cmp::PartialOrd for bitcoin::taproot::ControlBlock
+impl core::cmp::PartialOrd for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::PartialOrd for bitcoin::taproot::LeafNode
+impl core::cmp::PartialOrd for bitcoin::taproot::LeafVersion
+impl core::cmp::PartialOrd for bitcoin::taproot::NodeInfo
+impl core::cmp::PartialOrd for bitcoin::taproot::Signature
+impl core::cmp::PartialOrd for bitcoin::taproot::TapBranchTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeaf
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeafHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeafTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TapNodeHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapTweakHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapTweakTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TaprootBuilder
+impl core::cmp::PartialOrd for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::PartialOrd for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::PartialOrd for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialOrd<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::Script
+impl core::cmp::PartialOrd<bitcoin::taproot::serialized_signature::SerializedSignature> for [u8]
+impl core::convert::AsMut<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::AsMut<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::convert::AsMut<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsMut<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsMut<[u8; 4]> for bitcoin::p2p::Magic
+impl core::convert::AsMut<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::convert::AsMut<[u8]> for bitcoin::bip152::ShortId
+impl core::convert::AsMut<[u8]> for bitcoin::bip32::ChainCode
+impl core::convert::AsMut<[u8]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::Script
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsMut<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsMut<[u8]> for bitcoin::p2p::Magic
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 0]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 10]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 11]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 12]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 13]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 14]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 15]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 16]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 17]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 18]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 19]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 1]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 20]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 21]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 22]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 23]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 24]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 25]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 26]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 27]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 28]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 29]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 2]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 30]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 31]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 32]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 33]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 34]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 35]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 36]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 37]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 38]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 39]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 3]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 40]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 41]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 42]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 43]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 44]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 45]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 46]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 47]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 48]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 49]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 4]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 50]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 51]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 52]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 53]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 54]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 55]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 56]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 57]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 58]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 59]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 5]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 60]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 61]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 62]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 63]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 64]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 65]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 66]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 67]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 68]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 69]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 6]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 70]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 71]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 72]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 73]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 7]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 8]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 9]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::AsMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::Script
+impl core::convert::AsMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<[bitcoin::bip32::ChildNumber]> for bitcoin::bip32::ChildNumber
+impl core::convert::AsRef<[bitcoin::bip32::ChildNumber]> for bitcoin::bip32::DerivationPath
+impl core::convert::AsRef<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::AsRef<[u8; 20]> for bitcoin::PubkeyHash
+impl core::convert::AsRef<[u8; 20]> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<[u8; 20]> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::AsRef<[u8; 20]> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::LegacySighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::SegwitV0Sighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::TapSighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip158::FilterHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip158::FilterHeader
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapLeafHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapNodeHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapTweakHash
+impl core::convert::AsRef<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsRef<[u8; 4]> for bitcoin::p2p::Magic
+impl core::convert::AsRef<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::convert::AsRef<[u8]> for bitcoin::LegacySighash
+impl core::convert::AsRef<[u8]> for bitcoin::PubkeyHash
+impl core::convert::AsRef<[u8]> for bitcoin::SegwitV0Sighash
+impl core::convert::AsRef<[u8]> for bitcoin::TapSighash
+impl core::convert::AsRef<[u8]> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<[u8]> for bitcoin::bip152::ShortId
+impl core::convert::AsRef<[u8]> for bitcoin::bip158::FilterHash
+impl core::convert::AsRef<[u8]> for bitcoin::bip158::FilterHeader
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::ChainCode
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::Script
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsRef<[u8]> for bitcoin::p2p::Magic
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapLeafHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapNodeHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapTweakHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 0]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 10]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 11]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 12]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 13]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 14]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 15]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 16]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 17]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 18]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 19]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 1]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 20]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 21]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 22]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 23]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 24]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 25]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 26]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 27]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 28]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 29]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 2]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 30]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 31]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 32]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 33]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 34]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 35]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 36]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 37]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 38]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 39]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 3]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 40]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 41]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 42]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 43]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 44]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 45]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 46]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 47]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 48]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 49]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 4]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 50]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 51]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 52]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 53]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 54]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 55]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 56]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 57]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 58]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 59]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 5]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 60]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 61]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 62]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 63]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 64]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 65]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 66]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 67]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 68]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 69]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 6]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 70]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 71]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 72]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 73]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 7]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 8]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 9]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::PubkeyHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsRef<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::Script
+impl core::convert::AsRef<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<bitcoin::blockdata::transaction::Transaction> for bitcoin::bip152::PrefilledTransaction
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin::error::ParseIntError
+impl core::convert::AsRef<str> for bitcoin::p2p::message::CommandString
+impl core::convert::From<&[&[u8]]> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<&[alloc::vec::Vec<u8>]> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<&bitcoin::CompressedPublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<&bitcoin::CompressedPublicKey> for bitcoin::WPubkeyHash
+impl core::convert::From<&bitcoin::PublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<&bitcoin::bip32::Xpub> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<&bitcoin::blockdata::block::Block> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<&bitcoin::blockdata::block::Header> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<&bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<&bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<&bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<&bitcoin::network::Network> for &'static bitcoin::consensus::params::Params
+impl core::convert::From<&bitcoin::network::Network> for bitcoin::consensus::params::Params
+impl core::convert::From<&bitcoin::taproot::LeafNode> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<&bitcoin::taproot::TaprootSpendInfo> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 0]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 100]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 101]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 102]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 103]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 104]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 105]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 106]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 107]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 108]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 109]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 10]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 110]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 111]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 112]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 113]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 114]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 115]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 116]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 117]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 118]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 119]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 11]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 120]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 121]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 122]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 123]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 124]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 125]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 126]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 127]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 128]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 12]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 13]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 14]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 15]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 16]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 17]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 18]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 19]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 1]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 20]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 21]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 22]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 23]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 24]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 25]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 26]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 27]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 28]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 29]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 2]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 30]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 31]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 32]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 33]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 34]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 35]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 36]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 37]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 38]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 39]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 3]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 40]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 41]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 42]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 43]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 44]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 45]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 46]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 47]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 48]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 49]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 4]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 50]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 51]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 52]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 53]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 54]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 55]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 56]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 57]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 58]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 59]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 5]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 60]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 61]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 62]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 63]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 64]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 65]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 66]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 67]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 68]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 69]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 6]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 70]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 71]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 72]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 73]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 74]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 75]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 76]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 77]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 78]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 79]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 7]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 80]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 81]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 82]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 83]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 84]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 85]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 86]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 87]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 88]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 89]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 8]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 90]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 91]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 92]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 93]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 94]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 95]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 96]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 97]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 98]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 99]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 9]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[u8; 0]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 10]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 11]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 12]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 13]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 14]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 15]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 16]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 17]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 18]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 19]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 1]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 20]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 21]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 22]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 23]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 24]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 25]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 26]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 27]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 28]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 29]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 2]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 30]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 31]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 32]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 33]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 34]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 35]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 36]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 37]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 38]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 39]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 3]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 40]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 41]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 42]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 43]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 44]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 45]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 46]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 47]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 48]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 49]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 4]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 50]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 51]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 52]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 53]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 54]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 55]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 56]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 57]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 58]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 59]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 5]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 60]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 61]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 62]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 63]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 64]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 65]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 66]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 67]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 68]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 69]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 6]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 70]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 71]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 72]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 73]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 7]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 8]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 9]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<alloc::vec::Vec<bitcoin::bip32::ChildNumber>> for bitcoin::bip32::DerivationPath
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::Builder
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::From<bech32::segwit::DecodeError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::PublicKey
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::WPubkeyHash
+impl core::convert::From<bitcoin::CompressedPublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::EcdsaSighashType> for bitcoin::TapSighashType
+impl core::convert::From<bitcoin::EcdsaSighashType> for bitcoin::psbt::PsbtSighashType
+impl core::convert::From<bitcoin::LegacySighash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::PubkeyHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::PubkeyHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::PublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin::PublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::SegwitV0Sighash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::TapSighash> for bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+impl core::convert::From<bitcoin::TapSighashType> for bitcoin::psbt::PsbtSighashType
+impl core::convert::From<bitcoin::WPubkeyHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::WPubkeyHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::address::Address> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::From<bitcoin::address::error::UnknownHrpError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::bip32::Error
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::key::Error
+impl core::convert::From<bitcoin::bip158::FilterHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::bip158::FilterHeader> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::bip32::ChildNumber> for u32
+impl core::convert::From<bitcoin::bip32::DerivationPath> for alloc::vec::Vec<bitcoin::bip32::ChildNumber>
+impl core::convert::From<bitcoin::bip32::Error> for bitcoin::psbt::GetKeyError
+impl core::convert::From<bitcoin::bip32::XKeyIdentifier> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::bip32::Xpub> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<bitcoin::blockdata::block::Block> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin::blockdata::block::BlockHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::Header> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin::blockdata::block::TxMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::WitnessCommitment> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::WitnessMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::fee_rate::FeeRate> for u64
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::ConversionError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::Height> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::OperationError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::Time> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::relative::Height> for bitcoin::blockdata::locktime::relative::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::relative::Time> for bitcoin::blockdata::locktime::relative::LockTime
+impl core::convert::From<bitcoin::blockdata::script::PushBytesBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin::blockdata::script::Script>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<bitcoin::blockdata::script::ScriptHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::blockdata::script::ScriptHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::blockdata::script::WScriptHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::blockdata::script::WScriptHash> for bitcoin_hashes::sha256::Hash
+impl core::convert::From<bitcoin::blockdata::script::witness_program::Error> for bitcoin::address::error::Error
+impl core::convert::From<bitcoin::blockdata::script::witness_program::Error> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::Error
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bech32::primitives::gf32::Fe32
+impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bitcoin::blockdata::opcodes::Opcode
+impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::InputsIndexError
+impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::convert::From<bitcoin::blockdata::transaction::InputsIndexError> for bitcoin::sighash::P2wpkhError
+impl core::convert::From<bitcoin::blockdata::transaction::InputsIndexError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::blockdata::transaction::Sequence> for u32
+impl core::convert::From<bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<bitcoin::blockdata::transaction::Txid> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::From<bitcoin::blockdata::transaction::Txid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::transaction::Wtxid> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::From<bitcoin::blockdata::transaction::Wtxid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::weight::Weight> for u64
+impl core::convert::From<bitcoin::consensus::encode::Error> for bitcoin::psbt::Error
+impl core::convert::From<bitcoin::consensus::validation::BitcoinconsensusError> for bitcoin::consensus::validation::TxVerifyError
+impl core::convert::From<bitcoin::error::ParseIntError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::error::ParseIntError> for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::convert::From<bitcoin::error::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin::key::Error> for bitcoin::bip32::Error
+impl core::convert::From<bitcoin::key::TweakedKeypair> for bitcoin::key::TweakedPublicKey
+impl core::convert::From<bitcoin::key::TweakedKeypair> for secp256k1::key::Keypair
+impl core::convert::From<bitcoin::key::TweakedPublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::network::Network> for &'static bitcoin::consensus::params::Params
+impl core::convert::From<bitcoin::network::Network> for bitcoin::address::KnownHrp
+impl core::convert::From<bitcoin::network::Network> for bitcoin::consensus::params::Params
+impl core::convert::From<bitcoin::network::Network> for bitcoin::network::NetworkKind
+impl core::convert::From<bitcoin::network::Network> for bitcoin::p2p::Magic
+impl core::convert::From<bitcoin::p2p::ServiceFlags> for u64
+impl core::convert::From<bitcoin::pow::CompactTarget> for bitcoin::pow::Target
+impl core::convert::From<bitcoin::psbt::IndexOutOfBoundsError> for bitcoin::psbt::SignError
+impl core::convert::From<bitcoin::sighash::InvalidSighashTypeError> for bitcoin::taproot::SigFromSliceError
+impl core::convert::From<bitcoin::sighash::NonStandardSighashTypeError> for bitcoin::ecdsa::Error
+impl core::convert::From<bitcoin::sighash::P2wpkhError> for bitcoin::psbt::SignError
+impl core::convert::From<bitcoin::sighash::PrevoutsIndexError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::sighash::PrevoutsKindError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::sighash::PrevoutsSizeError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::taproot::LeafNode> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin::taproot::Signature> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::convert::From<bitcoin::taproot::TapLeafHash> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin::taproot::TapLeafHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+impl core::convert::From<bitcoin::taproot::TapNodeHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+impl core::convert::From<bitcoin::taproot::TapTree> for bitcoin::taproot::NodeInfo
+impl core::convert::From<bitcoin::taproot::TapTweakHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+impl core::convert::From<bitcoin::taproot::TaprootSpendInfo> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<bitcoin::taproot::merkle_branch::TaprootMerkleBranch> for alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+impl core::convert::From<bitcoin_hashes::FromSliceError> for bitcoin::psbt::Error
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::WPubkeyHash
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<bitcoin_hashes::sha256::Hash> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::LegacySighash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::SegwitV0Sighash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::bip158::FilterHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::bip158::FilterHeader
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>> for bitcoin::TapSighash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>> for bitcoin::taproot::TapLeafHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::bip158::Error
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::consensus::encode::Error
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::psbt::Error
+impl core::convert::From<hex_conservative::parse::HexToArrayError> for bitcoin::key::Error
+impl core::convert::From<hex_conservative::parse::HexToBytesError> for bitcoin::ecdsa::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::bip32::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::ecdsa::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::key::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::sign_message::MessageSignatureError
+impl core::convert::From<secp256k1::Error> for bitcoin::taproot::SigFromSliceError
+impl core::convert::From<secp256k1::key::PublicKey> for bitcoin::PublicKey
+impl core::convert::From<u16> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::From<u16> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u32> for bitcoin::bip32::ChildNumber
+impl core::convert::From<u32> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u64> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u64> for bitcoin::p2p::ServiceFlags
+impl core::convert::From<u8> for bitcoin::blockdata::opcodes::Opcode
+impl core::convert::From<u8> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<usize> for bitcoin::consensus::encode::VarInt
+impl core::convert::TryFrom<&[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<[bitcoin::taproot::TapNodeHash]>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::p2p::message::CommandString
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::p2p::message::CommandString
+impl core::convert::TryFrom<alloc::vec::Vec<bitcoin::taproot::TapNodeHash>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::TryFrom<bech32::primitives::gf32::Fe32> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::convert::TryFrom<bitcoin::PublicKey> for bitcoin::CompressedPublicKey
+impl core::convert::TryFrom<bitcoin::blockdata::constants::ChainHash> for bitcoin::network::Network
+impl core::convert::TryFrom<bitcoin::blockdata::opcodes::Opcode> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::convert::TryFrom<bitcoin::p2p::Magic> for bitcoin::network::Network
+impl core::convert::TryFrom<bitcoin::taproot::NodeInfo> for bitcoin::taproot::TapTree
+impl core::convert::TryFrom<bitcoin::taproot::TaprootBuilder> for bitcoin::taproot::NodeInfo
+impl core::convert::TryFrom<bitcoin::taproot::TaprootBuilder> for bitcoin::taproot::TapTree
+impl core::convert::TryFrom<bitcoin::taproot::serialized_signature::SerializedSignature> for bitcoin::taproot::Signature
+impl core::convert::TryFrom<u8> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::default::Default for bitcoin::TapSighashTag
+impl core::default::Default for bitcoin::bip152::ShortId
+impl core::default::Default for bitcoin::bip32::DerivationPath
+impl core::default::Default for bitcoin::bip32::Fingerprint
+impl core::default::Default for bitcoin::blockdata::block::Version
+impl core::default::Default for bitcoin::blockdata::locktime::relative::Height
+impl core::default::Default for bitcoin::blockdata::locktime::relative::Time
+impl core::default::Default for bitcoin::blockdata::script::Builder
+impl core::default::Default for bitcoin::blockdata::script::PushBytesBuf
+impl core::default::Default for bitcoin::blockdata::script::ScriptBuf
+impl core::default::Default for bitcoin::blockdata::transaction::OutPoint
+impl core::default::Default for bitcoin::blockdata::transaction::Sequence
+impl core::default::Default for bitcoin::blockdata::transaction::TxIn
+impl core::default::Default for bitcoin::blockdata::witness::Witness
+impl core::default::Default for bitcoin::p2p::ServiceFlags
+impl core::default::Default for bitcoin::pow::CompactTarget
+impl core::default::Default for bitcoin::psbt::Input
+impl core::default::Default for bitcoin::psbt::Output
+impl core::default::Default for bitcoin::taproot::TapBranchTag
+impl core::default::Default for bitcoin::taproot::TapLeafTag
+impl core::default::Default for bitcoin::taproot::TapTweakTag
+impl core::default::Default for bitcoin::taproot::TaprootBuilder
+impl core::default::Default for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::error::Error for bitcoin::address::error::Error
+impl core::error::Error for bitcoin::address::error::ParseError
+impl core::error::Error for bitcoin::address::error::UnknownAddressTypeError
+impl core::error::Error for bitcoin::address::error::UnknownHrpError
+impl core::error::Error for bitcoin::base58::Error
+impl core::error::Error for bitcoin::bip152::Error
+impl core::error::Error for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::error::Error for bitcoin::bip158::Error
+impl core::error::Error for bitcoin::bip32::Error
+impl core::error::Error for bitcoin::blockdata::block::Bip34Error
+impl core::error::Error for bitcoin::blockdata::block::ValidationError
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::Error
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::error::Error for bitcoin::blockdata::locktime::relative::Error
+impl core::error::Error for bitcoin::blockdata::script::Error
+impl core::error::Error for bitcoin::blockdata::script::PushBytesError
+impl core::error::Error for bitcoin::blockdata::script::witness_program::Error
+impl core::error::Error for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::error::Error for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::error::Error for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::error::Error for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::error::Error for bitcoin::blockdata::transaction::InputsIndexError
+impl core::error::Error for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::error::Error for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::error::Error for bitcoin::consensus::encode::Error
+impl core::error::Error for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::error::Error for bitcoin::consensus::validation::TxVerifyError
+impl core::error::Error for bitcoin::ecdsa::Error
+impl core::error::Error for bitcoin::error::ParseIntError
+impl core::error::Error for bitcoin::key::Error
+impl core::error::Error for bitcoin::key::UncompressedPubkeyError
+impl core::error::Error for bitcoin::merkle_tree::MerkleBlockError
+impl core::error::Error for bitcoin::network::ParseNetworkError
+impl core::error::Error for bitcoin::network::UnknownChainHashError
+impl core::error::Error for bitcoin::p2p::ParseMagicError
+impl core::error::Error for bitcoin::p2p::UnknownMagicError
+impl core::error::Error for bitcoin::p2p::message::CommandStringError
+impl core::error::Error for bitcoin::pow::TryFromError
+impl core::error::Error for bitcoin::psbt::Error
+impl core::error::Error for bitcoin::psbt::ExtractTxError
+impl core::error::Error for bitcoin::psbt::GetKeyError
+impl core::error::Error for bitcoin::psbt::IndexOutOfBoundsError
+impl core::error::Error for bitcoin::psbt::PsbtParseError
+impl core::error::Error for bitcoin::psbt::SignError
+impl core::error::Error for bitcoin::sighash::AnnexError
+impl core::error::Error for bitcoin::sighash::InvalidSighashTypeError
+impl core::error::Error for bitcoin::sighash::NonStandardSighashTypeError
+impl core::error::Error for bitcoin::sighash::P2wpkhError
+impl core::error::Error for bitcoin::sighash::PrevoutsIndexError
+impl core::error::Error for bitcoin::sighash::PrevoutsKindError
+impl core::error::Error for bitcoin::sighash::PrevoutsSizeError
+impl core::error::Error for bitcoin::sighash::SighashTypeParseError
+impl core::error::Error for bitcoin::sighash::SingleMissingOutputError
+impl core::error::Error for bitcoin::sighash::TaprootError
+impl core::error::Error for bitcoin::sign_message::MessageSignatureError
+impl core::error::Error for bitcoin::taproot::HiddenNodesError
+impl core::error::Error for bitcoin::taproot::IncompleteBuilderError
+impl core::error::Error for bitcoin::taproot::SigFromSliceError
+impl core::error::Error for bitcoin::taproot::TaprootBuilderError
+impl core::error::Error for bitcoin::taproot::TaprootError
+impl core::fmt::Debug for bitcoin::CompressedPublicKey
+impl core::fmt::Debug for bitcoin::EcdsaSighashType
+impl core::fmt::Debug for bitcoin::LegacySighash
+impl core::fmt::Debug for bitcoin::MerkleBlock
+impl core::fmt::Debug for bitcoin::PrivateKey
+impl core::fmt::Debug for bitcoin::PubkeyHash
+impl core::fmt::Debug for bitcoin::PublicKey
+impl core::fmt::Debug for bitcoin::SegwitV0Sighash
+impl core::fmt::Debug for bitcoin::TapSighash
+impl core::fmt::Debug for bitcoin::TapSighashType
+impl core::fmt::Debug for bitcoin::WPubkeyHash
+impl core::fmt::Debug for bitcoin::address::AddressType
+impl core::fmt::Debug for bitcoin::address::KnownHrp
+impl core::fmt::Debug for bitcoin::address::NetworkChecked
+impl core::fmt::Debug for bitcoin::address::NetworkUnchecked
+impl core::fmt::Debug for bitcoin::address::error::Error
+impl core::fmt::Debug for bitcoin::address::error::ParseError
+impl core::fmt::Debug for bitcoin::address::error::UnknownAddressTypeError
+impl core::fmt::Debug for bitcoin::address::error::UnknownHrpError
+impl core::fmt::Debug for bitcoin::base58::Error
+impl core::fmt::Debug for bitcoin::bip152::BlockTransactions
+impl core::fmt::Debug for bitcoin::bip152::BlockTransactionsRequest
+impl core::fmt::Debug for bitcoin::bip152::Error
+impl core::fmt::Debug for bitcoin::bip152::HeaderAndShortIds
+impl core::fmt::Debug for bitcoin::bip152::PrefilledTransaction
+impl core::fmt::Debug for bitcoin::bip152::ShortId
+impl core::fmt::Debug for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::fmt::Debug for bitcoin::bip158::BlockFilter
+impl core::fmt::Debug for bitcoin::bip158::Error
+impl core::fmt::Debug for bitcoin::bip158::FilterHash
+impl core::fmt::Debug for bitcoin::bip158::FilterHeader
+impl core::fmt::Debug for bitcoin::bip32::ChainCode
+impl core::fmt::Debug for bitcoin::bip32::ChildNumber
+impl core::fmt::Debug for bitcoin::bip32::DerivationPath
+impl core::fmt::Debug for bitcoin::bip32::Error
+impl core::fmt::Debug for bitcoin::bip32::Fingerprint
+impl core::fmt::Debug for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::Debug for bitcoin::bip32::Xpriv
+impl core::fmt::Debug for bitcoin::bip32::Xpub
+impl core::fmt::Debug for bitcoin::blockdata::block::Bip34Error
+impl core::fmt::Debug for bitcoin::blockdata::block::Block
+impl core::fmt::Debug for bitcoin::blockdata::block::BlockHash
+impl core::fmt::Debug for bitcoin::blockdata::block::Header
+impl core::fmt::Debug for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::Debug for bitcoin::blockdata::block::ValidationError
+impl core::fmt::Debug for bitcoin::blockdata::block::Version
+impl core::fmt::Debug for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::Debug for bitcoin::blockdata::fee_rate::FeeRate
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Error
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Time
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Error
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Height
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::LockTime
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Time
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::Class
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::Opcode
+impl core::fmt::Debug for bitcoin::blockdata::script::Builder
+impl core::fmt::Debug for bitcoin::blockdata::script::Error
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytes
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytesBuf
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytesError
+impl core::fmt::Debug for bitcoin::blockdata::script::Script
+impl core::fmt::Debug for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::Debug for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::Debug for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_program::Error
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::fmt::Debug for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::fmt::Debug for bitcoin::blockdata::transaction::InputsIndexError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::OutPoint
+impl core::fmt::Debug for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Transaction
+impl core::fmt::Debug for bitcoin::blockdata::transaction::TxIn
+impl core::fmt::Debug for bitcoin::blockdata::transaction::TxOut
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Txid
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Version
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::Debug for bitcoin::blockdata::weight::Weight
+impl core::fmt::Debug for bitcoin::blockdata::witness::Witness
+impl core::fmt::Debug for bitcoin::consensus::encode::CheckedData
+impl core::fmt::Debug for bitcoin::consensus::encode::Error
+impl core::fmt::Debug for bitcoin::consensus::encode::VarInt
+impl core::fmt::Debug for bitcoin::consensus::params::Params
+impl core::fmt::Debug for bitcoin::consensus::serde::hex::DecodeError
+impl core::fmt::Debug for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::fmt::Debug for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::fmt::Debug for bitcoin::consensus::validation::TxVerifyError
+impl core::fmt::Debug for bitcoin::ecdsa::Error
+impl core::fmt::Debug for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::Debug for bitcoin::ecdsa::Signature
+impl core::fmt::Debug for bitcoin::error::ParseIntError
+impl core::fmt::Debug for bitcoin::key::Error
+impl core::fmt::Debug for bitcoin::key::SortKey
+impl core::fmt::Debug for bitcoin::key::TweakedKeypair
+impl core::fmt::Debug for bitcoin::key::TweakedPublicKey
+impl core::fmt::Debug for bitcoin::key::UncompressedPubkeyError
+impl core::fmt::Debug for bitcoin::merkle_tree::MerkleBlockError
+impl core::fmt::Debug for bitcoin::merkle_tree::PartialMerkleTree
+impl core::fmt::Debug for bitcoin::network::Network
+impl core::fmt::Debug for bitcoin::network::NetworkKind
+impl core::fmt::Debug for bitcoin::network::ParseNetworkError
+impl core::fmt::Debug for bitcoin::network::UnknownChainHashError
+impl core::fmt::Debug for bitcoin::p2p::Magic
+impl core::fmt::Debug for bitcoin::p2p::ParseMagicError
+impl core::fmt::Debug for bitcoin::p2p::ServiceFlags
+impl core::fmt::Debug for bitcoin::p2p::UnknownMagicError
+impl core::fmt::Debug for bitcoin::p2p::address::AddrV2
+impl core::fmt::Debug for bitcoin::p2p::address::AddrV2Message
+impl core::fmt::Debug for bitcoin::p2p::address::Address
+impl core::fmt::Debug for bitcoin::p2p::message::CommandString
+impl core::fmt::Debug for bitcoin::p2p::message::CommandStringError
+impl core::fmt::Debug for bitcoin::p2p::message::NetworkMessage
+impl core::fmt::Debug for bitcoin::p2p::message::RawNetworkMessage
+impl core::fmt::Debug for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::fmt::Debug for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::fmt::Debug for bitcoin::p2p::message_blockdata::Inventory
+impl core::fmt::Debug for bitcoin::p2p::message_bloom::BloomFlags
+impl core::fmt::Debug for bitcoin::p2p::message_bloom::FilterAdd
+impl core::fmt::Debug for bitcoin::p2p::message_bloom::FilterLoad
+impl core::fmt::Debug for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::fmt::Debug for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::fmt::Debug for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::fmt::Debug for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::fmt::Debug for bitcoin::p2p::message_filter::CFCheckpt
+impl core::fmt::Debug for bitcoin::p2p::message_filter::CFHeaders
+impl core::fmt::Debug for bitcoin::p2p::message_filter::CFilter
+impl core::fmt::Debug for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::fmt::Debug for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::fmt::Debug for bitcoin::p2p::message_filter::GetCFilters
+impl core::fmt::Debug for bitcoin::p2p::message_network::Reject
+impl core::fmt::Debug for bitcoin::p2p::message_network::RejectReason
+impl core::fmt::Debug for bitcoin::p2p::message_network::VersionMessage
+impl core::fmt::Debug for bitcoin::pow::CompactTarget
+impl core::fmt::Debug for bitcoin::pow::Target
+impl core::fmt::Debug for bitcoin::pow::TryFromError
+impl core::fmt::Debug for bitcoin::pow::Work
+impl core::fmt::Debug for bitcoin::psbt::Error
+impl core::fmt::Debug for bitcoin::psbt::ExtractTxError
+impl core::fmt::Debug for bitcoin::psbt::GetKeyError
+impl core::fmt::Debug for bitcoin::psbt::IndexOutOfBoundsError
+impl core::fmt::Debug for bitcoin::psbt::Input
+impl core::fmt::Debug for bitcoin::psbt::KeyRequest
+impl core::fmt::Debug for bitcoin::psbt::Output
+impl core::fmt::Debug for bitcoin::psbt::OutputType
+impl core::fmt::Debug for bitcoin::psbt::Psbt
+impl core::fmt::Debug for bitcoin::psbt::PsbtParseError
+impl core::fmt::Debug for bitcoin::psbt::PsbtSighashType
+impl core::fmt::Debug for bitcoin::psbt::SignError
+impl core::fmt::Debug for bitcoin::psbt::SigningAlgorithm
+impl core::fmt::Debug for bitcoin::psbt::raw::Key
+impl core::fmt::Debug for bitcoin::psbt::raw::Pair
+impl core::fmt::Debug for bitcoin::sighash::AnnexError
+impl core::fmt::Debug for bitcoin::sighash::InvalidSighashTypeError
+impl core::fmt::Debug for bitcoin::sighash::NonStandardSighashTypeError
+impl core::fmt::Debug for bitcoin::sighash::P2wpkhError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsIndexError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsKindError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsSizeError
+impl core::fmt::Debug for bitcoin::sighash::SighashTypeParseError
+impl core::fmt::Debug for bitcoin::sighash::SingleMissingOutputError
+impl core::fmt::Debug for bitcoin::sighash::TaprootError
+impl core::fmt::Debug for bitcoin::sign_message::MessageSignature
+impl core::fmt::Debug for bitcoin::sign_message::MessageSignatureError
+impl core::fmt::Debug for bitcoin::taproot::ControlBlock
+impl core::fmt::Debug for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::Debug for bitcoin::taproot::HiddenNodesError
+impl core::fmt::Debug for bitcoin::taproot::IncompleteBuilderError
+impl core::fmt::Debug for bitcoin::taproot::LeafNode
+impl core::fmt::Debug for bitcoin::taproot::LeafVersion
+impl core::fmt::Debug for bitcoin::taproot::NodeInfo
+impl core::fmt::Debug for bitcoin::taproot::SigFromSliceError
+impl core::fmt::Debug for bitcoin::taproot::Signature
+impl core::fmt::Debug for bitcoin::taproot::TapLeaf
+impl core::fmt::Debug for bitcoin::taproot::TapLeafHash
+impl core::fmt::Debug for bitcoin::taproot::TapNodeHash
+impl core::fmt::Debug for bitcoin::taproot::TapTree
+impl core::fmt::Debug for bitcoin::taproot::TapTweakHash
+impl core::fmt::Debug for bitcoin::taproot::TaprootBuilder
+impl core::fmt::Debug for bitcoin::taproot::TaprootBuilderError
+impl core::fmt::Debug for bitcoin::taproot::TaprootError
+impl core::fmt::Debug for bitcoin::taproot::TaprootSpendInfo
+impl core::fmt::Debug for bitcoin::taproot::merkle_branch::IntoIter
+impl core::fmt::Debug for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::fmt::Debug for bitcoin::taproot::serialized_signature::IntoIter
+impl core::fmt::Debug for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::fmt::Display for bitcoin::CompressedPublicKey
+impl core::fmt::Display for bitcoin::EcdsaSighashType
+impl core::fmt::Display for bitcoin::LegacySighash
+impl core::fmt::Display for bitcoin::PrivateKey
+impl core::fmt::Display for bitcoin::PubkeyHash
+impl core::fmt::Display for bitcoin::PublicKey
+impl core::fmt::Display for bitcoin::SegwitV0Sighash
+impl core::fmt::Display for bitcoin::TapSighash
+impl core::fmt::Display for bitcoin::TapSighashType
+impl core::fmt::Display for bitcoin::WPubkeyHash
+impl core::fmt::Display for bitcoin::address::Address
+impl core::fmt::Display for bitcoin::address::AddressType
+impl core::fmt::Display for bitcoin::address::error::Error
+impl core::fmt::Display for bitcoin::address::error::ParseError
+impl core::fmt::Display for bitcoin::address::error::UnknownAddressTypeError
+impl core::fmt::Display for bitcoin::address::error::UnknownHrpError
+impl core::fmt::Display for bitcoin::base58::Error
+impl core::fmt::Display for bitcoin::bip152::Error
+impl core::fmt::Display for bitcoin::bip152::ShortId
+impl core::fmt::Display for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::fmt::Display for bitcoin::bip158::Error
+impl core::fmt::Display for bitcoin::bip158::FilterHash
+impl core::fmt::Display for bitcoin::bip158::FilterHeader
+impl core::fmt::Display for bitcoin::bip32::ChainCode
+impl core::fmt::Display for bitcoin::bip32::ChildNumber
+impl core::fmt::Display for bitcoin::bip32::DerivationPath
+impl core::fmt::Display for bitcoin::bip32::Error
+impl core::fmt::Display for bitcoin::bip32::Fingerprint
+impl core::fmt::Display for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::Display for bitcoin::bip32::Xpriv
+impl core::fmt::Display for bitcoin::bip32::Xpub
+impl core::fmt::Display for bitcoin::blockdata::block::Bip34Error
+impl core::fmt::Display for bitcoin::blockdata::block::BlockHash
+impl core::fmt::Display for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::Display for bitcoin::blockdata::block::ValidationError
+impl core::fmt::Display for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::Display for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::Display for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::Display for bitcoin::blockdata::fee_rate::FeeRate
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Error
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Height
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Time
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Error
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Height
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::LockTime
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Time
+impl core::fmt::Display for bitcoin::blockdata::opcodes::Opcode
+impl core::fmt::Display for bitcoin::blockdata::script::Builder
+impl core::fmt::Display for bitcoin::blockdata::script::Error
+impl core::fmt::Display for bitcoin::blockdata::script::PushBytesError
+impl core::fmt::Display for bitcoin::blockdata::script::Script
+impl core::fmt::Display for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::Display for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::Display for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::Display for bitcoin::blockdata::script::witness_program::Error
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::fmt::Display for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::fmt::Display for bitcoin::blockdata::transaction::InputsIndexError
+impl core::fmt::Display for bitcoin::blockdata::transaction::OutPoint
+impl core::fmt::Display for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::fmt::Display for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::fmt::Display for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::Display for bitcoin::blockdata::transaction::Txid
+impl core::fmt::Display for bitcoin::blockdata::transaction::Version
+impl core::fmt::Display for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::Display for bitcoin::blockdata::weight::Weight
+impl core::fmt::Display for bitcoin::consensus::encode::Error
+impl core::fmt::Display for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::fmt::Display for bitcoin::consensus::validation::TxVerifyError
+impl core::fmt::Display for bitcoin::ecdsa::Error
+impl core::fmt::Display for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::Display for bitcoin::ecdsa::Signature
+impl core::fmt::Display for bitcoin::error::ParseIntError
+impl core::fmt::Display for bitcoin::key::Error
+impl core::fmt::Display for bitcoin::key::TweakedPublicKey
+impl core::fmt::Display for bitcoin::key::UncompressedPubkeyError
+impl core::fmt::Display for bitcoin::merkle_tree::MerkleBlockError
+impl core::fmt::Display for bitcoin::network::Network
+impl core::fmt::Display for bitcoin::network::ParseNetworkError
+impl core::fmt::Display for bitcoin::network::UnknownChainHashError
+impl core::fmt::Display for bitcoin::p2p::Magic
+impl core::fmt::Display for bitcoin::p2p::ParseMagicError
+impl core::fmt::Display for bitcoin::p2p::ServiceFlags
+impl core::fmt::Display for bitcoin::p2p::UnknownMagicError
+impl core::fmt::Display for bitcoin::p2p::message::CommandString
+impl core::fmt::Display for bitcoin::p2p::message::CommandStringError
+impl core::fmt::Display for bitcoin::pow::Target
+impl core::fmt::Display for bitcoin::pow::TryFromError
+impl core::fmt::Display for bitcoin::pow::Work
+impl core::fmt::Display for bitcoin::psbt::Error
+impl core::fmt::Display for bitcoin::psbt::ExtractTxError
+impl core::fmt::Display for bitcoin::psbt::GetKeyError
+impl core::fmt::Display for bitcoin::psbt::IndexOutOfBoundsError
+impl core::fmt::Display for bitcoin::psbt::Psbt
+impl core::fmt::Display for bitcoin::psbt::PsbtParseError
+impl core::fmt::Display for bitcoin::psbt::PsbtSighashType
+impl core::fmt::Display for bitcoin::psbt::SignError
+impl core::fmt::Display for bitcoin::psbt::raw::Key
+impl core::fmt::Display for bitcoin::sighash::AnnexError
+impl core::fmt::Display for bitcoin::sighash::InvalidSighashTypeError
+impl core::fmt::Display for bitcoin::sighash::NonStandardSighashTypeError
+impl core::fmt::Display for bitcoin::sighash::P2wpkhError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsIndexError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsKindError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsSizeError
+impl core::fmt::Display for bitcoin::sighash::SighashTypeParseError
+impl core::fmt::Display for bitcoin::sighash::SingleMissingOutputError
+impl core::fmt::Display for bitcoin::sighash::TaprootError
+impl core::fmt::Display for bitcoin::sign_message::MessageSignature
+impl core::fmt::Display for bitcoin::sign_message::MessageSignatureError
+impl core::fmt::Display for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::Display for bitcoin::taproot::HiddenNodesError
+impl core::fmt::Display for bitcoin::taproot::IncompleteBuilderError
+impl core::fmt::Display for bitcoin::taproot::LeafVersion
+impl core::fmt::Display for bitcoin::taproot::SigFromSliceError
+impl core::fmt::Display for bitcoin::taproot::TapLeafHash
+impl core::fmt::Display for bitcoin::taproot::TapNodeHash
+impl core::fmt::Display for bitcoin::taproot::TapTweakHash
+impl core::fmt::Display for bitcoin::taproot::TaprootBuilderError
+impl core::fmt::Display for bitcoin::taproot::TaprootError
+impl core::fmt::Display for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::fmt::LowerHex for bitcoin::LegacySighash
+impl core::fmt::LowerHex for bitcoin::PubkeyHash
+impl core::fmt::LowerHex for bitcoin::SegwitV0Sighash
+impl core::fmt::LowerHex for bitcoin::TapSighash
+impl core::fmt::LowerHex for bitcoin::WPubkeyHash
+impl core::fmt::LowerHex for bitcoin::bip152::ShortId
+impl core::fmt::LowerHex for bitcoin::bip158::FilterHash
+impl core::fmt::LowerHex for bitcoin::bip158::FilterHeader
+impl core::fmt::LowerHex for bitcoin::bip32::ChainCode
+impl core::fmt::LowerHex for bitcoin::bip32::Fingerprint
+impl core::fmt::LowerHex for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::LowerHex for bitcoin::blockdata::block::BlockHash
+impl core::fmt::LowerHex for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::LowerHex for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::LowerHex for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::LowerHex for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::LowerHex for bitcoin::blockdata::script::Script
+impl core::fmt::LowerHex for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::LowerHex for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::LowerHex for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Txid
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::LowerHex for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::LowerHex for bitcoin::key::TweakedPublicKey
+impl core::fmt::LowerHex for bitcoin::p2p::Magic
+impl core::fmt::LowerHex for bitcoin::p2p::ServiceFlags
+impl core::fmt::LowerHex for bitcoin::pow::CompactTarget
+impl core::fmt::LowerHex for bitcoin::pow::Target
+impl core::fmt::LowerHex for bitcoin::pow::Work
+impl core::fmt::LowerHex for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::LowerHex for bitcoin::taproot::LeafVersion
+impl core::fmt::LowerHex for bitcoin::taproot::TapLeafHash
+impl core::fmt::LowerHex for bitcoin::taproot::TapNodeHash
+impl core::fmt::LowerHex for bitcoin::taproot::TapTweakHash
+impl core::fmt::UpperHex for bitcoin::LegacySighash
+impl core::fmt::UpperHex for bitcoin::PubkeyHash
+impl core::fmt::UpperHex for bitcoin::SegwitV0Sighash
+impl core::fmt::UpperHex for bitcoin::TapSighash
+impl core::fmt::UpperHex for bitcoin::WPubkeyHash
+impl core::fmt::UpperHex for bitcoin::bip152::ShortId
+impl core::fmt::UpperHex for bitcoin::bip158::FilterHash
+impl core::fmt::UpperHex for bitcoin::bip158::FilterHeader
+impl core::fmt::UpperHex for bitcoin::bip32::ChainCode
+impl core::fmt::UpperHex for bitcoin::bip32::Fingerprint
+impl core::fmt::UpperHex for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::UpperHex for bitcoin::blockdata::block::BlockHash
+impl core::fmt::UpperHex for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::UpperHex for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::UpperHex for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::UpperHex for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::UpperHex for bitcoin::blockdata::script::Script
+impl core::fmt::UpperHex for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::UpperHex for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::UpperHex for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Txid
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::UpperHex for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::UpperHex for bitcoin::p2p::Magic
+impl core::fmt::UpperHex for bitcoin::p2p::ServiceFlags
+impl core::fmt::UpperHex for bitcoin::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin::pow::Target
+impl core::fmt::UpperHex for bitcoin::pow::Work
+impl core::fmt::UpperHex for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::UpperHex for bitcoin::taproot::LeafVersion
+impl core::fmt::UpperHex for bitcoin::taproot::TapLeafHash
+impl core::fmt::UpperHex for bitcoin::taproot::TapNodeHash
+impl core::fmt::UpperHex for bitcoin::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin::CompressedPublicKey
+impl core::hash::Hash for bitcoin::EcdsaSighashType
+impl core::hash::Hash for bitcoin::LegacySighash
+impl core::hash::Hash for bitcoin::PubkeyHash
+impl core::hash::Hash for bitcoin::PublicKey
+impl core::hash::Hash for bitcoin::SegwitV0Sighash
+impl core::hash::Hash for bitcoin::TapSighash
+impl core::hash::Hash for bitcoin::TapSighashTag
+impl core::hash::Hash for bitcoin::TapSighashType
+impl core::hash::Hash for bitcoin::WPubkeyHash
+impl core::hash::Hash for bitcoin::address::AddressType
+impl core::hash::Hash for bitcoin::address::KnownHrp
+impl core::hash::Hash for bitcoin::address::NetworkChecked
+impl core::hash::Hash for bitcoin::address::NetworkUnchecked
+impl core::hash::Hash for bitcoin::bip152::BlockTransactions
+impl core::hash::Hash for bitcoin::bip152::BlockTransactionsRequest
+impl core::hash::Hash for bitcoin::bip152::HeaderAndShortIds
+impl core::hash::Hash for bitcoin::bip152::PrefilledTransaction
+impl core::hash::Hash for bitcoin::bip152::ShortId
+impl core::hash::Hash for bitcoin::bip158::FilterHash
+impl core::hash::Hash for bitcoin::bip158::FilterHeader
+impl core::hash::Hash for bitcoin::bip32::ChainCode
+impl core::hash::Hash for bitcoin::bip32::ChildNumber
+impl core::hash::Hash for bitcoin::bip32::DerivationPath
+impl core::hash::Hash for bitcoin::bip32::Fingerprint
+impl core::hash::Hash for bitcoin::bip32::XKeyIdentifier
+impl core::hash::Hash for bitcoin::bip32::Xpub
+impl core::hash::Hash for bitcoin::blockdata::block::BlockHash
+impl core::hash::Hash for bitcoin::blockdata::block::Header
+impl core::hash::Hash for bitcoin::blockdata::block::TxMerkleNode
+impl core::hash::Hash for bitcoin::blockdata::block::Version
+impl core::hash::Hash for bitcoin::blockdata::block::WitnessCommitment
+impl core::hash::Hash for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::hash::Hash for bitcoin::blockdata::constants::ChainHash
+impl core::hash::Hash for bitcoin::blockdata::fee_rate::FeeRate
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::Height
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::Time
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::Height
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::LockTime
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::Time
+impl core::hash::Hash for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::hash::Hash for bitcoin::blockdata::script::PushBytes
+impl core::hash::Hash for bitcoin::blockdata::script::PushBytesBuf
+impl core::hash::Hash for bitcoin::blockdata::script::Script
+impl core::hash::Hash for bitcoin::blockdata::script::ScriptBuf
+impl core::hash::Hash for bitcoin::blockdata::script::ScriptHash
+impl core::hash::Hash for bitcoin::blockdata::script::WScriptHash
+impl core::hash::Hash for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::hash::Hash for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::hash::Hash for bitcoin::blockdata::transaction::OutPoint
+impl core::hash::Hash for bitcoin::blockdata::transaction::Sequence
+impl core::hash::Hash for bitcoin::blockdata::transaction::Transaction
+impl core::hash::Hash for bitcoin::blockdata::transaction::TxIn
+impl core::hash::Hash for bitcoin::blockdata::transaction::TxOut
+impl core::hash::Hash for bitcoin::blockdata::transaction::Txid
+impl core::hash::Hash for bitcoin::blockdata::transaction::Version
+impl core::hash::Hash for bitcoin::blockdata::transaction::Wtxid
+impl core::hash::Hash for bitcoin::blockdata::weight::Weight
+impl core::hash::Hash for bitcoin::blockdata::witness::Witness
+impl core::hash::Hash for bitcoin::ecdsa::SerializedSignature
+impl core::hash::Hash for bitcoin::ecdsa::Signature
+impl core::hash::Hash for bitcoin::key::SortKey
+impl core::hash::Hash for bitcoin::key::TweakedKeypair
+impl core::hash::Hash for bitcoin::key::TweakedPublicKey
+impl core::hash::Hash for bitcoin::network::Network
+impl core::hash::Hash for bitcoin::network::NetworkKind
+impl core::hash::Hash for bitcoin::p2p::Magic
+impl core::hash::Hash for bitcoin::p2p::ServiceFlags
+impl core::hash::Hash for bitcoin::p2p::address::AddrV2
+impl core::hash::Hash for bitcoin::p2p::address::AddrV2Message
+impl core::hash::Hash for bitcoin::p2p::address::Address
+impl core::hash::Hash for bitcoin::p2p::message_blockdata::Inventory
+impl core::hash::Hash for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::hash::Hash for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::hash::Hash for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::hash::Hash for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::hash::Hash for bitcoin::pow::CompactTarget
+impl core::hash::Hash for bitcoin::pow::Target
+impl core::hash::Hash for bitcoin::pow::Work
+impl core::hash::Hash for bitcoin::psbt::Input
+impl core::hash::Hash for bitcoin::psbt::Output
+impl core::hash::Hash for bitcoin::psbt::OutputType
+impl core::hash::Hash for bitcoin::psbt::Psbt
+impl core::hash::Hash for bitcoin::psbt::PsbtSighashType
+impl core::hash::Hash for bitcoin::psbt::SigningAlgorithm
+impl core::hash::Hash for bitcoin::psbt::raw::Key
+impl core::hash::Hash for bitcoin::taproot::ControlBlock
+impl core::hash::Hash for bitcoin::taproot::FutureLeafVersion
+impl core::hash::Hash for bitcoin::taproot::LeafNode
+impl core::hash::Hash for bitcoin::taproot::LeafVersion
+impl core::hash::Hash for bitcoin::taproot::NodeInfo
+impl core::hash::Hash for bitcoin::taproot::Signature
+impl core::hash::Hash for bitcoin::taproot::TapBranchTag
+impl core::hash::Hash for bitcoin::taproot::TapLeaf
+impl core::hash::Hash for bitcoin::taproot::TapLeafHash
+impl core::hash::Hash for bitcoin::taproot::TapLeafTag
+impl core::hash::Hash for bitcoin::taproot::TapNodeHash
+impl core::hash::Hash for bitcoin::taproot::TapTree
+impl core::hash::Hash for bitcoin::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin::taproot::TapTweakTag
+impl core::hash::Hash for bitcoin::taproot::TaprootBuilder
+impl core::hash::Hash for bitcoin::taproot::TaprootSpendInfo
+impl core::hash::Hash for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::hash::Hash for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::iter::traits::accum::Sum for bitcoin::blockdata::weight::Weight
+impl core::iter::traits::collect::FromIterator<bitcoin::bip32::ChildNumber> for bitcoin::bip32::DerivationPath
+impl core::iter::traits::collect::IntoIterator for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::iter::traits::collect::IntoIterator for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::iterator::Iterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::iterator::Iterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::InstructionIndices<'_>
+impl core::iter::traits::marker::FusedIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::marker::FusedIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Copy for bitcoin::CompressedPublicKey
+impl core::marker::Copy for bitcoin::EcdsaSighashType
+impl core::marker::Copy for bitcoin::LegacySighash
+impl core::marker::Copy for bitcoin::PrivateKey
+impl core::marker::Copy for bitcoin::PubkeyHash
+impl core::marker::Copy for bitcoin::PublicKey
+impl core::marker::Copy for bitcoin::SegwitV0Sighash
+impl core::marker::Copy for bitcoin::TapSighash
+impl core::marker::Copy for bitcoin::TapSighashTag
+impl core::marker::Copy for bitcoin::TapSighashType
+impl core::marker::Copy for bitcoin::WPubkeyHash
+impl core::marker::Copy for bitcoin::address::AddressType
+impl core::marker::Copy for bitcoin::address::KnownHrp
+impl core::marker::Copy for bitcoin::bip152::ShortId
+impl core::marker::Copy for bitcoin::bip158::FilterHash
+impl core::marker::Copy for bitcoin::bip158::FilterHeader
+impl core::marker::Copy for bitcoin::bip32::ChainCode
+impl core::marker::Copy for bitcoin::bip32::ChildNumber
+impl core::marker::Copy for bitcoin::bip32::Fingerprint
+impl core::marker::Copy for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Copy for bitcoin::bip32::Xpriv
+impl core::marker::Copy for bitcoin::bip32::Xpub
+impl core::marker::Copy for bitcoin::blockdata::block::BlockHash
+impl core::marker::Copy for bitcoin::blockdata::block::Header
+impl core::marker::Copy for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Copy for bitcoin::blockdata::block::Version
+impl core::marker::Copy for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Copy for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Copy for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Copy for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Copy for bitcoin::blockdata::opcodes::Class
+impl core::marker::Copy for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Copy for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Copy for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Copy for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Copy for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Copy for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Copy for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Copy for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Copy for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Copy for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Copy for bitcoin::blockdata::transaction::Txid
+impl core::marker::Copy for bitcoin::blockdata::transaction::Version
+impl core::marker::Copy for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Copy for bitcoin::blockdata::weight::Weight
+impl core::marker::Copy for bitcoin::consensus::serde::hex::DecodeError
+impl core::marker::Copy for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::marker::Copy for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Copy for bitcoin::ecdsa::Signature
+impl core::marker::Copy for bitcoin::key::SortKey
+impl core::marker::Copy for bitcoin::key::TweakedKeypair
+impl core::marker::Copy for bitcoin::key::TweakedPublicKey
+impl core::marker::Copy for bitcoin::network::Network
+impl core::marker::Copy for bitcoin::network::NetworkKind
+impl core::marker::Copy for bitcoin::p2p::Magic
+impl core::marker::Copy for bitcoin::p2p::ServiceFlags
+impl core::marker::Copy for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::Copy for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::Copy for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::Copy for bitcoin::p2p::message_network::RejectReason
+impl core::marker::Copy for bitcoin::pow::CompactTarget
+impl core::marker::Copy for bitcoin::pow::Target
+impl core::marker::Copy for bitcoin::pow::Work
+impl core::marker::Copy for bitcoin::psbt::OutputType
+impl core::marker::Copy for bitcoin::psbt::PsbtSighashType
+impl core::marker::Copy for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Copy for bitcoin::sign_message::MessageSignature
+impl core::marker::Copy for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Copy for bitcoin::taproot::LeafVersion
+impl core::marker::Copy for bitcoin::taproot::Signature
+impl core::marker::Copy for bitcoin::taproot::TapBranchTag
+impl core::marker::Copy for bitcoin::taproot::TapLeafHash
+impl core::marker::Copy for bitcoin::taproot::TapLeafTag
+impl core::marker::Copy for bitcoin::taproot::TapNodeHash
+impl core::marker::Copy for bitcoin::taproot::TapTweakHash
+impl core::marker::Copy for bitcoin::taproot::TapTweakTag
+impl core::marker::Copy for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::Send for bitcoin::CompressedPublicKey
+impl core::marker::Send for bitcoin::EcdsaSighashType
+impl core::marker::Send for bitcoin::LegacySighash
+impl core::marker::Send for bitcoin::MerkleBlock
+impl core::marker::Send for bitcoin::PrivateKey
+impl core::marker::Send for bitcoin::PubkeyHash
+impl core::marker::Send for bitcoin::PublicKey
+impl core::marker::Send for bitcoin::SegwitV0Sighash
+impl core::marker::Send for bitcoin::TapSighash
+impl core::marker::Send for bitcoin::TapSighashTag
+impl core::marker::Send for bitcoin::TapSighashType
+impl core::marker::Send for bitcoin::WPubkeyHash
+impl core::marker::Send for bitcoin::address::AddressType
+impl core::marker::Send for bitcoin::address::KnownHrp
+impl core::marker::Send for bitcoin::address::NetworkChecked
+impl core::marker::Send for bitcoin::address::NetworkUnchecked
+impl core::marker::Send for bitcoin::address::error::Error
+impl core::marker::Send for bitcoin::address::error::ParseError
+impl core::marker::Send for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Send for bitcoin::address::error::UnknownHrpError
+impl core::marker::Send for bitcoin::base58::Error
+impl core::marker::Send for bitcoin::bip152::BlockTransactions
+impl core::marker::Send for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Send for bitcoin::bip152::Error
+impl core::marker::Send for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Send for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Send for bitcoin::bip152::ShortId
+impl core::marker::Send for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Send for bitcoin::bip158::BlockFilter
+impl core::marker::Send for bitcoin::bip158::BlockFilterReader
+impl core::marker::Send for bitcoin::bip158::Error
+impl core::marker::Send for bitcoin::bip158::FilterHash
+impl core::marker::Send for bitcoin::bip158::FilterHeader
+impl core::marker::Send for bitcoin::bip158::GcsFilterReader
+impl core::marker::Send for bitcoin::bip32::ChainCode
+impl core::marker::Send for bitcoin::bip32::ChildNumber
+impl core::marker::Send for bitcoin::bip32::DerivationPath
+impl core::marker::Send for bitcoin::bip32::Error
+impl core::marker::Send for bitcoin::bip32::Fingerprint
+impl core::marker::Send for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Send for bitcoin::bip32::Xpriv
+impl core::marker::Send for bitcoin::bip32::Xpub
+impl core::marker::Send for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Send for bitcoin::blockdata::block::Block
+impl core::marker::Send for bitcoin::blockdata::block::BlockHash
+impl core::marker::Send for bitcoin::blockdata::block::Header
+impl core::marker::Send for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Send for bitcoin::blockdata::block::ValidationError
+impl core::marker::Send for bitcoin::blockdata::block::Version
+impl core::marker::Send for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Send for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Send for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Send for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Send for bitcoin::blockdata::opcodes::Class
+impl core::marker::Send for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Send for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Send for bitcoin::blockdata::script::Builder
+impl core::marker::Send for bitcoin::blockdata::script::Error
+impl core::marker::Send for bitcoin::blockdata::script::PushBytes
+impl core::marker::Send for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Send for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Send for bitcoin::blockdata::script::Script
+impl core::marker::Send for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Send for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Send for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Send for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Send for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Send for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Send for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Send for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Send for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Send for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Send for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Send for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Send for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Send for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Send for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Send for bitcoin::blockdata::transaction::Txid
+impl core::marker::Send for bitcoin::blockdata::transaction::Version
+impl core::marker::Send for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Send for bitcoin::blockdata::weight::Weight
+impl core::marker::Send for bitcoin::blockdata::witness::Witness
+impl core::marker::Send for bitcoin::consensus::encode::CheckedData
+impl core::marker::Send for bitcoin::consensus::encode::Error
+impl core::marker::Send for bitcoin::consensus::encode::VarInt
+impl core::marker::Send for bitcoin::consensus::params::Params
+impl core::marker::Send for bitcoin::consensus::serde::hex::DecodeError
+impl core::marker::Send for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::marker::Send for bitcoin::consensus::serde::hex::Lower
+impl core::marker::Send for bitcoin::consensus::serde::hex::Upper
+impl core::marker::Send for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::marker::Send for bitcoin::consensus::validation::TxVerifyError
+impl core::marker::Send for bitcoin::ecdsa::Error
+impl core::marker::Send for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Send for bitcoin::ecdsa::Signature
+impl core::marker::Send for bitcoin::error::ParseIntError
+impl core::marker::Send for bitcoin::key::Error
+impl core::marker::Send for bitcoin::key::SortKey
+impl core::marker::Send for bitcoin::key::TweakedKeypair
+impl core::marker::Send for bitcoin::key::TweakedPublicKey
+impl core::marker::Send for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Send for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Send for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Send for bitcoin::network::Network
+impl core::marker::Send for bitcoin::network::NetworkKind
+impl core::marker::Send for bitcoin::network::ParseNetworkError
+impl core::marker::Send for bitcoin::network::UnknownChainHashError
+impl core::marker::Send for bitcoin::p2p::Magic
+impl core::marker::Send for bitcoin::p2p::ParseMagicError
+impl core::marker::Send for bitcoin::p2p::ServiceFlags
+impl core::marker::Send for bitcoin::p2p::UnknownMagicError
+impl core::marker::Send for bitcoin::p2p::address::AddrV2
+impl core::marker::Send for bitcoin::p2p::address::AddrV2Message
+impl core::marker::Send for bitcoin::p2p::address::Address
+impl core::marker::Send for bitcoin::p2p::message::CommandString
+impl core::marker::Send for bitcoin::p2p::message::CommandStringError
+impl core::marker::Send for bitcoin::p2p::message::NetworkMessage
+impl core::marker::Send for bitcoin::p2p::message::RawNetworkMessage
+impl core::marker::Send for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::marker::Send for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::marker::Send for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::Send for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::Send for bitcoin::p2p::message_bloom::FilterAdd
+impl core::marker::Send for bitcoin::p2p::message_bloom::FilterLoad
+impl core::marker::Send for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::marker::Send for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::marker::Send for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::marker::Send for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::Send for bitcoin::p2p::message_filter::CFCheckpt
+impl core::marker::Send for bitcoin::p2p::message_filter::CFHeaders
+impl core::marker::Send for bitcoin::p2p::message_filter::CFilter
+impl core::marker::Send for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::marker::Send for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::marker::Send for bitcoin::p2p::message_filter::GetCFilters
+impl core::marker::Send for bitcoin::p2p::message_network::Reject
+impl core::marker::Send for bitcoin::p2p::message_network::RejectReason
+impl core::marker::Send for bitcoin::p2p::message_network::VersionMessage
+impl core::marker::Send for bitcoin::pow::CompactTarget
+impl core::marker::Send for bitcoin::pow::Target
+impl core::marker::Send for bitcoin::pow::TryFromError
+impl core::marker::Send for bitcoin::pow::Work
+impl core::marker::Send for bitcoin::psbt::Error
+impl core::marker::Send for bitcoin::psbt::ExtractTxError
+impl core::marker::Send for bitcoin::psbt::GetKeyError
+impl core::marker::Send for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Send for bitcoin::psbt::Input
+impl core::marker::Send for bitcoin::psbt::KeyRequest
+impl core::marker::Send for bitcoin::psbt::Output
+impl core::marker::Send for bitcoin::psbt::OutputType
+impl core::marker::Send for bitcoin::psbt::Psbt
+impl core::marker::Send for bitcoin::psbt::PsbtParseError
+impl core::marker::Send for bitcoin::psbt::PsbtSighashType
+impl core::marker::Send for bitcoin::psbt::SignError
+impl core::marker::Send for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Send for bitcoin::psbt::raw::Key
+impl core::marker::Send for bitcoin::psbt::raw::Pair
+impl core::marker::Send for bitcoin::sighash::AnnexError
+impl core::marker::Send for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Send for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Send for bitcoin::sighash::P2wpkhError
+impl core::marker::Send for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Send for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Send for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Send for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Send for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Send for bitcoin::sighash::TaprootError
+impl core::marker::Send for bitcoin::sign_message::MessageSignature
+impl core::marker::Send for bitcoin::sign_message::MessageSignatureError
+impl core::marker::Send for bitcoin::taproot::ControlBlock
+impl core::marker::Send for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Send for bitcoin::taproot::HiddenNodesError
+impl core::marker::Send for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Send for bitcoin::taproot::LeafNode
+impl core::marker::Send for bitcoin::taproot::LeafVersion
+impl core::marker::Send for bitcoin::taproot::NodeInfo
+impl core::marker::Send for bitcoin::taproot::SigFromSliceError
+impl core::marker::Send for bitcoin::taproot::Signature
+impl core::marker::Send for bitcoin::taproot::TapBranchTag
+impl core::marker::Send for bitcoin::taproot::TapLeaf
+impl core::marker::Send for bitcoin::taproot::TapLeafHash
+impl core::marker::Send for bitcoin::taproot::TapLeafTag
+impl core::marker::Send for bitcoin::taproot::TapNodeHash
+impl core::marker::Send for bitcoin::taproot::TapTree
+impl core::marker::Send for bitcoin::taproot::TapTweakHash
+impl core::marker::Send for bitcoin::taproot::TapTweakTag
+impl core::marker::Send for bitcoin::taproot::TaprootBuilder
+impl core::marker::Send for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Send for bitcoin::taproot::TaprootError
+impl core::marker::Send for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Send for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Send for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Send for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Send for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::StructuralPartialEq for bitcoin::CompressedPublicKey
+impl core::marker::StructuralPartialEq for bitcoin::EcdsaSighashType
+impl core::marker::StructuralPartialEq for bitcoin::LegacySighash
+impl core::marker::StructuralPartialEq for bitcoin::MerkleBlock
+impl core::marker::StructuralPartialEq for bitcoin::PrivateKey
+impl core::marker::StructuralPartialEq for bitcoin::PubkeyHash
+impl core::marker::StructuralPartialEq for bitcoin::PublicKey
+impl core::marker::StructuralPartialEq for bitcoin::SegwitV0Sighash
+impl core::marker::StructuralPartialEq for bitcoin::TapSighash
+impl core::marker::StructuralPartialEq for bitcoin::TapSighashTag
+impl core::marker::StructuralPartialEq for bitcoin::TapSighashType
+impl core::marker::StructuralPartialEq for bitcoin::WPubkeyHash
+impl core::marker::StructuralPartialEq for bitcoin::address::AddressType
+impl core::marker::StructuralPartialEq for bitcoin::address::KnownHrp
+impl core::marker::StructuralPartialEq for bitcoin::address::NetworkChecked
+impl core::marker::StructuralPartialEq for bitcoin::address::NetworkUnchecked
+impl core::marker::StructuralPartialEq for bitcoin::address::error::Error
+impl core::marker::StructuralPartialEq for bitcoin::address::error::ParseError
+impl core::marker::StructuralPartialEq for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::StructuralPartialEq for bitcoin::address::error::UnknownHrpError
+impl core::marker::StructuralPartialEq for bitcoin::base58::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip152::BlockTransactions
+impl core::marker::StructuralPartialEq for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::StructuralPartialEq for bitcoin::bip152::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::StructuralPartialEq for bitcoin::bip152::PrefilledTransaction
+impl core::marker::StructuralPartialEq for bitcoin::bip152::ShortId
+impl core::marker::StructuralPartialEq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin::bip158::BlockFilter
+impl core::marker::StructuralPartialEq for bitcoin::bip158::FilterHash
+impl core::marker::StructuralPartialEq for bitcoin::bip158::FilterHeader
+impl core::marker::StructuralPartialEq for bitcoin::bip32::ChainCode
+impl core::marker::StructuralPartialEq for bitcoin::bip32::ChildNumber
+impl core::marker::StructuralPartialEq for bitcoin::bip32::DerivationPath
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Fingerprint
+impl core::marker::StructuralPartialEq for bitcoin::bip32::XKeyIdentifier
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Xpriv
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Xpub
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Bip34Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Block
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Header
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::ValidationError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Version
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::constants::ChainHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::Class
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Builder
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytes
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytesError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Script
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::ScriptHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::WScriptHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Sequence
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Transaction
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::TxIn
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::TxOut
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::weight::Weight
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::witness::Witness
+impl core::marker::StructuralPartialEq for bitcoin::consensus::encode::CheckedData
+impl core::marker::StructuralPartialEq for bitcoin::consensus::encode::VarInt
+impl core::marker::StructuralPartialEq for bitcoin::consensus::serde::hex::DecodeError
+impl core::marker::StructuralPartialEq for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::marker::StructuralPartialEq for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::marker::StructuralPartialEq for bitcoin::consensus::validation::TxVerifyError
+impl core::marker::StructuralPartialEq for bitcoin::ecdsa::Error
+impl core::marker::StructuralPartialEq for bitcoin::ecdsa::Signature
+impl core::marker::StructuralPartialEq for bitcoin::error::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin::key::Error
+impl core::marker::StructuralPartialEq for bitcoin::key::SortKey
+impl core::marker::StructuralPartialEq for bitcoin::key::TweakedKeypair
+impl core::marker::StructuralPartialEq for bitcoin::key::TweakedPublicKey
+impl core::marker::StructuralPartialEq for bitcoin::key::UncompressedPubkeyError
+impl core::marker::StructuralPartialEq for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::StructuralPartialEq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::StructuralPartialEq for bitcoin::network::Network
+impl core::marker::StructuralPartialEq for bitcoin::network::NetworkKind
+impl core::marker::StructuralPartialEq for bitcoin::network::ParseNetworkError
+impl core::marker::StructuralPartialEq for bitcoin::network::UnknownChainHashError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::Magic
+impl core::marker::StructuralPartialEq for bitcoin::p2p::ParseMagicError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::ServiceFlags
+impl core::marker::StructuralPartialEq for bitcoin::p2p::UnknownMagicError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::address::AddrV2
+impl core::marker::StructuralPartialEq for bitcoin::p2p::address::AddrV2Message
+impl core::marker::StructuralPartialEq for bitcoin::p2p::address::Address
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message::CommandString
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message::CommandStringError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message::NetworkMessage
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message::RawNetworkMessage
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_bloom::FilterAdd
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_bloom::FilterLoad
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::CFCheckpt
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::CFHeaders
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::CFilter
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::GetCFilters
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_network::Reject
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_network::RejectReason
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_network::VersionMessage
+impl core::marker::StructuralPartialEq for bitcoin::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin::pow::Target
+impl core::marker::StructuralPartialEq for bitcoin::pow::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin::pow::Work
+impl core::marker::StructuralPartialEq for bitcoin::psbt::ExtractTxError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::GetKeyError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Input
+impl core::marker::StructuralPartialEq for bitcoin::psbt::KeyRequest
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Output
+impl core::marker::StructuralPartialEq for bitcoin::psbt::OutputType
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Psbt
+impl core::marker::StructuralPartialEq for bitcoin::psbt::PsbtSighashType
+impl core::marker::StructuralPartialEq for bitcoin::psbt::SignError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::SigningAlgorithm
+impl core::marker::StructuralPartialEq for bitcoin::psbt::raw::Key
+impl core::marker::StructuralPartialEq for bitcoin::psbt::raw::Pair
+impl core::marker::StructuralPartialEq for bitcoin::sighash::AnnexError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::P2wpkhError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsKindError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::SighashTypeParseError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::TaprootError
+impl core::marker::StructuralPartialEq for bitcoin::sign_message::MessageSignature
+impl core::marker::StructuralPartialEq for bitcoin::sign_message::MessageSignatureError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::ControlBlock
+impl core::marker::StructuralPartialEq for bitcoin::taproot::FutureLeafVersion
+impl core::marker::StructuralPartialEq for bitcoin::taproot::HiddenNodesError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::LeafNode
+impl core::marker::StructuralPartialEq for bitcoin::taproot::LeafVersion
+impl core::marker::StructuralPartialEq for bitcoin::taproot::SigFromSliceError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::Signature
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapBranchTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeaf
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeafHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeafTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapNodeHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTree
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTweakHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTweakTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootBuilder
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootBuilderError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::StructuralPartialEq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Sync for bitcoin::CompressedPublicKey
+impl core::marker::Sync for bitcoin::EcdsaSighashType
+impl core::marker::Sync for bitcoin::LegacySighash
+impl core::marker::Sync for bitcoin::MerkleBlock
+impl core::marker::Sync for bitcoin::PrivateKey
+impl core::marker::Sync for bitcoin::PubkeyHash
+impl core::marker::Sync for bitcoin::PublicKey
+impl core::marker::Sync for bitcoin::SegwitV0Sighash
+impl core::marker::Sync for bitcoin::TapSighash
+impl core::marker::Sync for bitcoin::TapSighashTag
+impl core::marker::Sync for bitcoin::TapSighashType
+impl core::marker::Sync for bitcoin::WPubkeyHash
+impl core::marker::Sync for bitcoin::address::AddressType
+impl core::marker::Sync for bitcoin::address::KnownHrp
+impl core::marker::Sync for bitcoin::address::NetworkChecked
+impl core::marker::Sync for bitcoin::address::NetworkUnchecked
+impl core::marker::Sync for bitcoin::address::error::Error
+impl core::marker::Sync for bitcoin::address::error::ParseError
+impl core::marker::Sync for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Sync for bitcoin::address::error::UnknownHrpError
+impl core::marker::Sync for bitcoin::base58::Error
+impl core::marker::Sync for bitcoin::bip152::BlockTransactions
+impl core::marker::Sync for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Sync for bitcoin::bip152::Error
+impl core::marker::Sync for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Sync for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Sync for bitcoin::bip152::ShortId
+impl core::marker::Sync for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Sync for bitcoin::bip158::BlockFilter
+impl core::marker::Sync for bitcoin::bip158::BlockFilterReader
+impl core::marker::Sync for bitcoin::bip158::Error
+impl core::marker::Sync for bitcoin::bip158::FilterHash
+impl core::marker::Sync for bitcoin::bip158::FilterHeader
+impl core::marker::Sync for bitcoin::bip158::GcsFilterReader
+impl core::marker::Sync for bitcoin::bip32::ChainCode
+impl core::marker::Sync for bitcoin::bip32::ChildNumber
+impl core::marker::Sync for bitcoin::bip32::DerivationPath
+impl core::marker::Sync for bitcoin::bip32::Error
+impl core::marker::Sync for bitcoin::bip32::Fingerprint
+impl core::marker::Sync for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Sync for bitcoin::bip32::Xpriv
+impl core::marker::Sync for bitcoin::bip32::Xpub
+impl core::marker::Sync for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Sync for bitcoin::blockdata::block::Block
+impl core::marker::Sync for bitcoin::blockdata::block::BlockHash
+impl core::marker::Sync for bitcoin::blockdata::block::Header
+impl core::marker::Sync for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Sync for bitcoin::blockdata::block::ValidationError
+impl core::marker::Sync for bitcoin::blockdata::block::Version
+impl core::marker::Sync for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Sync for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Sync for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Sync for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Sync for bitcoin::blockdata::opcodes::Class
+impl core::marker::Sync for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Sync for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Sync for bitcoin::blockdata::script::Builder
+impl core::marker::Sync for bitcoin::blockdata::script::Error
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytes
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Sync for bitcoin::blockdata::script::Script
+impl core::marker::Sync for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Sync for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Sync for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Sync for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Sync for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Sync for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Sync for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Sync for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Sync for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Sync for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Sync for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Sync for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Sync for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Sync for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Sync for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Sync for bitcoin::blockdata::transaction::Txid
+impl core::marker::Sync for bitcoin::blockdata::transaction::Version
+impl core::marker::Sync for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Sync for bitcoin::blockdata::weight::Weight
+impl core::marker::Sync for bitcoin::blockdata::witness::Witness
+impl core::marker::Sync for bitcoin::consensus::encode::CheckedData
+impl core::marker::Sync for bitcoin::consensus::encode::Error
+impl core::marker::Sync for bitcoin::consensus::encode::VarInt
+impl core::marker::Sync for bitcoin::consensus::params::Params
+impl core::marker::Sync for bitcoin::consensus::serde::hex::DecodeError
+impl core::marker::Sync for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::marker::Sync for bitcoin::consensus::serde::hex::Lower
+impl core::marker::Sync for bitcoin::consensus::serde::hex::Upper
+impl core::marker::Sync for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::marker::Sync for bitcoin::consensus::validation::TxVerifyError
+impl core::marker::Sync for bitcoin::ecdsa::Error
+impl core::marker::Sync for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Sync for bitcoin::ecdsa::Signature
+impl core::marker::Sync for bitcoin::error::ParseIntError
+impl core::marker::Sync for bitcoin::key::Error
+impl core::marker::Sync for bitcoin::key::SortKey
+impl core::marker::Sync for bitcoin::key::TweakedKeypair
+impl core::marker::Sync for bitcoin::key::TweakedPublicKey
+impl core::marker::Sync for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Sync for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Sync for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Sync for bitcoin::network::Network
+impl core::marker::Sync for bitcoin::network::NetworkKind
+impl core::marker::Sync for bitcoin::network::ParseNetworkError
+impl core::marker::Sync for bitcoin::network::UnknownChainHashError
+impl core::marker::Sync for bitcoin::p2p::Magic
+impl core::marker::Sync for bitcoin::p2p::ParseMagicError
+impl core::marker::Sync for bitcoin::p2p::ServiceFlags
+impl core::marker::Sync for bitcoin::p2p::UnknownMagicError
+impl core::marker::Sync for bitcoin::p2p::address::AddrV2
+impl core::marker::Sync for bitcoin::p2p::address::AddrV2Message
+impl core::marker::Sync for bitcoin::p2p::address::Address
+impl core::marker::Sync for bitcoin::p2p::message::CommandString
+impl core::marker::Sync for bitcoin::p2p::message::CommandStringError
+impl core::marker::Sync for bitcoin::p2p::message::NetworkMessage
+impl core::marker::Sync for bitcoin::p2p::message::RawNetworkMessage
+impl core::marker::Sync for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::marker::Sync for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::marker::Sync for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::Sync for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::Sync for bitcoin::p2p::message_bloom::FilterAdd
+impl core::marker::Sync for bitcoin::p2p::message_bloom::FilterLoad
+impl core::marker::Sync for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::marker::Sync for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::marker::Sync for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::marker::Sync for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::Sync for bitcoin::p2p::message_filter::CFCheckpt
+impl core::marker::Sync for bitcoin::p2p::message_filter::CFHeaders
+impl core::marker::Sync for bitcoin::p2p::message_filter::CFilter
+impl core::marker::Sync for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::marker::Sync for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::marker::Sync for bitcoin::p2p::message_filter::GetCFilters
+impl core::marker::Sync for bitcoin::p2p::message_network::Reject
+impl core::marker::Sync for bitcoin::p2p::message_network::RejectReason
+impl core::marker::Sync for bitcoin::p2p::message_network::VersionMessage
+impl core::marker::Sync for bitcoin::pow::CompactTarget
+impl core::marker::Sync for bitcoin::pow::Target
+impl core::marker::Sync for bitcoin::pow::TryFromError
+impl core::marker::Sync for bitcoin::pow::Work
+impl core::marker::Sync for bitcoin::psbt::Error
+impl core::marker::Sync for bitcoin::psbt::ExtractTxError
+impl core::marker::Sync for bitcoin::psbt::GetKeyError
+impl core::marker::Sync for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Sync for bitcoin::psbt::Input
+impl core::marker::Sync for bitcoin::psbt::KeyRequest
+impl core::marker::Sync for bitcoin::psbt::Output
+impl core::marker::Sync for bitcoin::psbt::OutputType
+impl core::marker::Sync for bitcoin::psbt::Psbt
+impl core::marker::Sync for bitcoin::psbt::PsbtParseError
+impl core::marker::Sync for bitcoin::psbt::PsbtSighashType
+impl core::marker::Sync for bitcoin::psbt::SignError
+impl core::marker::Sync for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Sync for bitcoin::psbt::raw::Key
+impl core::marker::Sync for bitcoin::psbt::raw::Pair
+impl core::marker::Sync for bitcoin::sighash::AnnexError
+impl core::marker::Sync for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Sync for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Sync for bitcoin::sighash::P2wpkhError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Sync for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Sync for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Sync for bitcoin::sighash::TaprootError
+impl core::marker::Sync for bitcoin::sign_message::MessageSignature
+impl core::marker::Sync for bitcoin::sign_message::MessageSignatureError
+impl core::marker::Sync for bitcoin::taproot::ControlBlock
+impl core::marker::Sync for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Sync for bitcoin::taproot::HiddenNodesError
+impl core::marker::Sync for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Sync for bitcoin::taproot::LeafNode
+impl core::marker::Sync for bitcoin::taproot::LeafVersion
+impl core::marker::Sync for bitcoin::taproot::NodeInfo
+impl core::marker::Sync for bitcoin::taproot::SigFromSliceError
+impl core::marker::Sync for bitcoin::taproot::Signature
+impl core::marker::Sync for bitcoin::taproot::TapBranchTag
+impl core::marker::Sync for bitcoin::taproot::TapLeaf
+impl core::marker::Sync for bitcoin::taproot::TapLeafHash
+impl core::marker::Sync for bitcoin::taproot::TapLeafTag
+impl core::marker::Sync for bitcoin::taproot::TapNodeHash
+impl core::marker::Sync for bitcoin::taproot::TapTree
+impl core::marker::Sync for bitcoin::taproot::TapTweakHash
+impl core::marker::Sync for bitcoin::taproot::TapTweakTag
+impl core::marker::Sync for bitcoin::taproot::TaprootBuilder
+impl core::marker::Sync for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Sync for bitcoin::taproot::TaprootError
+impl core::marker::Sync for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Sync for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Sync for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Sync for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Sync for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::Unpin for bitcoin::CompressedPublicKey
+impl core::marker::Unpin for bitcoin::EcdsaSighashType
+impl core::marker::Unpin for bitcoin::LegacySighash
+impl core::marker::Unpin for bitcoin::MerkleBlock
+impl core::marker::Unpin for bitcoin::PrivateKey
+impl core::marker::Unpin for bitcoin::PubkeyHash
+impl core::marker::Unpin for bitcoin::PublicKey
+impl core::marker::Unpin for bitcoin::SegwitV0Sighash
+impl core::marker::Unpin for bitcoin::TapSighash
+impl core::marker::Unpin for bitcoin::TapSighashTag
+impl core::marker::Unpin for bitcoin::TapSighashType
+impl core::marker::Unpin for bitcoin::WPubkeyHash
+impl core::marker::Unpin for bitcoin::address::AddressType
+impl core::marker::Unpin for bitcoin::address::KnownHrp
+impl core::marker::Unpin for bitcoin::address::NetworkChecked
+impl core::marker::Unpin for bitcoin::address::NetworkUnchecked
+impl core::marker::Unpin for bitcoin::address::error::Error
+impl core::marker::Unpin for bitcoin::address::error::ParseError
+impl core::marker::Unpin for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Unpin for bitcoin::address::error::UnknownHrpError
+impl core::marker::Unpin for bitcoin::base58::Error
+impl core::marker::Unpin for bitcoin::bip152::BlockTransactions
+impl core::marker::Unpin for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Unpin for bitcoin::bip152::Error
+impl core::marker::Unpin for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Unpin for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Unpin for bitcoin::bip152::ShortId
+impl core::marker::Unpin for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Unpin for bitcoin::bip158::BlockFilter
+impl core::marker::Unpin for bitcoin::bip158::BlockFilterReader
+impl core::marker::Unpin for bitcoin::bip158::Error
+impl core::marker::Unpin for bitcoin::bip158::FilterHash
+impl core::marker::Unpin for bitcoin::bip158::FilterHeader
+impl core::marker::Unpin for bitcoin::bip158::GcsFilterReader
+impl core::marker::Unpin for bitcoin::bip32::ChainCode
+impl core::marker::Unpin for bitcoin::bip32::ChildNumber
+impl core::marker::Unpin for bitcoin::bip32::DerivationPath
+impl core::marker::Unpin for bitcoin::bip32::Error
+impl core::marker::Unpin for bitcoin::bip32::Fingerprint
+impl core::marker::Unpin for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Unpin for bitcoin::bip32::Xpriv
+impl core::marker::Unpin for bitcoin::bip32::Xpub
+impl core::marker::Unpin for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Unpin for bitcoin::blockdata::block::Block
+impl core::marker::Unpin for bitcoin::blockdata::block::BlockHash
+impl core::marker::Unpin for bitcoin::blockdata::block::Header
+impl core::marker::Unpin for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Unpin for bitcoin::blockdata::block::ValidationError
+impl core::marker::Unpin for bitcoin::blockdata::block::Version
+impl core::marker::Unpin for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Unpin for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::Class
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Unpin for bitcoin::blockdata::script::Builder
+impl core::marker::Unpin for bitcoin::blockdata::script::Error
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytes
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Unpin for bitcoin::blockdata::script::Script
+impl core::marker::Unpin for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Unpin for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Unpin for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Unpin for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Unpin for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Unpin for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Unpin for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Unpin for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Txid
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Version
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Unpin for bitcoin::blockdata::weight::Weight
+impl core::marker::Unpin for bitcoin::blockdata::witness::Witness
+impl core::marker::Unpin for bitcoin::consensus::encode::CheckedData
+impl core::marker::Unpin for bitcoin::consensus::encode::Error
+impl core::marker::Unpin for bitcoin::consensus::encode::VarInt
+impl core::marker::Unpin for bitcoin::consensus::params::Params
+impl core::marker::Unpin for bitcoin::consensus::serde::hex::DecodeError
+impl core::marker::Unpin for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::marker::Unpin for bitcoin::consensus::serde::hex::Lower
+impl core::marker::Unpin for bitcoin::consensus::serde::hex::Upper
+impl core::marker::Unpin for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::marker::Unpin for bitcoin::consensus::validation::TxVerifyError
+impl core::marker::Unpin for bitcoin::ecdsa::Error
+impl core::marker::Unpin for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Unpin for bitcoin::ecdsa::Signature
+impl core::marker::Unpin for bitcoin::error::ParseIntError
+impl core::marker::Unpin for bitcoin::key::Error
+impl core::marker::Unpin for bitcoin::key::SortKey
+impl core::marker::Unpin for bitcoin::key::TweakedKeypair
+impl core::marker::Unpin for bitcoin::key::TweakedPublicKey
+impl core::marker::Unpin for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Unpin for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Unpin for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Unpin for bitcoin::network::Network
+impl core::marker::Unpin for bitcoin::network::NetworkKind
+impl core::marker::Unpin for bitcoin::network::ParseNetworkError
+impl core::marker::Unpin for bitcoin::network::UnknownChainHashError
+impl core::marker::Unpin for bitcoin::p2p::Magic
+impl core::marker::Unpin for bitcoin::p2p::ParseMagicError
+impl core::marker::Unpin for bitcoin::p2p::ServiceFlags
+impl core::marker::Unpin for bitcoin::p2p::UnknownMagicError
+impl core::marker::Unpin for bitcoin::p2p::address::AddrV2
+impl core::marker::Unpin for bitcoin::p2p::address::AddrV2Message
+impl core::marker::Unpin for bitcoin::p2p::address::Address
+impl core::marker::Unpin for bitcoin::p2p::message::CommandString
+impl core::marker::Unpin for bitcoin::p2p::message::CommandStringError
+impl core::marker::Unpin for bitcoin::p2p::message::NetworkMessage
+impl core::marker::Unpin for bitcoin::p2p::message::RawNetworkMessage
+impl core::marker::Unpin for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::marker::Unpin for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::marker::Unpin for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::Unpin for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::Unpin for bitcoin::p2p::message_bloom::FilterAdd
+impl core::marker::Unpin for bitcoin::p2p::message_bloom::FilterLoad
+impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::Unpin for bitcoin::p2p::message_filter::CFCheckpt
+impl core::marker::Unpin for bitcoin::p2p::message_filter::CFHeaders
+impl core::marker::Unpin for bitcoin::p2p::message_filter::CFilter
+impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFilters
+impl core::marker::Unpin for bitcoin::p2p::message_network::Reject
+impl core::marker::Unpin for bitcoin::p2p::message_network::RejectReason
+impl core::marker::Unpin for bitcoin::p2p::message_network::VersionMessage
+impl core::marker::Unpin for bitcoin::pow::CompactTarget
+impl core::marker::Unpin for bitcoin::pow::Target
+impl core::marker::Unpin for bitcoin::pow::TryFromError
+impl core::marker::Unpin for bitcoin::pow::Work
+impl core::marker::Unpin for bitcoin::psbt::Error
+impl core::marker::Unpin for bitcoin::psbt::ExtractTxError
+impl core::marker::Unpin for bitcoin::psbt::GetKeyError
+impl core::marker::Unpin for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Unpin for bitcoin::psbt::Input
+impl core::marker::Unpin for bitcoin::psbt::KeyRequest
+impl core::marker::Unpin for bitcoin::psbt::Output
+impl core::marker::Unpin for bitcoin::psbt::OutputType
+impl core::marker::Unpin for bitcoin::psbt::Psbt
+impl core::marker::Unpin for bitcoin::psbt::PsbtParseError
+impl core::marker::Unpin for bitcoin::psbt::PsbtSighashType
+impl core::marker::Unpin for bitcoin::psbt::SignError
+impl core::marker::Unpin for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Unpin for bitcoin::psbt::raw::Key
+impl core::marker::Unpin for bitcoin::psbt::raw::Pair
+impl core::marker::Unpin for bitcoin::sighash::AnnexError
+impl core::marker::Unpin for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Unpin for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Unpin for bitcoin::sighash::P2wpkhError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Unpin for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Unpin for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Unpin for bitcoin::sighash::TaprootError
+impl core::marker::Unpin for bitcoin::sign_message::MessageSignature
+impl core::marker::Unpin for bitcoin::sign_message::MessageSignatureError
+impl core::marker::Unpin for bitcoin::taproot::ControlBlock
+impl core::marker::Unpin for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Unpin for bitcoin::taproot::HiddenNodesError
+impl core::marker::Unpin for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Unpin for bitcoin::taproot::LeafNode
+impl core::marker::Unpin for bitcoin::taproot::LeafVersion
+impl core::marker::Unpin for bitcoin::taproot::NodeInfo
+impl core::marker::Unpin for bitcoin::taproot::SigFromSliceError
+impl core::marker::Unpin for bitcoin::taproot::Signature
+impl core::marker::Unpin for bitcoin::taproot::TapBranchTag
+impl core::marker::Unpin for bitcoin::taproot::TapLeaf
+impl core::marker::Unpin for bitcoin::taproot::TapLeafHash
+impl core::marker::Unpin for bitcoin::taproot::TapLeafTag
+impl core::marker::Unpin for bitcoin::taproot::TapNodeHash
+impl core::marker::Unpin for bitcoin::taproot::TapTree
+impl core::marker::Unpin for bitcoin::taproot::TapTweakHash
+impl core::marker::Unpin for bitcoin::taproot::TapTweakTag
+impl core::marker::Unpin for bitcoin::taproot::TaprootBuilder
+impl core::marker::Unpin for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Unpin for bitcoin::taproot::TaprootError
+impl core::marker::Unpin for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Unpin for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Unpin for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Unpin for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Unpin for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::ops::arith::Add for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Add for bitcoin::pow::Work
+impl core::ops::arith::AddAssign for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Div for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Div<bitcoin::blockdata::weight::Weight> for bitcoin_units::amount::Amount
+impl core::ops::arith::Div<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::DivAssign<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Mul<bitcoin::blockdata::fee_rate::FeeRate> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Mul<bitcoin::blockdata::weight::Weight> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::ops::arith::Mul<bitcoin::blockdata::weight::Weight> for u64
+impl core::ops::arith::Mul<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::MulAssign<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Sub for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Sub for bitcoin::pow::Work
+impl core::ops::arith::SubAssign for bitcoin::blockdata::weight::Weight
+impl core::ops::bit::BitOr for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitOrAssign for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitXor for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitXorAssign for bitcoin::p2p::ServiceFlags
+impl core::ops::deref::Deref for bitcoin::blockdata::script::PushBytesBuf
+impl core::ops::deref::Deref for bitcoin::blockdata::script::ScriptBuf
+impl core::ops::deref::Deref for bitcoin::ecdsa::SerializedSignature
+impl core::ops::deref::Deref for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::ops::deref::Deref for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::ops::deref::DerefMut for bitcoin::blockdata::script::PushBytesBuf
+impl core::ops::deref::DerefMut for bitcoin::blockdata::script::ScriptBuf
+impl core::ops::deref::DerefMut for bitcoin::ecdsa::SerializedSignature
+impl core::ops::deref::DerefMut for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::PrivateKey
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<usize> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<usize> for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::CompressedPublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::EcdsaSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::LegacySighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::MerkleBlock
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PrivateKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PubkeyHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::SegwitV0Sighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighashTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::WPubkeyHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::AddressType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::KnownHrp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::NetworkChecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::NetworkUnchecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::UnknownAddressTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::UnknownHrpError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::base58::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::BlockTransactions
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::BlockTransactionsRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::HeaderAndShortIds
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::PrefilledTransaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::ShortId
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilterReader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::FilterHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::FilterHeader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::GcsFilterReader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::ChainCode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::ChildNumber
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::DerivationPath
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Fingerprint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::XKeyIdentifier
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Xpriv
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Xpub
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Bip34Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Block
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::ValidationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::constants::ChainHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::Class
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::Opcode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Builder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytes
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytesBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Script
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::ScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::WScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_program::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::InputsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Sequence
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Transaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::TxIn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::TxOut
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::weight::Weight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::CheckedData
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::VarInt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::params::Params
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::DecodeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::Lower
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::Upper
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::validation::TxVerifyError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::SerializedSignature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::Signature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::error::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::SortKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::TweakedKeypair
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::TweakedPublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::UncompressedPubkeyError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::merkle_tree::MerkleBlockError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::merkle_tree::PartialMerkleTree
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::Network
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::NetworkKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::ParseNetworkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::UnknownChainHashError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::Magic
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::ParseMagicError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::ServiceFlags
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::UnknownMagicError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::AddrV2
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::AddrV2Message
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::Address
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::CommandString
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::CommandStringError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::NetworkMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::RawNetworkMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::Inventory
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::BloomFlags
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::FilterAdd
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::FilterLoad
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFCheckpt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFHeaders
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFilter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFilters
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::Reject
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::RejectReason
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::VersionMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::Target
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::Work
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::ExtractTxError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::GetKeyError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::IndexOutOfBoundsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Input
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::KeyRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Output
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::OutputType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Psbt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::PsbtSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SignError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SigningAlgorithm
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::Key
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::Pair
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::AnnexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::InvalidSighashTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::NonStandardSighashTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::P2wpkhError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsKindError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsSizeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SighashTypeParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SingleMissingOutputError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::TaprootError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sign_message::MessageSignature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sign_message::MessageSignatureError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ControlBlock
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::FutureLeafVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::HiddenNodesError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::IncompleteBuilderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::NodeInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::SigFromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::Signature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapBranchTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeaf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeafHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeafTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapNodeHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTree
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTweakHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTweakTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootBuilder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootBuilderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootSpendInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::merkle_branch::IntoIter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::serialized_signature::IntoIter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::CompressedPublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::EcdsaSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::LegacySighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::MerkleBlock
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PrivateKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PubkeyHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::SegwitV0Sighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighashTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::WPubkeyHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::AddressType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::KnownHrp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::NetworkChecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::NetworkUnchecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::UnknownAddressTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::UnknownHrpError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::base58::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::BlockTransactions
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::BlockTransactionsRequest
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::HeaderAndShortIds
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::PrefilledTransaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::ShortId
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilterReader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::FilterHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::FilterHeader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::GcsFilterReader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::ChainCode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::ChildNumber
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::DerivationPath
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Fingerprint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::XKeyIdentifier
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Xpriv
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Xpub
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Bip34Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Block
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::ValidationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::constants::ChainHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::fee_rate::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::Class
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::Opcode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Builder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytes
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytesBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytesError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Script
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::ScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::WScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_program::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::InputsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Sequence
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Transaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::TxIn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::TxOut
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::weight::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::CheckedData
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::VarInt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::params::Params
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::DecodeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::DecodeInitError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::Lower
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::Upper
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::validation::BitcoinconsensusError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::validation::TxVerifyError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::SerializedSignature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::Signature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::error::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::SortKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::TweakedKeypair
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::TweakedPublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::UncompressedPubkeyError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::merkle_tree::MerkleBlockError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::merkle_tree::PartialMerkleTree
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::Network
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::NetworkKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::ParseNetworkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::UnknownChainHashError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::Magic
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::ParseMagicError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::ServiceFlags
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::UnknownMagicError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::AddrV2
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::AddrV2Message
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::Address
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::CommandString
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::CommandStringError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::NetworkMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::RawNetworkMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::Inventory
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::BloomFlags
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::FilterAdd
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::FilterLoad
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFCheckpt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFHeaders
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFilter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFilters
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::Reject
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::RejectReason
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::VersionMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::Target
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::Work
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::ExtractTxError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::GetKeyError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::IndexOutOfBoundsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Input
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::KeyRequest
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Output
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::OutputType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Psbt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::PsbtSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SignError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SigningAlgorithm
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::Key
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::Pair
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::AnnexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::InvalidSighashTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::NonStandardSighashTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::P2wpkhError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsKindError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsSizeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SighashTypeParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SingleMissingOutputError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::TaprootError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sign_message::MessageSignature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sign_message::MessageSignatureError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ControlBlock
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::FutureLeafVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::HiddenNodesError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::IncompleteBuilderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::NodeInfo
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::SigFromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::Signature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapBranchTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeaf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeafHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeafTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapNodeHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTree
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTweakHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTweakTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootBuilder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootBuilderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootSpendInfo
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::merkle_branch::IntoIter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::serialized_signature::IntoIter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::str::traits::FromStr for bitcoin::CompressedPublicKey
+impl core::str::traits::FromStr for bitcoin::EcdsaSighashType
+impl core::str::traits::FromStr for bitcoin::LegacySighash
+impl core::str::traits::FromStr for bitcoin::PrivateKey
+impl core::str::traits::FromStr for bitcoin::PubkeyHash
+impl core::str::traits::FromStr for bitcoin::PublicKey
+impl core::str::traits::FromStr for bitcoin::SegwitV0Sighash
+impl core::str::traits::FromStr for bitcoin::TapSighash
+impl core::str::traits::FromStr for bitcoin::TapSighashType
+impl core::str::traits::FromStr for bitcoin::WPubkeyHash
+impl core::str::traits::FromStr for bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+impl core::str::traits::FromStr for bitcoin::address::AddressType
+impl core::str::traits::FromStr for bitcoin::bip152::ShortId
+impl core::str::traits::FromStr for bitcoin::bip158::FilterHash
+impl core::str::traits::FromStr for bitcoin::bip158::FilterHeader
+impl core::str::traits::FromStr for bitcoin::bip32::ChainCode
+impl core::str::traits::FromStr for bitcoin::bip32::ChildNumber
+impl core::str::traits::FromStr for bitcoin::bip32::DerivationPath
+impl core::str::traits::FromStr for bitcoin::bip32::Fingerprint
+impl core::str::traits::FromStr for bitcoin::bip32::XKeyIdentifier
+impl core::str::traits::FromStr for bitcoin::bip32::Xpriv
+impl core::str::traits::FromStr for bitcoin::bip32::Xpub
+impl core::str::traits::FromStr for bitcoin::blockdata::block::BlockHash
+impl core::str::traits::FromStr for bitcoin::blockdata::block::TxMerkleNode
+impl core::str::traits::FromStr for bitcoin::blockdata::block::WitnessCommitment
+impl core::str::traits::FromStr for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin::blockdata::constants::ChainHash
+impl core::str::traits::FromStr for bitcoin::blockdata::fee_rate::FeeRate
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::Time
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::relative::Height
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::relative::Time
+impl core::str::traits::FromStr for bitcoin::blockdata::script::ScriptHash
+impl core::str::traits::FromStr for bitcoin::blockdata::script::WScriptHash
+impl core::str::traits::FromStr for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::OutPoint
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Sequence
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Txid
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Wtxid
+impl core::str::traits::FromStr for bitcoin::blockdata::weight::Weight
+impl core::str::traits::FromStr for bitcoin::ecdsa::Signature
+impl core::str::traits::FromStr for bitcoin::network::Network
+impl core::str::traits::FromStr for bitcoin::p2p::Magic
+impl core::str::traits::FromStr for bitcoin::p2p::message::CommandString
+impl core::str::traits::FromStr for bitcoin::psbt::Psbt
+impl core::str::traits::FromStr for bitcoin::psbt::PsbtSighashType
+impl core::str::traits::FromStr for bitcoin::sign_message::MessageSignature
+impl core::str::traits::FromStr for bitcoin::taproot::TapLeafHash
+impl core::str::traits::FromStr for bitcoin::taproot::TapNodeHash
+impl core::str::traits::FromStr for bitcoin::taproot::TapTweakHash
+impl hex_conservative::parse::FromHex for bitcoin::bip152::ShortId
+impl hex_conservative::parse::FromHex for bitcoin::bip32::ChainCode
+impl hex_conservative::parse::FromHex for bitcoin::bip32::Fingerprint
+impl hex_conservative::parse::FromHex for bitcoin::blockdata::constants::ChainHash
+impl ordered::ArbitraryOrd for bitcoin::blockdata::locktime::absolute::LockTime
+impl secp256k1::ThirtyTwoByteHash for bitcoin::LegacySighash
+impl secp256k1::ThirtyTwoByteHash for bitcoin::SegwitV0Sighash
+impl secp256k1::ThirtyTwoByteHash for bitcoin::TapSighash
+impl serde::ser::Serialize for bitcoin::CompressedPublicKey
+impl serde::ser::Serialize for bitcoin::EcdsaSighashType
+impl serde::ser::Serialize for bitcoin::LegacySighash
+impl serde::ser::Serialize for bitcoin::PrivateKey
+impl serde::ser::Serialize for bitcoin::PubkeyHash
+impl serde::ser::Serialize for bitcoin::PublicKey
+impl serde::ser::Serialize for bitcoin::SegwitV0Sighash
+impl serde::ser::Serialize for bitcoin::TapSighash
+impl serde::ser::Serialize for bitcoin::TapSighashType
+impl serde::ser::Serialize for bitcoin::WPubkeyHash
+impl serde::ser::Serialize for bitcoin::bip152::ShortId
+impl serde::ser::Serialize for bitcoin::bip158::FilterHash
+impl serde::ser::Serialize for bitcoin::bip158::FilterHeader
+impl serde::ser::Serialize for bitcoin::bip32::ChainCode
+impl serde::ser::Serialize for bitcoin::bip32::ChildNumber
+impl serde::ser::Serialize for bitcoin::bip32::DerivationPath
+impl serde::ser::Serialize for bitcoin::bip32::Fingerprint
+impl serde::ser::Serialize for bitcoin::bip32::XKeyIdentifier
+impl serde::ser::Serialize for bitcoin::bip32::Xpriv
+impl serde::ser::Serialize for bitcoin::bip32::Xpub
+impl serde::ser::Serialize for bitcoin::blockdata::block::Block
+impl serde::ser::Serialize for bitcoin::blockdata::block::BlockHash
+impl serde::ser::Serialize for bitcoin::blockdata::block::Header
+impl serde::ser::Serialize for bitcoin::blockdata::block::TxMerkleNode
+impl serde::ser::Serialize for bitcoin::blockdata::block::Version
+impl serde::ser::Serialize for bitcoin::blockdata::block::WitnessCommitment
+impl serde::ser::Serialize for bitcoin::blockdata::block::WitnessMerkleNode
+impl serde::ser::Serialize for bitcoin::blockdata::constants::ChainHash
+impl serde::ser::Serialize for bitcoin::blockdata::fee_rate::FeeRate
+impl serde::ser::Serialize for bitcoin::blockdata::locktime::absolute::Height
+impl serde::ser::Serialize for bitcoin::blockdata::locktime::absolute::LockTime
+impl serde::ser::Serialize for bitcoin::blockdata::locktime::absolute::Time
+impl serde::ser::Serialize for bitcoin::blockdata::locktime::relative::Height
+impl serde::ser::Serialize for bitcoin::blockdata::locktime::relative::LockTime
+impl serde::ser::Serialize for bitcoin::blockdata::locktime::relative::Time
+impl serde::ser::Serialize for bitcoin::blockdata::opcodes::Opcode
+impl serde::ser::Serialize for bitcoin::blockdata::script::Script
+impl serde::ser::Serialize for bitcoin::blockdata::script::ScriptBuf
+impl serde::ser::Serialize for bitcoin::blockdata::script::ScriptHash
+impl serde::ser::Serialize for bitcoin::blockdata::script::WScriptHash
+impl serde::ser::Serialize for bitcoin::blockdata::transaction::OutPoint
+impl serde::ser::Serialize for bitcoin::blockdata::transaction::Sequence
+impl serde::ser::Serialize for bitcoin::blockdata::transaction::Transaction
+impl serde::ser::Serialize for bitcoin::blockdata::transaction::TxIn
+impl serde::ser::Serialize for bitcoin::blockdata::transaction::TxOut
+impl serde::ser::Serialize for bitcoin::blockdata::transaction::Txid
+impl serde::ser::Serialize for bitcoin::blockdata::transaction::Version
+impl serde::ser::Serialize for bitcoin::blockdata::transaction::Wtxid
+impl serde::ser::Serialize for bitcoin::blockdata::weight::Weight
+impl serde::ser::Serialize for bitcoin::blockdata::witness::Witness
+impl serde::ser::Serialize for bitcoin::ecdsa::Signature
+impl serde::ser::Serialize for bitcoin::key::TweakedKeypair
+impl serde::ser::Serialize for bitcoin::key::TweakedPublicKey
+impl serde::ser::Serialize for bitcoin::network::Network
+impl serde::ser::Serialize for bitcoin::pow::CompactTarget
+impl serde::ser::Serialize for bitcoin::pow::Target
+impl serde::ser::Serialize for bitcoin::pow::Work
+impl serde::ser::Serialize for bitcoin::psbt::Input
+impl serde::ser::Serialize for bitcoin::psbt::Output
+impl serde::ser::Serialize for bitcoin::psbt::Psbt
+impl serde::ser::Serialize for bitcoin::psbt::PsbtSighashType
+impl serde::ser::Serialize for bitcoin::psbt::raw::Key
+impl serde::ser::Serialize for bitcoin::psbt::raw::Pair
+impl serde::ser::Serialize for bitcoin::taproot::ControlBlock
+impl serde::ser::Serialize for bitcoin::taproot::LeafVersion
+impl serde::ser::Serialize for bitcoin::taproot::NodeInfo
+impl serde::ser::Serialize for bitcoin::taproot::Signature
+impl serde::ser::Serialize for bitcoin::taproot::TapLeaf
+impl serde::ser::Serialize for bitcoin::taproot::TapLeafHash
+impl serde::ser::Serialize for bitcoin::taproot::TapNodeHash
+impl serde::ser::Serialize for bitcoin::taproot::TapTree
+impl serde::ser::Serialize for bitcoin::taproot::TapTweakHash
+impl serde::ser::Serialize for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl std::net::socket_addr::ToSocketAddrs for bitcoin::p2p::address::AddrV2Message
+impl std::net::socket_addr::ToSocketAddrs for bitcoin::p2p::address::Address
+impl<'a, C: bitcoin::consensus::serde::hex::Case> bitcoin::consensus::serde::ByteDecoder<'a> for bitcoin::consensus::serde::Hex<C>
+impl<'a, R: bitcoin_io::BufRead + core::marker::Sized> bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, R: core::marker::Sized> core::marker::Send for bitcoin::bip158::BitStreamReader<'a, R> where R: core::marker::Send
+impl<'a, R: core::marker::Sized> core::marker::Sync for bitcoin::bip158::BitStreamReader<'a, R> where R: core::marker::Sync
+impl<'a, R: core::marker::Sized> core::marker::Unpin for bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, R: core::marker::Sized> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BitStreamReader<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for &'a T
+impl<'a, T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for &'a mut T
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> core::marker::Send for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Send for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Send for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Sync for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Sync for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Sync for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a> bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> bitcoin::bip32::IntoDerivationPath for &'a str
+impl<'a> bitcoin::blockdata::script::Instruction<'a>
+impl<'a> bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> bitcoin::blockdata::script::Instructions<'a>
+impl<'a> bitcoin::consensus::encode::Encodable for bitcoin::sighash::Annex<'a>
+impl<'a> bitcoin::sighash::Annex<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::clone::Clone for bitcoin::sighash::Annex<'a>
+impl<'a> core::cmp::Eq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::cmp::Eq for bitcoin::sighash::Annex<'a>
+impl<'a> core::cmp::PartialEq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::cmp::PartialEq for bitcoin::sighash::Annex<'a>
+impl<'a> core::convert::From<&'a [bitcoin::bip32::ChildNumber]> for bitcoin::bip32::DerivationPath
+impl<'a> core::convert::From<&'a [u8; 0]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 0]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 10]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 10]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 11]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 11]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 12]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 12]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 13]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 13]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 14]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 14]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 15]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 15]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 16]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 16]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 17]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 17]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 18]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 18]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 19]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 19]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 1]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 1]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 20]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 20]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 21]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 21]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 22]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 22]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 23]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 23]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 24]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 24]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 25]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 25]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 26]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 26]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 27]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 27]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 28]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 28]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 29]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 29]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 2]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 2]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 30]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 30]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 31]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 31]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 32]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 33]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 33]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 34]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 34]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 35]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 35]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 36]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 36]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 37]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 37]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 38]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 38]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 39]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 39]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 3]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 3]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 40]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 40]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 41]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 41]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 42]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 42]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 43]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 43]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 44]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 44]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 45]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 45]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 46]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 46]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 47]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 47]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 48]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 48]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 49]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 49]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 4]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 4]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::From<&'a [u8; 4]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 50]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 50]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 51]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 51]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 52]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 52]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 53]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 53]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 54]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 54]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 55]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 55]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 56]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 56]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 57]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 57]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 58]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 58]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 59]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 59]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 5]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 5]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 60]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 60]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 61]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 61]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 62]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 62]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 63]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 63]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 64]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 64]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 65]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 65]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 66]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 66]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 67]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 67]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 68]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 68]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 69]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 69]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 6]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 6]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::From<&'a [u8; 6]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 70]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 70]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 71]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 71]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 72]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 72]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 73]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 73]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 7]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 7]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 8]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 8]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 9]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 9]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::rc::Rc<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::sync::Arc<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::convert::From<&'a bitcoin::taproot::Signature> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl<'a> core::convert::From<&'a mut [u8; 0]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 10]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 11]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 12]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 13]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 14]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 15]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 16]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 17]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 18]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 19]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 1]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 20]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 21]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 22]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 23]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 24]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 25]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 26]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 27]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 28]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 29]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 2]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 30]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 31]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 32]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 33]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 34]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 35]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 36]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 37]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 38]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 39]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 3]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 40]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 41]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 42]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 43]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 44]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 45]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 46]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 47]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 48]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 49]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 4]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 50]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 51]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 52]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 53]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 54]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 55]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 56]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 57]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 58]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 59]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 5]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 60]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 61]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 62]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 63]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 64]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 65]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 66]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 67]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 68]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 69]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 6]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 70]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 71]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 72]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 73]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 7]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 8]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 9]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<[u8; 32]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::From<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::From<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::From<[u8; 6]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::convert::TryFrom<&'a [u8]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::TryFrom<&'a bitcoin::taproot::serialized_signature::SerializedSignature> for bitcoin::taproot::Signature
+impl<'a> core::convert::TryFrom<&'a mut [u8]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::TryFrom<&'a str> for bitcoin::p2p::message::CommandString
+impl<'a> core::convert::TryFrom<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::fmt::Debug for bitcoin::sighash::Annex<'a>
+impl<'a> core::hash::Hash for bitcoin::sighash::Annex<'a>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin::blockdata::weight::Weight> for bitcoin::blockdata::weight::Weight
+impl<'a> core::iter::traits::collect::Extend<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::iter::traits::collect::FromIterator<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::bip32::DerivationPath
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::blockdata::witness::Witness
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::ecdsa::SerializedSignature
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::taproot::serialized_signature::SerializedSignature
+impl<'a> core::iter::traits::collect::IntoIterator for &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl<'a> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::consensus::serde::hex::Decoder<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Copy for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Send for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Send for bitcoin::consensus::serde::hex::Decoder<'a>
+impl<'a> core::marker::Send for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Send for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::marker::StructuralPartialEq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::StructuralPartialEq for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Sync for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Sync for bitcoin::consensus::serde::hex::Decoder<'a>
+impl<'a> core::marker::Sync for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Sync for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::marker::Unpin for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Unpin for bitcoin::consensus::serde::hex::Decoder<'a>
+impl<'a> core::marker::Unpin for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Unpin for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::Decoder<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::Annex<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::Decoder<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::Annex<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafNodes<'a>
+impl<'de, Subtype> serde::de::Deserialize<'de> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + serde::de::Deserialize<'de>
+impl<'de> serde::de::Deserialize<'de> for &'de bitcoin::blockdata::script::Script
+impl<'de> serde::de::Deserialize<'de> for bitcoin::CompressedPublicKey
+impl<'de> serde::de::Deserialize<'de> for bitcoin::EcdsaSighashType
+impl<'de> serde::de::Deserialize<'de> for bitcoin::LegacySighash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::PrivateKey
+impl<'de> serde::de::Deserialize<'de> for bitcoin::PubkeyHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::PublicKey
+impl<'de> serde::de::Deserialize<'de> for bitcoin::SegwitV0Sighash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::TapSighash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::TapSighashType
+impl<'de> serde::de::Deserialize<'de> for bitcoin::WPubkeyHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip152::ShortId
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip158::FilterHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip158::FilterHeader
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::ChainCode
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::ChildNumber
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::DerivationPath
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::Fingerprint
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::XKeyIdentifier
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::Xpriv
+impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::Xpub
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::Block
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::BlockHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::Header
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::TxMerkleNode
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::Version
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::WitnessCommitment
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::WitnessMerkleNode
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::constants::ChainHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::fee_rate::FeeRate
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::locktime::absolute::Height
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::locktime::absolute::LockTime
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::locktime::absolute::Time
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::locktime::relative::Height
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::locktime::relative::LockTime
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::locktime::relative::Time
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::script::ScriptBuf
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::script::ScriptHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::script::WScriptHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::OutPoint
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Sequence
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Transaction
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::TxIn
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::TxOut
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Txid
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Version
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Wtxid
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::weight::Weight
+impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::witness::Witness
+impl<'de> serde::de::Deserialize<'de> for bitcoin::ecdsa::Signature
+impl<'de> serde::de::Deserialize<'de> for bitcoin::key::TweakedKeypair
+impl<'de> serde::de::Deserialize<'de> for bitcoin::key::TweakedPublicKey
+impl<'de> serde::de::Deserialize<'de> for bitcoin::network::Network
+impl<'de> serde::de::Deserialize<'de> for bitcoin::pow::CompactTarget
+impl<'de> serde::de::Deserialize<'de> for bitcoin::pow::Target
+impl<'de> serde::de::Deserialize<'de> for bitcoin::pow::Work
+impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::Input
+impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::Output
+impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::Psbt
+impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::PsbtSighashType
+impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::raw::Key
+impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::raw::Pair
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::ControlBlock
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::LeafVersion
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::NodeInfo
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::Signature
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapLeaf
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapLeafHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapNodeHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapTree
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapTweakHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl<'leaf> bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::clone::Clone for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::Eq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::Ord for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::PartialEq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::PartialOrd for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::fmt::Debug for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::hash::Hash for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Send for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::StructuralPartialEq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Sync for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Unpin for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'s> bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::clone::Clone for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::Eq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::Ord for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::PartialEq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::PartialOrd for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::convert::From<bitcoin::sighash::ScriptPath<'s>> for bitcoin::taproot::TapLeafHash
+impl<'s> core::fmt::Debug for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::hash::Hash for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Send for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::StructuralPartialEq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Sync for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Unpin for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::ScriptPath<'s>
+impl<'tree> core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::iterator::Iterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::marker::FusedIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::marker::FusedIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Send for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Sync for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Unpin for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'u, T> core::clone::Clone for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::clone::Clone
+impl<'u, T> core::cmp::Eq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::Eq
+impl<'u, T> core::cmp::Ord for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::Ord
+impl<'u, T> core::cmp::PartialEq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::PartialEq
+impl<'u, T> core::cmp::PartialOrd for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::PartialOrd
+impl<'u, T> core::fmt::Debug for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::fmt::Debug
+impl<'u, T> core::hash::Hash for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::hash::Hash
+impl<'u, T> core::marker::Send for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Sync + core::marker::Send
+impl<'u, T> core::marker::StructuralPartialEq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>
+impl<'u, T> core::marker::Sync for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Sync
+impl<'u, T> core::marker::Unpin for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Unpin
+impl<'u, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::Prevouts<'u, T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<'u, T> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::Prevouts<'u, T> where T: core::panic::unwind_safe::UnwindSafe + core::panic::unwind_safe::RefUnwindSafe
+impl<C: bitcoin::consensus::serde::hex::Case> bitcoin::consensus::serde::ByteEncoder for bitcoin::consensus::serde::Hex<C>
+impl<C: bitcoin::consensus::serde::hex::Case> bitcoin::consensus::serde::EncodeBytes for bitcoin::consensus::serde::hex::Encoder<C>
+impl<C: bitcoin::consensus::serde::hex::Case> core::convert::From<bitcoin::consensus::serde::Hex<C>> for bitcoin::consensus::serde::hex::Encoder<C>
+impl<C: bitcoin::consensus::serde::hex::Case> core::default::Default for bitcoin::consensus::serde::Hex<C>
+impl<C> core::marker::Send for bitcoin::consensus::serde::hex::Encoder<C> where C: core::marker::Send
+impl<C> core::marker::Sync for bitcoin::consensus::serde::hex::Encoder<C> where C: core::marker::Sync
+impl<C> core::marker::Unpin for bitcoin::consensus::serde::hex::Encoder<C> where C: core::marker::Unpin
+impl<C> core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::Encoder<C> where C: core::panic::unwind_safe::RefUnwindSafe
+impl<C> core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::Encoder<C> where C: core::panic::unwind_safe::UnwindSafe
+impl<Case> core::marker::Send for bitcoin::consensus::serde::Hex<Case> where Case: core::marker::Send
+impl<Case> core::marker::Sync for bitcoin::consensus::serde::Hex<Case> where Case: core::marker::Sync
+impl<Case> core::marker::Unpin for bitcoin::consensus::serde::Hex<Case> where Case: core::marker::Unpin
+impl<Case> core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::Hex<Case> where Case: core::panic::unwind_safe::RefUnwindSafe
+impl<Case> core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::Hex<Case> where Case: core::panic::unwind_safe::UnwindSafe
+impl<E: core::clone::Clone> core::clone::Clone for bitcoin::string::FromHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for bitcoin::string::FromHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin::string::FromHexError<E>
+impl<E: core::error::Error + 'static> core::error::Error for bitcoin::sighash::SigningDataError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for bitcoin::sighash::SigningDataError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for bitcoin::string::FromHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for bitcoin::sighash::SigningDataError<E>
+impl<E: core::fmt::Display> core::fmt::Display for bitcoin::string::FromHexError<E>
+impl<E> !core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SigningDataError<E>
+impl<E> !core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SigningDataError<E>
+impl<E> bitcoin::consensus::serde::With<E>
+impl<E> bitcoin::sighash::EncodeSigningDataResult<E>
+impl<E> core::convert::From<E> for bitcoin::string::FromHexError<E>
+impl<E> core::convert::From<bitcoin_io::error::Error> for bitcoin::sighash::SigningDataError<E>
+impl<E> core::error::Error for bitcoin::string::FromHexError<E> where E: core::error::Error + 'static
+impl<E> core::marker::Send for bitcoin::consensus::serde::With<E> where E: core::marker::Send
+impl<E> core::marker::Send for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Send
+impl<E> core::marker::Send for bitcoin::sighash::SigningDataError<E> where E: core::marker::Send
+impl<E> core::marker::Send for bitcoin::string::FromHexError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for bitcoin::string::FromHexError<E>
+impl<E> core::marker::Sync for bitcoin::consensus::serde::With<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for bitcoin::sighash::SigningDataError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for bitcoin::string::FromHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for bitcoin::consensus::serde::With<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for bitcoin::sighash::SigningDataError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for bitcoin::string::FromHexError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::With<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::string::FromHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::With<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::string::FromHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::LegacySighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::PubkeyHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::SegwitV0Sighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::TapSighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::WPubkeyHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip158::FilterHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip158::FilterHeader
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip32::XKeyIdentifier
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::BlockHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::TxMerkleNode
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::WitnessCommitment
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::WitnessMerkleNode
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::script::ScriptHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::script::WScriptHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::transaction::Txid
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::transaction::Wtxid
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapLeafHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapNodeHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapTweakHash
+impl<I> core::ops::index::Index<I> for bitcoin::bip152::ShortId where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::ChainCode where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::DerivationPath where alloc::vec::Vec<bitcoin::bip32::ChildNumber>: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::Fingerprint where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::blockdata::constants::ChainHash where [u8]: core::ops::index::Index<I>
+impl<N: bitcoin::address::NetworkValidation> serde::ser::Serialize for bitcoin::address::Address<N>
+impl<R: bitcoin_io::Read + core::marker::Sized> bitcoin::consensus::encode::ReadExt for R
+impl<R: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>> bitcoin::sighash::SighashCache<R>
+impl<R: core::borrow::BorrowMut<bitcoin::blockdata::transaction::Transaction>> bitcoin::sighash::SighashCache<R>
+impl<Subtype> bitcoin::consensus::encode::Decodable for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> bitcoin::consensus::encode::Encodable for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::clone::Clone for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::clone::Clone
+impl<Subtype> core::cmp::Eq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::Eq
+impl<Subtype> core::cmp::Ord for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::Ord
+impl<Subtype> core::cmp::PartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::PartialEq
+impl<Subtype> core::cmp::PartialOrd for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::PartialOrd
+impl<Subtype> core::convert::TryFrom<bitcoin::psbt::raw::Key> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::fmt::Debug for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::fmt::Debug
+impl<Subtype> core::hash::Hash for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::hash::Hash
+impl<Subtype> core::marker::Send for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Send
+impl<Subtype> core::marker::StructuralPartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::marker::Sync for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Sync
+impl<Subtype> core::marker::Unpin for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Unpin
+impl<Subtype> core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::panic::unwind_safe::RefUnwindSafe
+impl<Subtype> core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::panic::unwind_safe::UnwindSafe
+impl<Subtype> serde::ser::Serialize for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + serde::ser::Serialize
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable, T6: bitcoin::consensus::encode::Decodable, T7: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5, T6, T7)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable, T6: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5, T6)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable, T6: bitcoin::consensus::encode::Encodable, T7: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5, T6, T7)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable, T6: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5, T6)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1)
+impl<T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for alloc::rc::Rc<T>
+impl<T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for alloc::sync::Arc<T>
+impl<T: core::fmt::Debug + core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>> core::fmt::Debug for bitcoin::sighash::SighashCache<T>
+impl<T: sealed::Case> bitcoin::consensus::serde::hex::Case for T
+impl<T> bitcoin::bip32::IntoDerivationPath for T where T: core::convert::Into<bitcoin::bip32::DerivationPath>
+impl<T> core::marker::Send for bitcoin::sighash::SighashCache<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin::sighash::SighashCache<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin::sighash::SighashCache<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SighashCache<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SighashCache<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<V: bitcoin::address::NetworkValidation> bitcoin::address::Address<V>
+impl<V: bitcoin::address::NetworkValidation> core::fmt::Debug for bitcoin::address::Address<V>
+impl<V> core::clone::Clone for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::clone::Clone
+impl<V> core::cmp::Eq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::Eq
+impl<V> core::cmp::Ord for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::Ord
+impl<V> core::cmp::PartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialEq
+impl<V> core::cmp::PartialOrd for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialOrd
+impl<V> core::hash::Hash for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::hash::Hash
+impl<V> core::marker::Send for bitcoin::address::Address<V>
+impl<V> core::marker::StructuralPartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation
+impl<V> core::marker::Sync for bitcoin::address::Address<V>
+impl<V> core::marker::Unpin for bitcoin::address::Address<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::Address<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for bitcoin::address::Address<V> where V: core::panic::unwind_safe::UnwindSafe
+impl<W: bitcoin_io::Write + core::marker::Sized> bitcoin::consensus::encode::WriteExt for W
+pub bitcoin::AddressType::P2pkh
+pub bitcoin::AddressType::P2sh
+pub bitcoin::AddressType::P2tr
+pub bitcoin::AddressType::P2wpkh
+pub bitcoin::AddressType::P2wsh
+pub bitcoin::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::EcdsaSighashType::All = 1
+pub bitcoin::EcdsaSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::EcdsaSighashType::None = 2
+pub bitcoin::EcdsaSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::EcdsaSighashType::Single = 3
+pub bitcoin::EcdsaSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::KnownHrp::Mainnet
+pub bitcoin::KnownHrp::Regtest
+pub bitcoin::KnownHrp::Testnets
+pub bitcoin::MerkleBlock::header: bitcoin::blockdata::block::Header
+pub bitcoin::MerkleBlock::txn: bitcoin::merkle_tree::PartialMerkleTree
+pub bitcoin::Network::Bitcoin
+pub bitcoin::Network::Regtest
+pub bitcoin::Network::Signet
+pub bitcoin::Network::Testnet
+pub bitcoin::NetworkKind::Main
+pub bitcoin::NetworkKind::Test
+pub bitcoin::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::OutPoint::vout: u32
+pub bitcoin::PrivateKey::compressed: bool
+pub bitcoin::PrivateKey::inner: secp256k1::key::SecretKey
+pub bitcoin::PrivateKey::network: bitcoin::network::NetworkKind
+pub bitcoin::Psbt::inputs: alloc::vec::Vec<bitcoin::psbt::Input>
+pub bitcoin::Psbt::outputs: alloc::vec::Vec<bitcoin::psbt::Output>
+pub bitcoin::Psbt::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::Psbt::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::Psbt::unsigned_tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::Psbt::version: u32
+pub bitcoin::Psbt::xpub: alloc::collections::btree::map::BTreeMap<bitcoin::bip32::Xpub, bitcoin::bip32::KeySource>
+pub bitcoin::PublicKey::compressed: bool
+pub bitcoin::PublicKey::inner: secp256k1::key::PublicKey
+pub bitcoin::TapSighashType::All = 1
+pub bitcoin::TapSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::TapSighashType::Default = 0
+pub bitcoin::TapSighashType::None = 2
+pub bitcoin::TapSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::TapSighashType::Single = 3
+pub bitcoin::TapSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::WitnessVersion::V0 = 0
+pub bitcoin::WitnessVersion::V1 = 1
+pub bitcoin::WitnessVersion::V10 = 10
+pub bitcoin::WitnessVersion::V11 = 11
+pub bitcoin::WitnessVersion::V12 = 12
+pub bitcoin::WitnessVersion::V13 = 13
+pub bitcoin::WitnessVersion::V14 = 14
+pub bitcoin::WitnessVersion::V15 = 15
+pub bitcoin::WitnessVersion::V16 = 16
+pub bitcoin::WitnessVersion::V2 = 2
+pub bitcoin::WitnessVersion::V3 = 3
+pub bitcoin::WitnessVersion::V4 = 4
+pub bitcoin::WitnessVersion::V5 = 5
+pub bitcoin::WitnessVersion::V6 = 6
+pub bitcoin::WitnessVersion::V7 = 7
+pub bitcoin::WitnessVersion::V8 = 8
+pub bitcoin::WitnessVersion::V9 = 9
+pub bitcoin::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::absolute::OperationError::InvalidComparison
+pub bitcoin::address::AddressType::P2pkh
+pub bitcoin::address::AddressType::P2sh
+pub bitcoin::address::AddressType::P2tr
+pub bitcoin::address::AddressType::P2wpkh
+pub bitcoin::address::AddressType::P2wsh
+pub bitcoin::address::Error::ExcessiveScriptSize
+pub bitcoin::address::Error::NetworkValidation
+pub bitcoin::address::Error::NetworkValidation::address: bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub bitcoin::address::Error::NetworkValidation::required: bitcoin::network::Network
+pub bitcoin::address::Error::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::Error::UnrecognizedScript
+pub bitcoin::address::Error::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::Error::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::KnownHrp::Mainnet
+pub bitcoin::address::KnownHrp::Regtest
+pub bitcoin::address::KnownHrp::Testnets
+pub bitcoin::address::ParseError::Base58(bitcoin::base58::Error)
+pub bitcoin::address::ParseError::Bech32(bech32::segwit::DecodeError)
+pub bitcoin::address::ParseError::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::ParseError::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::ParseError::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::error::Error::ExcessiveScriptSize
+pub bitcoin::address::error::Error::NetworkValidation
+pub bitcoin::address::error::Error::NetworkValidation::address: bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub bitcoin::address::error::Error::NetworkValidation::required: bitcoin::network::Network
+pub bitcoin::address::error::Error::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::error::Error::UnrecognizedScript
+pub bitcoin::address::error::Error::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::error::Error::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::error::ParseError::Base58(bitcoin::base58::Error)
+pub bitcoin::address::error::ParseError::Bech32(bech32::segwit::DecodeError)
+pub bitcoin::address::error::ParseError::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::error::ParseError::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::error::ParseError::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::base58::Error::BadByte(u8)
+pub bitcoin::base58::Error::BadChecksum(u32, u32)
+pub bitcoin::base58::Error::InvalidAddressVersion(u8)
+pub bitcoin::base58::Error::InvalidExtendedKeyVersion([u8; 4])
+pub bitcoin::base58::Error::InvalidLength(usize)
+pub bitcoin::base58::Error::TooShort(usize)
+pub bitcoin::bip152::BlockTransactions::block_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::bip152::BlockTransactions::transactions: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::bip152::BlockTransactionsRequest::block_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::bip152::BlockTransactionsRequest::indexes: alloc::vec::Vec<u64>
+pub bitcoin::bip152::Error::InvalidPrefill
+pub bitcoin::bip152::Error::UnknownVersion
+pub bitcoin::bip152::HeaderAndShortIds::header: bitcoin::blockdata::block::Header
+pub bitcoin::bip152::HeaderAndShortIds::nonce: u64
+pub bitcoin::bip152::HeaderAndShortIds::prefilled_txs: alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+pub bitcoin::bip152::HeaderAndShortIds::short_ids: alloc::vec::Vec<bitcoin::bip152::ShortId>
+pub bitcoin::bip152::PrefilledTransaction::idx: u16
+pub bitcoin::bip152::PrefilledTransaction::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::bip158::BlockFilter::content: alloc::vec::Vec<u8>
+pub bitcoin::bip158::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::bip158::Error::UtxoMissing(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::bip32::ChildNumber::Hardened
+pub bitcoin::bip32::ChildNumber::Hardened::index: u32
+pub bitcoin::bip32::ChildNumber::Normal
+pub bitcoin::bip32::ChildNumber::Normal::index: u32
+pub bitcoin::bip32::Error::Base58(bitcoin::base58::Error)
+pub bitcoin::bip32::Error::CannotDeriveFromHardenedKey
+pub bitcoin::bip32::Error::Hex(hex_conservative::parse::HexToArrayError)
+pub bitcoin::bip32::Error::InvalidChildNumber(u32)
+pub bitcoin::bip32::Error::InvalidChildNumberFormat
+pub bitcoin::bip32::Error::InvalidDerivationPathFormat
+pub bitcoin::bip32::Error::InvalidPublicKeyHexLength(usize)
+pub bitcoin::bip32::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::bip32::Error::UnknownVersion([u8; 4])
+pub bitcoin::bip32::Error::WrongExtendedKeyLength(usize)
+pub bitcoin::bip32::Xpriv::chain_code: bitcoin::bip32::ChainCode
+pub bitcoin::bip32::Xpriv::child_number: bitcoin::bip32::ChildNumber
+pub bitcoin::bip32::Xpriv::depth: u8
+pub bitcoin::bip32::Xpriv::network: bitcoin::network::NetworkKind
+pub bitcoin::bip32::Xpriv::parent_fingerprint: bitcoin::bip32::Fingerprint
+pub bitcoin::bip32::Xpriv::private_key: secp256k1::key::SecretKey
+pub bitcoin::bip32::Xpub::chain_code: bitcoin::bip32::ChainCode
+pub bitcoin::bip32::Xpub::child_number: bitcoin::bip32::ChildNumber
+pub bitcoin::bip32::Xpub::depth: u8
+pub bitcoin::bip32::Xpub::network: bitcoin::network::NetworkKind
+pub bitcoin::bip32::Xpub::parent_fingerprint: bitcoin::bip32::Fingerprint
+pub bitcoin::bip32::Xpub::public_key: secp256k1::key::PublicKey
+pub bitcoin::block::Bip34Error::NegativeHeight
+pub bitcoin::block::Bip34Error::NotPresent
+pub bitcoin::block::Bip34Error::UnexpectedPush(alloc::vec::Vec<u8>)
+pub bitcoin::block::Bip34Error::Unsupported
+pub bitcoin::block::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::block::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::block::Header::bits: bitcoin::pow::CompactTarget
+pub bitcoin::block::Header::merkle_root: bitcoin::blockdata::block::TxMerkleNode
+pub bitcoin::block::Header::nonce: u32
+pub bitcoin::block::Header::prev_blockhash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::block::Header::time: u32
+pub bitcoin::block::Header::version: bitcoin::blockdata::block::Version
+pub bitcoin::block::ValidationError::BadProofOfWork
+pub bitcoin::block::ValidationError::BadTarget
+pub bitcoin::blockdata::block::Bip34Error::NegativeHeight
+pub bitcoin::blockdata::block::Bip34Error::NotPresent
+pub bitcoin::blockdata::block::Bip34Error::UnexpectedPush(alloc::vec::Vec<u8>)
+pub bitcoin::blockdata::block::Bip34Error::Unsupported
+pub bitcoin::blockdata::block::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::blockdata::block::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::blockdata::block::Header::bits: bitcoin::pow::CompactTarget
+pub bitcoin::blockdata::block::Header::merkle_root: bitcoin::blockdata::block::TxMerkleNode
+pub bitcoin::blockdata::block::Header::nonce: u32
+pub bitcoin::blockdata::block::Header::prev_blockhash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::blockdata::block::Header::time: u32
+pub bitcoin::blockdata::block::Header::version: bitcoin::blockdata::block::Version
+pub bitcoin::blockdata::block::ValidationError::BadProofOfWork
+pub bitcoin::blockdata::block::ValidationError::BadTarget
+pub bitcoin::blockdata::locktime::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::blockdata::locktime::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::blockdata::locktime::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::locktime::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::blockdata::locktime::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::blockdata::locktime::absolute::OperationError::InvalidComparison
+pub bitcoin::blockdata::locktime::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::blockdata::locktime::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::blockdata::locktime::relative::Error::IntegerOverflow(u32)
+pub bitcoin::blockdata::locktime::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::blockdata::locktime::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::blockdata::opcodes::Class::IllegalOp
+pub bitcoin::blockdata::opcodes::Class::NoOp
+pub bitcoin::blockdata::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin::blockdata::opcodes::Class::PushBytes(u32)
+pub bitcoin::blockdata::opcodes::Class::PushNum(i32)
+pub bitcoin::blockdata::opcodes::Class::ReturnOp
+pub bitcoin::blockdata::opcodes::Class::SuccessOp
+pub bitcoin::blockdata::opcodes::ClassifyContext::Legacy
+pub bitcoin::blockdata::opcodes::ClassifyContext::TapScript
+pub bitcoin::blockdata::script::Error::EarlyEndOfScript
+pub bitcoin::blockdata::script::Error::NonMinimalPush
+pub bitcoin::blockdata::script::Error::NumericOverflow
+pub bitcoin::blockdata::script::Error::Serialization
+pub bitcoin::blockdata::script::Error::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::blockdata::script::Instruction::Op(bitcoin::blockdata::opcodes::Opcode)
+pub bitcoin::blockdata::script::Instruction::PushBytes(&'a bitcoin::blockdata::script::PushBytes)
+pub bitcoin::blockdata::script::witness_program::Error::InvalidLength(usize)
+pub bitcoin::blockdata::script::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::blockdata::script::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::blockdata::script::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::script::witness_version::TryFromError::invalid: u8
+pub bitcoin::blockdata::script::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::blockdata::script::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V9 = 9
+pub bitcoin::blockdata::transaction::IndexOutOfBoundsError::index: usize
+pub bitcoin::blockdata::transaction::IndexOutOfBoundsError::length: usize
+pub bitcoin::blockdata::transaction::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::blockdata::transaction::OutPoint::vout: u32
+pub bitcoin::blockdata::transaction::ParseOutPointError::Format
+pub bitcoin::blockdata::transaction::ParseOutPointError::TooLong
+pub bitcoin::blockdata::transaction::ParseOutPointError::Txid(hex_conservative::parse::HexToArrayError)
+pub bitcoin::blockdata::transaction::ParseOutPointError::Vout(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin::blockdata::transaction::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::blockdata::transaction::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::blockdata::transaction::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::blockdata::transaction::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::blockdata::transaction::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::blockdata::transaction::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::blockdata::transaction::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::blockdata::transaction::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::blockdata::transaction::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::blockdata::transaction::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::blockdata::transaction::TxVerifyError::ScriptVerification(bitcoin::consensus::validation::BitcoinconsensusError)
+pub bitcoin::blockdata::transaction::TxVerifyError::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::consensus::Params::allow_min_difficulty_blocks: bool
+pub bitcoin::consensus::Params::bip16_time: u32
+pub bitcoin::consensus::Params::bip34_height: u32
+pub bitcoin::consensus::Params::bip65_height: u32
+pub bitcoin::consensus::Params::bip66_height: u32
+pub bitcoin::consensus::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::Params::network: bitcoin::network::Network
+pub bitcoin::consensus::Params::no_pow_retargeting: bool
+pub bitcoin::consensus::Params::pow_limit: bitcoin::pow::Target
+pub bitcoin::consensus::Params::pow_target_spacing: u64
+pub bitcoin::consensus::Params::pow_target_timespan: u64
+pub bitcoin::consensus::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::encode::Error::InvalidChecksum
+pub bitcoin::consensus::encode::Error::InvalidChecksum::actual: [u8; 4]
+pub bitcoin::consensus::encode::Error::InvalidChecksum::expected: [u8; 4]
+pub bitcoin::consensus::encode::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::consensus::encode::Error::NonMinimalVarInt
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation::max: usize
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation::requested: usize
+pub bitcoin::consensus::encode::Error::ParseFailed(&'static str)
+pub bitcoin::consensus::encode::Error::UnsupportedSegwitFlag(u8)
+pub bitcoin::consensus::params::Params::allow_min_difficulty_blocks: bool
+pub bitcoin::consensus::params::Params::bip16_time: u32
+pub bitcoin::consensus::params::Params::bip34_height: u32
+pub bitcoin::consensus::params::Params::bip65_height: u32
+pub bitcoin::consensus::params::Params::bip66_height: u32
+pub bitcoin::consensus::params::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::params::Params::network: bitcoin::network::Network
+pub bitcoin::consensus::params::Params::no_pow_retargeting: bool
+pub bitcoin::consensus::params::Params::pow_limit: bitcoin::pow::Target
+pub bitcoin::consensus::params::Params::pow_target_spacing: u64
+pub bitcoin::consensus::params::Params::pow_target_timespan: u64
+pub bitcoin::consensus::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::validation::TxVerifyError::ScriptVerification(bitcoin::consensus::validation::BitcoinconsensusError)
+pub bitcoin::consensus::validation::TxVerifyError::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::ecdsa::Error::EmptySignature
+pub bitcoin::ecdsa::Error::Hex(hex_conservative::parse::HexToBytesError)
+pub bitcoin::ecdsa::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::ecdsa::Error::SighashType(bitcoin::sighash::NonStandardSighashTypeError)
+pub bitcoin::ecdsa::Signature::sighash_type: bitcoin::EcdsaSighashType
+pub bitcoin::ecdsa::Signature::signature: secp256k1::ecdsa::Signature
+pub bitcoin::key::Error::Base58(bitcoin::base58::Error)
+pub bitcoin::key::Error::Hex(hex_conservative::parse::HexToArrayError)
+pub bitcoin::key::Error::InvalidHexLength(usize)
+pub bitcoin::key::Error::InvalidKeyPrefix(u8)
+pub bitcoin::key::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::key::PrivateKey::compressed: bool
+pub bitcoin::key::PrivateKey::inner: secp256k1::key::SecretKey
+pub bitcoin::key::PrivateKey::network: bitcoin::network::NetworkKind
+pub bitcoin::key::PublicKey::compressed: bool
+pub bitcoin::key::PublicKey::inner: secp256k1::key::PublicKey
+pub bitcoin::locktime::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::locktime::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::locktime::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::locktime::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::locktime::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::locktime::absolute::OperationError::InvalidComparison
+pub bitcoin::locktime::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::locktime::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::locktime::relative::Error::IntegerOverflow(u32)
+pub bitcoin::locktime::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::locktime::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::merkle_tree::MerkleBlock::header: bitcoin::blockdata::block::Header
+pub bitcoin::merkle_tree::MerkleBlock::txn: bitcoin::merkle_tree::PartialMerkleTree
+pub bitcoin::merkle_tree::MerkleBlockError::BitsArrayOverflow
+pub bitcoin::merkle_tree::MerkleBlockError::HashesArrayOverflow
+pub bitcoin::merkle_tree::MerkleBlockError::IdenticalHashesFound
+pub bitcoin::merkle_tree::MerkleBlockError::MerkleRootMismatch
+pub bitcoin::merkle_tree::MerkleBlockError::NoTransactions
+pub bitcoin::merkle_tree::MerkleBlockError::NotAllBitsConsumed
+pub bitcoin::merkle_tree::MerkleBlockError::NotAllHashesConsumed
+pub bitcoin::merkle_tree::MerkleBlockError::NotEnoughBits
+pub bitcoin::merkle_tree::MerkleBlockError::TooManyHashes
+pub bitcoin::merkle_tree::MerkleBlockError::TooManyTransactions
+pub bitcoin::network::Network::Bitcoin
+pub bitcoin::network::Network::Regtest
+pub bitcoin::network::Network::Signet
+pub bitcoin::network::Network::Testnet
+pub bitcoin::network::NetworkKind::Main
+pub bitcoin::network::NetworkKind::Test
+pub bitcoin::opcodes::Class::IllegalOp
+pub bitcoin::opcodes::Class::NoOp
+pub bitcoin::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin::opcodes::Class::PushBytes(u32)
+pub bitcoin::opcodes::Class::PushNum(i32)
+pub bitcoin::opcodes::Class::ReturnOp
+pub bitcoin::opcodes::Class::SuccessOp
+pub bitcoin::opcodes::ClassifyContext::Legacy
+pub bitcoin::opcodes::ClassifyContext::TapScript
+pub bitcoin::p2p::Address::address: [u16; 8]
+pub bitcoin::p2p::Address::port: u16
+pub bitcoin::p2p::Address::services: bitcoin::p2p::ServiceFlags
+pub bitcoin::p2p::address::AddrV2::Cjdns(core::net::ip_addr::Ipv6Addr)
+pub bitcoin::p2p::address::AddrV2::I2p([u8; 32])
+pub bitcoin::p2p::address::AddrV2::Ipv4(core::net::ip_addr::Ipv4Addr)
+pub bitcoin::p2p::address::AddrV2::Ipv6(core::net::ip_addr::Ipv6Addr)
+pub bitcoin::p2p::address::AddrV2::TorV2([u8; 10])
+pub bitcoin::p2p::address::AddrV2::TorV3([u8; 32])
+pub bitcoin::p2p::address::AddrV2::Unknown(u8, alloc::vec::Vec<u8>)
+pub bitcoin::p2p::address::AddrV2Message::addr: bitcoin::p2p::address::AddrV2
+pub bitcoin::p2p::address::AddrV2Message::port: u16
+pub bitcoin::p2p::address::AddrV2Message::services: bitcoin::p2p::ServiceFlags
+pub bitcoin::p2p::address::AddrV2Message::time: u32
+pub bitcoin::p2p::address::Address::address: [u16; 8]
+pub bitcoin::p2p::address::Address::port: u16
+pub bitcoin::p2p::address::Address::services: bitcoin::p2p::ServiceFlags
+pub bitcoin::p2p::message::NetworkMessage::Addr(alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>)
+pub bitcoin::p2p::message::NetworkMessage::AddrV2(alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>)
+pub bitcoin::p2p::message::NetworkMessage::Alert(alloc::vec::Vec<u8>)
+pub bitcoin::p2p::message::NetworkMessage::Block(bitcoin::blockdata::block::Block)
+pub bitcoin::p2p::message::NetworkMessage::BlockTxn(bitcoin::p2p::message_compact_blocks::BlockTxn)
+pub bitcoin::p2p::message::NetworkMessage::CFCheckpt(bitcoin::p2p::message_filter::CFCheckpt)
+pub bitcoin::p2p::message::NetworkMessage::CFHeaders(bitcoin::p2p::message_filter::CFHeaders)
+pub bitcoin::p2p::message::NetworkMessage::CFilter(bitcoin::p2p::message_filter::CFilter)
+pub bitcoin::p2p::message::NetworkMessage::CmpctBlock(bitcoin::p2p::message_compact_blocks::CmpctBlock)
+pub bitcoin::p2p::message::NetworkMessage::FeeFilter(i64)
+pub bitcoin::p2p::message::NetworkMessage::FilterAdd(bitcoin::p2p::message_bloom::FilterAdd)
+pub bitcoin::p2p::message::NetworkMessage::FilterClear
+pub bitcoin::p2p::message::NetworkMessage::FilterLoad(bitcoin::p2p::message_bloom::FilterLoad)
+pub bitcoin::p2p::message::NetworkMessage::GetAddr
+pub bitcoin::p2p::message::NetworkMessage::GetBlockTxn(bitcoin::p2p::message_compact_blocks::GetBlockTxn)
+pub bitcoin::p2p::message::NetworkMessage::GetBlocks(bitcoin::p2p::message_blockdata::GetBlocksMessage)
+pub bitcoin::p2p::message::NetworkMessage::GetCFCheckpt(bitcoin::p2p::message_filter::GetCFCheckpt)
+pub bitcoin::p2p::message::NetworkMessage::GetCFHeaders(bitcoin::p2p::message_filter::GetCFHeaders)
+pub bitcoin::p2p::message::NetworkMessage::GetCFilters(bitcoin::p2p::message_filter::GetCFilters)
+pub bitcoin::p2p::message::NetworkMessage::GetData(alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>)
+pub bitcoin::p2p::message::NetworkMessage::GetHeaders(bitcoin::p2p::message_blockdata::GetHeadersMessage)
+pub bitcoin::p2p::message::NetworkMessage::Headers(alloc::vec::Vec<bitcoin::blockdata::block::Header>)
+pub bitcoin::p2p::message::NetworkMessage::Inv(alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>)
+pub bitcoin::p2p::message::NetworkMessage::MemPool
+pub bitcoin::p2p::message::NetworkMessage::MerkleBlock(bitcoin::MerkleBlock)
+pub bitcoin::p2p::message::NetworkMessage::NotFound(alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>)
+pub bitcoin::p2p::message::NetworkMessage::Ping(u64)
+pub bitcoin::p2p::message::NetworkMessage::Pong(u64)
+pub bitcoin::p2p::message::NetworkMessage::Reject(bitcoin::p2p::message_network::Reject)
+pub bitcoin::p2p::message::NetworkMessage::SendAddrV2
+pub bitcoin::p2p::message::NetworkMessage::SendCmpct(bitcoin::p2p::message_compact_blocks::SendCmpct)
+pub bitcoin::p2p::message::NetworkMessage::SendHeaders
+pub bitcoin::p2p::message::NetworkMessage::Tx(bitcoin::blockdata::transaction::Transaction)
+pub bitcoin::p2p::message::NetworkMessage::Unknown
+pub bitcoin::p2p::message::NetworkMessage::Unknown::command: bitcoin::p2p::message::CommandString
+pub bitcoin::p2p::message::NetworkMessage::Unknown::payload: alloc::vec::Vec<u8>
+pub bitcoin::p2p::message::NetworkMessage::Verack
+pub bitcoin::p2p::message::NetworkMessage::Version(bitcoin::p2p::message_network::VersionMessage)
+pub bitcoin::p2p::message::NetworkMessage::WtxidRelay
+pub bitcoin::p2p::message_blockdata::GetBlocksMessage::locator_hashes: alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+pub bitcoin::p2p::message_blockdata::GetBlocksMessage::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_blockdata::GetBlocksMessage::version: u32
+pub bitcoin::p2p::message_blockdata::GetHeadersMessage::locator_hashes: alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+pub bitcoin::p2p::message_blockdata::GetHeadersMessage::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_blockdata::GetHeadersMessage::version: u32
+pub bitcoin::p2p::message_blockdata::Inventory::Block(bitcoin::blockdata::block::BlockHash)
+pub bitcoin::p2p::message_blockdata::Inventory::CompactBlock(bitcoin::blockdata::block::BlockHash)
+pub bitcoin::p2p::message_blockdata::Inventory::Error
+pub bitcoin::p2p::message_blockdata::Inventory::Transaction(bitcoin::blockdata::transaction::Txid)
+pub bitcoin::p2p::message_blockdata::Inventory::Unknown
+pub bitcoin::p2p::message_blockdata::Inventory::Unknown::hash: [u8; 32]
+pub bitcoin::p2p::message_blockdata::Inventory::Unknown::inv_type: u32
+pub bitcoin::p2p::message_blockdata::Inventory::WTx(bitcoin::blockdata::transaction::Wtxid)
+pub bitcoin::p2p::message_blockdata::Inventory::WitnessBlock(bitcoin::blockdata::block::BlockHash)
+pub bitcoin::p2p::message_blockdata::Inventory::WitnessTransaction(bitcoin::blockdata::transaction::Txid)
+pub bitcoin::p2p::message_bloom::BloomFlags::All
+pub bitcoin::p2p::message_bloom::BloomFlags::None
+pub bitcoin::p2p::message_bloom::BloomFlags::PubkeyOnly
+pub bitcoin::p2p::message_bloom::FilterAdd::data: alloc::vec::Vec<u8>
+pub bitcoin::p2p::message_bloom::FilterLoad::filter: alloc::vec::Vec<u8>
+pub bitcoin::p2p::message_bloom::FilterLoad::flags: bitcoin::p2p::message_bloom::BloomFlags
+pub bitcoin::p2p::message_bloom::FilterLoad::hash_funcs: u32
+pub bitcoin::p2p::message_bloom::FilterLoad::tweak: u32
+pub bitcoin::p2p::message_compact_blocks::BlockTxn::transactions: bitcoin::bip152::BlockTransactions
+pub bitcoin::p2p::message_compact_blocks::CmpctBlock::compact_block: bitcoin::bip152::HeaderAndShortIds
+pub bitcoin::p2p::message_compact_blocks::GetBlockTxn::txs_request: bitcoin::bip152::BlockTransactionsRequest
+pub bitcoin::p2p::message_compact_blocks::SendCmpct::send_compact: bool
+pub bitcoin::p2p::message_compact_blocks::SendCmpct::version: u64
+pub bitcoin::p2p::message_filter::CFCheckpt::filter_headers: alloc::vec::Vec<bitcoin::bip158::FilterHeader>
+pub bitcoin::p2p::message_filter::CFCheckpt::filter_type: u8
+pub bitcoin::p2p::message_filter::CFCheckpt::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::CFHeaders::filter_hashes: alloc::vec::Vec<bitcoin::bip158::FilterHash>
+pub bitcoin::p2p::message_filter::CFHeaders::filter_type: u8
+pub bitcoin::p2p::message_filter::CFHeaders::previous_filter_header: bitcoin::bip158::FilterHeader
+pub bitcoin::p2p::message_filter::CFHeaders::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::CFilter::block_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::CFilter::filter: alloc::vec::Vec<u8>
+pub bitcoin::p2p::message_filter::CFilter::filter_type: u8
+pub bitcoin::p2p::message_filter::GetCFCheckpt::filter_type: u8
+pub bitcoin::p2p::message_filter::GetCFCheckpt::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::GetCFHeaders::filter_type: u8
+pub bitcoin::p2p::message_filter::GetCFHeaders::start_height: u32
+pub bitcoin::p2p::message_filter::GetCFHeaders::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::GetCFilters::filter_type: u8
+pub bitcoin::p2p::message_filter::GetCFilters::start_height: u32
+pub bitcoin::p2p::message_filter::GetCFilters::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_network::Reject::ccode: bitcoin::p2p::message_network::RejectReason
+pub bitcoin::p2p::message_network::Reject::hash: bitcoin_hashes::sha256d::Hash
+pub bitcoin::p2p::message_network::Reject::message: alloc::borrow::Cow<'static, str>
+pub bitcoin::p2p::message_network::Reject::reason: alloc::borrow::Cow<'static, str>
+pub bitcoin::p2p::message_network::RejectReason::Checkpoint = 67
+pub bitcoin::p2p::message_network::RejectReason::Duplicate = 18
+pub bitcoin::p2p::message_network::RejectReason::Dust = 65
+pub bitcoin::p2p::message_network::RejectReason::Fee = 66
+pub bitcoin::p2p::message_network::RejectReason::Invalid = 16
+pub bitcoin::p2p::message_network::RejectReason::Malformed = 1
+pub bitcoin::p2p::message_network::RejectReason::NonStandard = 64
+pub bitcoin::p2p::message_network::RejectReason::Obsolete = 17
+pub bitcoin::p2p::message_network::VersionMessage::nonce: u64
+pub bitcoin::p2p::message_network::VersionMessage::receiver: bitcoin::p2p::address::Address
+pub bitcoin::p2p::message_network::VersionMessage::relay: bool
+pub bitcoin::p2p::message_network::VersionMessage::sender: bitcoin::p2p::address::Address
+pub bitcoin::p2p::message_network::VersionMessage::services: bitcoin::p2p::ServiceFlags
+pub bitcoin::p2p::message_network::VersionMessage::start_height: i32
+pub bitcoin::p2p::message_network::VersionMessage::timestamp: i64
+pub bitcoin::p2p::message_network::VersionMessage::user_agent: alloc::string::String
+pub bitcoin::p2p::message_network::VersionMessage::version: u32
+pub bitcoin::psbt::Error::CombineInconsistentKeySources(alloc::boxed::Box<bitcoin::bip32::Xpub>)
+pub bitcoin::psbt::Error::ConsensusEncoding(bitcoin::consensus::encode::Error)
+pub bitcoin::psbt::Error::DuplicateKey(bitcoin::psbt::raw::Key)
+pub bitcoin::psbt::Error::FeeOverflow
+pub bitcoin::psbt::Error::InvalidControlBlock
+pub bitcoin::psbt::Error::InvalidEcdsaSignature(bitcoin::ecdsa::Error)
+pub bitcoin::psbt::Error::InvalidHash(bitcoin_hashes::FromSliceError)
+pub bitcoin::psbt::Error::InvalidKey(bitcoin::psbt::raw::Key)
+pub bitcoin::psbt::Error::InvalidLeafVersion
+pub bitcoin::psbt::Error::InvalidMagic
+pub bitcoin::psbt::Error::InvalidPreimageHashPair
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::hash: alloc::boxed::Box<[u8]>
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::hash_type: PsbtHash
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::preimage: alloc::boxed::Box<[u8]>
+pub bitcoin::psbt::Error::InvalidProprietaryKey
+pub bitcoin::psbt::Error::InvalidPublicKey(bitcoin::key::Error)
+pub bitcoin::psbt::Error::InvalidSecp256k1PublicKey(secp256k1::Error)
+pub bitcoin::psbt::Error::InvalidSeparator
+pub bitcoin::psbt::Error::InvalidTaprootSignature(bitcoin::taproot::SigFromSliceError)
+pub bitcoin::psbt::Error::InvalidXOnlyPublicKey
+pub bitcoin::psbt::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::psbt::Error::MissingUtxo
+pub bitcoin::psbt::Error::MustHaveUnsignedTx
+pub bitcoin::psbt::Error::NegativeFee
+pub bitcoin::psbt::Error::NoMorePairs
+pub bitcoin::psbt::Error::NonStandardSighashType(u32)
+pub bitcoin::psbt::Error::PartialDataConsumption
+pub bitcoin::psbt::Error::PsbtUtxoOutOfbounds
+pub bitcoin::psbt::Error::TapTree(bitcoin::taproot::IncompleteBuilderError)
+pub bitcoin::psbt::Error::Taproot(&'static str)
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx::actual: alloc::boxed::Box<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx::expected: alloc::boxed::Box<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Error::UnsignedTxHasScriptSigs
+pub bitcoin::psbt::Error::UnsignedTxHasScriptWitnesses
+pub bitcoin::psbt::Error::Version(&'static str)
+pub bitcoin::psbt::Error::XPubKey(&'static str)
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate::fee_rate: bitcoin::blockdata::fee_rate::FeeRate
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::ExtractTxError::MissingInputValue
+pub bitcoin::psbt::ExtractTxError::MissingInputValue::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::ExtractTxError::SendingTooMuch
+pub bitcoin::psbt::ExtractTxError::SendingTooMuch::psbt: bitcoin::psbt::Psbt
+pub bitcoin::psbt::GetKeyError::Bip32(bitcoin::bip32::Error)
+pub bitcoin::psbt::GetKeyError::NotSupported
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs::index: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs::length: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput::index: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput::length: usize
+pub bitcoin::psbt::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
+pub bitcoin::psbt::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::hash256_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::sha256d::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::non_witness_utxo: core::option::Option<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Input::partial_sigs: alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::ecdsa::Signature>
+pub bitcoin::psbt::Input::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::redeem_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::ripemd160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::ripemd160::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::sha256_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::sha256::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::sighash_type: core::option::Option<bitcoin::psbt::PsbtSighashType>
+pub bitcoin::psbt::Input::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
+pub bitcoin::psbt::Input::tap_key_origins: alloc::collections::btree::map::BTreeMap<secp256k1::key::XOnlyPublicKey, (alloc::vec::Vec<bitcoin::taproot::TapLeafHash>, bitcoin::bip32::KeySource)>
+pub bitcoin::psbt::Input::tap_key_sig: core::option::Option<bitcoin::taproot::Signature>
+pub bitcoin::psbt::Input::tap_merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>
+pub bitcoin::psbt::Input::tap_script_sigs: alloc::collections::btree::map::BTreeMap<(secp256k1::key::XOnlyPublicKey, bitcoin::taproot::TapLeafHash), bitcoin::taproot::Signature>
+pub bitcoin::psbt::Input::tap_scripts: alloc::collections::btree::map::BTreeMap<bitcoin::taproot::ControlBlock, (bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)>
+pub bitcoin::psbt::Input::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::witness_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::witness_utxo: core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::psbt::KeyRequest::Bip32(bitcoin::bip32::KeySource)
+pub bitcoin::psbt::KeyRequest::Pubkey(bitcoin::PublicKey)
+pub bitcoin::psbt::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::Output::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Output::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
+pub bitcoin::psbt::Output::tap_key_origins: alloc::collections::btree::map::BTreeMap<secp256k1::key::XOnlyPublicKey, (alloc::vec::Vec<bitcoin::taproot::TapLeafHash>, bitcoin::bip32::KeySource)>
+pub bitcoin::psbt::Output::tap_tree: core::option::Option<bitcoin::taproot::TapTree>
+pub bitcoin::psbt::Output::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Output::witness_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::OutputType::Bare
+pub bitcoin::psbt::OutputType::Sh
+pub bitcoin::psbt::OutputType::ShWpkh
+pub bitcoin::psbt::OutputType::ShWsh
+pub bitcoin::psbt::OutputType::Tr
+pub bitcoin::psbt::OutputType::Wpkh
+pub bitcoin::psbt::OutputType::Wsh
+pub bitcoin::psbt::Psbt::inputs: alloc::vec::Vec<bitcoin::psbt::Input>
+pub bitcoin::psbt::Psbt::outputs: alloc::vec::Vec<bitcoin::psbt::Output>
+pub bitcoin::psbt::Psbt::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Psbt::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Psbt::unsigned_tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::Psbt::version: u32
+pub bitcoin::psbt::Psbt::xpub: alloc::collections::btree::map::BTreeMap<bitcoin::bip32::Xpub, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::PsbtParseError::Base64Encoding(base64::decode::DecodeError)
+pub bitcoin::psbt::PsbtParseError::PsbtEncoding(bitcoin::psbt::Error)
+pub bitcoin::psbt::SignError::IndexOutOfBounds(bitcoin::psbt::IndexOutOfBoundsError)
+pub bitcoin::psbt::SignError::InvalidSighashType
+pub bitcoin::psbt::SignError::KeyNotFound
+pub bitcoin::psbt::SignError::MismatchedAlgoKey
+pub bitcoin::psbt::SignError::MissingInputUtxo
+pub bitcoin::psbt::SignError::MissingRedeemScript
+pub bitcoin::psbt::SignError::MissingSpendUtxo
+pub bitcoin::psbt::SignError::MissingWitnessScript
+pub bitcoin::psbt::SignError::NotEcdsa
+pub bitcoin::psbt::SignError::NotWpkh
+pub bitcoin::psbt::SignError::P2wpkhSighash(bitcoin::sighash::P2wpkhError)
+pub bitcoin::psbt::SignError::SegwitV0Sighash(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::psbt::SignError::UnknownOutputType
+pub bitcoin::psbt::SignError::Unsupported
+pub bitcoin::psbt::SignError::WrongSigningAlgorithm
+pub bitcoin::psbt::SigningAlgorithm::Ecdsa
+pub bitcoin::psbt::SigningAlgorithm::Schnorr
+pub bitcoin::psbt::raw::Key::key: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::Key::type_value: u8
+pub bitcoin::psbt::raw::Pair::key: bitcoin::psbt::raw::Key
+pub bitcoin::psbt::raw::Pair::value: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::key: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::prefix: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::subtype: Subtype
+pub bitcoin::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::relative::Error::IntegerOverflow(u32)
+pub bitcoin::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::script::Error::EarlyEndOfScript
+pub bitcoin::script::Error::NonMinimalPush
+pub bitcoin::script::Error::NumericOverflow
+pub bitcoin::script::Error::Serialization
+pub bitcoin::script::Error::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::script::Instruction::Op(bitcoin::blockdata::opcodes::Opcode)
+pub bitcoin::script::Instruction::PushBytes(&'a bitcoin::blockdata::script::PushBytes)
+pub bitcoin::script::witness_program::Error::InvalidLength(usize)
+pub bitcoin::script::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::script::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::script::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::script::witness_version::TryFromError::invalid: u8
+pub bitcoin::script::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::script::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::script::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::script::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::script::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::script::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::script::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::script::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::script::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::script::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::script::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::script::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::script::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::script::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::script::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::script::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::script::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::script::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::script::witness_version::WitnessVersion::V9 = 9
+pub bitcoin::sighash::AnnexError::Empty
+pub bitcoin::sighash::AnnexError::IncorrectPrefix(u8)
+pub bitcoin::sighash::EcdsaSighashType::All = 1
+pub bitcoin::sighash::EcdsaSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::sighash::EcdsaSighashType::None = 2
+pub bitcoin::sighash::EcdsaSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::sighash::EcdsaSighashType::Single = 3
+pub bitcoin::sighash::EcdsaSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::sighash::EncodeSigningDataResult::SighashSingleBug
+pub bitcoin::sighash::EncodeSigningDataResult::WriteResult(core::result::Result<(), E>)
+pub bitcoin::sighash::P2wpkhError::NotP2wpkhScript
+pub bitcoin::sighash::P2wpkhError::Sighash(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::sighash::Prevouts::All(&'u [T])
+pub bitcoin::sighash::Prevouts::One(usize, T)
+pub bitcoin::sighash::PrevoutsIndexError::InvalidAllIndex
+pub bitcoin::sighash::PrevoutsIndexError::InvalidOneIndex
+pub bitcoin::sighash::SighashTypeParseError::unrecognized: alloc::string::String
+pub bitcoin::sighash::SigningDataError::Io(bitcoin_io::error::Error)
+pub bitcoin::sighash::SigningDataError::Sighash(E)
+pub bitcoin::sighash::SingleMissingOutputError::input_index: usize
+pub bitcoin::sighash::SingleMissingOutputError::outputs_length: usize
+pub bitcoin::sighash::TapSighashType::All = 1
+pub bitcoin::sighash::TapSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::sighash::TapSighashType::Default = 0
+pub bitcoin::sighash::TapSighashType::None = 2
+pub bitcoin::sighash::TapSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::sighash::TapSighashType::Single = 3
+pub bitcoin::sighash::TapSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::sighash::TaprootError::InputsIndex(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::sighash::TaprootError::InvalidSighashType(u32)
+pub bitcoin::sighash::TaprootError::PrevoutsIndex(bitcoin::sighash::PrevoutsIndexError)
+pub bitcoin::sighash::TaprootError::PrevoutsKind(bitcoin::sighash::PrevoutsKindError)
+pub bitcoin::sighash::TaprootError::PrevoutsSize(bitcoin::sighash::PrevoutsSizeError)
+pub bitcoin::sighash::TaprootError::SingleMissingOutput(bitcoin::sighash::SingleMissingOutputError)
+pub bitcoin::sign_message::MessageSignature::compressed: bool
+pub bitcoin::sign_message::MessageSignature::signature: secp256k1::ecdsa::recovery::RecoverableSignature
+pub bitcoin::sign_message::MessageSignatureError::InvalidBase64
+pub bitcoin::sign_message::MessageSignatureError::InvalidEncoding(secp256k1::Error)
+pub bitcoin::sign_message::MessageSignatureError::InvalidLength
+pub bitcoin::sign_message::MessageSignatureError::UnsupportedAddressType(bitcoin::address::AddressType)
+pub bitcoin::string::FromHexError::MissingPrefix(alloc::string::String)
+pub bitcoin::string::FromHexError::ParseHex(E)
+pub bitcoin::taproot::ControlBlock::internal_key: bitcoin::key::UntweakedPublicKey
+pub bitcoin::taproot::ControlBlock::leaf_version: bitcoin::taproot::LeafVersion
+pub bitcoin::taproot::ControlBlock::merkle_branch: bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub bitcoin::taproot::ControlBlock::output_key_parity: secp256k1::key::Parity
+pub bitcoin::taproot::HiddenNodesError::HiddenParts(bitcoin::taproot::NodeInfo)
+pub bitcoin::taproot::IncompleteBuilderError::HiddenParts(bitcoin::taproot::TaprootBuilder)
+pub bitcoin::taproot::IncompleteBuilderError::NotFinalized(bitcoin::taproot::TaprootBuilder)
+pub bitcoin::taproot::LeafVersion::Future(bitcoin::taproot::FutureLeafVersion)
+pub bitcoin::taproot::LeafVersion::TapScript
+pub bitcoin::taproot::SigFromSliceError::InvalidSignatureSize(usize)
+pub bitcoin::taproot::SigFromSliceError::Secp256k1(secp256k1::Error)
+pub bitcoin::taproot::SigFromSliceError::SighashType(bitcoin::sighash::InvalidSighashTypeError)
+pub bitcoin::taproot::Signature::sighash_type: bitcoin::TapSighashType
+pub bitcoin::taproot::Signature::signature: secp256k1::schnorr::Signature
+pub bitcoin::taproot::TapLeaf::Hidden(bitcoin::taproot::TapNodeHash)
+pub bitcoin::taproot::TapLeaf::Script(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)
+pub bitcoin::taproot::TaprootBuilderError::EmptyTree
+pub bitcoin::taproot::TaprootBuilderError::InvalidInternalKey(secp256k1::Error)
+pub bitcoin::taproot::TaprootBuilderError::InvalidMerkleTreeDepth(usize)
+pub bitcoin::taproot::TaprootBuilderError::NodeNotInDfsOrder
+pub bitcoin::taproot::TaprootBuilderError::OverCompleteTree
+pub bitcoin::taproot::TaprootError::EmptyTree
+pub bitcoin::taproot::TaprootError::InvalidControlBlockSize(usize)
+pub bitcoin::taproot::TaprootError::InvalidInternalKey(secp256k1::Error)
+pub bitcoin::taproot::TaprootError::InvalidMerkleBranchSize(usize)
+pub bitcoin::taproot::TaprootError::InvalidMerkleTreeDepth(usize)
+pub bitcoin::taproot::TaprootError::InvalidTaprootLeafVersion(u8)
+pub bitcoin::transaction::IndexOutOfBoundsError::index: usize
+pub bitcoin::transaction::IndexOutOfBoundsError::length: usize
+pub bitcoin::transaction::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::transaction::OutPoint::vout: u32
+pub bitcoin::transaction::ParseOutPointError::Format
+pub bitcoin::transaction::ParseOutPointError::TooLong
+pub bitcoin::transaction::ParseOutPointError::Txid(hex_conservative::parse::HexToArrayError)
+pub bitcoin::transaction::ParseOutPointError::Vout(bitcoin::error::ParseIntError)
+pub bitcoin::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin::transaction::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::transaction::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::transaction::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::transaction::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::transaction::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::transaction::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::transaction::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::transaction::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::transaction::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::transaction::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::transaction::TxVerifyError::ScriptVerification(bitcoin::consensus::validation::BitcoinconsensusError)
+pub bitcoin::transaction::TxVerifyError::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::witness_program::Error::InvalidLength(usize)
+pub bitcoin::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::witness_version::TryFromError::invalid: u8
+pub bitcoin::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::witness_version::WitnessVersion::V9 = 9
+pub const bitcoin::LegacySighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::LegacySighash::LEN: usize
+pub const bitcoin::LegacySighash::N: usize
+pub const bitcoin::PubkeyHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::PubkeyHash::LEN: usize
+pub const bitcoin::PubkeyHash::N: usize
+pub const bitcoin::SegwitV0Sighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::SegwitV0Sighash::LEN: usize
+pub const bitcoin::SegwitV0Sighash::N: usize
+pub const bitcoin::TapSighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::TapSighash::LEN: usize
+pub const bitcoin::TapSighash::N: usize
+pub const bitcoin::WPubkeyHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::WPubkeyHash::LEN: usize
+pub const bitcoin::WPubkeyHash::N: usize
+pub const bitcoin::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::address::NetworkChecked::IS_CHECKED: bool
+pub const bitcoin::address::NetworkUnchecked::IS_CHECKED: bool
+pub const bitcoin::address::NetworkValidation::IS_CHECKED: bool
+pub const bitcoin::bip158::FilterHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip158::FilterHash::LEN: usize
+pub const bitcoin::bip158::FilterHash::N: usize
+pub const bitcoin::bip158::FilterHeader::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip158::FilterHeader::LEN: usize
+pub const bitcoin::bip158::FilterHeader::N: usize
+pub const bitcoin::bip32::XKeyIdentifier::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip32::XKeyIdentifier::LEN: usize
+pub const bitcoin::bip32::XKeyIdentifier::N: usize
+pub const bitcoin::blockdata::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::BlockHash::LEN: usize
+pub const bitcoin::blockdata::block::BlockHash::N: usize
+pub const bitcoin::blockdata::block::Header::SIZE: usize
+pub const bitcoin::blockdata::block::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::TxMerkleNode::LEN: usize
+pub const bitcoin::blockdata::block::TxMerkleNode::N: usize
+pub const bitcoin::blockdata::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin::blockdata::block::Version::ONE: Self
+pub const bitcoin::blockdata::block::Version::TWO: Self
+pub const bitcoin::blockdata::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::WitnessCommitment::LEN: usize
+pub const bitcoin::blockdata::block::WitnessCommitment::N: usize
+pub const bitcoin::blockdata::block::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::WitnessMerkleNode::LEN: usize
+pub const bitcoin::blockdata::block::WitnessMerkleNode::N: usize
+pub const bitcoin::blockdata::constants::COINBASE_MATURITY: u32 = 100u32
+pub const bitcoin::blockdata::constants::ChainHash::BITCOIN: Self
+pub const bitcoin::blockdata::constants::ChainHash::REGTEST: Self
+pub const bitcoin::blockdata::constants::ChainHash::SIGNET: Self
+pub const bitcoin::blockdata::constants::ChainHash::TESTNET: Self
+pub const bitcoin::blockdata::constants::DIFFCHANGE_INTERVAL: u32 = 2_016u32
+pub const bitcoin::blockdata::constants::DIFFCHANGE_TIMESPAN: _
+pub const bitcoin::blockdata::constants::MAX_BLOCK_SIGOPS_COST: i64 = 80_000i64
+pub const bitcoin::blockdata::constants::MAX_SCRIPTNUM_VALUE: u32 = 2_147_483_648u32
+pub const bitcoin::blockdata::constants::MAX_SCRIPT_ELEMENT_SIZE: usize = 520usize
+pub const bitcoin::blockdata::constants::PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0u8
+pub const bitcoin::blockdata::constants::PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111u8
+pub const bitcoin::blockdata::constants::SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5u8
+pub const bitcoin::blockdata::constants::SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196u8
+pub const bitcoin::blockdata::constants::SUBSIDY_HALVING_INTERVAL: u32 = 210_000u32
+pub const bitcoin::blockdata::constants::TARGET_BLOCK_SPACING: u32 = 600u32
+pub const bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR: usize = 4usize
+pub const bitcoin::blockdata::fee_rate::FeeRate::BROADCAST_MIN: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::DUST: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::MAX: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::MIN: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::ZERO: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::locktime::absolute::Height::MAX: Self
+pub const bitcoin::blockdata::locktime::absolute::Height::MIN: Self
+pub const bitcoin::blockdata::locktime::absolute::Height::ZERO: Self
+pub const bitcoin::blockdata::locktime::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::blockdata::locktime::absolute::LockTime::SIZE: usize
+pub const bitcoin::blockdata::locktime::absolute::LockTime::ZERO: bitcoin::blockdata::locktime::absolute::LockTime
+pub const bitcoin::blockdata::locktime::absolute::Time::MAX: Self
+pub const bitcoin::blockdata::locktime::absolute::Time::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Height::MAX: Self
+pub const bitcoin::blockdata::locktime::relative::Height::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Height::ZERO: Self
+pub const bitcoin::blockdata::locktime::relative::Time::MAX: Self
+pub const bitcoin::blockdata::locktime::relative::Time::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Time::ZERO: Self
+pub const bitcoin::blockdata::opcodes::all::OP_0NOTEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_1ADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_1SUB: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DIV: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DROP: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_2MUL: _
+pub const bitcoin::blockdata::opcodes::all::OP_2OVER: _
+pub const bitcoin::blockdata::opcodes::all::OP_2ROT: _
+pub const bitcoin::blockdata::opcodes::all::OP_2SWAP: _
+pub const bitcoin::blockdata::opcodes::all::OP_3DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_ABS: _
+pub const bitcoin::blockdata::opcodes::all::OP_ADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_AND: _
+pub const bitcoin::blockdata::opcodes::all::OP_BOOLAND: _
+pub const bitcoin::blockdata::opcodes::all::OP_BOOLOR: _
+pub const bitcoin::blockdata::opcodes::all::OP_CAT: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKMULTISIG: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKMULTISIGVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIG: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIGADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIGVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_CLTV: _
+pub const bitcoin::blockdata::opcodes::all::OP_CODESEPARATOR: _
+pub const bitcoin::blockdata::opcodes::all::OP_CSV: _
+pub const bitcoin::blockdata::opcodes::all::OP_DEPTH: _
+pub const bitcoin::blockdata::opcodes::all::OP_DIV: _
+pub const bitcoin::blockdata::opcodes::all::OP_DROP: _
+pub const bitcoin::blockdata::opcodes::all::OP_DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_ELSE: _
+pub const bitcoin::blockdata::opcodes::all::OP_ENDIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_EQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_EQUALVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_FROMALTSTACK: _
+pub const bitcoin::blockdata::opcodes::all::OP_GREATERTHAN: _
+pub const bitcoin::blockdata::opcodes::all::OP_GREATERTHANOREQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_HASH160: _
+pub const bitcoin::blockdata::opcodes::all::OP_HASH256: _
+pub const bitcoin::blockdata::opcodes::all::OP_IF: _
+pub const bitcoin::blockdata::opcodes::all::OP_IFDUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_INVALIDOPCODE: _
+pub const bitcoin::blockdata::opcodes::all::OP_INVERT: _
+pub const bitcoin::blockdata::opcodes::all::OP_LEFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_LESSTHAN: _
+pub const bitcoin::blockdata::opcodes::all::OP_LESSTHANOREQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_LSHIFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_MAX: _
+pub const bitcoin::blockdata::opcodes::all::OP_MIN: _
+pub const bitcoin::blockdata::opcodes::all::OP_MOD: _
+pub const bitcoin::blockdata::opcodes::all::OP_MUL: _
+pub const bitcoin::blockdata::opcodes::all::OP_NEGATE: _
+pub const bitcoin::blockdata::opcodes::all::OP_NIP: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP10: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP1: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP4: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP5: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP6: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP7: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP8: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP9: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOT: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOTIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMEQUALVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMNOTEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_OR: _
+pub const bitcoin::blockdata::opcodes::all::OP_OVER: _
+pub const bitcoin::blockdata::opcodes::all::OP_PICK: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_0: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_10: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_11: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_12: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_13: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_14: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_15: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_16: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_17: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_18: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_19: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_20: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_21: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_22: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_23: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_24: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_25: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_26: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_27: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_28: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_29: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_30: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_31: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_32: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_33: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_34: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_35: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_36: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_37: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_38: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_39: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_3: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_40: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_41: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_42: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_43: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_44: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_45: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_46: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_47: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_48: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_49: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_50: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_51: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_52: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_53: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_54: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_55: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_56: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_57: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_58: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_59: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_5: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_60: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_61: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_62: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_63: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_64: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_65: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_66: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_67: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_68: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_69: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_6: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_70: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_71: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_72: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_73: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_74: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_75: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_7: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_8: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_9: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_10: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_11: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_12: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_13: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_14: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_15: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_16: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_3: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_5: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_6: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_7: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_8: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_9: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_NEG1: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED1: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED2: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_187: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_188: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_189: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_190: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_191: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_192: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_193: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_194: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_195: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_196: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_197: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_198: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_199: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_200: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_201: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_202: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_203: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_204: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_205: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_206: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_207: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_208: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_209: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_210: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_211: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_212: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_213: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_214: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_215: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_216: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_217: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_218: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_219: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_220: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_221: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_222: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_223: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_224: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_225: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_226: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_227: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_228: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_229: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_230: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_231: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_232: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_233: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_234: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_235: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_236: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_237: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_238: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_239: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_240: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_241: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_242: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_243: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_244: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_245: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_246: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_247: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_248: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_249: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_250: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_251: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_252: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_253: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_254: _
+pub const bitcoin::blockdata::opcodes::all::OP_RIGHT: _
+pub const bitcoin::blockdata::opcodes::all::OP_RIPEMD160: _
+pub const bitcoin::blockdata::opcodes::all::OP_ROLL: _
+pub const bitcoin::blockdata::opcodes::all::OP_ROT: _
+pub const bitcoin::blockdata::opcodes::all::OP_RSHIFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_SHA1: _
+pub const bitcoin::blockdata::opcodes::all::OP_SHA256: _
+pub const bitcoin::blockdata::opcodes::all::OP_SIZE: _
+pub const bitcoin::blockdata::opcodes::all::OP_SUB: _
+pub const bitcoin::blockdata::opcodes::all::OP_SUBSTR: _
+pub const bitcoin::blockdata::opcodes::all::OP_SWAP: _
+pub const bitcoin::blockdata::opcodes::all::OP_TOALTSTACK: _
+pub const bitcoin::blockdata::opcodes::all::OP_TUCK: _
+pub const bitcoin::blockdata::opcodes::all::OP_VER: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERNOTIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_WITHIN: _
+pub const bitcoin::blockdata::opcodes::all::OP_XOR: _
+pub const bitcoin::blockdata::script::ScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::script::ScriptHash::LEN: usize
+pub const bitcoin::blockdata::script::ScriptHash::N: usize
+pub const bitcoin::blockdata::script::WScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::script::WScriptHash::LEN: usize
+pub const bitcoin::blockdata::script::WScriptHash::N: usize
+pub const bitcoin::blockdata::script::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::blockdata::script::witness_program::MIN_SIZE: usize = 2usize
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2PKH_COMPRESSED_MAX: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2PKH_UNCOMPRESSED_MAX: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2TR_KEY_DEFAULT_SIGHASH: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2TR_KEY_NON_DEFAULT_SIGHASH: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2WPKH_MAX: Self
+pub const bitcoin::blockdata::transaction::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
+pub const bitcoin::blockdata::transaction::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
+pub const bitcoin::blockdata::transaction::Sequence::MAX: Self
+pub const bitcoin::blockdata::transaction::Sequence::ZERO: Self
+pub const bitcoin::blockdata::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::transaction::TxOut::NULL: Self
+pub const bitcoin::blockdata::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::transaction::Txid::LEN: usize
+pub const bitcoin::blockdata::transaction::Txid::N: usize
+pub const bitcoin::blockdata::transaction::Version::ONE: Self
+pub const bitcoin::blockdata::transaction::Version::TWO: Self
+pub const bitcoin::blockdata::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::transaction::Wtxid::LEN: usize
+pub const bitcoin::blockdata::transaction::Wtxid::N: usize
+pub const bitcoin::blockdata::weight::Weight::MAX: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MAX_BLOCK: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MIN: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MIN_TRANSACTION: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin::blockdata::weight::Weight::ZERO: bitcoin::blockdata::weight::Weight
+pub const bitcoin::consensus::encode::MAX_VEC_SIZE: usize = 4_000_000usize
+pub const bitcoin::constants::COINBASE_MATURITY: u32 = 100u32
+pub const bitcoin::constants::DIFFCHANGE_INTERVAL: u32 = 2_016u32
+pub const bitcoin::constants::DIFFCHANGE_TIMESPAN: _
+pub const bitcoin::constants::MAX_BLOCK_SIGOPS_COST: i64 = 80_000i64
+pub const bitcoin::constants::MAX_SCRIPTNUM_VALUE: u32 = 2_147_483_648u32
+pub const bitcoin::constants::MAX_SCRIPT_ELEMENT_SIZE: usize = 520usize
+pub const bitcoin::constants::PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0u8
+pub const bitcoin::constants::PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111u8
+pub const bitcoin::constants::SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5u8
+pub const bitcoin::constants::SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196u8
+pub const bitcoin::constants::SUBSIDY_HALVING_INTERVAL: u32 = 210_000u32
+pub const bitcoin::constants::TARGET_BLOCK_SPACING: u32 = 600u32
+pub const bitcoin::constants::WITNESS_SCALE_FACTOR: usize = 4usize
+pub const bitcoin::locktime::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::opcodes::all::OP_0NOTEQUAL: _
+pub const bitcoin::opcodes::all::OP_1ADD: _
+pub const bitcoin::opcodes::all::OP_1SUB: _
+pub const bitcoin::opcodes::all::OP_2DIV: _
+pub const bitcoin::opcodes::all::OP_2DROP: _
+pub const bitcoin::opcodes::all::OP_2DUP: _
+pub const bitcoin::opcodes::all::OP_2MUL: _
+pub const bitcoin::opcodes::all::OP_2OVER: _
+pub const bitcoin::opcodes::all::OP_2ROT: _
+pub const bitcoin::opcodes::all::OP_2SWAP: _
+pub const bitcoin::opcodes::all::OP_3DUP: _
+pub const bitcoin::opcodes::all::OP_ABS: _
+pub const bitcoin::opcodes::all::OP_ADD: _
+pub const bitcoin::opcodes::all::OP_AND: _
+pub const bitcoin::opcodes::all::OP_BOOLAND: _
+pub const bitcoin::opcodes::all::OP_BOOLOR: _
+pub const bitcoin::opcodes::all::OP_CAT: _
+pub const bitcoin::opcodes::all::OP_CHECKMULTISIG: _
+pub const bitcoin::opcodes::all::OP_CHECKMULTISIGVERIFY: _
+pub const bitcoin::opcodes::all::OP_CHECKSIG: _
+pub const bitcoin::opcodes::all::OP_CHECKSIGADD: _
+pub const bitcoin::opcodes::all::OP_CHECKSIGVERIFY: _
+pub const bitcoin::opcodes::all::OP_CLTV: _
+pub const bitcoin::opcodes::all::OP_CODESEPARATOR: _
+pub const bitcoin::opcodes::all::OP_CSV: _
+pub const bitcoin::opcodes::all::OP_DEPTH: _
+pub const bitcoin::opcodes::all::OP_DIV: _
+pub const bitcoin::opcodes::all::OP_DROP: _
+pub const bitcoin::opcodes::all::OP_DUP: _
+pub const bitcoin::opcodes::all::OP_ELSE: _
+pub const bitcoin::opcodes::all::OP_ENDIF: _
+pub const bitcoin::opcodes::all::OP_EQUAL: _
+pub const bitcoin::opcodes::all::OP_EQUALVERIFY: _
+pub const bitcoin::opcodes::all::OP_FROMALTSTACK: _
+pub const bitcoin::opcodes::all::OP_GREATERTHAN: _
+pub const bitcoin::opcodes::all::OP_GREATERTHANOREQUAL: _
+pub const bitcoin::opcodes::all::OP_HASH160: _
+pub const bitcoin::opcodes::all::OP_HASH256: _
+pub const bitcoin::opcodes::all::OP_IF: _
+pub const bitcoin::opcodes::all::OP_IFDUP: _
+pub const bitcoin::opcodes::all::OP_INVALIDOPCODE: _
+pub const bitcoin::opcodes::all::OP_INVERT: _
+pub const bitcoin::opcodes::all::OP_LEFT: _
+pub const bitcoin::opcodes::all::OP_LESSTHAN: _
+pub const bitcoin::opcodes::all::OP_LESSTHANOREQUAL: _
+pub const bitcoin::opcodes::all::OP_LSHIFT: _
+pub const bitcoin::opcodes::all::OP_MAX: _
+pub const bitcoin::opcodes::all::OP_MIN: _
+pub const bitcoin::opcodes::all::OP_MOD: _
+pub const bitcoin::opcodes::all::OP_MUL: _
+pub const bitcoin::opcodes::all::OP_NEGATE: _
+pub const bitcoin::opcodes::all::OP_NIP: _
+pub const bitcoin::opcodes::all::OP_NOP10: _
+pub const bitcoin::opcodes::all::OP_NOP1: _
+pub const bitcoin::opcodes::all::OP_NOP4: _
+pub const bitcoin::opcodes::all::OP_NOP5: _
+pub const bitcoin::opcodes::all::OP_NOP6: _
+pub const bitcoin::opcodes::all::OP_NOP7: _
+pub const bitcoin::opcodes::all::OP_NOP8: _
+pub const bitcoin::opcodes::all::OP_NOP9: _
+pub const bitcoin::opcodes::all::OP_NOP: _
+pub const bitcoin::opcodes::all::OP_NOT: _
+pub const bitcoin::opcodes::all::OP_NOTIF: _
+pub const bitcoin::opcodes::all::OP_NUMEQUAL: _
+pub const bitcoin::opcodes::all::OP_NUMEQUALVERIFY: _
+pub const bitcoin::opcodes::all::OP_NUMNOTEQUAL: _
+pub const bitcoin::opcodes::all::OP_OR: _
+pub const bitcoin::opcodes::all::OP_OVER: _
+pub const bitcoin::opcodes::all::OP_PICK: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_0: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_10: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_11: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_12: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_13: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_14: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_15: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_16: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_17: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_18: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_19: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_1: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_20: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_21: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_22: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_23: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_24: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_25: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_26: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_27: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_28: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_29: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_2: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_30: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_31: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_32: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_33: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_34: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_35: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_36: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_37: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_38: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_39: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_3: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_40: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_41: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_42: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_43: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_44: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_45: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_46: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_47: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_48: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_49: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_4: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_50: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_51: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_52: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_53: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_54: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_55: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_56: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_57: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_58: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_59: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_5: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_60: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_61: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_62: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_63: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_64: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_65: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_66: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_67: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_68: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_69: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_6: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_70: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_71: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_72: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_73: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_74: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_75: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_7: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_8: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_9: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA1: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA2: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA4: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_10: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_11: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_12: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_13: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_14: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_15: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_16: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_1: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_2: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_3: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_4: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_5: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_6: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_7: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_8: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_9: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_NEG1: _
+pub const bitcoin::opcodes::all::OP_RESERVED1: _
+pub const bitcoin::opcodes::all::OP_RESERVED2: _
+pub const bitcoin::opcodes::all::OP_RESERVED: _
+pub const bitcoin::opcodes::all::OP_RETURN: _
+pub const bitcoin::opcodes::all::OP_RETURN_187: _
+pub const bitcoin::opcodes::all::OP_RETURN_188: _
+pub const bitcoin::opcodes::all::OP_RETURN_189: _
+pub const bitcoin::opcodes::all::OP_RETURN_190: _
+pub const bitcoin::opcodes::all::OP_RETURN_191: _
+pub const bitcoin::opcodes::all::OP_RETURN_192: _
+pub const bitcoin::opcodes::all::OP_RETURN_193: _
+pub const bitcoin::opcodes::all::OP_RETURN_194: _
+pub const bitcoin::opcodes::all::OP_RETURN_195: _
+pub const bitcoin::opcodes::all::OP_RETURN_196: _
+pub const bitcoin::opcodes::all::OP_RETURN_197: _
+pub const bitcoin::opcodes::all::OP_RETURN_198: _
+pub const bitcoin::opcodes::all::OP_RETURN_199: _
+pub const bitcoin::opcodes::all::OP_RETURN_200: _
+pub const bitcoin::opcodes::all::OP_RETURN_201: _
+pub const bitcoin::opcodes::all::OP_RETURN_202: _
+pub const bitcoin::opcodes::all::OP_RETURN_203: _
+pub const bitcoin::opcodes::all::OP_RETURN_204: _
+pub const bitcoin::opcodes::all::OP_RETURN_205: _
+pub const bitcoin::opcodes::all::OP_RETURN_206: _
+pub const bitcoin::opcodes::all::OP_RETURN_207: _
+pub const bitcoin::opcodes::all::OP_RETURN_208: _
+pub const bitcoin::opcodes::all::OP_RETURN_209: _
+pub const bitcoin::opcodes::all::OP_RETURN_210: _
+pub const bitcoin::opcodes::all::OP_RETURN_211: _
+pub const bitcoin::opcodes::all::OP_RETURN_212: _
+pub const bitcoin::opcodes::all::OP_RETURN_213: _
+pub const bitcoin::opcodes::all::OP_RETURN_214: _
+pub const bitcoin::opcodes::all::OP_RETURN_215: _
+pub const bitcoin::opcodes::all::OP_RETURN_216: _
+pub const bitcoin::opcodes::all::OP_RETURN_217: _
+pub const bitcoin::opcodes::all::OP_RETURN_218: _
+pub const bitcoin::opcodes::all::OP_RETURN_219: _
+pub const bitcoin::opcodes::all::OP_RETURN_220: _
+pub const bitcoin::opcodes::all::OP_RETURN_221: _
+pub const bitcoin::opcodes::all::OP_RETURN_222: _
+pub const bitcoin::opcodes::all::OP_RETURN_223: _
+pub const bitcoin::opcodes::all::OP_RETURN_224: _
+pub const bitcoin::opcodes::all::OP_RETURN_225: _
+pub const bitcoin::opcodes::all::OP_RETURN_226: _
+pub const bitcoin::opcodes::all::OP_RETURN_227: _
+pub const bitcoin::opcodes::all::OP_RETURN_228: _
+pub const bitcoin::opcodes::all::OP_RETURN_229: _
+pub const bitcoin::opcodes::all::OP_RETURN_230: _
+pub const bitcoin::opcodes::all::OP_RETURN_231: _
+pub const bitcoin::opcodes::all::OP_RETURN_232: _
+pub const bitcoin::opcodes::all::OP_RETURN_233: _
+pub const bitcoin::opcodes::all::OP_RETURN_234: _
+pub const bitcoin::opcodes::all::OP_RETURN_235: _
+pub const bitcoin::opcodes::all::OP_RETURN_236: _
+pub const bitcoin::opcodes::all::OP_RETURN_237: _
+pub const bitcoin::opcodes::all::OP_RETURN_238: _
+pub const bitcoin::opcodes::all::OP_RETURN_239: _
+pub const bitcoin::opcodes::all::OP_RETURN_240: _
+pub const bitcoin::opcodes::all::OP_RETURN_241: _
+pub const bitcoin::opcodes::all::OP_RETURN_242: _
+pub const bitcoin::opcodes::all::OP_RETURN_243: _
+pub const bitcoin::opcodes::all::OP_RETURN_244: _
+pub const bitcoin::opcodes::all::OP_RETURN_245: _
+pub const bitcoin::opcodes::all::OP_RETURN_246: _
+pub const bitcoin::opcodes::all::OP_RETURN_247: _
+pub const bitcoin::opcodes::all::OP_RETURN_248: _
+pub const bitcoin::opcodes::all::OP_RETURN_249: _
+pub const bitcoin::opcodes::all::OP_RETURN_250: _
+pub const bitcoin::opcodes::all::OP_RETURN_251: _
+pub const bitcoin::opcodes::all::OP_RETURN_252: _
+pub const bitcoin::opcodes::all::OP_RETURN_253: _
+pub const bitcoin::opcodes::all::OP_RETURN_254: _
+pub const bitcoin::opcodes::all::OP_RIGHT: _
+pub const bitcoin::opcodes::all::OP_RIPEMD160: _
+pub const bitcoin::opcodes::all::OP_ROLL: _
+pub const bitcoin::opcodes::all::OP_ROT: _
+pub const bitcoin::opcodes::all::OP_RSHIFT: _
+pub const bitcoin::opcodes::all::OP_SHA1: _
+pub const bitcoin::opcodes::all::OP_SHA256: _
+pub const bitcoin::opcodes::all::OP_SIZE: _
+pub const bitcoin::opcodes::all::OP_SUB: _
+pub const bitcoin::opcodes::all::OP_SUBSTR: _
+pub const bitcoin::opcodes::all::OP_SWAP: _
+pub const bitcoin::opcodes::all::OP_TOALTSTACK: _
+pub const bitcoin::opcodes::all::OP_TUCK: _
+pub const bitcoin::opcodes::all::OP_VER: _
+pub const bitcoin::opcodes::all::OP_VERIF: _
+pub const bitcoin::opcodes::all::OP_VERIFY: _
+pub const bitcoin::opcodes::all::OP_VERNOTIF: _
+pub const bitcoin::opcodes::all::OP_WITHIN: _
+pub const bitcoin::opcodes::all::OP_XOR: _
+pub const bitcoin::p2p::Magic::BITCOIN: Self
+pub const bitcoin::p2p::Magic::REGTEST: Self
+pub const bitcoin::p2p::Magic::SIGNET: Self
+pub const bitcoin::p2p::Magic::TESTNET: Self
+pub const bitcoin::p2p::PROTOCOL_VERSION: u32 = 70_001u32
+pub const bitcoin::p2p::ServiceFlags::BLOOM: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::COMPACT_FILTERS: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::GETUTXO: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NETWORK: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NETWORK_LIMITED: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NONE: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::WITNESS: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::message::MAX_INV_SIZE: usize = 50_000usize
+pub const bitcoin::p2p::message::MAX_MSG_SIZE: usize = 5_000_000usize
+pub const bitcoin::policy::DEFAULT_BYTES_PER_SIGOP: u32 = 20u32
+pub const bitcoin::policy::DEFAULT_INCREMENTAL_RELAY_FEE: u32 = 1_000u32
+pub const bitcoin::policy::DEFAULT_MEMPOOL_EXPIRY: u32 = 336u32
+pub const bitcoin::policy::DEFAULT_MIN_RELAY_TX_FEE: u32 = 1_000u32
+pub const bitcoin::policy::DUST_RELAY_TX_FEE: u32 = 3_000u32
+pub const bitcoin::policy::MAX_STANDARD_TX_SIGOPS_COST: _
+pub const bitcoin::policy::MAX_STANDARD_TX_WEIGHT: u32 = 400_000u32
+pub const bitcoin::policy::MIN_STANDARD_TX_NONWITNESS_SIZE: u32 = 82u32
+pub const bitcoin::pow::Target::MAX: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_MAINNET: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_REGTEST: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_SIGNET: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_TESTNET: Self
+pub const bitcoin::pow::Target::ZERO: bitcoin::pow::Target
+pub const bitcoin::psbt::Psbt::DEFAULT_MAX_FEE_RATE: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::script::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::script::witness_program::MIN_SIZE: usize = 2usize
+pub const bitcoin::sign_message::BITCOIN_SIGNED_MSG_PREFIX: &[u8]
+pub const bitcoin::taproot::TAPROOT_ANNEX_PREFIX: u8 = 80u8
+pub const bitcoin::taproot::TAPROOT_CONTROL_BASE_SIZE: usize = 33usize
+pub const bitcoin::taproot::TAPROOT_CONTROL_MAX_NODE_COUNT: usize = 128usize
+pub const bitcoin::taproot::TAPROOT_CONTROL_MAX_SIZE: _
+pub const bitcoin::taproot::TAPROOT_CONTROL_NODE_SIZE: usize = 32usize
+pub const bitcoin::taproot::TAPROOT_LEAF_MASK: u8 = 254u8
+pub const bitcoin::taproot::TAPROOT_LEAF_TAPSCRIPT: u8 = 192u8
+pub const bitcoin::taproot::TapLeafHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapLeafHash::LEN: usize
+pub const bitcoin::taproot::TapLeafHash::N: usize
+pub const bitcoin::taproot::TapNodeHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapNodeHash::LEN: usize
+pub const bitcoin::taproot::TapNodeHash::N: usize
+pub const bitcoin::taproot::TapTweakHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapTweakHash::LEN: usize
+pub const bitcoin::taproot::TapTweakHash::N: usize
+pub const bitcoin::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::witness_program::MIN_SIZE: usize = 2usize
+pub const fn bitcoin::blockdata::constants::ChainHash::using_genesis_block(network: bitcoin::network::Network) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_vb_unchecked(sat_vb: u64) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_kwu(self) -> u64
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin::blockdata::opcodes::Opcode::to_u8(self) -> u8
+pub const fn bitcoin::blockdata::script::ScriptBuf::new() -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::from_slice(input_script_len: usize, witness_element_lengths: &[usize]) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::ground_p2pkh_compressed(bytes_to_grind: usize) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::ground_p2wpkh(bytes_to_grind: usize) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::transaction::predict_weight_from_slices(inputs: &[bitcoin::blockdata::transaction::InputWeightPrediction], output_script_lens: &[usize]) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::weight::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_wu_usize(wu: usize) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_wu(self) -> u64
+pub const fn bitcoin::consensus::encode::VarInt::size(&self) -> usize
+pub const fn bitcoin::consensus::params::Params::new(network: bitcoin::network::Network) -> Self
+pub const fn bitcoin::network::Network::params(self) -> &'static bitcoin::consensus::params::Params
+pub const fn bitcoin::transaction::predict_weight_from_slices(inputs: &[bitcoin::blockdata::transaction::InputWeightPrediction], output_script_lens: &[usize]) -> bitcoin::blockdata::weight::Weight
+pub enum bitcoin::EcdsaSighashType
+pub enum bitcoin::NetworkKind
+pub enum bitcoin::TapSighashType
+pub enum bitcoin::absolute::LockTime
+pub enum bitcoin::address::NetworkChecked
+pub enum bitcoin::address::NetworkUnchecked
+pub enum bitcoin::bip32::ChildNumber
+pub enum bitcoin::blockdata::locktime::absolute::LockTime
+pub enum bitcoin::blockdata::locktime::relative::LockTime
+pub enum bitcoin::blockdata::opcodes::Class
+pub enum bitcoin::blockdata::opcodes::ClassifyContext
+pub enum bitcoin::blockdata::script::Instruction<'a>
+pub enum bitcoin::consensus::serde::hex::Lower
+pub enum bitcoin::consensus::serde::hex::Upper
+pub enum bitcoin::locktime::absolute::LockTime
+pub enum bitcoin::locktime::relative::LockTime
+pub enum bitcoin::network::NetworkKind
+pub enum bitcoin::opcodes::Class
+pub enum bitcoin::opcodes::ClassifyContext
+pub enum bitcoin::p2p::address::AddrV2
+pub enum bitcoin::p2p::message::NetworkMessage
+pub enum bitcoin::p2p::message_blockdata::Inventory
+pub enum bitcoin::p2p::message_bloom::BloomFlags
+pub enum bitcoin::p2p::message_network::RejectReason
+pub enum bitcoin::psbt::SigningAlgorithm
+pub enum bitcoin::relative::LockTime
+pub enum bitcoin::script::Instruction<'a>
+pub enum bitcoin::sighash::EcdsaSighashType
+pub enum bitcoin::sighash::EncodeSigningDataResult<E>
+pub enum bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>
+pub enum bitcoin::sighash::SigningDataError<E>
+pub enum bitcoin::sighash::TapSighashType
+pub enum bitcoin::taproot::LeafVersion
+pub enum bitcoin::taproot::TapLeaf
+pub extern crate bitcoin::base64
+pub extern crate bitcoin::hashes
+pub extern crate bitcoin::hex
+pub extern crate bitcoin::io
+pub extern crate bitcoin::ordered
+pub extern crate bitcoin::secp256k1
+pub fn &'a T::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn &'a bitcoin::bip32::DerivationPath::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 0]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 10]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 11]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 12]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 13]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 14]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 15]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 16]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 17]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 18]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 19]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 1]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 20]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 21]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 22]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 23]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 24]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 25]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 26]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 27]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 28]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 29]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 2]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 30]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 31]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 32]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 33]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 34]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 35]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 36]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 37]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 38]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 39]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 3]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 40]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 41]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 42]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 43]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 44]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 45]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 46]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 47]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 48]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 49]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 4]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 50]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 51]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 52]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 53]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 54]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 55]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 56]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 57]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 58]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 59]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 5]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 60]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 61]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 62]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 63]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 64]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 65]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 66]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 67]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 68]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 69]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 6]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 70]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 71]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 72]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 73]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 7]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 8]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 9]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::try_from(bytes: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn &'a bitcoin::blockdata::witness::Witness::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::ecdsa::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::taproot::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn &'a mut T::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 0]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 10]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 11]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 12]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 13]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 14]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 15]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 16]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 17]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 18]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 19]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 1]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 20]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 21]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 22]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 23]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 24]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 25]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 26]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 27]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 28]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 29]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 2]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 30]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 31]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 32]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 33]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 34]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 35]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 36]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 37]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 38]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 39]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 3]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 40]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 41]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 42]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 43]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 44]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 45]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 46]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 47]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 48]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 49]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 4]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 50]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 51]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 52]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 53]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 54]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 55]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 56]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 57]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 58]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 59]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 5]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 60]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 61]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 62]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 63]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 64]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 65]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 66]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 67]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 68]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 69]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 6]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 70]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 71]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 72]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 73]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 7]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 8]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 9]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::try_from(bytes: &'a mut [u8]) -> core::result::Result<Self, Self::Error>
+pub fn &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn &'a str::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn &'de bitcoin::blockdata::script::Script::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn &'static bitcoin::consensus::params::Params::from(value: &bitcoin::network::Network) -> Self
+pub fn &'static bitcoin::consensus::params::Params::from(value: bitcoin::network::Network) -> Self
+pub fn (T0, T1)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6, T7)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6, T7)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn R::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn R::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn R::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn R::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn R::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn R::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn R::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn R::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn R::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn R::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn T::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn W::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn [u16; 8]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u16; 8]::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 0]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 0]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 10]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 11]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 11]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 12]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 13]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 13]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 14]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 14]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 15]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 15]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 16]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 17]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 17]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 18]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 18]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 19]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 19]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 1]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 1]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 20]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 20]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 21]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 21]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 22]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 22]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 23]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 23]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 24]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 24]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 25]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 25]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 26]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 26]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 27]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 27]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 28]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 28]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 29]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 29]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 2]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 30]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 30]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 31]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 31]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 32]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 33]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 33]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 33]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 33]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 34]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 34]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 35]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 35]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 36]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 36]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 37]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 37]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 38]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 38]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 39]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 39]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 3]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 3]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 40]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 40]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 41]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 41]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 42]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 42]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 43]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 43]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 44]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 44]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 45]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 45]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 46]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 46]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 47]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 47]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 48]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 48]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 49]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 49]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 4]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 50]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 50]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 51]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 51]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 52]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 52]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 53]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 53]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 54]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 54]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 55]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 55]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 56]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 56]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 57]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 57]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 58]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 58]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 59]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 59]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 5]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 5]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 60]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 60]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 61]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 61]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 62]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 62]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 63]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 63]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 64]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 64]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 65]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 65]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 66]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 66]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 67]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 67]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 68]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 68]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 69]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 69]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 6]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 70]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 70]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 71]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 71]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 72]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 72]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 73]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 73]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 7]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 7]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 8]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 9]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 9]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8]::eq(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> bool
+pub fn [u8]::partial_cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn alloc::borrow::Cow<'_, bitcoin::blockdata::script::Script>::from(value: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::borrow::Cow<'static, str>::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<alloc::borrow::Cow<'static, str>, bitcoin::consensus::encode::Error>
+pub fn alloc::borrow::Cow<'static, str>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::boxed::Box<[u8]>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::boxed::Box<[u8]>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(value: alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>) -> Self
+pub fn alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn alloc::rc::Rc<T>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::rc::Rc<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::string::String::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<alloc::string::String, bitcoin::consensus::encode::Error>
+pub fn alloc::string::String::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::string::String::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn alloc::sync::Arc<T>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::sync::Arc<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<alloc::vec::Vec<u8>>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<alloc::vec::Vec<u8>>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::ShortId>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::ShortId>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHeader>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHeader>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip32::ChildNumber>::from(path: bitcoin::bip32::DerivationPath) -> Self
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::Header>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::Header>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::consensus::encode::VarInt>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::consensus::encode::VarInt>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapLeafHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapLeafHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapNodeHash>::from(branch: bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> Self
+pub fn alloc::vec::Vec<u64>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<u64>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<u8>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<u8>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<u8>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::vec::Vec<u8>::from(value: bitcoin::blockdata::script::PushBytesBuf) -> Self
+pub fn bech32::primitives::gf32::Fe32::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> Self
+pub fn bitcoin::CompressedPublicKey::clone(&self) -> bitcoin::CompressedPublicKey
+pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::cmp::Ordering
+pub fn bitcoin::CompressedPublicKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::CompressedPublicKey::eq(&self, other: &bitcoin::CompressedPublicKey) -> bool
+pub fn bitcoin::CompressedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPubkeyError>
+pub fn bitcoin::CompressedPublicKey::from_slice(data: &[u8]) -> core::result::Result<Self, secp256k1::Error>
+pub fn bitcoin::CompressedPublicKey::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::CompressedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::CompressedPublicKey::partial_cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::CompressedPublicKey::pubkey_hash(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::CompressedPublicKey::read_from<R: bitcoin_io::Read + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin::CompressedPublicKey::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::CompressedPublicKey::to_bytes(&self) -> [u8; 33]
+pub fn bitcoin::CompressedPublicKey::try_from(value: bitcoin::PublicKey) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::CompressedPublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), bitcoin::key::Error>
+pub fn bitcoin::CompressedPublicKey::wpubkey_hash(&self) -> bitcoin::WPubkeyHash
+pub fn bitcoin::CompressedPublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::EcdsaSighashType::clone(&self) -> bitcoin::EcdsaSighashType
+pub fn bitcoin::EcdsaSighashType::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::EcdsaSighashType, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::EcdsaSighashType::eq(&self, other: &bitcoin::EcdsaSighashType) -> bool
+pub fn bitcoin::EcdsaSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::EcdsaSighashType::from_consensus(n: u32) -> bitcoin::EcdsaSighashType
+pub fn bitcoin::EcdsaSighashType::from_standard(n: u32) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::EcdsaSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
+pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::LegacySighash::borrow(&self) -> &[u8]
+pub fn bitcoin::LegacySighash::clone(&self) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::cmp(&self, other: &bitcoin::LegacySighash) -> core::cmp::Ordering
+pub fn bitcoin::LegacySighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::LegacySighash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::LegacySighash::engine() -> Self::Engine
+pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
+pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::LegacySighash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::LegacySighash::from_str(s: &str) -> core::result::Result<bitcoin::LegacySighash, Self::Err>
+pub fn bitcoin::LegacySighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::LegacySighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::LegacySighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::LegacySighash::partial_cmp(&self, other: &bitcoin::LegacySighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::LegacySighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::LegacySighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::LegacySighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::MerkleBlock::clone(&self) -> bitcoin::MerkleBlock
+pub fn bitcoin::MerkleBlock::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::MerkleBlock::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::MerkleBlock::eq(&self, other: &bitcoin::MerkleBlock) -> bool
+pub fn bitcoin::MerkleBlock::extract_matches(&self, matches: &mut alloc::vec::Vec<bitcoin::blockdata::transaction::Txid>, indexes: &mut alloc::vec::Vec<u32>) -> core::result::Result<(), bitcoin::merkle_tree::MerkleBlockError>
+pub fn bitcoin::MerkleBlock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::MerkleBlock::from_block_with_predicate<F>(block: &bitcoin::blockdata::block::Block, match_txids: F) -> Self where F: core::ops::function::Fn(&bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::MerkleBlock::from_header_txids_with_predicate<F>(header: &bitcoin::blockdata::block::Header, block_txids: &[bitcoin::blockdata::transaction::Txid], match_txids: F) -> Self where F: core::ops::function::Fn(&bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::PrivateKey::clone(&self) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PrivateKey, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::PrivateKey::eq(&self, other: &bitcoin::PrivateKey) -> bool
+pub fn bitcoin::PrivateKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PrivateKey::fmt_wif(&self, fmt: &mut dyn core::fmt::Write) -> core::fmt::Result
+pub fn bitcoin::PrivateKey::from_slice(data: &[u8], network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::from_str(s: &str) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::from_wif(wif: &str) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::generate(network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::index(&self, core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin::PrivateKey::new(key: secp256k1::key::SecretKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::new_uncompressed(key: secp256k1::key::SecretKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::public_key<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::PublicKey
+pub fn bitcoin::PrivateKey::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
+pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::PubkeyHash::borrow(&self) -> &[u8]
+pub fn bitcoin::PubkeyHash::clone(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::cmp(&self, other: &bitcoin::PubkeyHash) -> core::cmp::Ordering
+pub fn bitcoin::PubkeyHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PubkeyHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::PubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::PubkeyHash::eq(&self, other: &bitcoin::PubkeyHash) -> bool
+pub fn bitcoin::PubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::PubkeyHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::PubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::PubkeyHash, Self::Err>
+pub fn bitcoin::PubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PubkeyHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::PubkeyHash::partial_cmp(&self, other: &bitcoin::PubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::PubkeyHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::PubkeyHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::PubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::PublicKey::clone(&self) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::cmp(&self, other: &bitcoin::PublicKey) -> core::cmp::Ordering
+pub fn bitcoin::PublicKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PublicKey, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::PublicKey::eq(&self, other: &bitcoin::PublicKey) -> bool
+pub fn bitcoin::PublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PublicKey::from(pk: secp256k1::key::PublicKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from(value: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from_slice(data: &[u8]) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::Error>
+pub fn bitcoin::PublicKey::from_str(s: &str) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::Error>
+pub fn bitcoin::PublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PublicKey::new(key: impl core::convert::Into<secp256k1::key::PublicKey>) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::new_uncompressed(key: impl core::convert::Into<secp256k1::key::PublicKey>) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::partial_cmp(&self, other: &bitcoin::PublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::PublicKey::pubkey_hash(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::PublicKey::read_from<R: bitcoin_io::Read + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin::PublicKey::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::PublicKey::to_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::PublicKey::to_sort_key(self) -> bitcoin::key::SortKey
+pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), bitcoin::key::Error>
+pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPubkeyError>
+pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::SegwitV0Sighash::borrow(&self) -> &[u8]
+pub fn bitcoin::SegwitV0Sighash::clone(&self) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::cmp::Ordering
+pub fn bitcoin::SegwitV0Sighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::SegwitV0Sighash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
+pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
+pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::SegwitV0Sighash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::SegwitV0Sighash::from_str(s: &str) -> core::result::Result<bitcoin::SegwitV0Sighash, Self::Err>
+pub fn bitcoin::SegwitV0Sighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::SegwitV0Sighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::SegwitV0Sighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::TapSighash::borrow(&self) -> &[u8]
+pub fn bitcoin::TapSighash::clone(&self) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::cmp(&self, other: &bitcoin::TapSighash) -> core::cmp::Ordering
+pub fn bitcoin::TapSighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::TapSighash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::TapSighash::engine() -> Self::Engine
+pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
+pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::TapSighash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::TapSighash::from_str(s: &str) -> core::result::Result<bitcoin::TapSighash, Self::Err>
+pub fn bitcoin::TapSighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::TapSighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::TapSighash::partial_cmp(&self, other: &bitcoin::TapSighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::TapSighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::TapSighash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin::TapSighashTag::clone(&self) -> bitcoin::TapSighashTag
+pub fn bitcoin::TapSighashTag::cmp(&self, other: &bitcoin::TapSighashTag) -> core::cmp::Ordering
+pub fn bitcoin::TapSighashTag::default() -> bitcoin::TapSighashTag
+pub fn bitcoin::TapSighashTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::TapSighashTag::eq(&self, other: &bitcoin::TapSighashTag) -> bool
+pub fn bitcoin::TapSighashTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighashTag::partial_cmp(&self, other: &bitcoin::TapSighashTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighashType::clone(&self) -> bitcoin::TapSighashType
+pub fn bitcoin::TapSighashType::cmp(&self, other: &bitcoin::TapSighashType) -> core::cmp::Ordering
+pub fn bitcoin::TapSighashType::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::TapSighashType, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::TapSighashType::eq(&self, other: &bitcoin::TapSighashType) -> bool
+pub fn bitcoin::TapSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::TapSighashType::from(s: bitcoin::EcdsaSighashType) -> Self
+pub fn bitcoin::TapSighashType::from_consensus_u8(sighash_type: u8) -> core::result::Result<Self, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::WPubkeyHash::borrow(&self) -> &[u8]
+pub fn bitcoin::WPubkeyHash::clone(&self) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::cmp(&self, other: &bitcoin::WPubkeyHash) -> core::cmp::Ordering
+pub fn bitcoin::WPubkeyHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::WPubkeyHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::WPubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::WPubkeyHash::eq(&self, other: &bitcoin::WPubkeyHash) -> bool
+pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::WPubkeyHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::WPubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::WPubkeyHash, Self::Err>
+pub fn bitcoin::WPubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::WPubkeyHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::WPubkeyHash::partial_cmp(&self, other: &bitcoin::WPubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::WPubkeyHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::WPubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bitcoin::address::AddressType>
+pub fn bitcoin::address::Address::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::Address::from_script(script: &bitcoin::blockdata::script::Script, network: bitcoin::network::Network) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::Address::from_witness_program(program: bitcoin::blockdata::script::witness_program::WitnessProgram, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: &bitcoin::PublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: &secp256k1::key::XOnlyPublicKey) -> bool
+pub fn bitcoin::address::Address::is_spend_standard(&self) -> bool
+pub fn bitcoin::address::Address::matches_script_pubkey(&self, script: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::address::Address::p2pkh(pk: impl core::convert::Into<bitcoin::PubkeyHash>, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2sh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::Address::p2shwpkh(pk: &bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2shwsh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2wpkh(pk: &bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
+pub fn bitcoin::address::Address::p2wsh(script: &bitcoin::blockdata::script::Script, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bitcoin::PubkeyHash>
+pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
+pub fn bitcoin::address::Address::script_pubkey(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::address::Address::to_qr_uri(&self) -> alloc::string::String
+pub fn bitcoin::address::Address<N>::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::address::Address<V>::as_unchecked(&self) -> &bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub fn bitcoin::address::Address<V>::clone(&self) -> bitcoin::address::Address<V>
+pub fn bitcoin::address::Address<V>::cmp(&self, other: &bitcoin::address::Address<V>) -> core::cmp::Ordering
+pub fn bitcoin::address::Address<V>::eq(&self, other: &bitcoin::address::Address<V>) -> bool
+pub fn bitcoin::address::Address<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::Address<V>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::Address<V>::partial_cmp(&self, other: &bitcoin::address::Address<V>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::assume_checked(self) -> bitcoin::address::Address
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::assume_checked_ref(&self) -> &bitcoin::address::Address
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::address::Address<bitcoin::address::NetworkUnchecked>, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::from_str(s: &str) -> core::result::Result<bitcoin::address::Address<bitcoin::address::NetworkUnchecked>, bitcoin::address::error::ParseError>
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::is_valid_for_network(&self, n: bitcoin::network::Network) -> bool
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::require_network(self, required: bitcoin::network::Network) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::AddressType::clone(&self) -> bitcoin::address::AddressType
+pub fn bitcoin::address::AddressType::cmp(&self, other: &bitcoin::address::AddressType) -> core::cmp::Ordering
+pub fn bitcoin::address::AddressType::eq(&self, other: &bitcoin::address::AddressType) -> bool
+pub fn bitcoin::address::AddressType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::AddressType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::address::AddressType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::AddressType::partial_cmp(&self, other: &bitcoin::address::AddressType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::KnownHrp::clone(&self) -> bitcoin::address::KnownHrp
+pub fn bitcoin::address::KnownHrp::cmp(&self, other: &bitcoin::address::KnownHrp) -> core::cmp::Ordering
+pub fn bitcoin::address::KnownHrp::eq(&self, other: &bitcoin::address::KnownHrp) -> bool
+pub fn bitcoin::address::KnownHrp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::KnownHrp::from(n: bitcoin::network::Network) -> Self
+pub fn bitcoin::address::KnownHrp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::KnownHrp::partial_cmp(&self, other: &bitcoin::address::KnownHrp) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::NetworkChecked::clone(&self) -> bitcoin::address::NetworkChecked
+pub fn bitcoin::address::NetworkChecked::cmp(&self, other: &bitcoin::address::NetworkChecked) -> core::cmp::Ordering
+pub fn bitcoin::address::NetworkChecked::eq(&self, other: &bitcoin::address::NetworkChecked) -> bool
+pub fn bitcoin::address::NetworkChecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::NetworkChecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::NetworkChecked::partial_cmp(&self, other: &bitcoin::address::NetworkChecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::NetworkUnchecked::clone(&self) -> bitcoin::address::NetworkUnchecked
+pub fn bitcoin::address::NetworkUnchecked::cmp(&self, other: &bitcoin::address::NetworkUnchecked) -> core::cmp::Ordering
+pub fn bitcoin::address::NetworkUnchecked::eq(&self, other: &bitcoin::address::NetworkUnchecked) -> bool
+pub fn bitcoin::address::NetworkUnchecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::NetworkUnchecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::NetworkUnchecked::partial_cmp(&self, other: &bitcoin::address::NetworkUnchecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::error::Error::clone(&self) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::Error::eq(&self, other: &bitcoin::address::error::Error) -> bool
+pub fn bitcoin::address::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::Error::from(e: bitcoin::blockdata::script::witness_program::Error) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::Error::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::address::error::ParseError::clone(&self) -> bitcoin::address::error::ParseError
+pub fn bitcoin::address::error::ParseError::eq(&self, other: &bitcoin::address::error::ParseError) -> bool
+pub fn bitcoin::address::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::ParseError::from(e: bech32::segwit::DecodeError) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::address::error::UnknownHrpError) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::base58::Error) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::blockdata::script::witness_program::Error) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::address::error::ParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::address::error::UnknownAddressTypeError::clone(&self) -> bitcoin::address::error::UnknownAddressTypeError
+pub fn bitcoin::address::error::UnknownAddressTypeError::eq(&self, other: &bitcoin::address::error::UnknownAddressTypeError) -> bool
+pub fn bitcoin::address::error::UnknownAddressTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::UnknownAddressTypeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::address::error::UnknownHrpError::clone(&self) -> bitcoin::address::error::UnknownHrpError
+pub fn bitcoin::address::error::UnknownHrpError::eq(&self, other: &bitcoin::address::error::UnknownHrpError) -> bool
+pub fn bitcoin::address::error::UnknownHrpError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::UnknownHrpError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::base58::Error::clone(&self) -> bitcoin::base58::Error
+pub fn bitcoin::base58::Error::eq(&self, other: &bitcoin::base58::Error) -> bool
+pub fn bitcoin::base58::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::base58::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::base58::decode(data: &str) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin::base58::Error>
+pub fn bitcoin::base58::decode_check(data: &str) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin::base58::Error>
+pub fn bitcoin::base58::encode(data: &[u8]) -> alloc::string::String
+pub fn bitcoin::base58::encode_check(data: &[u8]) -> alloc::string::String
+pub fn bitcoin::base58::encode_check_to_fmt(fmt: &mut core::fmt::Formatter<'_>, data: &[u8]) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactions::clone(&self) -> bitcoin::bip152::BlockTransactions
+pub fn bitcoin::bip152::BlockTransactions::cmp(&self, other: &bitcoin::bip152::BlockTransactions) -> core::cmp::Ordering
+pub fn bitcoin::bip152::BlockTransactions::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactions::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactions::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::BlockTransactions::eq(&self, other: &bitcoin::bip152::BlockTransactions) -> bool
+pub fn bitcoin::bip152::BlockTransactions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactions::from_request(request: &bitcoin::bip152::BlockTransactionsRequest, block: &bitcoin::blockdata::block::Block) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::bip152::TxIndexOutOfRangeError>
+pub fn bitcoin::bip152::BlockTransactions::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::BlockTransactions::partial_cmp(&self, other: &bitcoin::bip152::BlockTransactions) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::BlockTransactionsRequest::clone(&self) -> bitcoin::bip152::BlockTransactionsRequest
+pub fn bitcoin::bip152::BlockTransactionsRequest::cmp(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> core::cmp::Ordering
+pub fn bitcoin::bip152::BlockTransactionsRequest::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactionsRequest::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::BlockTransactionsRequest::eq(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> bool
+pub fn bitcoin::bip152::BlockTransactionsRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactionsRequest::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::BlockTransactionsRequest::partial_cmp(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::Error::clone(&self) -> bitcoin::bip152::Error
+pub fn bitcoin::bip152::Error::eq(&self, other: &bitcoin::bip152::Error) -> bool
+pub fn bitcoin::bip152::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::bip152::HeaderAndShortIds::clone(&self) -> bitcoin::bip152::HeaderAndShortIds
+pub fn bitcoin::bip152::HeaderAndShortIds::cmp(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> core::cmp::Ordering
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::eq(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> bool
+pub fn bitcoin::bip152::HeaderAndShortIds::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::HeaderAndShortIds::from_block(block: &bitcoin::blockdata::block::Block, nonce: u64, version: u32, prefill: &[usize]) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::bip152::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::HeaderAndShortIds::partial_cmp(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::PrefilledTransaction::as_ref(&self) -> &bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::bip152::PrefilledTransaction::clone(&self) -> bitcoin::bip152::PrefilledTransaction
+pub fn bitcoin::bip152::PrefilledTransaction::cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::cmp::Ordering
+pub fn bitcoin::bip152::PrefilledTransaction::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::PrefilledTransaction::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::PrefilledTransaction::eq(&self, other: &bitcoin::bip152::PrefilledTransaction) -> bool
+pub fn bitcoin::bip152::PrefilledTransaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::PrefilledTransaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::PrefilledTransaction::partial_cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8; 6]
+pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip152::ShortId::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip152::ShortId::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip152::ShortId::as_ref(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip152::ShortId::borrow(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::borrow(&self) -> &[u8]
+pub fn bitcoin::bip152::ShortId::borrow_mut(&mut self) -> &mut [u8; 6]
+pub fn bitcoin::bip152::ShortId::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip152::ShortId::calculate_siphash_keys(header: &bitcoin::blockdata::block::Header, nonce: u64) -> (u64, u64)
+pub fn bitcoin::bip152::ShortId::clone(&self) -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::ShortId::cmp(&self, other: &bitcoin::bip152::ShortId) -> core::cmp::Ordering
+pub fn bitcoin::bip152::ShortId::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::ShortId, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::ShortId::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::ShortId::default() -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::ShortId::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip152::ShortId, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::bip152::ShortId::eq(&self, other: &bitcoin::bip152::ShortId) -> bool
+pub fn bitcoin::bip152::ShortId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::ShortId::from(data: &'a [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from(data: [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip152::ShortId::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip152::ShortId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::ShortId::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip152::ShortId::is_empty(&self) -> bool
+pub fn bitcoin::bip152::ShortId::len(&self) -> usize
+pub fn bitcoin::bip152::ShortId::partial_cmp(&self, other: &bitcoin::bip152::ShortId) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::ShortId::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip152::ShortId::to_bytes(self) -> [u8; 6]
+pub fn bitcoin::bip152::ShortId::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip152::ShortId::with_siphash_keys<T: core::convert::AsRef<[u8]>>(txid: &T, siphash_keys: (u64, u64)) -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::clone(&self) -> bitcoin::bip152::TxIndexOutOfRangeError
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::eq(&self, other: &bitcoin::bip152::TxIndexOutOfRangeError) -> bool
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::bip158::BitStreamReader<'a, R>::new(reader: &'a mut R) -> bitcoin::bip158::BitStreamReader<'a, R>
+pub fn bitcoin::bip158::BitStreamReader<'a, R>::read(&mut self, nbits: u8) -> core::result::Result<u64, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::flush(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::new(writer: &'a mut W) -> bitcoin::bip158::BitStreamWriter<'a, W>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::write(&mut self, data: u64, nbits: u8) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BlockFilter::clone(&self) -> bitcoin::bip158::BlockFilter
+pub fn bitcoin::bip158::BlockFilter::eq(&self, other: &bitcoin::bip158::BlockFilter) -> bool
+pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::BlockFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::new(content: &[u8]) -> bitcoin::bip158::BlockFilter
+pub fn bitcoin::bip158::BlockFilter::new_script_filter<M, S>(block: &bitcoin::blockdata::block::Block, script_for_coin: M) -> core::result::Result<bitcoin::bip158::BlockFilter, bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
+pub fn bitcoin::bip158::BlockFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::BlockFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: &bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_element(&mut self, data: &[u8])
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_input_scripts<M, S>(&mut self, script_for_coin: M) -> core::result::Result<(), bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_output_scripts(&mut self)
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::new(writer: &'a mut W, block: &'a bitcoin::blockdata::block::Block) -> bitcoin::bip158::BlockFilterWriter<'a, W>
+pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::bip158::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHash::borrow(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHash::clone(&self) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::cmp::Ordering
+pub fn bitcoin::bip158::FilterHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::FilterHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::bip158::FilterHash::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
+pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip158::FilterHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip158::FilterHash::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHash, Self::Err>
+pub fn bitcoin::bip158::FilterHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHeader::borrow(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHeader::clone(&self) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::cmp::Ordering
+pub fn bitcoin::bip158::FilterHeader::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip158::FilterHeader::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::FilterHeader::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHeader, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
+pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip158::FilterHeader::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip158::FilterHeader::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHeader, Self::Err>
+pub fn bitcoin::bip158::FilterHeader::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHeader::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip158::FilterHeader::partial_cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHeader::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip158::FilterHeader::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::GcsFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::GcsFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::GcsFilterReader::new(k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterReader
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::add_element(&mut self, element: &[u8])
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::new(writer: &'a mut W, k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterWriter<'a, W>
+pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::ChainCode::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip32::ChainCode::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip32::ChainCode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::ChainCode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::ChainCode::borrow_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::bip32::ChainCode::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::ChainCode::clone(&self) -> bitcoin::bip32::ChainCode
+pub fn bitcoin::bip32::ChainCode::cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::cmp::Ordering
+pub fn bitcoin::bip32::ChainCode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::ChainCode, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::bip32::ChainCode::eq(&self, other: &bitcoin::bip32::ChainCode) -> bool
+pub fn bitcoin::bip32::ChainCode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::ChainCode::from(data: &'a [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from(data: [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip32::ChainCode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip32::ChainCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::ChainCode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::ChainCode::is_empty(&self) -> bool
+pub fn bitcoin::bip32::ChainCode::len(&self) -> usize
+pub fn bitcoin::bip32::ChainCode::partial_cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::ChainCode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip32::ChainCode::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::bip32::ChainCode::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip32::ChildNumber::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
+pub fn bitcoin::bip32::ChildNumber::clone(&self) -> bitcoin::bip32::ChildNumber
+pub fn bitcoin::bip32::ChildNumber::cmp(&self, other: &bitcoin::bip32::ChildNumber) -> core::cmp::Ordering
+pub fn bitcoin::bip32::ChildNumber::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::bip32::ChildNumber::eq(&self, other: &bitcoin::bip32::ChildNumber) -> bool
+pub fn bitcoin::bip32::ChildNumber::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::ChildNumber::from(number: u32) -> Self
+pub fn bitcoin::bip32::ChildNumber::from_hardened_idx(index: u32) -> core::result::Result<Self, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::from_normal_idx(index: u32) -> core::result::Result<Self, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::ChildNumber, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::ChildNumber::increment(self) -> core::result::Result<bitcoin::bip32::ChildNumber, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::is_hardened(&self) -> bool
+pub fn bitcoin::bip32::ChildNumber::is_normal(&self) -> bool
+pub fn bitcoin::bip32::ChildNumber::partial_cmp(&self, other: &bitcoin::bip32::ChildNumber) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::ChildNumber::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::bip32::DerivationPath::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
+pub fn bitcoin::bip32::DerivationPath::child(&self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::children_from(&self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::clone(&self) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::cmp(&self, other: &bitcoin::bip32::DerivationPath) -> core::cmp::Ordering
+pub fn bitcoin::bip32::DerivationPath::default() -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::DerivationPath, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::bip32::DerivationPath::eq(&self, other: &bitcoin::bip32::DerivationPath) -> bool
+pub fn bitcoin::bip32::DerivationPath::extend<T: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, path: T) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::DerivationPath::from(numbers: &'a [bitcoin::bip32::ChildNumber]) -> Self
+pub fn bitcoin::bip32::DerivationPath::from(numbers: alloc::vec::Vec<bitcoin::bip32::ChildNumber>) -> Self
+pub fn bitcoin::bip32::DerivationPath::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::bip32::ChildNumber>
+pub fn bitcoin::bip32::DerivationPath::from_str(path: &str) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::DerivationPath::hardened_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::DerivationPath::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::DerivationPath::into_child(self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::is_empty(&self) -> bool
+pub fn bitcoin::bip32::DerivationPath::is_master(&self) -> bool
+pub fn bitcoin::bip32::DerivationPath::len(&self) -> usize
+pub fn bitcoin::bip32::DerivationPath::master() -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::normal_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::partial_cmp(&self, other: &bitcoin::bip32::DerivationPath) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::DerivationPath::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::bip32::DerivationPath::to_u32_vec(&self) -> alloc::vec::Vec<u32>
+pub fn bitcoin::bip32::DerivationPathIterator<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::bip32::DerivationPathIterator<'a>::start_from(path: &'a bitcoin::bip32::DerivationPath, start: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPathIterator<'a>
+pub fn bitcoin::bip32::Error::clone(&self) -> bitcoin::bip32::Error
+pub fn bitcoin::bip32::Error::eq(&self, other: &bitcoin::bip32::Error) -> bool
+pub fn bitcoin::bip32::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Error::from(e: secp256k1::Error) -> bitcoin::bip32::Error
+pub fn bitcoin::bip32::Error::from(err: bitcoin::base58::Error) -> Self
+pub fn bitcoin::bip32::Error::from(err: bitcoin::key::Error) -> Self
+pub fn bitcoin::bip32::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::Fingerprint::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip32::Fingerprint::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip32::Fingerprint::as_ref(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::Fingerprint::borrow(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::Fingerprint::borrow_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::Fingerprint::clone(&self) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Fingerprint::cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::cmp::Ordering
+pub fn bitcoin::bip32::Fingerprint::default() -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Fingerprint::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::Fingerprint, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::bip32::Fingerprint::eq(&self, other: &bitcoin::bip32::Fingerprint) -> bool
+pub fn bitcoin::bip32::Fingerprint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Fingerprint::from(data: &'a [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from(data: [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip32::Fingerprint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip32::Fingerprint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::Fingerprint::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::Fingerprint::is_empty(&self) -> bool
+pub fn bitcoin::bip32::Fingerprint::len(&self) -> usize
+pub fn bitcoin::bip32::Fingerprint::partial_cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::Fingerprint::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip32::Fingerprint::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip32::IntoDerivationPath::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::XKeyIdentifier::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::XKeyIdentifier::clone(&self) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::cmp::Ordering
+pub fn bitcoin::bip32::XKeyIdentifier::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::bip32::XKeyIdentifier::engine() -> Self::Engine
+pub fn bitcoin::bip32::XKeyIdentifier::eq(&self, other: &bitcoin::bip32::XKeyIdentifier) -> bool
+pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip32::XKeyIdentifier::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip32::XKeyIdentifier::from_str(s: &str) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, Self::Err>
+pub fn bitcoin::bip32::XKeyIdentifier::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::XKeyIdentifier::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::XKeyIdentifier::partial_cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::XKeyIdentifier::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip32::XKeyIdentifier::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::bip32::Xpriv::clone(&self) -> bitcoin::bip32::Xpriv
+pub fn bitcoin::bip32::Xpriv::decode(data: &[u8]) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::derive_priv<C: secp256k1::context::Signing, P: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, secp: &secp256k1::Secp256k1<C>, path: &P) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::Xpriv, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::bip32::Xpriv::encode(&self) -> [u8; 78]
+pub fn bitcoin::bip32::Xpriv::eq(&self, other: &bitcoin::bip32::Xpriv) -> bool
+pub fn bitcoin::bip32::Xpriv::fingerprint<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Xpriv::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpriv::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpriv::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn bitcoin::bip32::Xpriv::identifier<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::Xpriv::new_master(network: impl core::convert::Into<bitcoin::network::NetworkKind>, seed: &[u8]) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::bip32::Xpriv::to_keypair<C: secp256k1::context::Signing>(self, secp: &secp256k1::Secp256k1<C>) -> secp256k1::key::Keypair
+pub fn bitcoin::bip32::Xpriv::to_priv(self) -> bitcoin::PrivateKey
+pub fn bitcoin::bip32::Xpub::ckd_pub<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, i: bitcoin::bip32::ChildNumber) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::ckd_pub_tweak(&self, i: bitcoin::bip32::ChildNumber) -> core::result::Result<(secp256k1::key::SecretKey, bitcoin::bip32::ChainCode), bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::clone(&self) -> bitcoin::bip32::Xpub
+pub fn bitcoin::bip32::Xpub::cmp(&self, other: &bitcoin::bip32::Xpub) -> core::cmp::Ordering
+pub fn bitcoin::bip32::Xpub::decode(data: &[u8]) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::derive_pub<C: secp256k1::context::Verification, P: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, secp: &secp256k1::Secp256k1<C>, path: &P) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::Xpub, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::bip32::Xpub::encode(&self) -> [u8; 78]
+pub fn bitcoin::bip32::Xpub::eq(&self, other: &bitcoin::bip32::Xpub) -> bool
+pub fn bitcoin::bip32::Xpub::fingerprint(&self) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Xpub::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpub::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpub::from_priv<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::bip32::Xpriv) -> bitcoin::bip32::Xpub
+pub fn bitcoin::bip32::Xpub::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::Xpub::identifier(&self) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::Xpub::partial_cmp(&self, other: &bitcoin::bip32::Xpub) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::Xpub::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::bip32::Xpub::to_pub(self) -> bitcoin::CompressedPublicKey
+pub fn bitcoin::bip32::Xpub::to_x_only_pub(self) -> secp256k1::key::XOnlyPublicKey
+pub fn bitcoin::blockdata::block::Bip34Error::clone(&self) -> bitcoin::blockdata::block::Bip34Error
+pub fn bitcoin::blockdata::block::Bip34Error::eq(&self, other: &bitcoin::blockdata::block::Bip34Error) -> bool
+pub fn bitcoin::blockdata::block::Bip34Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Bip34Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::block::Block::bip34_block_height(&self) -> core::result::Result<u64, bitcoin::blockdata::block::Bip34Error>
+pub fn bitcoin::blockdata::block::Block::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::Block::check_merkle_root(&self) -> bool
+pub fn bitcoin::blockdata::block::Block::check_witness_commitment(&self) -> bool
+pub fn bitcoin::blockdata::block::Block::clone(&self) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::blockdata::block::Block::coinbase(&self) -> core::option::Option<&bitcoin::blockdata::transaction::Transaction>
+pub fn bitcoin::blockdata::block::Block::compute_merkle_root(&self) -> core::option::Option<bitcoin::blockdata::block::TxMerkleNode>
+pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: &bitcoin::blockdata::block::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::Block::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Block::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Block::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Block::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::block::Block::eq(&self, other: &bitcoin::blockdata::block::Block) -> bool
+pub fn bitcoin::blockdata::block::Block::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Block::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
+pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
+pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::BlockHash::clone(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::BlockHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::BlockHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::BlockHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::BlockHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::block::BlockHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::BlockHash::eq(&self, other: &bitcoin::blockdata::block::BlockHash) -> bool
+pub fn bitcoin::blockdata::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::BlockHash::from(block: &bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::BlockHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::BlockHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::BlockHash, Self::Err>
+pub fn bitcoin::blockdata::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::BlockHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::BlockHash::partial_cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::BlockHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::BlockHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::Header::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::Header::clone(&self) -> bitcoin::blockdata::block::Header
+pub fn bitcoin::blockdata::block::Header::cmp(&self, other: &bitcoin::blockdata::block::Header) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::Header::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Header, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Header::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Header, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Header::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Header::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::block::Header::difficulty(&self, network: bitcoin::network::Network) -> u128
+pub fn bitcoin::blockdata::block::Header::difficulty_float(&self) -> f64
+pub fn bitcoin::blockdata::block::Header::eq(&self, other: &bitcoin::blockdata::block::Header) -> bool
+pub fn bitcoin::blockdata::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::Header::partial_cmp(&self, other: &bitcoin::blockdata::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::Header::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
+pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
+pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
+pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::TxMerkleNode::clone(&self) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> bool
+pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::TxMerkleNode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::TxMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::TxMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::ValidationError::clone(&self) -> bitcoin::blockdata::block::ValidationError
+pub fn bitcoin::blockdata::block::ValidationError::eq(&self, other: &bitcoin::blockdata::block::ValidationError) -> bool
+pub fn bitcoin::blockdata::block::ValidationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::ValidationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::block::Version::clone(&self) -> bitcoin::blockdata::block::Version
+pub fn bitcoin::blockdata::block::Version::cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::Version::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Version::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Version::default() -> bitcoin::blockdata::block::Version
+pub fn bitcoin::blockdata::block::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::block::Version::eq(&self, other: &bitcoin::blockdata::block::Version) -> bool
+pub fn bitcoin::blockdata::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Version::from_consensus(v: i32) -> Self
+pub fn bitcoin::blockdata::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::Version::is_signalling_soft_fork(&self, bit: u8) -> bool
+pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
+pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessCommitment::clone(&self) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::WitnessCommitment::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
+pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessCommitment::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::clone(&self) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> bool
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::blockdata::constants::ChainHash::as_ptr(&self) -> *const u8
+pub fn bitcoin::blockdata::constants::ChainHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::constants::ChainHash::clone(&self) -> bitcoin::blockdata::constants::ChainHash
+pub fn bitcoin::blockdata::constants::ChainHash::cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::constants::ChainHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::constants::ChainHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::constants::ChainHash::eq(&self, other: &bitcoin::blockdata::constants::ChainHash) -> bool
+pub fn bitcoin::blockdata::constants::ChainHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::constants::ChainHash::from(data: &'a [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from(data: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::blockdata::constants::ChainHash::from_genesis_block_hash(block_hash: bitcoin::blockdata::block::BlockHash) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::constants::ChainHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::constants::ChainHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::constants::ChainHash::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::constants::ChainHash::len(&self) -> usize
+pub fn bitcoin::blockdata::constants::ChainHash::partial_cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::constants::ChainHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::constants::ChainHash::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::constants::genesis_block(network: bitcoin::network::Network) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin::blockdata::weight::Weight) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::clone(&self) -> bitcoin::blockdata::fee_rate::FeeRate
+pub fn bitcoin::blockdata::fee_rate::FeeRate::cmp(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::fee_rate::FeeRate::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::eq(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> bool
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fee_wu(self, weight: bitcoin::blockdata::weight::Weight) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_vb(sat_vb: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::fee_rate::FeeRate::mul(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::fee_rate::FeeRate::partial_cmp(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ConversionError
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::Error::clone(&self) -> bitcoin::blockdata::locktime::absolute::Error
+pub fn bitcoin::blockdata::locktime::absolute::Error::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Error) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::blockdata::locktime::absolute::ConversionError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::blockdata::locktime::absolute::OperationError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::error::ParseIntError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::Height::clone(&self) -> bitcoin::blockdata::locktime::absolute::Height
+pub fn bitcoin::blockdata::locktime::absolute::Height::cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::absolute::Height::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::locktime::absolute::Height::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_consensus(n: u32) -> core::result::Result<bitcoin::blockdata::locktime::absolute::Height, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::Height::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::locktime::absolute::Height::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::arbitrary_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::clone(&self) -> bitcoin::blockdata::locktime::absolute::LockTime
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::eq(&self, other: &bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from(h: bitcoin::blockdata::locktime::absolute::Height) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from(t: bitcoin::blockdata::locktime::absolute::Time) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_consensus(n: u32) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_height(n: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_time(n: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_block_height(&self) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_block_time(&self) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_implied_by(&self, other: bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_same_unit(&self, other: bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_satisfied_by(&self, height: bitcoin::blockdata::locktime::absolute::Height, time: bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::LockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::clone(&self) -> bitcoin::blockdata::locktime::absolute::OperationError
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::OperationError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::Time::clone(&self) -> bitcoin::blockdata::locktime::absolute::Time
+pub fn bitcoin::blockdata::locktime::absolute::Time::cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::absolute::Time::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::locktime::absolute::Time::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_consensus(n: u32) -> core::result::Result<bitcoin::blockdata::locktime::absolute::Time, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::Time::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::Time::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::locktime::absolute::Time::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Error::clone(&self) -> bitcoin::blockdata::locktime::relative::Error
+pub fn bitcoin::blockdata::locktime::relative::Error::eq(&self, other: &bitcoin::blockdata::locktime::relative::Error) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::relative::Height::clone(&self) -> bitcoin::blockdata::locktime::relative::Height
+pub fn bitcoin::blockdata::locktime::relative::Height::cmp(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::relative::Height::default() -> bitcoin::blockdata::locktime::relative::Height
+pub fn bitcoin::blockdata::locktime::relative::Height::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::locktime::relative::Height::eq(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Height::from(value: u16) -> Self
+pub fn bitcoin::blockdata::locktime::relative::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::relative::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::Height::partial_cmp(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::relative::Height::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::value(self) -> u16
+pub fn bitcoin::blockdata::locktime::relative::LockTime::clone(&self) -> bitcoin::blockdata::locktime::relative::LockTime
+pub fn bitcoin::blockdata::locktime::relative::LockTime::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::locktime::relative::LockTime::eq(&self, other: &bitcoin::blockdata::locktime::relative::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::LockTime::from(h: bitcoin::blockdata::locktime::relative::Height) -> Self
+pub fn bitcoin::blockdata::locktime::relative::LockTime::from(t: bitcoin::blockdata::locktime::relative::Time) -> Self
+pub fn bitcoin::blockdata::locktime::relative::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_implied_by(&self, other: bitcoin::blockdata::locktime::relative::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by(&self, h: bitcoin::blockdata::locktime::relative::Height, t: bitcoin::blockdata::locktime::relative::Time) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by_height(&self, h: bitcoin::blockdata::locktime::relative::Height) -> core::result::Result<bool, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by_time(&self, t: bitcoin::blockdata::locktime::relative::Time) -> core::result::Result<bool, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::LockTime::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::locktime::relative::Time::clone(&self) -> bitcoin::blockdata::locktime::relative::Time
+pub fn bitcoin::blockdata::locktime::relative::Time::cmp(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::relative::Time::default() -> bitcoin::blockdata::locktime::relative::Time
+pub fn bitcoin::blockdata::locktime::relative::Time::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::locktime::relative::Time::eq(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin::blockdata::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::relative::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::Time::partial_cmp(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::relative::Time::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::value(self) -> u16
+pub fn bitcoin::blockdata::opcodes::Class::clone(&self) -> bitcoin::blockdata::opcodes::Class
+pub fn bitcoin::blockdata::opcodes::Class::eq(&self, other: &bitcoin::blockdata::opcodes::Class) -> bool
+pub fn bitcoin::blockdata::opcodes::Class::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::clone(&self) -> bitcoin::blockdata::opcodes::ClassifyContext
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::cmp(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::eq(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> bool
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::partial_cmp(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::opcodes::Opcode::classify(self, ctx: bitcoin::blockdata::opcodes::ClassifyContext) -> bitcoin::blockdata::opcodes::Class
+pub fn bitcoin::blockdata::opcodes::Opcode::clone(&self) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::opcodes::Opcode::eq(&self, other: &bitcoin::blockdata::opcodes::Opcode) -> bool
+pub fn bitcoin::blockdata::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::opcodes::Opcode::from(b: u8) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::opcodes::Opcode::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::opcodes::Opcode::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::blockdata::script::Builder::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Builder::as_script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Builder::clone(&self) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::default() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::eq(&self, other: &bitcoin::blockdata::script::Builder) -> bool
+pub fn bitcoin::blockdata::script::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::script::Builder::from(v: alloc::vec::Vec<u8>) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::Builder::into_script(self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Builder::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::Builder::len(&self) -> usize
+pub fn bitcoin::blockdata::script::Builder::new() -> Self
+pub fn bitcoin::blockdata::script::Builder::push_int(self, data: i64) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_key(self, key: &bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_lock_time(self, lock_time: bitcoin::blockdata::locktime::absolute::LockTime) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_opcode(self, data: bitcoin::blockdata::opcodes::Opcode) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_sequence(self, sequence: bitcoin::blockdata::transaction::Sequence) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(self, data: T) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_verify(self) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: &secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Bytes<'_>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::nth_back(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::Error::clone(&self) -> bitcoin::blockdata::script::Error
+pub fn bitcoin::blockdata::script::Error::eq(&self, other: &bitcoin::blockdata::script::Error) -> bool
+pub fn bitcoin::blockdata::script::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::Instruction<'a>::clone(&self) -> bitcoin::blockdata::script::Instruction<'a>
+pub fn bitcoin::blockdata::script::Instruction<'a>::eq(&self, other: &bitcoin::blockdata::script::Instruction<'a>) -> bool
+pub fn bitcoin::blockdata::script::Instruction<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Instruction<'a>::opcode(&self) -> core::option::Option<bitcoin::blockdata::opcodes::Opcode>
+pub fn bitcoin::blockdata::script::Instruction<'a>::push_bytes(&self) -> core::option::Option<&bitcoin::blockdata::script::PushBytes>
+pub fn bitcoin::blockdata::script::Instruction<'a>::script_num(&self) -> core::option::Option<i64>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::as_script(&self) -> &'a bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::clone(&self) -> bitcoin::blockdata::script::InstructionIndices<'a>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::Instructions<'a>::as_script(&self) -> &'a bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Instructions<'a>::clone(&self) -> bitcoin::blockdata::script::Instructions<'a>
+pub fn bitcoin::blockdata::script::Instructions<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Instructions<'a>::next(&mut self) -> core::option::Option<core::result::Result<bitcoin::blockdata::script::Instruction<'a>, bitcoin::blockdata::script::Error>>
+pub fn bitcoin::blockdata::script::Instructions<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::PushBytes::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytes::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytes::cmp(&self, other: &bitcoin::blockdata::script::PushBytes) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::PushBytes::empty() -> &'static Self
+pub fn bitcoin::blockdata::script::PushBytes::eq(&self, other: &bitcoin::blockdata::script::PushBytes) -> bool
+pub fn bitcoin::blockdata::script::PushBytes::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytes::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::PushBytes::len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytes::partial_cmp(&self, other: &bitcoin::blockdata::script::PushBytes) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::PushBytes::to_owned(&self) -> Self::Owned
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_mut_push_bytes(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_push_bytes(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::borrow(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::borrow_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::capacity(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesBuf::clear(&mut self)
+pub fn bitcoin::blockdata::script::PushBytesBuf::clone(&self) -> bitcoin::blockdata::script::PushBytesBuf
+pub fn bitcoin::blockdata::script::PushBytesBuf::cmp(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::PushBytesBuf::default() -> bitcoin::blockdata::script::PushBytesBuf
+pub fn bitcoin::blockdata::script::PushBytesBuf::deref(&self) -> &Self::Target
+pub fn bitcoin::blockdata::script::PushBytesBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::blockdata::script::PushBytesBuf::eq(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> bool
+pub fn bitcoin::blockdata::script::PushBytesBuf::extend_from_slice(&mut self, bytes: &[u8]) -> core::result::Result<(), bitcoin::blockdata::script::PushBytesError>
+pub fn bitcoin::blockdata::script::PushBytesBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 0]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 10]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 11]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 12]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 13]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 14]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 15]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 16]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 17]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 18]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 19]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 1]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 20]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 21]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 22]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 23]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 24]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 25]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 26]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 27]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 28]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 29]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 2]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 30]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 31]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 32]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 33]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 34]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 35]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 36]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 37]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 38]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 39]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 3]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 40]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 41]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 42]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 43]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 44]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 45]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 46]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 47]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 48]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 49]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 4]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 50]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 51]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 52]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 53]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 54]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 55]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 56]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 57]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 58]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 59]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 5]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 60]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 61]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 62]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 63]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 64]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 65]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 66]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 67]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 68]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 69]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 6]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 70]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 71]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 72]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 73]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 7]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 8]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 9]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 0]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 10]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 11]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 12]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 13]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 14]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 15]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 16]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 17]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 18]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 19]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 1]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 20]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 21]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 22]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 23]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 24]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 25]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 26]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 27]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 28]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 29]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 2]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 30]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 31]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 33]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 34]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 35]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 36]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 37]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 38]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 39]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 3]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 40]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 41]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 42]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 43]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 44]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 45]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 46]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 47]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 48]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 49]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 4]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 50]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 51]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 52]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 53]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 54]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 55]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 56]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 57]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 58]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 59]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 5]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 60]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 61]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 62]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 63]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 64]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 65]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 66]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 67]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 68]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 69]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 6]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 70]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 71]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 72]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 73]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 7]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 8]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 9]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::PushBytesBuf::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::PushBytesBuf::len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesBuf::new() -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::PushBytesBuf::pop(&mut self) -> core::option::Option<u8>
+pub fn bitcoin::blockdata::script::PushBytesBuf::push(&mut self, byte: u8) -> core::result::Result<(), bitcoin::blockdata::script::PushBytesError>
+pub fn bitcoin::blockdata::script::PushBytesBuf::remove(&mut self, index: usize) -> u8
+pub fn bitcoin::blockdata::script::PushBytesBuf::reserve(&mut self, additional_capacity: usize)
+pub fn bitcoin::blockdata::script::PushBytesBuf::truncate(&mut self, len: usize)
+pub fn bitcoin::blockdata::script::PushBytesBuf::try_from(vec: alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::PushBytesBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin::blockdata::script::PushBytesError::clone(&self) -> bitcoin::blockdata::script::PushBytesError
+pub fn bitcoin::blockdata::script::PushBytesError::eq(&self, other: &bitcoin::blockdata::script::PushBytesError) -> bool
+pub fn bitcoin::blockdata::script::PushBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytesError::input_len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::PushBytesErrorReport::input_len(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Script::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::Script::as_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::Script::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Script::as_ref(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::builder() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Script::bytes(&self) -> bitcoin::blockdata::script::Bytes<'_>
+pub fn bitcoin::blockdata::script::Script::cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::Script::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::script::Script::count_sigops(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::count_sigops_legacy(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::eq(&self, other: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::blockdata::script::Script::eq(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> bool
+pub fn bitcoin::blockdata::script::Script::first_opcode(&self) -> core::option::Option<bitcoin::blockdata::opcodes::Opcode>
+pub fn bitcoin::blockdata::script::Script::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Script::fmt_asm(&self, f: &mut dyn core::fmt::Write) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Script::from_bytes(bytes: &[u8]) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::from_bytes_mut(bytes: &mut [u8]) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::Script::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::instruction_indices(&self) -> bitcoin::blockdata::script::InstructionIndices<'_>
+pub fn bitcoin::blockdata::script::Script::instruction_indices_minimal(&self) -> bitcoin::blockdata::script::InstructionIndices<'_>
+pub fn bitcoin::blockdata::script::Script::instructions(&self) -> bitcoin::blockdata::script::Instructions<'_>
+pub fn bitcoin::blockdata::script::Script::instructions_minimal(&self) -> bitcoin::blockdata::script::Instructions<'_>
+pub fn bitcoin::blockdata::script::Script::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_multisig(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_op_return(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2pk(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2pkh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2sh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2tr(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2wpkh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2wsh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_provably_unspendable(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_push_only(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_witness_program(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::len(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::minimal_non_dust(&self) -> bitcoin_units::amount::Amount
+pub fn bitcoin::blockdata::script::Script::minimal_non_dust_custom(&self, dust_relay_fee: bitcoin::blockdata::fee_rate::FeeRate) -> bitcoin_units::amount::Amount
+pub fn bitcoin::blockdata::script::Script::new() -> &'static bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::p2pk_public_key(&self) -> core::option::Option<bitcoin::PublicKey>
+pub fn bitcoin::blockdata::script::Script::p2wpkh_script_code(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub fn bitcoin::blockdata::script::Script::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::Script::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::Script::script_hash(&self) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::Script::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::blockdata::script::Script::tapscript_leaf_hash(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::blockdata::script::Script::to_asm_string(&self) -> alloc::string::String
+pub fn bitcoin::blockdata::script::Script::to_bytes(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::Script::to_hex_string(&self) -> alloc::string::String
+pub fn bitcoin::blockdata::script::Script::to_owned(&self) -> Self::Owned
+pub fn bitcoin::blockdata::script::Script::to_p2sh(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::to_p2tr<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::to_p2wsh(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::verify(&self, index: usize, amount: bitcoin_units::amount::Amount, spending_tx: &[u8]) -> core::result::Result<(), bitcoin::consensus::validation::BitcoinconsensusError>
+pub fn bitcoin::blockdata::script::Script::verify_with_flags<F: core::convert::Into<u32>>(&self, index: usize, amount: bitcoin_units::amount::Amount, spending_tx: &[u8], flags: F) -> core::result::Result<(), bitcoin::consensus::validation::BitcoinconsensusError>
+pub fn bitcoin::blockdata::script::Script::witness_version(&self) -> core::option::Option<bitcoin::blockdata::script::witness_version::WitnessVersion>
+pub fn bitcoin::blockdata::script::Script::wscript_hash(&self) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut_script(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptBuf::as_ref(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::borrow(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::borrow_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::builder() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::ScriptBuf::clone(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::ScriptBuf::cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::ScriptBuf::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::script::ScriptBuf::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::script::ScriptBuf::default() -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::ScriptBuf::deref(&self) -> &Self::Target
+pub fn bitcoin::blockdata::script::ScriptBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::blockdata::script::ScriptBuf::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::script::ScriptBuf::eq(&self, other: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::blockdata::script::ScriptBuf::eq(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> bool
+pub fn bitcoin::blockdata::script::ScriptBuf::extend<T>(&mut self, iter: T) where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::script::Instruction<'a>>
+pub fn bitcoin::blockdata::script::ScriptBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::ScriptBuf::from(a: bitcoin::address::Address) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(v: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(value: alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::parse::HexToBytesError>
+pub fn bitcoin::blockdata::script::ScriptBuf::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::script::Instruction<'a>>
+pub fn bitcoin::blockdata::script::ScriptBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: &bitcoin::PublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: &bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: &bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_witness_program(witness_program: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptBuf::push_instruction(&mut self, instruction: bitcoin::blockdata::script::Instruction<'_>)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_instruction_no_opt(&mut self, instruction: bitcoin::blockdata::script::Instruction<'_>)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_opcode(&mut self, data: bitcoin::blockdata::opcodes::Opcode)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(&mut self, data: T)
+pub fn bitcoin::blockdata::script::ScriptBuf::reserve(&mut self, additional_len: usize)
+pub fn bitcoin::blockdata::script::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
+pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
+pub fn bitcoin::blockdata::script::ScriptBuf::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::ScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptHash::clone(&self) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::ScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::script::ScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::ScriptHash::eq(&self, other: &bitcoin::blockdata::script::ScriptHash) -> bool
+pub fn bitcoin::blockdata::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::script::ScriptHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::script::ScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::WScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::WScriptHash::clone(&self) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::WScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::script::WScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::WScriptHash::eq(&self, other: &bitcoin::blockdata::script::WScriptHash) -> bool
+pub fn bitcoin::blockdata::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::script::WScriptHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::script::WScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::WScriptHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::script::WScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::WScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::script::WScriptHash::to_raw_hash(self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin::blockdata::script::read_scriptbool(v: &[u8]) -> bool
+pub fn bitcoin::blockdata::script::read_scriptint(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::blockdata::script::read_scriptint_non_minimal(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::blockdata::script::witness_program::Error::clone(&self) -> bitcoin::blockdata::script::witness_program::Error
+pub fn bitcoin::blockdata::script::witness_program::Error::eq(&self, other: &bitcoin::blockdata::script::witness_program::Error) -> bool
+pub fn bitcoin::blockdata::script::witness_program::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_program::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::clone(&self) -> bitcoin::blockdata::script::witness_program::WitnessProgram
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::eq(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2tr(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wpkh(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wsh(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::new(version: bitcoin::blockdata::script::witness_version::WitnessVersion, bytes: &[u8]) -> core::result::Result<Self, bitcoin::blockdata::script::witness_program::Error>
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wsh(script: &bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::program(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::version(&self) -> bitcoin::blockdata::script::witness_version::WitnessVersion
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::clone(&self) -> bitcoin::blockdata::script::witness_version::FromStrError
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::eq(&self, other: &bitcoin::blockdata::script::witness_version::FromStrError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::from(e: bitcoin::error::ParseIntError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::clone(&self) -> bitcoin::blockdata::script::witness_version::TryFromError
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::eq(&self, other: &bitcoin::blockdata::script::witness_version::TryFromError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::clone(&self) -> bitcoin::blockdata::script::witness_version::TryFromInstructionError
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::eq(&self, other: &bitcoin::blockdata::script::witness_version::TryFromInstructionError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::clone(&self) -> bitcoin::blockdata::script::witness_version::WitnessVersion
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::eq(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> bool
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_fe(self) -> bech32::primitives::gf32::Fe32
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_num(self) -> u8
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(instruction: bitcoin::blockdata::script::Instruction<'_>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(opcode: bitcoin::blockdata::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(value: bech32::primitives::gf32::Fe32) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::clone(&self) -> bitcoin::blockdata::transaction::IndexOutOfBoundsError
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::eq(&self, other: &bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> bool
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::clone(&self) -> bitcoin::blockdata::transaction::InputWeightPrediction
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::new<T>(input_script_len: usize, witness_element_lengths: T) -> Self where T: core::iter::traits::collect::IntoIterator, <T as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<usize>
+pub fn bitcoin::blockdata::transaction::InputsIndexError::clone(&self) -> bitcoin::blockdata::transaction::InputsIndexError
+pub fn bitcoin::blockdata::transaction::InputsIndexError::eq(&self, other: &bitcoin::blockdata::transaction::InputsIndexError) -> bool
+pub fn bitcoin::blockdata::transaction::InputsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::InputsIndexError::from(e: bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::blockdata::transaction::InputsIndexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::transaction::OutPoint::clone(&self) -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::cmp(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::OutPoint::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::OutPoint::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::OutPoint::default() -> Self
+pub fn bitcoin::blockdata::transaction::OutPoint::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::blockdata::transaction::OutPoint, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::transaction::OutPoint::eq(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> bool
+pub fn bitcoin::blockdata::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::OutPoint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::OutPoint::is_null(&self) -> bool
+pub fn bitcoin::blockdata::transaction::OutPoint::new(txid: bitcoin::blockdata::transaction::Txid, vout: u32) -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::null() -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::partial_cmp(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::OutPoint::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::clone(&self) -> bitcoin::blockdata::transaction::OutputsIndexError
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::eq(&self, other: &bitcoin::blockdata::transaction::OutputsIndexError) -> bool
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::from(e: bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::clone(&self) -> bitcoin::blockdata::transaction::ParseOutPointError
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::eq(&self, other: &bitcoin::blockdata::transaction::ParseOutPointError) -> bool
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::transaction::Sequence::clone(&self) -> bitcoin::blockdata::transaction::Sequence
+pub fn bitcoin::blockdata::transaction::Sequence::cmp(&self, other: &bitcoin::blockdata::transaction::Sequence) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Sequence::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::default() -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::transaction::Sequence::enables_absolute_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::eq(&self, other: &bitcoin::blockdata::transaction::Sequence) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Sequence::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_consensus(n: u32) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_height(height: u16) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::transaction::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Sequence::is_final(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_height_locked(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_rbf(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_relative_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_time_locked(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Sequence) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Sequence::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::transaction::Sequence::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::transaction::Sequence::to_relative_lock_time(&self) -> core::option::Option<bitcoin::blockdata::locktime::relative::LockTime>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::base_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::clone(&self) -> bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::blockdata::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Transaction::compute_txid(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Transaction::compute_wtxid(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Transaction::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::transaction::Transaction::eq(&self, other: &bitcoin::blockdata::transaction::Transaction) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Transaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Transaction::is_absolute_timelock_satisfied(&self, height: bitcoin::blockdata::locktime::absolute::Height, time: bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_coinbase(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_explicitly_rbf(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_lock_time_enabled(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Transaction::script_pubkey_lens(&self) -> impl core::iter::traits::iterator::Iterator<Item = usize> + '_
+pub fn bitcoin::blockdata::transaction::Transaction::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::transaction::Transaction::total_sigop_cost<S>(&self, spent: S) -> usize where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub fn bitcoin::blockdata::transaction::Transaction::total_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::tx_in(&self, input_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxIn, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::blockdata::transaction::Transaction::tx_out(&self, output_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::blockdata::transaction::OutputsIndexError>
+pub fn bitcoin::blockdata::transaction::Transaction::txid(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Transaction::verify<S>(&self, spent: S) -> core::result::Result<(), bitcoin::consensus::validation::TxVerifyError> where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub fn bitcoin::blockdata::transaction::Transaction::verify_with_flags<S, F>(&self, spent: S, flags: F) -> core::result::Result<(), bitcoin::consensus::validation::TxVerifyError> where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>, F: core::convert::Into<u32>
+pub fn bitcoin::blockdata::transaction::Transaction::vsize(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::Transaction::wtxid(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::TxIn::base_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxIn::clone(&self) -> bitcoin::blockdata::transaction::TxIn
+pub fn bitcoin::blockdata::transaction::TxIn::cmp(&self, other: &bitcoin::blockdata::transaction::TxIn) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::TxIn::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxIn::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::TxIn::default() -> bitcoin::blockdata::transaction::TxIn
+pub fn bitcoin::blockdata::transaction::TxIn::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::transaction::TxIn::enables_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::TxIn::eq(&self, other: &bitcoin::blockdata::transaction::TxIn) -> bool
+pub fn bitcoin::blockdata::transaction::TxIn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::TxIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::TxIn::legacy_weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::TxIn::partial_cmp(&self, other: &bitcoin::blockdata::transaction::TxIn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::TxIn::segwit_weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::TxIn::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::transaction::TxIn::total_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxOut::clone(&self) -> bitcoin::blockdata::transaction::TxOut
+pub fn bitcoin::blockdata::transaction::TxOut::cmp(&self, other: &bitcoin::blockdata::transaction::TxOut) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::transaction::TxOut, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::transaction::TxOut, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::transaction::TxOut::eq(&self, other: &bitcoin::blockdata::transaction::TxOut) -> bool
+pub fn bitcoin::blockdata::transaction::TxOut::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::TxOut::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::TxOut::minimal_non_dust(script_pubkey: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn bitcoin::blockdata::transaction::TxOut::minimal_non_dust_custom(script_pubkey: bitcoin::blockdata::script::ScriptBuf, dust_relay_fee: bitcoin::blockdata::fee_rate::FeeRate) -> Self
+pub fn bitcoin::blockdata::transaction::TxOut::partial_cmp(&self, other: &bitcoin::blockdata::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::TxOut::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Txid::clone(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Txid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Txid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Txid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::transaction::Txid, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::transaction::Txid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Txid::eq(&self, other: &bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::transaction::Txid::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::transaction::Txid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Txid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Txid::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::transaction::Txid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Txid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::transaction::Txid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Version::clone(&self) -> bitcoin::blockdata::transaction::Version
+pub fn bitcoin::blockdata::transaction::Version::cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Version::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Version::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::transaction::Version::eq(&self, other: &bitcoin::blockdata::transaction::Version) -> bool
+pub fn bitcoin::blockdata::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Version::is_standard(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Version::non_standard(version: i32) -> bitcoin::blockdata::transaction::Version
+pub fn bitcoin::blockdata::transaction::Version::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::transaction::Wtxid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Wtxid::clone(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Wtxid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Wtxid::eq(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> bool
+pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::transaction::Wtxid::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::transaction::Wtxid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Wtxid::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::transaction::Wtxid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Wtxid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::transaction::Wtxid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::effective_value(fee_rate: bitcoin::blockdata::fee_rate::FeeRate, satisfaction_weight: bitcoin::blockdata::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin::blockdata::transaction::predict_weight<I, O>(inputs: I, output_script_lens: O) -> bitcoin::blockdata::weight::Weight where I: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::transaction::InputWeightPrediction>, O: core::iter::traits::collect::IntoIterator<Item = usize>
+pub fn bitcoin::blockdata::weight::Weight::add(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::add_assign(&mut self, rhs: Self)
+pub fn bitcoin::blockdata::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::clone(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::weight::Weight::cmp(&self, other: &bitcoin::blockdata::weight::Weight) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::weight::Weight::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::weight::Weight::div(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin::blockdata::weight::Weight::eq(&self, other: &bitcoin::blockdata::weight::Weight) -> bool
+pub fn bitcoin::blockdata::weight::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::weight::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::weight::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::weight::Weight::mul(self, rhs: bitcoin::blockdata::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin::blockdata::weight::Weight::partial_cmp(&self, other: &bitcoin::blockdata::weight::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::weight::Weight::scale_by_witness_factor(self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::blockdata::weight::Weight::sub(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin::blockdata::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin::blockdata::weight::Weight>
+pub fn bitcoin::blockdata::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::witness::Iter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::witness::Witness::clear(&mut self)
+pub fn bitcoin::blockdata::witness::Witness::clone(&self) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::witness::Witness::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::witness::Witness::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::witness::Witness::default() -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::blockdata::witness::Witness::eq(&self, other: &bitcoin::blockdata::witness::Witness) -> bool
+pub fn bitcoin::blockdata::witness::Witness::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::witness::Witness::from(slice: &[&[u8]]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(slice: &[alloc::vec::Vec<u8>]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(vec: alloc::vec::Vec<&[u8]>) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(vec: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from_slice<T: core::convert::AsRef<[u8]>>(slice: &[T]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::witness::Witness::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin::blockdata::witness::Witness::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::witness::Witness::iter(&self) -> bitcoin::blockdata::witness::Iter<'_>
+pub fn bitcoin::blockdata::witness::Witness::last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::len(&self) -> usize
+pub fn bitcoin::blockdata::witness::Witness::new() -> Self
+pub fn bitcoin::blockdata::witness::Witness::nth(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::p2tr_key_spend(signature: &bitcoin::taproot::Signature) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: &secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::partial_cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
+pub fn bitcoin::blockdata::witness::Witness::push_ecdsa_signature(&mut self, signature: &bitcoin::ecdsa::Signature)
+pub fn bitcoin::blockdata::witness::Witness::second_to_last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::blockdata::witness::Witness::size(&self) -> usize
+pub fn bitcoin::blockdata::witness::Witness::tapscript(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
+pub fn bitcoin::consensus::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::Encodable::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::ReadExt::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::WriteExt::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::deserialize<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<T, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::deserialize_partial<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<(T, usize), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::CheckedData::checksum(&self) -> [u8; 4]
+pub fn bitcoin::consensus::encode::CheckedData::clone(&self) -> bitcoin::consensus::encode::CheckedData
+pub fn bitcoin::consensus::encode::CheckedData::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::CheckedData::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::CheckedData::data(&self) -> &[u8]
+pub fn bitcoin::consensus::encode::CheckedData::eq(&self, other: &bitcoin::consensus::encode::CheckedData) -> bool
+pub fn bitcoin::consensus::encode::CheckedData::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::CheckedData::into_data(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::consensus::encode::CheckedData::new(data: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::consensus::encode::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::Encodable::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::Error::from(error: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::consensus::encode::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::consensus::encode::ReadExt::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::VarInt::clone(&self) -> bitcoin::consensus::encode::VarInt
+pub fn bitcoin::consensus::encode::VarInt::cmp(&self, other: &bitcoin::consensus::encode::VarInt) -> core::cmp::Ordering
+pub fn bitcoin::consensus::encode::VarInt::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::VarInt::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::VarInt::eq(&self, other: &bitcoin::consensus::encode::VarInt) -> bool
+pub fn bitcoin::consensus::encode::VarInt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::VarInt::from(x: u16) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u32) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u64) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u8) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: usize) -> Self
+pub fn bitcoin::consensus::encode::VarInt::partial_cmp(&self, other: &bitcoin::consensus::encode::VarInt) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::consensus::encode::WriteExt::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::deserialize<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<T, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::deserialize_partial<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<(T, usize), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::serialize<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::vec::Vec<u8>
+pub fn bitcoin::consensus::encode::serialize_hex<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::string::String
+pub fn bitcoin::consensus::params::Params::clone(&self) -> bitcoin::consensus::params::Params
+pub fn bitcoin::consensus::params::Params::difficulty_adjustment_interval(&self) -> u64
+pub fn bitcoin::consensus::params::Params::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::params::Params::from(value: &bitcoin::network::Network) -> Self
+pub fn bitcoin::consensus::params::Params::from(value: bitcoin::network::Network) -> Self
+pub fn bitcoin::consensus::serde::ByteDecoder::from_str(s: &'a str) -> core::result::Result<Self::Decoder, Self::InitError>
+pub fn bitcoin::consensus::serde::EncodeBytes::encode_chunk<W: core::fmt::Write>(&mut self, writer: &mut W, bytes: &[u8]) -> core::fmt::Result
+pub fn bitcoin::consensus::serde::EncodeBytes::flush<W: core::fmt::Write>(&mut self, writer: &mut W) -> core::fmt::Result
+pub fn bitcoin::consensus::serde::Hex<C>::default() -> Self
+pub fn bitcoin::consensus::serde::Hex<C>::from_str(s: &'a str) -> core::result::Result<Self::Decoder, Self::InitError>
+pub fn bitcoin::consensus::serde::IntoDeError::into_de_error<E: serde::de::Error>(self) -> E
+pub fn bitcoin::consensus::serde::With<E>::deserialize<'d, T: bitcoin::consensus::encode::Decodable, D: serde::de::Deserializer<'d>>(deserializer: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where for<'a> E: bitcoin::consensus::serde::ByteDecoder<'a>
+pub fn bitcoin::consensus::serde::With<E>::serialize<T: bitcoin::consensus::encode::Encodable, S: serde::ser::Serializer>(value: &T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where E: bitcoin::consensus::serde::ByteEncoder
+pub fn bitcoin::consensus::serde::hex::DecodeError::clone(&self) -> bitcoin::consensus::serde::hex::DecodeError
+pub fn bitcoin::consensus::serde::hex::DecodeError::eq(&self, other: &bitcoin::consensus::serde::hex::DecodeError) -> bool
+pub fn bitcoin::consensus::serde::hex::DecodeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::serde::hex::DecodeError::into_de_error<E: serde::de::Error>(self) -> E
+pub fn bitcoin::consensus::serde::hex::DecodeInitError::clone(&self) -> bitcoin::consensus::serde::hex::DecodeInitError
+pub fn bitcoin::consensus::serde::hex::DecodeInitError::eq(&self, other: &bitcoin::consensus::serde::hex::DecodeInitError) -> bool
+pub fn bitcoin::consensus::serde::hex::DecodeInitError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::serde::hex::DecodeInitError::into_de_error<E: serde::de::Error>(self) -> E
+pub fn bitcoin::consensus::serde::hex::Decoder<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::consensus::serde::hex::Encoder<C>::encode_chunk<W: core::fmt::Write>(&mut self, writer: &mut W, bytes: &[u8]) -> core::fmt::Result
+pub fn bitcoin::consensus::serde::hex::Encoder<C>::flush<W: core::fmt::Write>(&mut self, writer: &mut W) -> core::fmt::Result
+pub fn bitcoin::consensus::serde::hex::Encoder<C>::from(bitcoin::consensus::serde::Hex<C>) -> Self
+pub fn bitcoin::consensus::serialize<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::vec::Vec<u8>
+pub fn bitcoin::consensus::validation::BitcoinconsensusError::clone(&self) -> bitcoin::consensus::validation::BitcoinconsensusError
+pub fn bitcoin::consensus::validation::BitcoinconsensusError::eq(&self, other: &bitcoin::consensus::validation::BitcoinconsensusError) -> bool
+pub fn bitcoin::consensus::validation::BitcoinconsensusError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::validation::BitcoinconsensusError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::consensus::validation::TxVerifyError::clone(&self) -> bitcoin::consensus::validation::TxVerifyError
+pub fn bitcoin::consensus::validation::TxVerifyError::eq(&self, other: &bitcoin::consensus::validation::TxVerifyError) -> bool
+pub fn bitcoin::consensus::validation::TxVerifyError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::validation::TxVerifyError::from(e: bitcoin::consensus::validation::BitcoinconsensusError) -> Self
+pub fn bitcoin::consensus::validation::TxVerifyError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::consensus::validation::verify_script(script: &bitcoin::blockdata::script::Script, index: usize, amount: bitcoin_units::amount::Amount, spending_tx: &[u8]) -> core::result::Result<(), bitcoin::consensus::validation::BitcoinconsensusError>
+pub fn bitcoin::consensus::validation::verify_script_with_flags<F: core::convert::Into<u32>>(script: &bitcoin::blockdata::script::Script, index: usize, amount: bitcoin_units::amount::Amount, spending_tx: &[u8], flags: F) -> core::result::Result<(), bitcoin::consensus::validation::BitcoinconsensusError>
+pub fn bitcoin::consensus::validation::verify_transaction<S>(tx: &bitcoin::blockdata::transaction::Transaction, spent: S) -> core::result::Result<(), bitcoin::consensus::validation::TxVerifyError> where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub fn bitcoin::consensus::validation::verify_transaction_with_flags<S, F>(tx: &bitcoin::blockdata::transaction::Transaction, spent: S, flags: F) -> core::result::Result<(), bitcoin::consensus::validation::TxVerifyError> where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>, F: core::convert::Into<u32>
+pub fn bitcoin::consensus::verify_script(script: &bitcoin::blockdata::script::Script, index: usize, amount: bitcoin_units::amount::Amount, spending_tx: &[u8]) -> core::result::Result<(), bitcoin::consensus::validation::BitcoinconsensusError>
+pub fn bitcoin::consensus::verify_script_with_flags<F: core::convert::Into<u32>>(script: &bitcoin::blockdata::script::Script, index: usize, amount: bitcoin_units::amount::Amount, spending_tx: &[u8], flags: F) -> core::result::Result<(), bitcoin::consensus::validation::BitcoinconsensusError>
+pub fn bitcoin::consensus::verify_transaction<S>(tx: &bitcoin::blockdata::transaction::Transaction, spent: S) -> core::result::Result<(), bitcoin::consensus::validation::TxVerifyError> where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub fn bitcoin::consensus::verify_transaction_with_flags<S, F>(tx: &bitcoin::blockdata::transaction::Transaction, spent: S, flags: F) -> core::result::Result<(), bitcoin::consensus::validation::TxVerifyError> where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>, F: core::convert::Into<u32>
+pub fn bitcoin::constants::genesis_block(network: bitcoin::network::Network) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::ecdsa::Error::clone(&self) -> bitcoin::ecdsa::Error
+pub fn bitcoin::ecdsa::Error::eq(&self, other: &bitcoin::ecdsa::Error) -> bool
+pub fn bitcoin::ecdsa::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::Error::from(e: secp256k1::Error) -> bitcoin::ecdsa::Error
+pub fn bitcoin::ecdsa::Error::from(err: bitcoin::sighash::NonStandardSighashTypeError) -> Self
+pub fn bitcoin::ecdsa::Error::from(err: hex_conservative::parse::HexToBytesError) -> Self
+pub fn bitcoin::ecdsa::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::ecdsa::SerializedSignature::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::ecdsa::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn bitcoin::ecdsa::SerializedSignature::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::ecdsa::SerializedSignature::borrow(&self) -> &[u8]
+pub fn bitcoin::ecdsa::SerializedSignature::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::ecdsa::SerializedSignature::clone(&self) -> bitcoin::ecdsa::SerializedSignature
+pub fn bitcoin::ecdsa::SerializedSignature::deref(&self) -> &Self::Target
+pub fn bitcoin::ecdsa::SerializedSignature::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::ecdsa::SerializedSignature::eq(&self, other: &bitcoin::ecdsa::SerializedSignature) -> bool
+pub fn bitcoin::ecdsa::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::ecdsa::SerializedSignature::iter(&self) -> core::slice::iter::Iter<'_, u8>
+pub fn bitcoin::ecdsa::SerializedSignature::write_to<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::ecdsa::Signature::clone(&self) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::ecdsa::Signature::eq(&self, other: &bitcoin::ecdsa::Signature) -> bool
+pub fn bitcoin::ecdsa::Signature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::Signature::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin::ecdsa::Error>
+pub fn bitcoin::ecdsa::Signature::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::ecdsa::Signature::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::ecdsa::Signature::serialize(&self) -> bitcoin::ecdsa::SerializedSignature
+pub fn bitcoin::ecdsa::Signature::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::ecdsa::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::ecdsa::Signature::sighash_all(signature: secp256k1::ecdsa::Signature) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::to_vec(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::error::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin::error::ParseIntError::clone(&self) -> bitcoin::error::ParseIntError
+pub fn bitcoin::error::ParseIntError::eq(&self, other: &bitcoin::error::ParseIntError) -> bool
+pub fn bitcoin::error::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::error::ParseIntError::input(&self) -> &str
+pub fn bitcoin::error::ParseIntError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::key::Error::clone(&self) -> bitcoin::key::Error
+pub fn bitcoin::key::Error::eq(&self, other: &bitcoin::key::Error) -> bool
+pub fn bitcoin::key::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::Error::from(e: bitcoin::base58::Error) -> bitcoin::key::Error
+pub fn bitcoin::key::Error::from(e: hex_conservative::parse::HexToArrayError) -> Self
+pub fn bitcoin::key::Error::from(e: secp256k1::Error) -> bitcoin::key::Error
+pub fn bitcoin::key::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::key::SortKey::clone(&self) -> bitcoin::key::SortKey
+pub fn bitcoin::key::SortKey::cmp(&self, other: &bitcoin::key::SortKey) -> core::cmp::Ordering
+pub fn bitcoin::key::SortKey::eq(&self, other: &bitcoin::key::SortKey) -> bool
+pub fn bitcoin::key::SortKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::SortKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::SortKey::partial_cmp(&self, other: &bitcoin::key::SortKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TapTweak::dangerous_assume_tweaked(self) -> Self::TweakedKey
+pub fn bitcoin::key::TapTweak::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self::TweakedAux
+pub fn bitcoin::key::TweakedKeypair::clone(&self) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::TweakedKeypair::cmp(&self, other: &bitcoin::key::TweakedKeypair) -> core::cmp::Ordering
+pub fn bitcoin::key::TweakedKeypair::dangerous_assume_tweaked(pair: secp256k1::key::Keypair) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::TweakedKeypair::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::key::TweakedKeypair::eq(&self, other: &bitcoin::key::TweakedKeypair) -> bool
+pub fn bitcoin::key::TweakedKeypair::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::TweakedKeypair::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::TweakedKeypair::partial_cmp(&self, other: &bitcoin::key::TweakedKeypair) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TweakedKeypair::public_parts(&self) -> (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub fn bitcoin::key::TweakedKeypair::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::key::TweakedKeypair::to_inner(self) -> secp256k1::key::Keypair
+pub fn bitcoin::key::TweakedPublicKey::clone(&self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::TweakedPublicKey::cmp(&self, other: &bitcoin::key::TweakedPublicKey) -> core::cmp::Ordering
+pub fn bitcoin::key::TweakedPublicKey::dangerous_assume_tweaked(key: secp256k1::key::XOnlyPublicKey) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::TweakedPublicKey::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::key::TweakedPublicKey::eq(&self, other: &bitcoin::key::TweakedPublicKey) -> bool
+pub fn bitcoin::key::TweakedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::TweakedPublicKey::from(pair: bitcoin::key::TweakedKeypair) -> Self
+pub fn bitcoin::key::TweakedPublicKey::from_keypair(keypair: bitcoin::key::TweakedKeypair) -> Self
+pub fn bitcoin::key::TweakedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::TweakedPublicKey::partial_cmp(&self, other: &bitcoin::key::TweakedPublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TweakedPublicKey::serialize(&self) -> [u8; 32]
+pub fn bitcoin::key::TweakedPublicKey::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::key::TweakedPublicKey::to_inner(self) -> secp256k1::key::XOnlyPublicKey
+pub fn bitcoin::key::UncompressedPubkeyError::clone(&self) -> bitcoin::key::UncompressedPubkeyError
+pub fn bitcoin::key::UncompressedPubkeyError::eq(&self, other: &bitcoin::key::UncompressedPubkeyError) -> bool
+pub fn bitcoin::key::UncompressedPubkeyError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::UncompressedPubkeyError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::key::UntweakedKeypair::dangerous_assume_tweaked(self) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::UntweakedKeypair::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::UntweakedPublicKey::dangerous_assume_tweaked(self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::UntweakedPublicKey::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub fn bitcoin::merkle_tree::MerkleBlockError::clone(&self) -> bitcoin::merkle_tree::MerkleBlockError
+pub fn bitcoin::merkle_tree::MerkleBlockError::eq(&self, other: &bitcoin::merkle_tree::MerkleBlockError) -> bool
+pub fn bitcoin::merkle_tree::MerkleBlockError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::merkle_tree::MerkleBlockError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::bits(&self) -> &alloc::vec::Vec<bool>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::clone(&self) -> bitcoin::merkle_tree::PartialMerkleTree
+pub fn bitcoin::merkle_tree::PartialMerkleTree::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::eq(&self, other: &bitcoin::merkle_tree::PartialMerkleTree) -> bool
+pub fn bitcoin::merkle_tree::PartialMerkleTree::extract_matches(&self, matches: &mut alloc::vec::Vec<bitcoin::blockdata::transaction::Txid>, indexes: &mut alloc::vec::Vec<u32>) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin::merkle_tree::MerkleBlockError>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::merkle_tree::PartialMerkleTree::from_txids(txids: &[bitcoin::blockdata::transaction::Txid], matches: &[bool]) -> Self
+pub fn bitcoin::merkle_tree::PartialMerkleTree::hashes(&self) -> &alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::num_transactions(&self) -> u32
+pub fn bitcoin::merkle_tree::calculate_root<T, I>(hashes: I) -> core::option::Option<T> where T: bitcoin_hashes::Hash + bitcoin::consensus::encode::Encodable, <T as bitcoin_hashes::Hash>::Engine: bitcoin_io::Write, I: core::iter::traits::iterator::Iterator<Item = T>
+pub fn bitcoin::merkle_tree::calculate_root_inline<T>(hashes: &mut [T]) -> core::option::Option<T> where T: bitcoin_hashes::Hash + bitcoin::consensus::encode::Encodable, <T as bitcoin_hashes::Hash>::Engine: bitcoin_io::Write
+pub fn bitcoin::network::Network::chain_hash(self) -> bitcoin::blockdata::constants::ChainHash
+pub fn bitcoin::network::Network::clone(&self) -> bitcoin::network::Network
+pub fn bitcoin::network::Network::cmp(&self, other: &bitcoin::network::Network) -> core::cmp::Ordering
+pub fn bitcoin::network::Network::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::network::Network::eq(&self, other: &bitcoin::network::Network) -> bool
+pub fn bitcoin::network::Network::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::Network::from_chain_hash(chain_hash: bitcoin::blockdata::constants::ChainHash) -> core::option::Option<bitcoin::network::Network>
+pub fn bitcoin::network::Network::from_core_arg(core_arg: &str) -> core::result::Result<Self, bitcoin::network::ParseNetworkError>
+pub fn bitcoin::network::Network::from_magic(magic: bitcoin::p2p::Magic) -> core::option::Option<bitcoin::network::Network>
+pub fn bitcoin::network::Network::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::network::Network::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::network::Network::magic(self) -> bitcoin::p2p::Magic
+pub fn bitcoin::network::Network::partial_cmp(&self, other: &bitcoin::network::Network) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::network::Network::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::network::Network::to_core_arg(self) -> &'static str
+pub fn bitcoin::network::Network::try_from(chain_hash: bitcoin::blockdata::constants::ChainHash) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::network::Network::try_from(magic: bitcoin::p2p::Magic) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::network::NetworkKind::clone(&self) -> bitcoin::network::NetworkKind
+pub fn bitcoin::network::NetworkKind::cmp(&self, other: &bitcoin::network::NetworkKind) -> core::cmp::Ordering
+pub fn bitcoin::network::NetworkKind::eq(&self, other: &bitcoin::network::NetworkKind) -> bool
+pub fn bitcoin::network::NetworkKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::NetworkKind::from(n: bitcoin::network::Network) -> Self
+pub fn bitcoin::network::NetworkKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::network::NetworkKind::is_mainnet(&self) -> bool
+pub fn bitcoin::network::NetworkKind::partial_cmp(&self, other: &bitcoin::network::NetworkKind) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::network::ParseNetworkError::clone(&self) -> bitcoin::network::ParseNetworkError
+pub fn bitcoin::network::ParseNetworkError::eq(&self, other: &bitcoin::network::ParseNetworkError) -> bool
+pub fn bitcoin::network::ParseNetworkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::ParseNetworkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::network::ParseNetworkError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::network::UnknownChainHashError::clone(&self) -> bitcoin::network::UnknownChainHashError
+pub fn bitcoin::network::UnknownChainHashError::eq(&self, other: &bitcoin::network::UnknownChainHashError) -> bool
+pub fn bitcoin::network::UnknownChainHashError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::UnknownChainHashError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::network::as_core_arg::deserialize<'de, D>(deserializer: D) -> core::result::Result<bitcoin::network::Network, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::network::as_core_arg::serialize<S>(network: &bitcoin::network::Network, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::p2p::Magic::as_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::p2p::Magic::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::p2p::Magic::as_ref(&self) -> &[u8; 4]
+pub fn bitcoin::p2p::Magic::as_ref(&self) -> &[u8]
+pub fn bitcoin::p2p::Magic::borrow(&self) -> &[u8; 4]
+pub fn bitcoin::p2p::Magic::borrow(&self) -> &[u8]
+pub fn bitcoin::p2p::Magic::borrow_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::p2p::Magic::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::p2p::Magic::clone(&self) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::cmp(&self, other: &bitcoin::p2p::Magic) -> core::cmp::Ordering
+pub fn bitcoin::p2p::Magic::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::Magic::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::Magic::eq(&self, other: &bitcoin::p2p::Magic) -> bool
+pub fn bitcoin::p2p::Magic::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::p2p::Magic::from(network: bitcoin::network::Network) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::from_bytes(bytes: [u8; 4]) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::from_str(s: &str) -> core::result::Result<bitcoin::p2p::Magic, Self::Err>
+pub fn bitcoin::p2p::Magic::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::Magic::partial_cmp(&self, other: &bitcoin::p2p::Magic) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::Magic::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::p2p::ParseMagicError::clone(&self) -> bitcoin::p2p::ParseMagicError
+pub fn bitcoin::p2p::ParseMagicError::eq(&self, other: &bitcoin::p2p::ParseMagicError) -> bool
+pub fn bitcoin::p2p::ParseMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::ParseMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::p2p::ParseMagicError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::p2p::ServiceFlags::add(&mut self, other: bitcoin::p2p::ServiceFlags) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::bitor(self, rhs: Self) -> Self
+pub fn bitcoin::p2p::ServiceFlags::bitor_assign(&mut self, rhs: Self)
+pub fn bitcoin::p2p::ServiceFlags::bitxor(self, rhs: Self) -> Self
+pub fn bitcoin::p2p::ServiceFlags::bitxor_assign(&mut self, rhs: Self)
+pub fn bitcoin::p2p::ServiceFlags::clone(&self) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::cmp(&self, other: &bitcoin::p2p::ServiceFlags) -> core::cmp::Ordering
+pub fn bitcoin::p2p::ServiceFlags::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::ServiceFlags::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::ServiceFlags::default() -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::eq(&self, other: &bitcoin::p2p::ServiceFlags) -> bool
+pub fn bitcoin::p2p::ServiceFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::ServiceFlags::from(f: u64) -> Self
+pub fn bitcoin::p2p::ServiceFlags::has(self, flags: bitcoin::p2p::ServiceFlags) -> bool
+pub fn bitcoin::p2p::ServiceFlags::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::ServiceFlags::partial_cmp(&self, other: &bitcoin::p2p::ServiceFlags) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::ServiceFlags::remove(&mut self, other: bitcoin::p2p::ServiceFlags) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::to_u64(self) -> u64
+pub fn bitcoin::p2p::UnknownMagicError::clone(&self) -> bitcoin::p2p::UnknownMagicError
+pub fn bitcoin::p2p::UnknownMagicError::eq(&self, other: &bitcoin::p2p::UnknownMagicError) -> bool
+pub fn bitcoin::p2p::UnknownMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::UnknownMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::p2p::UnknownMagicError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::p2p::address::AddrV2::clone(&self) -> bitcoin::p2p::address::AddrV2
+pub fn bitcoin::p2p::address::AddrV2::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::address::AddrV2::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::AddrV2::eq(&self, other: &bitcoin::p2p::address::AddrV2) -> bool
+pub fn bitcoin::p2p::address::AddrV2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::address::AddrV2::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::address::AddrV2Message::clone(&self) -> bitcoin::p2p::address::AddrV2Message
+pub fn bitcoin::p2p::address::AddrV2Message::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::address::AddrV2Message::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::AddrV2Message::eq(&self, other: &bitcoin::p2p::address::AddrV2Message) -> bool
+pub fn bitcoin::p2p::address::AddrV2Message::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::address::AddrV2Message::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::address::AddrV2Message::socket_addr(&self) -> core::result::Result<core::net::socket_addr::SocketAddr, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::AddrV2Message::to_socket_addrs(&self) -> core::result::Result<Self::Iter, std::io::error::Error>
+pub fn bitcoin::p2p::address::Address::clone(&self) -> bitcoin::p2p::address::Address
+pub fn bitcoin::p2p::address::Address::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::address::Address::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::Address::eq(&self, other: &bitcoin::p2p::address::Address) -> bool
+pub fn bitcoin::p2p::address::Address::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::address::Address::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::address::Address::new(socket: &core::net::socket_addr::SocketAddr, services: bitcoin::p2p::ServiceFlags) -> bitcoin::p2p::address::Address
+pub fn bitcoin::p2p::address::Address::socket_addr(&self) -> core::result::Result<core::net::socket_addr::SocketAddr, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::Address::to_socket_addrs(&self) -> core::result::Result<Self::Iter, std::io::error::Error>
+pub fn bitcoin::p2p::message::CommandString::as_ref(&self) -> &str
+pub fn bitcoin::p2p::message::CommandString::clone(&self) -> bitcoin::p2p::message::CommandString
+pub fn bitcoin::p2p::message::CommandString::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message::CommandString::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message::CommandString::eq(&self, other: &bitcoin::p2p::message::CommandString) -> bool
+pub fn bitcoin::p2p::message::CommandString::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::CommandString::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::p2p::message::CommandString::try_from(value: &'a str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::p2p::message::CommandString::try_from(value: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::p2p::message::CommandString::try_from(value: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::p2p::message::CommandString::try_from_static(s: &'static str) -> core::result::Result<bitcoin::p2p::message::CommandString, bitcoin::p2p::message::CommandStringError>
+pub fn bitcoin::p2p::message::CommandStringError::clone(&self) -> bitcoin::p2p::message::CommandStringError
+pub fn bitcoin::p2p::message::CommandStringError::eq(&self, other: &bitcoin::p2p::message::CommandStringError) -> bool
+pub fn bitcoin::p2p::message::CommandStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::CommandStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::p2p::message::NetworkMessage::clone(&self) -> bitcoin::p2p::message::NetworkMessage
+pub fn bitcoin::p2p::message::NetworkMessage::cmd(&self) -> &'static str
+pub fn bitcoin::p2p::message::NetworkMessage::command(&self) -> bitcoin::p2p::message::CommandString
+pub fn bitcoin::p2p::message::NetworkMessage::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message::NetworkMessage::eq(&self, other: &bitcoin::p2p::message::NetworkMessage) -> bool
+pub fn bitcoin::p2p::message::NetworkMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::RawNetworkMessage::clone(&self) -> bitcoin::p2p::message::RawNetworkMessage
+pub fn bitcoin::p2p::message::RawNetworkMessage::cmd(&self) -> &'static str
+pub fn bitcoin::p2p::message::RawNetworkMessage::command(&self) -> bitcoin::p2p::message::CommandString
+pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message::RawNetworkMessage::eq(&self, other: &bitcoin::p2p::message::RawNetworkMessage) -> bool
+pub fn bitcoin::p2p::message::RawNetworkMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::RawNetworkMessage::magic(&self) -> &bitcoin::p2p::Magic
+pub fn bitcoin::p2p::message::RawNetworkMessage::new(magic: bitcoin::p2p::Magic, payload: bitcoin::p2p::message::NetworkMessage) -> Self
+pub fn bitcoin::p2p::message::RawNetworkMessage::payload(&self) -> &bitcoin::p2p::message::NetworkMessage
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::clone(&self) -> bitcoin::p2p::message_blockdata::GetBlocksMessage
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_blockdata::GetBlocksMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_blockdata::GetBlocksMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::eq(&self, other: &bitcoin::p2p::message_blockdata::GetBlocksMessage) -> bool
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::new(locator_hashes: alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>, stop_hash: bitcoin::blockdata::block::BlockHash) -> bitcoin::p2p::message_blockdata::GetBlocksMessage
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::clone(&self) -> bitcoin::p2p::message_blockdata::GetHeadersMessage
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_blockdata::GetHeadersMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_blockdata::GetHeadersMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::eq(&self, other: &bitcoin::p2p::message_blockdata::GetHeadersMessage) -> bool
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::new(locator_hashes: alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>, stop_hash: bitcoin::blockdata::block::BlockHash) -> bitcoin::p2p::message_blockdata::GetHeadersMessage
+pub fn bitcoin::p2p::message_blockdata::Inventory::clone(&self) -> bitcoin::p2p::message_blockdata::Inventory
+pub fn bitcoin::p2p::message_blockdata::Inventory::cmp(&self, other: &bitcoin::p2p::message_blockdata::Inventory) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_blockdata::Inventory::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::Inventory::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_blockdata::Inventory::eq(&self, other: &bitcoin::p2p::message_blockdata::Inventory) -> bool
+pub fn bitcoin::p2p::message_blockdata::Inventory::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_blockdata::Inventory::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_blockdata::Inventory::network_hash(&self) -> core::option::Option<[u8; 32]>
+pub fn bitcoin::p2p::message_blockdata::Inventory::partial_cmp(&self, other: &bitcoin::p2p::message_blockdata::Inventory) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_bloom::BloomFlags::clone(&self) -> bitcoin::p2p::message_bloom::BloomFlags
+pub fn bitcoin::p2p::message_bloom::BloomFlags::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::BloomFlags::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_bloom::BloomFlags::eq(&self, other: &bitcoin::p2p::message_bloom::BloomFlags) -> bool
+pub fn bitcoin::p2p::message_bloom::BloomFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_bloom::FilterAdd::clone(&self) -> bitcoin::p2p::message_bloom::FilterAdd
+pub fn bitcoin::p2p::message_bloom::FilterAdd::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_bloom::FilterAdd, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::FilterAdd::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_bloom::FilterAdd, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::FilterAdd::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_bloom::FilterAdd::eq(&self, other: &bitcoin::p2p::message_bloom::FilterAdd) -> bool
+pub fn bitcoin::p2p::message_bloom::FilterAdd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_bloom::FilterLoad::clone(&self) -> bitcoin::p2p::message_bloom::FilterLoad
+pub fn bitcoin::p2p::message_bloom::FilterLoad::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_bloom::FilterLoad, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::FilterLoad::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_bloom::FilterLoad, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::FilterLoad::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_bloom::FilterLoad::eq(&self, other: &bitcoin::p2p::message_bloom::FilterLoad) -> bool
+pub fn bitcoin::p2p::message_bloom::FilterLoad::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::clone(&self) -> bitcoin::p2p::message_compact_blocks::BlockTxn
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::cmp(&self, other: &bitcoin::p2p::message_compact_blocks::BlockTxn) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::BlockTxn, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::BlockTxn, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::eq(&self, other: &bitcoin::p2p::message_compact_blocks::BlockTxn) -> bool
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::partial_cmp(&self, other: &bitcoin::p2p::message_compact_blocks::BlockTxn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::clone(&self) -> bitcoin::p2p::message_compact_blocks::CmpctBlock
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::cmp(&self, other: &bitcoin::p2p::message_compact_blocks::CmpctBlock) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::CmpctBlock, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::CmpctBlock, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::eq(&self, other: &bitcoin::p2p::message_compact_blocks::CmpctBlock) -> bool
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::partial_cmp(&self, other: &bitcoin::p2p::message_compact_blocks::CmpctBlock) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::clone(&self) -> bitcoin::p2p::message_compact_blocks::GetBlockTxn
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::cmp(&self, other: &bitcoin::p2p::message_compact_blocks::GetBlockTxn) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::GetBlockTxn, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::GetBlockTxn, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::eq(&self, other: &bitcoin::p2p::message_compact_blocks::GetBlockTxn) -> bool
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::partial_cmp(&self, other: &bitcoin::p2p::message_compact_blocks::GetBlockTxn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::clone(&self) -> bitcoin::p2p::message_compact_blocks::SendCmpct
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::cmp(&self, other: &bitcoin::p2p::message_compact_blocks::SendCmpct) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::SendCmpct, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::SendCmpct, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::eq(&self, other: &bitcoin::p2p::message_compact_blocks::SendCmpct) -> bool
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::partial_cmp(&self, other: &bitcoin::p2p::message_compact_blocks::SendCmpct) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_filter::CFCheckpt::clone(&self) -> bitcoin::p2p::message_filter::CFCheckpt
+pub fn bitcoin::p2p::message_filter::CFCheckpt::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFCheckpt, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFCheckpt::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFCheckpt, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFCheckpt::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::CFCheckpt::eq(&self, other: &bitcoin::p2p::message_filter::CFCheckpt) -> bool
+pub fn bitcoin::p2p::message_filter::CFCheckpt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::CFHeaders::clone(&self) -> bitcoin::p2p::message_filter::CFHeaders
+pub fn bitcoin::p2p::message_filter::CFHeaders::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFHeaders, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFHeaders::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFHeaders, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFHeaders::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::CFHeaders::eq(&self, other: &bitcoin::p2p::message_filter::CFHeaders) -> bool
+pub fn bitcoin::p2p::message_filter::CFHeaders::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::CFilter::clone(&self) -> bitcoin::p2p::message_filter::CFilter
+pub fn bitcoin::p2p::message_filter::CFilter::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFilter, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFilter::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFilter, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFilter::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::CFilter::eq(&self, other: &bitcoin::p2p::message_filter::CFilter) -> bool
+pub fn bitcoin::p2p::message_filter::CFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::clone(&self) -> bitcoin::p2p::message_filter::GetCFCheckpt
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFCheckpt, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFCheckpt, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::eq(&self, other: &bitcoin::p2p::message_filter::GetCFCheckpt) -> bool
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::clone(&self) -> bitcoin::p2p::message_filter::GetCFHeaders
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFHeaders, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFHeaders, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::eq(&self, other: &bitcoin::p2p::message_filter::GetCFHeaders) -> bool
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::GetCFilters::clone(&self) -> bitcoin::p2p::message_filter::GetCFilters
+pub fn bitcoin::p2p::message_filter::GetCFilters::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFilters, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFilters::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFilters, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFilters::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::GetCFilters::eq(&self, other: &bitcoin::p2p::message_filter::GetCFilters) -> bool
+pub fn bitcoin::p2p::message_filter::GetCFilters::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_network::Reject::clone(&self) -> bitcoin::p2p::message_network::Reject
+pub fn bitcoin::p2p::message_network::Reject::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_network::Reject, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::Reject::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_network::Reject, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::Reject::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_network::Reject::eq(&self, other: &bitcoin::p2p::message_network::Reject) -> bool
+pub fn bitcoin::p2p::message_network::Reject::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_network::RejectReason::clone(&self) -> bitcoin::p2p::message_network::RejectReason
+pub fn bitcoin::p2p::message_network::RejectReason::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::RejectReason::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_network::RejectReason::eq(&self, other: &bitcoin::p2p::message_network::RejectReason) -> bool
+pub fn bitcoin::p2p::message_network::RejectReason::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_network::VersionMessage::clone(&self) -> bitcoin::p2p::message_network::VersionMessage
+pub fn bitcoin::p2p::message_network::VersionMessage::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_network::VersionMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::VersionMessage::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_network::VersionMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::VersionMessage::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_network::VersionMessage::eq(&self, other: &bitcoin::p2p::message_network::VersionMessage) -> bool
+pub fn bitcoin::p2p::message_network::VersionMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_network::VersionMessage::new(services: bitcoin::p2p::ServiceFlags, timestamp: i64, receiver: bitcoin::p2p::address::Address, sender: bitcoin::p2p::address::Address, nonce: u64, user_agent: alloc::string::String, start_height: i32) -> bitcoin::p2p::message_network::VersionMessage
+pub fn bitcoin::policy::get_virtual_tx_size(weight: i64, n_sigops: i64) -> i64
+pub fn bitcoin::pow::CompactTarget::clone(&self) -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTarget::cmp(&self, other: &bitcoin::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin::pow::CompactTarget::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::pow::CompactTarget::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::pow::CompactTarget::default() -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTarget::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::pow::CompactTarget::eq(&self, other: &bitcoin::pow::CompactTarget) -> bool
+pub fn bitcoin::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin::pow::CompactTarget::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::CompactTarget::partial_cmp(&self, other: &bitcoin::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::CompactTarget::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin::pow::Target::clone(&self) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::cmp(&self, other: &bitcoin::pow::Target) -> core::cmp::Ordering
+pub fn bitcoin::pow::Target::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::pow::Target::difficulty(&self, network: bitcoin::network::Network) -> u128
+pub fn bitcoin::pow::Target::difficulty_float(&self) -> f64
+pub fn bitcoin::pow::Target::eq(&self, other: &bitcoin::pow::Target) -> bool
+pub fn bitcoin::pow::Target::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::Target::from(c: bitcoin::pow::CompactTarget) -> Self
+pub fn bitcoin::pow::Target::from_be_bytes(bytes: [u8; 32]) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::from_compact(c: bitcoin::pow::CompactTarget) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::from_le_bytes(bytes: [u8; 32]) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::Target::is_met_by(&self, hash: bitcoin::blockdata::block::BlockHash) -> bool
+pub fn bitcoin::pow::Target::max_difficulty_transition_threshold(&self) -> Self
+pub fn bitcoin::pow::Target::min_difficulty_transition_threshold(&self) -> Self
+pub fn bitcoin::pow::Target::partial_cmp(&self, other: &bitcoin::pow::Target) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::Target::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::pow::Target::to_be_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Target::to_compact_lossy(self) -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::Target::to_le_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Target::to_work(self) -> bitcoin::pow::Work
+pub fn bitcoin::pow::TryFromError::clone(&self) -> bitcoin::pow::TryFromError
+pub fn bitcoin::pow::TryFromError::eq(&self, other: &bitcoin::pow::TryFromError) -> bool
+pub fn bitcoin::pow::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::TryFromError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::pow::Work::add(self, rhs: Self) -> Self
+pub fn bitcoin::pow::Work::clone(&self) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::cmp(&self, other: &bitcoin::pow::Work) -> core::cmp::Ordering
+pub fn bitcoin::pow::Work::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::pow::Work::eq(&self, other: &bitcoin::pow::Work) -> bool
+pub fn bitcoin::pow::Work::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::Work::from_be_bytes(bytes: [u8; 32]) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::from_le_bytes(bytes: [u8; 32]) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::Work::log2(self) -> f64
+pub fn bitcoin::pow::Work::partial_cmp(&self, other: &bitcoin::pow::Work) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::Work::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::pow::Work::sub(self, rhs: Self) -> Self
+pub fn bitcoin::pow::Work::to_be_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Work::to_le_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Work::to_target(self) -> bitcoin::pow::Target
+pub fn bitcoin::psbt::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Error::from(e: bitcoin::consensus::encode::Error) -> Self
+pub fn bitcoin::psbt::Error::from(e: bitcoin_hashes::FromSliceError) -> bitcoin::psbt::Error
+pub fn bitcoin::psbt::Error::from(e: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::psbt::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::ExtractTxError::clone(&self) -> bitcoin::psbt::ExtractTxError
+pub fn bitcoin::psbt::ExtractTxError::eq(&self, other: &bitcoin::psbt::ExtractTxError) -> bool
+pub fn bitcoin::psbt::ExtractTxError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::ExtractTxError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::GetKey::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn bitcoin::psbt::GetKeyError::clone(&self) -> bitcoin::psbt::GetKeyError
+pub fn bitcoin::psbt::GetKeyError::eq(&self, other: &bitcoin::psbt::GetKeyError) -> bool
+pub fn bitcoin::psbt::GetKeyError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::GetKeyError::from(e: bitcoin::bip32::Error) -> Self
+pub fn bitcoin::psbt::GetKeyError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::IndexOutOfBoundsError::clone(&self) -> bitcoin::psbt::IndexOutOfBoundsError
+pub fn bitcoin::psbt::IndexOutOfBoundsError::eq(&self, other: &bitcoin::psbt::IndexOutOfBoundsError) -> bool
+pub fn bitcoin::psbt::IndexOutOfBoundsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::IndexOutOfBoundsError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::Input::clone(&self) -> bitcoin::psbt::Input
+pub fn bitcoin::psbt::Input::combine(&mut self, other: Self)
+pub fn bitcoin::psbt::Input::default() -> bitcoin::psbt::Input
+pub fn bitcoin::psbt::Input::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::psbt::Input::ecdsa_hash_ty(&self) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::psbt::Input::eq(&self, other: &bitcoin::psbt::Input) -> bool
+pub fn bitcoin::psbt::Input::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Input::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::Input::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::psbt::Input::taproot_hash_ty(&self) -> core::result::Result<bitcoin::TapSighashType, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::psbt::KeyRequest::clone(&self) -> bitcoin::psbt::KeyRequest
+pub fn bitcoin::psbt::KeyRequest::eq(&self, other: &bitcoin::psbt::KeyRequest) -> bool
+pub fn bitcoin::psbt::KeyRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Output::clone(&self) -> bitcoin::psbt::Output
+pub fn bitcoin::psbt::Output::combine(&mut self, other: Self)
+pub fn bitcoin::psbt::Output::default() -> bitcoin::psbt::Output
+pub fn bitcoin::psbt::Output::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::psbt::Output::eq(&self, other: &bitcoin::psbt::Output) -> bool
+pub fn bitcoin::psbt::Output::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Output::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::Output::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::psbt::OutputType::clone(&self) -> bitcoin::psbt::OutputType
+pub fn bitcoin::psbt::OutputType::cmp(&self, other: &bitcoin::psbt::OutputType) -> core::cmp::Ordering
+pub fn bitcoin::psbt::OutputType::eq(&self, other: &bitcoin::psbt::OutputType) -> bool
+pub fn bitcoin::psbt::OutputType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::OutputType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::OutputType::partial_cmp(&self, other: &bitcoin::psbt::OutputType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::OutputType::signing_algorithm(&self) -> bitcoin::psbt::SigningAlgorithm
+pub fn bitcoin::psbt::Psbt::clone(&self) -> bitcoin::psbt::Psbt
+pub fn bitcoin::psbt::Psbt::combine(&mut self, other: Self) -> core::result::Result<(), bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::deserialize(bytes: &[u8]) -> core::result::Result<Self, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::psbt::Psbt::eq(&self, other: &bitcoin::psbt::Psbt) -> bool
+pub fn bitcoin::psbt::Psbt::extract_tx(self) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::extract_tx_fee_rate_limit(self) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::extract_tx_unchecked_fee_rate(self) -> bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::psbt::Psbt::extract_tx_with_fee_rate_limit(self, max_fee_rate: bitcoin::blockdata::fee_rate::FeeRate) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::fee(&self) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Psbt::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::psbt::Psbt::from_unsigned_tx(tx: bitcoin::blockdata::transaction::Transaction) -> core::result::Result<Self, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::Psbt::iter_funding_utxos(&self) -> impl core::iter::traits::iterator::Iterator<Item = core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::psbt::Error>>
+pub fn bitcoin::psbt::Psbt::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::psbt::Psbt::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::psbt::Psbt::serialize_hex(&self) -> alloc::string::String
+pub fn bitcoin::psbt::Psbt::sighash_ecdsa<T: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>>(&self, input_index: usize, cache: &mut bitcoin::sighash::SighashCache<T>) -> core::result::Result<(secp256k1::Message, bitcoin::EcdsaSighashType), bitcoin::psbt::SignError>
+pub fn bitcoin::psbt::Psbt::sign<C, K>(&mut self, k: &K, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<bitcoin::psbt::SigningKeys, (bitcoin::psbt::SigningKeys, bitcoin::psbt::SigningErrors)> where C: secp256k1::context::Signing, K: bitcoin::psbt::GetKey
+pub fn bitcoin::psbt::Psbt::spend_utxo(&self, input_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::psbt::SignError>
+pub fn bitcoin::psbt::PsbtParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::PsbtParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::PsbtSighashType::clone(&self) -> bitcoin::psbt::PsbtSighashType
+pub fn bitcoin::psbt::PsbtSighashType::cmp(&self, other: &bitcoin::psbt::PsbtSighashType) -> core::cmp::Ordering
+pub fn bitcoin::psbt::PsbtSighashType::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::psbt::PsbtSighashType::ecdsa_hash_ty(self) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::psbt::PsbtSighashType::eq(&self, other: &bitcoin::psbt::PsbtSighashType) -> bool
+pub fn bitcoin::psbt::PsbtSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::PsbtSighashType::from(ecdsa_hash_ty: bitcoin::EcdsaSighashType) -> Self
+pub fn bitcoin::psbt::PsbtSighashType::from(taproot_hash_ty: bitcoin::TapSighashType) -> Self
+pub fn bitcoin::psbt::PsbtSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::psbt::PsbtSighashType::from_u32(n: u32) -> bitcoin::psbt::PsbtSighashType
+pub fn bitcoin::psbt::PsbtSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::PsbtSighashType::partial_cmp(&self, other: &bitcoin::psbt::PsbtSighashType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::PsbtSighashType::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::psbt::PsbtSighashType::taproot_hash_ty(self) -> core::result::Result<bitcoin::TapSighashType, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::psbt::PsbtSighashType::to_u32(self) -> u32
+pub fn bitcoin::psbt::SignError::clone(&self) -> bitcoin::psbt::SignError
+pub fn bitcoin::psbt::SignError::eq(&self, other: &bitcoin::psbt::SignError) -> bool
+pub fn bitcoin::psbt::SignError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::SignError::from(e: bitcoin::psbt::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::psbt::SignError::from(e: bitcoin::sighash::P2wpkhError) -> Self
+pub fn bitcoin::psbt::SignError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::SigningAlgorithm::clone(&self) -> bitcoin::psbt::SigningAlgorithm
+pub fn bitcoin::psbt::SigningAlgorithm::cmp(&self, other: &bitcoin::psbt::SigningAlgorithm) -> core::cmp::Ordering
+pub fn bitcoin::psbt::SigningAlgorithm::eq(&self, other: &bitcoin::psbt::SigningAlgorithm) -> bool
+pub fn bitcoin::psbt::SigningAlgorithm::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::SigningAlgorithm::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::SigningAlgorithm::partial_cmp(&self, other: &bitcoin::psbt::SigningAlgorithm) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::Key::clone(&self) -> bitcoin::psbt::raw::Key
+pub fn bitcoin::psbt::raw::Key::cmp(&self, other: &bitcoin::psbt::raw::Key) -> core::cmp::Ordering
+pub fn bitcoin::psbt::raw::Key::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::psbt::raw::Key::eq(&self, other: &bitcoin::psbt::raw::Key) -> bool
+pub fn bitcoin::psbt::raw::Key::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::Key::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::raw::Key::partial_cmp(&self, other: &bitcoin::psbt::raw::Key) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::Key::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::psbt::raw::Pair::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::psbt::raw::Pair::eq(&self, other: &bitcoin::psbt::raw::Pair) -> bool
+pub fn bitcoin::psbt::raw::Pair::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::Pair::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::clone(&self) -> bitcoin::psbt::raw::ProprietaryKey<Subtype>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::cmp(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> core::cmp::Ordering
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::eq(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> bool
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::partial_cmp(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::to_key(&self) -> bitcoin::psbt::raw::Key
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::try_from(key: bitcoin::psbt::raw::Key) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::script::PushBytesErrorReport::input_len(&self) -> usize
+pub fn bitcoin::script::read_scriptbool(v: &[u8]) -> bool
+pub fn bitcoin::script::read_scriptint(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::script::read_scriptint_non_minimal(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
+pub fn bitcoin::sighash::Annex<'a>::as_bytes(&self) -> &[u8]
+pub fn bitcoin::sighash::Annex<'a>::clone(&self) -> bitcoin::sighash::Annex<'a>
+pub fn bitcoin::sighash::Annex<'a>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::sighash::Annex<'a>::eq(&self, other: &bitcoin::sighash::Annex<'a>) -> bool
+pub fn bitcoin::sighash::Annex<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::Annex<'a>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::Annex<'a>::new(annex_bytes: &'a [u8]) -> core::result::Result<Self, bitcoin::sighash::AnnexError>
+pub fn bitcoin::sighash::AnnexError::clone(&self) -> bitcoin::sighash::AnnexError
+pub fn bitcoin::sighash::AnnexError::eq(&self, other: &bitcoin::sighash::AnnexError) -> bool
+pub fn bitcoin::sighash::AnnexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::AnnexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::EncodeSigningDataResult<E>::is_sighash_single_bug(self) -> core::result::Result<bool, E>
+pub fn bitcoin::sighash::EncodeSigningDataResult<E>::map_err<E2, F>(self, f: F) -> bitcoin::sighash::EncodeSigningDataResult<E2> where F: core::ops::function::FnOnce(E) -> E2
+pub fn bitcoin::sighash::InvalidSighashTypeError::clone(&self) -> bitcoin::sighash::InvalidSighashTypeError
+pub fn bitcoin::sighash::InvalidSighashTypeError::eq(&self, other: &bitcoin::sighash::InvalidSighashTypeError) -> bool
+pub fn bitcoin::sighash::InvalidSighashTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::InvalidSighashTypeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::NonStandardSighashTypeError::clone(&self) -> bitcoin::sighash::NonStandardSighashTypeError
+pub fn bitcoin::sighash::NonStandardSighashTypeError::eq(&self, other: &bitcoin::sighash::NonStandardSighashTypeError) -> bool
+pub fn bitcoin::sighash::NonStandardSighashTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::NonStandardSighashTypeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::P2wpkhError::clone(&self) -> bitcoin::sighash::P2wpkhError
+pub fn bitcoin::sighash::P2wpkhError::eq(&self, other: &bitcoin::sighash::P2wpkhError) -> bool
+pub fn bitcoin::sighash::P2wpkhError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::P2wpkhError::from(value: bitcoin::blockdata::transaction::InputsIndexError) -> Self
+pub fn bitcoin::sighash::P2wpkhError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::Prevouts<'u, T>::clone(&self) -> bitcoin::sighash::Prevouts<'u, T>
+pub fn bitcoin::sighash::Prevouts<'u, T>::cmp(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> core::cmp::Ordering
+pub fn bitcoin::sighash::Prevouts<'u, T>::eq(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> bool
+pub fn bitcoin::sighash::Prevouts<'u, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::Prevouts<'u, T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::Prevouts<'u, T>::partial_cmp(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::sighash::PrevoutsIndexError::clone(&self) -> bitcoin::sighash::PrevoutsIndexError
+pub fn bitcoin::sighash::PrevoutsIndexError::eq(&self, other: &bitcoin::sighash::PrevoutsIndexError) -> bool
+pub fn bitcoin::sighash::PrevoutsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::PrevoutsIndexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::PrevoutsKindError::clone(&self) -> bitcoin::sighash::PrevoutsKindError
+pub fn bitcoin::sighash::PrevoutsKindError::eq(&self, other: &bitcoin::sighash::PrevoutsKindError) -> bool
+pub fn bitcoin::sighash::PrevoutsKindError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::PrevoutsKindError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::PrevoutsSizeError::clone(&self) -> bitcoin::sighash::PrevoutsSizeError
+pub fn bitcoin::sighash::PrevoutsSizeError::eq(&self, other: &bitcoin::sighash::PrevoutsSizeError) -> bool
+pub fn bitcoin::sighash::PrevoutsSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::PrevoutsSizeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::ScriptPath<'s>::clone(&self) -> bitcoin::sighash::ScriptPath<'s>
+pub fn bitcoin::sighash::ScriptPath<'s>::cmp(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> core::cmp::Ordering
+pub fn bitcoin::sighash::ScriptPath<'s>::eq(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> bool
+pub fn bitcoin::sighash::ScriptPath<'s>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::ScriptPath<'s>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::ScriptPath<'s>::leaf_hash(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::sighash::ScriptPath<'s>::new(script: &'s bitcoin::blockdata::script::Script, leaf_version: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::sighash::ScriptPath<'s>::partial_cmp(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::sighash::ScriptPath<'s>::with_defaults(script: &'s bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::sighash::SighashCache<R>::into_transaction(self) -> R
+pub fn bitcoin::sighash::SighashCache<R>::legacy_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized, U: core::convert::Into<u32>>(&self, writer: &mut W, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, sighash_type: U) -> bitcoin::sighash::EncodeSigningDataResult<bitcoin::sighash::SigningDataError<bitcoin::blockdata::transaction::InputsIndexError>>
+pub fn bitcoin::sighash::SighashCache<R>::legacy_signature_hash(&self, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, sighash_type: u32) -> core::result::Result<bitcoin::LegacySighash, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::sighash::SighashCache<R>::new(tx: R) -> Self
+pub fn bitcoin::sighash::SighashCache<R>::p2wpkh_signature_hash(&mut self, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin::sighash::P2wpkhError>
+pub fn bitcoin::sighash::SighashCache<R>::p2wsh_signature_hash(&mut self, input_index: usize, witness_script: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::sighash::SighashCache<R>::segwit_v0_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized>(&mut self, writer: &mut W, input_index: usize, script_code: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<(), bitcoin::sighash::SigningDataError<bitcoin::blockdata::transaction::InputsIndexError>>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized, T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, writer: &mut W, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, annex: core::option::Option<bitcoin::sighash::Annex<'_>>, leaf_hash_code_separator: core::option::Option<(bitcoin::taproot::TapLeafHash, u32)>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<(), bitcoin::sighash::SigningDataError<bitcoin::sighash::TaprootError>>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_key_spend_signature_hash<T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_script_spend_signature_hash<S: core::convert::Into<bitcoin::taproot::TapLeafHash>, T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, leaf_hash: S, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_signature_hash<T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, annex: core::option::Option<bitcoin::sighash::Annex<'_>>, leaf_hash_code_separator: core::option::Option<(bitcoin::taproot::TapLeafHash, u32)>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::transaction(&self) -> &bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::sighash::SighashCache<R>::witness_mut(&mut self, input_index: usize) -> core::option::Option<&mut bitcoin::blockdata::witness::Witness>
+pub fn bitcoin::sighash::SighashCache<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SighashTypeParseError::clone(&self) -> bitcoin::sighash::SighashTypeParseError
+pub fn bitcoin::sighash::SighashTypeParseError::eq(&self, other: &bitcoin::sighash::SighashTypeParseError) -> bool
+pub fn bitcoin::sighash::SighashTypeParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SighashTypeParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::SigningDataError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SigningDataError<E>::from(value: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::sighash::SigningDataError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::SingleMissingOutputError::clone(&self) -> bitcoin::sighash::SingleMissingOutputError
+pub fn bitcoin::sighash::SingleMissingOutputError::eq(&self, other: &bitcoin::sighash::SingleMissingOutputError) -> bool
+pub fn bitcoin::sighash::SingleMissingOutputError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SingleMissingOutputError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::TaprootError::clone(&self) -> bitcoin::sighash::TaprootError
+pub fn bitcoin::sighash::TaprootError::eq(&self, other: &bitcoin::sighash::TaprootError) -> bool
+pub fn bitcoin::sighash::TaprootError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::blockdata::transaction::InputsIndexError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsIndexError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsKindError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsSizeError) -> Self
+pub fn bitcoin::sighash::TaprootError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sign_message::MessageSignature::clone(&self) -> bitcoin::sign_message::MessageSignature
+pub fn bitcoin::sign_message::MessageSignature::eq(&self, other: &bitcoin::sign_message::MessageSignature) -> bool
+pub fn bitcoin::sign_message::MessageSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sign_message::MessageSignature::from_base64(s: &str) -> core::result::Result<bitcoin::sign_message::MessageSignature, bitcoin::sign_message::MessageSignatureError>
+pub fn bitcoin::sign_message::MessageSignature::from_slice(bytes: &[u8]) -> core::result::Result<bitcoin::sign_message::MessageSignature, bitcoin::sign_message::MessageSignatureError>
+pub fn bitcoin::sign_message::MessageSignature::from_str(s: &str) -> core::result::Result<bitcoin::sign_message::MessageSignature, bitcoin::sign_message::MessageSignatureError>
+pub fn bitcoin::sign_message::MessageSignature::is_signed_by_address<C: secp256k1::context::Verification>(&self, secp_ctx: &secp256k1::Secp256k1<C>, address: &bitcoin::address::Address, msg_hash: bitcoin_hashes::sha256d::Hash) -> core::result::Result<bool, bitcoin::sign_message::MessageSignatureError>
+pub fn bitcoin::sign_message::MessageSignature::new(signature: secp256k1::ecdsa::recovery::RecoverableSignature, compressed: bool) -> bitcoin::sign_message::MessageSignature
+pub fn bitcoin::sign_message::MessageSignature::recover_pubkey<C: secp256k1::context::Verification>(&self, secp_ctx: &secp256k1::Secp256k1<C>, msg_hash: bitcoin_hashes::sha256d::Hash) -> core::result::Result<bitcoin::PublicKey, bitcoin::sign_message::MessageSignatureError>
+pub fn bitcoin::sign_message::MessageSignature::serialize(&self) -> [u8; 65]
+pub fn bitcoin::sign_message::MessageSignature::to_base64(self) -> alloc::string::String
+pub fn bitcoin::sign_message::MessageSignatureError::clone(&self) -> bitcoin::sign_message::MessageSignatureError
+pub fn bitcoin::sign_message::MessageSignatureError::eq(&self, other: &bitcoin::sign_message::MessageSignatureError) -> bool
+pub fn bitcoin::sign_message::MessageSignatureError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sign_message::MessageSignatureError::from(e: secp256k1::Error) -> bitcoin::sign_message::MessageSignatureError
+pub fn bitcoin::sign_message::MessageSignatureError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sign_message::signed_msg_hash(msg: &str) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::string::FromHexError<E>::clone(&self) -> bitcoin::string::FromHexError<E>
+pub fn bitcoin::string::FromHexError<E>::eq(&self, other: &bitcoin::string::FromHexError<E>) -> bool
+pub fn bitcoin::string::FromHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::string::FromHexError<E>::from(e: E) -> Self
+pub fn bitcoin::string::FromHexError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::string::FromHexStr::from_hex_str<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, bitcoin::string::FromHexError<Self::Error>>
+pub fn bitcoin::string::FromHexStr::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::ControlBlock::clone(&self) -> bitcoin::taproot::ControlBlock
+pub fn bitcoin::taproot::ControlBlock::cmp(&self, other: &bitcoin::taproot::ControlBlock) -> core::cmp::Ordering
+pub fn bitcoin::taproot::ControlBlock::decode(sl: &[u8]) -> core::result::Result<bitcoin::taproot::ControlBlock, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::ControlBlock::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::taproot::ControlBlock::encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> bitcoin_io::Result<usize>
+pub fn bitcoin::taproot::ControlBlock::eq(&self, other: &bitcoin::taproot::ControlBlock) -> bool
+pub fn bitcoin::taproot::ControlBlock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::ControlBlock::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::ControlBlock::partial_cmp(&self, other: &bitcoin::taproot::ControlBlock) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::ControlBlock::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::ControlBlock::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::taproot::ControlBlock::size(&self) -> usize
+pub fn bitcoin::taproot::ControlBlock::verify_taproot_commitment<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, output_key: secp256k1::key::XOnlyPublicKey, script: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::taproot::FutureLeafVersion::clone(&self) -> bitcoin::taproot::FutureLeafVersion
+pub fn bitcoin::taproot::FutureLeafVersion::cmp(&self, other: &bitcoin::taproot::FutureLeafVersion) -> core::cmp::Ordering
+pub fn bitcoin::taproot::FutureLeafVersion::eq(&self, other: &bitcoin::taproot::FutureLeafVersion) -> bool
+pub fn bitcoin::taproot::FutureLeafVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::FutureLeafVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::FutureLeafVersion::partial_cmp(&self, other: &bitcoin::taproot::FutureLeafVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::FutureLeafVersion::to_consensus(self) -> u8
+pub fn bitcoin::taproot::HiddenNodesError::clone(&self) -> bitcoin::taproot::HiddenNodesError
+pub fn bitcoin::taproot::HiddenNodesError::eq(&self, other: &bitcoin::taproot::HiddenNodesError) -> bool
+pub fn bitcoin::taproot::HiddenNodesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::HiddenNodesError::into_node_info(self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::HiddenNodesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::IncompleteBuilderError::clone(&self) -> bitcoin::taproot::IncompleteBuilderError
+pub fn bitcoin::taproot::IncompleteBuilderError::eq(&self, other: &bitcoin::taproot::IncompleteBuilderError) -> bool
+pub fn bitcoin::taproot::IncompleteBuilderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::IncompleteBuilderError::into_builder(self) -> bitcoin::taproot::TaprootBuilder
+pub fn bitcoin::taproot::IncompleteBuilderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::LeafNode::clone(&self) -> bitcoin::taproot::LeafNode
+pub fn bitcoin::taproot::LeafNode::cmp(&self, other: &bitcoin::taproot::LeafNode) -> core::cmp::Ordering
+pub fn bitcoin::taproot::LeafNode::depth(&self) -> u8
+pub fn bitcoin::taproot::LeafNode::eq(&self, other: &bitcoin::taproot::LeafNode) -> bool
+pub fn bitcoin::taproot::LeafNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::LeafNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::LeafNode::leaf(&self) -> &bitcoin::taproot::TapLeaf
+pub fn bitcoin::taproot::LeafNode::leaf_hash(&self) -> core::option::Option<bitcoin::taproot::TapLeafHash>
+pub fn bitcoin::taproot::LeafNode::leaf_version(&self) -> core::option::Option<bitcoin::taproot::LeafVersion>
+pub fn bitcoin::taproot::LeafNode::merkle_branch(&self) -> &bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::LeafNode::new_hidden(hash: bitcoin::taproot::TapNodeHash) -> Self
+pub fn bitcoin::taproot::LeafNode::new_script(script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::taproot::LeafNode::node_hash(&self) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::LeafNode::partial_cmp(&self, other: &bitcoin::taproot::LeafNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::LeafNode::script(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::taproot::LeafNodes<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::LeafNodes<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::LeafNodes<'tree>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::LeafVersion::clone(&self) -> bitcoin::taproot::LeafVersion
+pub fn bitcoin::taproot::LeafVersion::cmp(&self, other: &bitcoin::taproot::LeafVersion) -> core::cmp::Ordering
+pub fn bitcoin::taproot::LeafVersion::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::taproot::LeafVersion::eq(&self, other: &bitcoin::taproot::LeafVersion) -> bool
+pub fn bitcoin::taproot::LeafVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::LeafVersion::from_consensus(version: u8) -> core::result::Result<Self, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::LeafVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::LeafVersion::partial_cmp(&self, other: &bitcoin::taproot::LeafVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::LeafVersion::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::taproot::LeafVersion::to_consensus(self) -> u8
+pub fn bitcoin::taproot::NodeInfo::clone(&self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::NodeInfo::cmp(&self, other: &bitcoin::taproot::NodeInfo) -> core::cmp::Ordering
+pub fn bitcoin::taproot::NodeInfo::combine(a: Self, b: Self) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::NodeInfo::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin::taproot::NodeInfo::eq(&self, other: &Self) -> bool
+pub fn bitcoin::taproot::NodeInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::NodeInfo::from(tree: bitcoin::taproot::TapTree) -> Self
+pub fn bitcoin::taproot::NodeInfo::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::taproot::NodeInfo::leaf_nodes(&self) -> bitcoin::taproot::LeafNodes<'_>
+pub fn bitcoin::taproot::NodeInfo::new_hidden_node(hash: bitcoin::taproot::TapNodeHash) -> Self
+pub fn bitcoin::taproot::NodeInfo::new_leaf_with_ver(script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::taproot::NodeInfo::partial_cmp(&self, other: &bitcoin::taproot::NodeInfo) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::NodeInfo::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::taproot::NodeInfo::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::clone(&self) -> bitcoin::taproot::ScriptLeaf<'leaf>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::cmp(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> core::cmp::Ordering
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::eq(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> bool
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::from_leaf_node(leaf_node: &'leaf bitcoin::taproot::LeafNode) -> core::option::Option<Self>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::merkle_branch(&self) -> &bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::partial_cmp(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::version(&self) -> bitcoin::taproot::LeafVersion
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::SigFromSliceError::clone(&self) -> bitcoin::taproot::SigFromSliceError
+pub fn bitcoin::taproot::SigFromSliceError::eq(&self, other: &bitcoin::taproot::SigFromSliceError) -> bool
+pub fn bitcoin::taproot::SigFromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::SigFromSliceError::from(e: secp256k1::Error) -> Self
+pub fn bitcoin::taproot::SigFromSliceError::from(err: bitcoin::sighash::InvalidSighashTypeError) -> Self
+pub fn bitcoin::taproot::SigFromSliceError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::Signature::clone(&self) -> bitcoin::taproot::Signature
+pub fn bitcoin::taproot::Signature::cmp(&self, other: &bitcoin::taproot::Signature) -> core::cmp::Ordering
+pub fn bitcoin::taproot::Signature::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::taproot::Signature::eq(&self, other: &bitcoin::taproot::Signature) -> bool
+pub fn bitcoin::taproot::Signature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::Signature::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin::taproot::SigFromSliceError>
+pub fn bitcoin::taproot::Signature::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::Signature::partial_cmp(&self, other: &bitcoin::taproot::Signature) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::Signature::serialize(self) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::Signature::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::taproot::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::taproot::Signature::to_vec(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::Signature::try_from(value: &'a bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::Signature::try_from(value: bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapBranchTag::clone(&self) -> bitcoin::taproot::TapBranchTag
+pub fn bitcoin::taproot::TapBranchTag::cmp(&self, other: &bitcoin::taproot::TapBranchTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapBranchTag::default() -> bitcoin::taproot::TapBranchTag
+pub fn bitcoin::taproot::TapBranchTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapBranchTag::eq(&self, other: &bitcoin::taproot::TapBranchTag) -> bool
+pub fn bitcoin::taproot::TapBranchTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapBranchTag::partial_cmp(&self, other: &bitcoin::taproot::TapBranchTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeaf::as_hidden(&self) -> core::option::Option<&bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::TapLeaf::as_script(&self) -> core::option::Option<(&bitcoin::blockdata::script::Script, bitcoin::taproot::LeafVersion)>
+pub fn bitcoin::taproot::TapLeaf::clone(&self) -> bitcoin::taproot::TapLeaf
+pub fn bitcoin::taproot::TapLeaf::cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeaf::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::taproot::TapLeaf::eq(&self, other: &bitcoin::taproot::TapLeaf) -> bool
+pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeaf::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapLeafHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapLeafHash::clone(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeafHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::taproot::TapLeafHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::taproot::TapLeafHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapLeafHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::taproot::TapLeafHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLeafHash) -> bool
+pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapLeafHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapLeafHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapLeafHash, Self::Err>
+pub fn bitcoin::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeafHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapLeafHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin::taproot::TapLeafTag::clone(&self) -> bitcoin::taproot::TapLeafTag
+pub fn bitcoin::taproot::TapLeafTag::cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeafTag::default() -> bitcoin::taproot::TapLeafTag
+pub fn bitcoin::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeafTag) -> bool
+pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapNodeHash::assume_hidden(hash: [u8; 32]) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapNodeHash::clone(&self) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapNodeHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapNodeHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::taproot::TapNodeHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapNodeHash::eq(&self, other: &bitcoin::taproot::TapNodeHash) -> bool
+pub fn bitcoin::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapNodeHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapNodeHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapNodeHash, Self::Err>
+pub fn bitcoin::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapNodeHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapNodeHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapNodeHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin::taproot::TapTree::clone(&self) -> bitcoin::taproot::TapTree
+pub fn bitcoin::taproot::TapTree::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::taproot::TapTree::eq(&self, other: &bitcoin::taproot::TapTree) -> bool
+pub fn bitcoin::taproot::TapTree::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapTree::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTree::into_node_info(self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::TapTree::node_info(&self) -> &bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::TapTree::script_leaves(&self) -> bitcoin::taproot::ScriptLeaves<'_>
+pub fn bitcoin::taproot::TapTree::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapTweakHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapTweakHash::clone(&self) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapTweakHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapTweakHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin::taproot::TapTweakHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapTweakHash::eq(&self, other: &bitcoin::taproot::TapTweakHash) -> bool
+pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapTweakHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapTweakHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapTweakHash, Self::Err>
+pub fn bitcoin::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapTweakHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapTweakHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin::taproot::TapTweakHash::to_scalar(self) -> secp256k1::scalar::Scalar
+pub fn bitcoin::taproot::TapTweakTag::clone(&self) -> bitcoin::taproot::TapTweakTag
+pub fn bitcoin::taproot::TapTweakTag::cmp(&self, other: &bitcoin::taproot::TapTweakTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapTweakTag::default() -> bitcoin::taproot::TapTweakTag
+pub fn bitcoin::taproot::TapTweakTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapTweakTag::eq(&self, other: &bitcoin::taproot::TapTweakTag) -> bool
+pub fn bitcoin::taproot::TapTweakTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakTag::partial_cmp(&self, other: &bitcoin::taproot::TapTweakTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootBuilder::add_hidden_node(self, depth: u8, hash: bitcoin::taproot::TapNodeHash) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::add_leaf(self, depth: u8, script: bitcoin::blockdata::script::ScriptBuf) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::add_leaf_with_ver(self, depth: u8, script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::clone(&self) -> bitcoin::taproot::TaprootBuilder
+pub fn bitcoin::taproot::TaprootBuilder::cmp(&self, other: &bitcoin::taproot::TaprootBuilder) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TaprootBuilder::default() -> Self
+pub fn bitcoin::taproot::TaprootBuilder::eq(&self, other: &bitcoin::taproot::TaprootBuilder) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::finalize<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey) -> core::result::Result<bitcoin::taproot::TaprootSpendInfo, bitcoin::taproot::TaprootBuilder>
+pub fn bitcoin::taproot::TaprootBuilder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootBuilder::has_hidden_nodes(&self) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TaprootBuilder::is_finalizable(&self) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::new() -> Self
+pub fn bitcoin::taproot::TaprootBuilder::partial_cmp(&self, other: &bitcoin::taproot::TaprootBuilder) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootBuilder::try_into_node_info(self) -> core::result::Result<bitcoin::taproot::NodeInfo, bitcoin::taproot::IncompleteBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::try_into_taptree(self) -> core::result::Result<bitcoin::taproot::TapTree, bitcoin::taproot::IncompleteBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::with_capacity(size: usize) -> Self
+pub fn bitcoin::taproot::TaprootBuilder::with_huffman_tree<I>(script_weights: I) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, bitcoin::blockdata::script::ScriptBuf)>
+pub fn bitcoin::taproot::TaprootBuilderError::clone(&self) -> bitcoin::taproot::TaprootBuilderError
+pub fn bitcoin::taproot::TaprootBuilderError::eq(&self, other: &bitcoin::taproot::TaprootBuilderError) -> bool
+pub fn bitcoin::taproot::TaprootBuilderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootBuilderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::TaprootError::clone(&self) -> bitcoin::taproot::TaprootError
+pub fn bitcoin::taproot::TaprootError::eq(&self, other: &bitcoin::taproot::TaprootError) -> bool
+pub fn bitcoin::taproot::TaprootError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::TaprootSpendInfo::clone(&self) -> bitcoin::taproot::TaprootSpendInfo
+pub fn bitcoin::taproot::TaprootSpendInfo::cmp(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TaprootSpendInfo::control_block(&self, script_ver: &(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)) -> core::option::Option<bitcoin::taproot::ControlBlock>
+pub fn bitcoin::taproot::TaprootSpendInfo::eq(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> bool
+pub fn bitcoin::taproot::TaprootSpendInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootSpendInfo::from_node_info<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, node: bitcoin::taproot::NodeInfo) -> bitcoin::taproot::TaprootSpendInfo
+pub fn bitcoin::taproot::TaprootSpendInfo::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TaprootSpendInfo::internal_key(&self) -> bitcoin::key::UntweakedPublicKey
+pub fn bitcoin::taproot::TaprootSpendInfo::merkle_root(&self) -> core::option::Option<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::TaprootSpendInfo::new_key_spend<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::taproot::TaprootSpendInfo::output_key(&self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::taproot::TaprootSpendInfo::output_key_parity(&self) -> secp256k1::key::Parity
+pub fn bitcoin::taproot::TaprootSpendInfo::partial_cmp(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootSpendInfo::script_map(&self) -> &alloc::collections::btree::map::BTreeMap<(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion), alloc::collections::btree::set::BTreeSet<bitcoin::taproot::merkle_branch::TaprootMerkleBranch>>
+pub fn bitcoin::taproot::TaprootSpendInfo::tap_tweak(&self) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TaprootSpendInfo::with_huffman_tree<C, I>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, script_weights: I) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, bitcoin::blockdata::script::ScriptBuf)>, C: secp256k1::context::Verification
+pub fn bitcoin::taproot::merkle_branch::IntoIter::as_mut_slice(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::IntoIter::as_slice(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::IntoIter::clone(&self) -> bitcoin::taproot::merkle_branch::IntoIter
+pub fn bitcoin::taproot::merkle_branch::IntoIter::count(self) -> usize
+pub fn bitcoin::taproot::merkle_branch::IntoIter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::merkle_branch::IntoIter::last(self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::nth_back(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_inner(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_mut(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_ref(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_slice(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::borrow(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::borrow_mut(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::clone(&self) -> bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::cmp(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> core::cmp::Ordering
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::decode(sl: &[u8]) -> core::result::Result<Self, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::default() -> bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deref(&self) -> &Self::Target
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::encode<Write: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut Write) -> bitcoin_io::Result<usize>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::eq(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> bool
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 0]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 100]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 101]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 102]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 103]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 104]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 105]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 106]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 107]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 108]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 109]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 10]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 110]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 111]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 112]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 113]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 114]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 115]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 116]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 117]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 118]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 119]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 11]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 120]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 121]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 122]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 123]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 124]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 125]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 126]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 127]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 128]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 12]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 13]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 14]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 15]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 16]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 17]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 18]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 19]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 1]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 20]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 21]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 22]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 23]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 24]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 25]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 26]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 27]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 28]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 29]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 2]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 30]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 31]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 32]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 33]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 34]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 35]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 36]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 37]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 38]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 39]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 3]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 40]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 41]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 42]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 43]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 44]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 45]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 46]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 47]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 48]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 49]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 4]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 50]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 51]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 52]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 53]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 54]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 55]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 56]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 57]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 58]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 59]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 5]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 60]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 61]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 62]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 63]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 64]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 65]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 66]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 67]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 68]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 69]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 6]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 70]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 71]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 72]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 73]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 74]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 75]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 76]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 77]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 78]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 79]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 7]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 80]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 81]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 82]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 83]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 84]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 85]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 86]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 87]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 88]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 89]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 8]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 90]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 91]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 92]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 93]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 94]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 95]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 96]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 97]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 98]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 99]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 9]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_inner(self) -> alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_vec(self) -> alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::is_empty(&self) -> bool
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::len(&self) -> usize
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::partial_cmp(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: &[bitcoin::taproot::TapNodeHash]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: alloc::boxed::Box<[bitcoin::taproot::TapNodeHash]>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: alloc::vec::Vec<bitcoin::taproot::TapNodeHash>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::as_slice(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::IntoIter::clone(&self) -> bitcoin::taproot::serialized_signature::IntoIter
+pub fn bitcoin::taproot::serialized_signature::IntoIter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::serialized_signature::IntoIter::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::clone(&self) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::cmp::Ordering
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::deref(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::eq(&self, other: &[u8]) -> bool
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::eq(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> bool
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from(value: &'a bitcoin::taproot::Signature) -> Self
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from(value: bitcoin::taproot::Signature) -> Self
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from_signature(sig: &bitcoin::taproot::Signature) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::len(&self) -> usize
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::partial_cmp(&self, other: &[u8]) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::partial_cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::to_signature(&self) -> core::result::Result<bitcoin::taproot::Signature, bitcoin::taproot::SigFromSliceError>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::write_to<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::transaction::effective_value(fee_rate: bitcoin::blockdata::fee_rate::FeeRate, satisfaction_weight: bitcoin::blockdata::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin::transaction::predict_weight<I, O>(inputs: I, output_script_lens: O) -> bitcoin::blockdata::weight::Weight where I: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::transaction::InputWeightPrediction>, O: core::iter::traits::collect::IntoIterator<Item = usize>
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::PubkeyHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::WPubkeyHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::bip32::XKeyIdentifier) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::blockdata::script::ScriptHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::sha256::Hash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_hashes::sha256::Hash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256::Hash::from(hashtype: bitcoin::blockdata::script::WScriptHash) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256d::Hash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_hashes::sha256d::Hash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::LegacySighash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::SegwitV0Sighash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::bip158::FilterHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::bip158::FilterHeader) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::BlockHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::TxMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::WitnessCommitment) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::WitnessMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::transaction::Txid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::transaction::Wtxid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>::from(hashtype: bitcoin::TapSighash) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>::from(hashtype: bitcoin::taproot::TapNodeHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>::from(hashtype: bitcoin::taproot::TapLeafHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>::from(hashtype: bitcoin::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin_units::amount::Amount::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::amount::Amount::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::amount::Amount::div(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bool::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bool::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn core::convert::Infallible::input_len(&self) -> usize
+pub fn core::num::error::ParseIntError::from(value: bitcoin::error::ParseIntError) -> Self
+pub fn i16::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i16::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i32::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i32::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i64::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i64::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i8::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i8::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn secp256k1::key::Keypair::from(pair: bitcoin::key::TweakedKeypair) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pair: bitcoin::key::TweakedPublicKey) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pk: bitcoin::CompressedPublicKey) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pk: bitcoin::PublicKey) -> secp256k1::key::XOnlyPublicKey
+pub fn std::collections::hash::map::HashMap<bitcoin::PublicKey, bitcoin::PrivateKey>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn std::collections::hash::set::HashSet<bitcoin::bip32::Xpriv>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn u16::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u16::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u32::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u32::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u32::from(cnum: bitcoin::bip32::ChildNumber) -> Self
+pub fn u32::from(sequence: bitcoin::blockdata::transaction::Sequence) -> u32
+pub fn u64::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u64::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u64::from(flags: bitcoin::p2p::ServiceFlags) -> Self
+pub fn u64::from(value: bitcoin::blockdata::fee_rate::FeeRate) -> Self
+pub fn u64::from(value: bitcoin::blockdata::weight::Weight) -> Self
+pub fn u64::mul(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn u8::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u8::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub mod bitcoin
+pub mod bitcoin::absolute
+pub mod bitcoin::address
+pub mod bitcoin::address::error
+pub mod bitcoin::amount
+pub mod bitcoin::base58
+pub mod bitcoin::bip152
+pub mod bitcoin::bip158
+pub mod bitcoin::bip32
+pub mod bitcoin::block
+pub mod bitcoin::blockdata
+pub mod bitcoin::blockdata::block
+pub mod bitcoin::blockdata::constants
+pub mod bitcoin::blockdata::fee_rate
+pub mod bitcoin::blockdata::locktime
+pub mod bitcoin::blockdata::locktime::absolute
+pub mod bitcoin::blockdata::locktime::relative
+pub mod bitcoin::blockdata::opcodes
+pub mod bitcoin::blockdata::opcodes::all
+pub mod bitcoin::blockdata::script
+pub mod bitcoin::blockdata::script::witness_program
+pub mod bitcoin::blockdata::script::witness_version
+pub mod bitcoin::blockdata::transaction
+pub mod bitcoin::blockdata::weight
+pub mod bitcoin::blockdata::witness
+pub mod bitcoin::consensus
+pub mod bitcoin::consensus::encode
+pub mod bitcoin::consensus::params
+pub mod bitcoin::consensus::serde
+pub mod bitcoin::consensus::serde::hex
+pub mod bitcoin::consensus::validation
+pub mod bitcoin::constants
+pub mod bitcoin::ecdsa
+pub mod bitcoin::error
+pub mod bitcoin::hash_types
+pub mod bitcoin::key
+pub mod bitcoin::locktime
+pub mod bitcoin::locktime::absolute
+pub mod bitcoin::locktime::relative
+pub mod bitcoin::merkle_tree
+pub mod bitcoin::network
+pub mod bitcoin::network::as_core_arg
+pub mod bitcoin::opcodes
+pub mod bitcoin::opcodes::all
+pub mod bitcoin::p2p
+pub mod bitcoin::p2p::address
+pub mod bitcoin::p2p::message
+pub mod bitcoin::p2p::message_blockdata
+pub mod bitcoin::p2p::message_bloom
+pub mod bitcoin::p2p::message_compact_blocks
+pub mod bitcoin::p2p::message_filter
+pub mod bitcoin::p2p::message_network
+pub mod bitcoin::policy
+pub mod bitcoin::pow
+pub mod bitcoin::psbt
+pub mod bitcoin::psbt::raw
+pub mod bitcoin::psbt::serialize
+pub mod bitcoin::relative
+pub mod bitcoin::script
+pub mod bitcoin::script::witness_program
+pub mod bitcoin::script::witness_version
+pub mod bitcoin::sighash
+pub mod bitcoin::sign_message
+pub mod bitcoin::string
+pub mod bitcoin::taproot
+pub mod bitcoin::taproot::merkle_branch
+pub mod bitcoin::taproot::serialized_signature
+pub mod bitcoin::transaction
+pub mod bitcoin::witness
+pub mod bitcoin::witness_program
+pub mod bitcoin::witness_version
+pub static bitcoin::blockdata::opcodes::OP_0: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_FALSE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_NOP2: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_NOP3: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_TRUE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_0: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_FALSE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_NOP2: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_NOP3: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_TRUE: bitcoin::blockdata::opcodes::Opcode
+pub struct bitcoin::Block
+pub struct bitcoin::BlockHash(_)
+pub struct bitcoin::CompactTarget(_)
+pub struct bitcoin::CompressedPublicKey(pub secp256k1::key::PublicKey)
+pub struct bitcoin::FeeRate(_)
+pub struct bitcoin::FilterHash(_)
+pub struct bitcoin::FilterHeader(_)
+pub struct bitcoin::LegacySighash(_)
+pub struct bitcoin::MerkleBlock
+pub struct bitcoin::Opcode
+pub struct bitcoin::OutPoint
+pub struct bitcoin::PrivateKey
+pub struct bitcoin::Psbt
+pub struct bitcoin::PubkeyHash(_)
+pub struct bitcoin::PublicKey
+pub struct bitcoin::ScriptBuf(_)
+pub struct bitcoin::ScriptHash(_)
+pub struct bitcoin::SegwitV0Sighash(_)
+pub struct bitcoin::Sequence(pub u32)
+pub struct bitcoin::TapBranchTag
+pub struct bitcoin::TapLeafHash(_)
+pub struct bitcoin::TapLeafTag
+pub struct bitcoin::TapNodeHash(_)
+pub struct bitcoin::TapSighash(_)
+pub struct bitcoin::TapSighashTag
+pub struct bitcoin::TapTweakHash(_)
+pub struct bitcoin::TapTweakTag
+pub struct bitcoin::Target(_)
+pub struct bitcoin::Transaction
+pub struct bitcoin::TxIn
+pub struct bitcoin::TxMerkleNode(_)
+pub struct bitcoin::TxOut
+pub struct bitcoin::Txid(_)
+pub struct bitcoin::VarInt(pub u64)
+pub struct bitcoin::WPubkeyHash(_)
+pub struct bitcoin::WScriptHash(_)
+pub struct bitcoin::Weight(_)
+pub struct bitcoin::Witness
+pub struct bitcoin::WitnessCommitment(_)
+pub struct bitcoin::WitnessMerkleNode(_)
+pub struct bitcoin::WitnessProgram
+pub struct bitcoin::Work(_)
+pub struct bitcoin::Wtxid(_)
+pub struct bitcoin::XKeyIdentifier(_)
+pub struct bitcoin::absolute::Height(_)
+pub struct bitcoin::absolute::ParseHeightError(_)
+pub struct bitcoin::absolute::ParseTimeError(_)
+pub struct bitcoin::absolute::Time(_)
+pub struct bitcoin::bip152::BlockTransactions
+pub struct bitcoin::bip152::BlockTransactionsRequest
+pub struct bitcoin::bip152::HeaderAndShortIds
+pub struct bitcoin::bip152::PrefilledTransaction
+pub struct bitcoin::bip152::ShortId(_)
+pub struct bitcoin::bip158::BitStreamReader<'a, R: core::marker::Sized>
+pub struct bitcoin::bip158::BitStreamWriter<'a, W>
+pub struct bitcoin::bip158::BlockFilter
+pub struct bitcoin::bip158::BlockFilterReader
+pub struct bitcoin::bip158::BlockFilterWriter<'a, W>
+pub struct bitcoin::bip158::FilterHash(_)
+pub struct bitcoin::bip158::FilterHeader(_)
+pub struct bitcoin::bip158::GcsFilterReader
+pub struct bitcoin::bip158::GcsFilterWriter<'a, W>
+pub struct bitcoin::bip32::ChainCode(_)
+pub struct bitcoin::bip32::DerivationPath(_)
+pub struct bitcoin::bip32::DerivationPathIterator<'a>
+pub struct bitcoin::bip32::Fingerprint(_)
+pub struct bitcoin::bip32::XKeyIdentifier(_)
+pub struct bitcoin::bip32::Xpriv
+pub struct bitcoin::bip32::Xpub
+pub struct bitcoin::block::Block
+pub struct bitcoin::block::BlockHash(_)
+pub struct bitcoin::block::Header
+pub struct bitcoin::block::TxMerkleNode(_)
+pub struct bitcoin::block::Version(_)
+pub struct bitcoin::block::WitnessCommitment(_)
+pub struct bitcoin::block::WitnessMerkleNode(_)
+pub struct bitcoin::blockdata::FeeRate(_)
+pub struct bitcoin::blockdata::Weight(_)
+pub struct bitcoin::blockdata::block::Block
+pub struct bitcoin::blockdata::block::BlockHash(_)
+pub struct bitcoin::blockdata::block::Header
+pub struct bitcoin::blockdata::block::TxMerkleNode(_)
+pub struct bitcoin::blockdata::block::Version(_)
+pub struct bitcoin::blockdata::block::WitnessCommitment(_)
+pub struct bitcoin::blockdata::block::WitnessMerkleNode(_)
+pub struct bitcoin::blockdata::constants::ChainHash(_)
+pub struct bitcoin::blockdata::fee_rate::FeeRate(_)
+pub struct bitcoin::blockdata::locktime::absolute::Height(_)
+pub struct bitcoin::blockdata::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin::blockdata::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin::blockdata::locktime::absolute::Time(_)
+pub struct bitcoin::blockdata::locktime::relative::Height(_)
+pub struct bitcoin::blockdata::locktime::relative::Time(_)
+pub struct bitcoin::blockdata::opcodes::Opcode
+pub struct bitcoin::blockdata::script::Builder(_, _)
+pub struct bitcoin::blockdata::script::Bytes<'a>(_)
+pub struct bitcoin::blockdata::script::InstructionIndices<'a>
+pub struct bitcoin::blockdata::script::Instructions<'a>
+pub struct bitcoin::blockdata::script::PushBytesBuf(_)
+pub struct bitcoin::blockdata::script::PushBytesError
+pub struct bitcoin::blockdata::script::ScriptBuf(_)
+pub struct bitcoin::blockdata::script::ScriptHash(_)
+pub struct bitcoin::blockdata::script::WScriptHash(_)
+pub struct bitcoin::blockdata::script::witness_program::WitnessProgram
+pub struct bitcoin::blockdata::transaction::InputWeightPrediction
+pub struct bitcoin::blockdata::transaction::OutPoint
+pub struct bitcoin::blockdata::transaction::Sequence(pub u32)
+pub struct bitcoin::blockdata::transaction::Transaction
+pub struct bitcoin::blockdata::transaction::TxIn
+pub struct bitcoin::blockdata::transaction::TxOut
+pub struct bitcoin::blockdata::transaction::Txid(_)
+pub struct bitcoin::blockdata::transaction::Version(pub i32)
+pub struct bitcoin::blockdata::transaction::Wtxid(_)
+pub struct bitcoin::blockdata::weight::Weight(_)
+pub struct bitcoin::blockdata::witness::Iter<'a>
+pub struct bitcoin::blockdata::witness::Witness
+pub struct bitcoin::consensus::encode::CheckedData
+pub struct bitcoin::consensus::encode::VarInt(pub u64)
+pub struct bitcoin::consensus::serde::Hex<Case> where Case: bitcoin::consensus::serde::hex::Case(_)
+pub struct bitcoin::consensus::serde::With<E>(_)
+pub struct bitcoin::consensus::serde::hex::DecodeError(_)
+pub struct bitcoin::consensus::serde::hex::DecodeInitError(_)
+pub struct bitcoin::consensus::serde::hex::Decoder<'a>(_)
+pub struct bitcoin::consensus::serde::hex::Encoder<C: bitcoin::consensus::serde::hex::Case>(_, _)
+pub struct bitcoin::constants::ChainHash(_)
+pub struct bitcoin::ecdsa::SerializedSignature
+pub struct bitcoin::ecdsa::Signature
+pub struct bitcoin::hash_types::BlockHash(_)
+pub struct bitcoin::hash_types::FilterHash(_)
+pub struct bitcoin::hash_types::FilterHeader(_)
+pub struct bitcoin::hash_types::TxMerkleNode(_)
+pub struct bitcoin::hash_types::Txid(_)
+pub struct bitcoin::hash_types::WitnessCommitment(_)
+pub struct bitcoin::hash_types::WitnessMerkleNode(_)
+pub struct bitcoin::hash_types::Wtxid(_)
+pub struct bitcoin::key::CompressedPublicKey(pub secp256k1::key::PublicKey)
+pub struct bitcoin::key::PrivateKey
+pub struct bitcoin::key::PubkeyHash(_)
+pub struct bitcoin::key::PublicKey
+pub struct bitcoin::key::SortKey(_)
+pub struct bitcoin::key::TweakedKeypair(_)
+pub struct bitcoin::key::TweakedPublicKey(_)
+pub struct bitcoin::key::WPubkeyHash(_)
+pub struct bitcoin::locktime::absolute::Height(_)
+pub struct bitcoin::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin::locktime::absolute::Time(_)
+pub struct bitcoin::locktime::relative::Height(_)
+pub struct bitcoin::locktime::relative::Time(_)
+pub struct bitcoin::merkle_tree::MerkleBlock
+pub struct bitcoin::merkle_tree::PartialMerkleTree
+pub struct bitcoin::opcodes::Opcode
+pub struct bitcoin::p2p::Address
+pub struct bitcoin::p2p::Magic(_)
+pub struct bitcoin::p2p::ServiceFlags(_)
+pub struct bitcoin::p2p::address::AddrV2Message
+pub struct bitcoin::p2p::address::Address
+pub struct bitcoin::p2p::message::CommandString(_)
+pub struct bitcoin::p2p::message::RawNetworkMessage
+pub struct bitcoin::p2p::message_blockdata::GetBlocksMessage
+pub struct bitcoin::p2p::message_blockdata::GetHeadersMessage
+pub struct bitcoin::p2p::message_bloom::FilterAdd
+pub struct bitcoin::p2p::message_bloom::FilterLoad
+pub struct bitcoin::p2p::message_compact_blocks::BlockTxn
+pub struct bitcoin::p2p::message_compact_blocks::CmpctBlock
+pub struct bitcoin::p2p::message_compact_blocks::GetBlockTxn
+pub struct bitcoin::p2p::message_compact_blocks::SendCmpct
+pub struct bitcoin::p2p::message_filter::CFCheckpt
+pub struct bitcoin::p2p::message_filter::CFHeaders
+pub struct bitcoin::p2p::message_filter::CFilter
+pub struct bitcoin::p2p::message_filter::GetCFCheckpt
+pub struct bitcoin::p2p::message_filter::GetCFHeaders
+pub struct bitcoin::p2p::message_filter::GetCFilters
+pub struct bitcoin::p2p::message_network::Reject
+pub struct bitcoin::p2p::message_network::VersionMessage
+pub struct bitcoin::pow::CompactTarget(_)
+pub struct bitcoin::pow::Target(_)
+pub struct bitcoin::pow::Work(_)
+pub struct bitcoin::psbt::Input
+pub struct bitcoin::psbt::Output
+pub struct bitcoin::psbt::Psbt
+pub struct bitcoin::psbt::PsbtSighashType
+pub struct bitcoin::psbt::raw::Key
+pub struct bitcoin::psbt::raw::Pair
+pub struct bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+pub struct bitcoin::relative::Height(_)
+pub struct bitcoin::relative::Time(_)
+pub struct bitcoin::script::Builder(_, _)
+pub struct bitcoin::script::Bytes<'a>(_)
+pub struct bitcoin::script::InstructionIndices<'a>
+pub struct bitcoin::script::Instructions<'a>
+pub struct bitcoin::script::PushBytesBuf(_)
+pub struct bitcoin::script::PushBytesError
+pub struct bitcoin::script::ScriptBuf(_)
+pub struct bitcoin::script::ScriptHash(_)
+pub struct bitcoin::script::WScriptHash(_)
+pub struct bitcoin::script::witness_program::WitnessProgram
+pub struct bitcoin::sighash::Annex<'a>(_)
+pub struct bitcoin::sighash::LegacySighash(_)
+pub struct bitcoin::sighash::ScriptPath<'s>
+pub struct bitcoin::sighash::SegwitV0Sighash(_)
+pub struct bitcoin::sighash::SighashCache<T: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>>
+pub struct bitcoin::sighash::TapSighash(_)
+pub struct bitcoin::sighash::TapSighashTag
+pub struct bitcoin::sign_message::MessageSignature
+pub struct bitcoin::taproot::ControlBlock
+pub struct bitcoin::taproot::FutureLeafVersion(_)
+pub struct bitcoin::taproot::LeafNode
+pub struct bitcoin::taproot::LeafNodes<'a>
+pub struct bitcoin::taproot::NodeInfo
+pub struct bitcoin::taproot::ScriptLeaf<'leaf>
+pub struct bitcoin::taproot::ScriptLeaves<'tree>
+pub struct bitcoin::taproot::Signature
+pub struct bitcoin::taproot::TapBranchTag
+pub struct bitcoin::taproot::TapLeafHash(_)
+pub struct bitcoin::taproot::TapLeafTag
+pub struct bitcoin::taproot::TapNodeHash(_)
+pub struct bitcoin::taproot::TapTree(_)
+pub struct bitcoin::taproot::TapTweakHash(_)
+pub struct bitcoin::taproot::TapTweakTag
+pub struct bitcoin::taproot::TaprootBuilder
+pub struct bitcoin::taproot::TaprootMerkleBranch(_)
+pub struct bitcoin::taproot::TaprootSpendInfo
+pub struct bitcoin::taproot::merkle_branch::IntoIter(_)
+pub struct bitcoin::taproot::merkle_branch::TaprootMerkleBranch(_)
+pub struct bitcoin::taproot::serialized_signature::IntoIter
+pub struct bitcoin::taproot::serialized_signature::SerializedSignature
+pub struct bitcoin::transaction::InputWeightPrediction
+pub struct bitcoin::transaction::OutPoint
+pub struct bitcoin::transaction::Sequence(pub u32)
+pub struct bitcoin::transaction::Transaction
+pub struct bitcoin::transaction::TxIn
+pub struct bitcoin::transaction::TxOut
+pub struct bitcoin::transaction::Txid(_)
+pub struct bitcoin::transaction::Version(pub i32)
+pub struct bitcoin::transaction::Wtxid(_)
+pub struct bitcoin::witness::Iter<'a>
+pub struct bitcoin::witness::Witness
+pub struct bitcoin::witness_program::WitnessProgram
+pub trait bitcoin::address::NetworkValidation: sealed::NetworkValidation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub trait bitcoin::bip32::IntoDerivationPath
+pub trait bitcoin::blockdata::script::PushBytesErrorReport
+pub trait bitcoin::consensus::Decodable: core::marker::Sized
+pub trait bitcoin::consensus::Encodable
+pub trait bitcoin::consensus::ReadExt: bitcoin_io::Read
+pub trait bitcoin::consensus::WriteExt: bitcoin_io::Write
+pub trait bitcoin::consensus::encode::Decodable: core::marker::Sized
+pub trait bitcoin::consensus::encode::Encodable
+pub trait bitcoin::consensus::encode::ReadExt: bitcoin_io::Read
+pub trait bitcoin::consensus::encode::WriteExt: bitcoin_io::Write
+pub trait bitcoin::consensus::serde::ByteDecoder<'a>
+pub trait bitcoin::consensus::serde::ByteEncoder: core::default::Default
+pub trait bitcoin::consensus::serde::EncodeBytes
+pub trait bitcoin::consensus::serde::IntoDeError
+pub trait bitcoin::consensus::serde::hex::Case: sealed::Case
+pub trait bitcoin::key::TapTweak
+pub trait bitcoin::psbt::GetKey
+pub trait bitcoin::script::PushBytesErrorReport
+pub trait bitcoin::string::FromHexStr: core::marker::Sized
+pub type &'a bitcoin::bip32::DerivationPath::IntoIter = core::slice::iter::Iter<'a, bitcoin::bip32::ChildNumber>
+pub type &'a bitcoin::bip32::DerivationPath::Item = &'a bitcoin::bip32::ChildNumber
+pub type &'a bitcoin::blockdata::script::PushBytes::Error = bitcoin::blockdata::script::PushBytesError
+pub type &'a bitcoin::blockdata::witness::Witness::IntoIter = bitcoin::blockdata::witness::Iter<'a>
+pub type &'a bitcoin::blockdata::witness::Witness::Item = &'a [u8]
+pub type &'a bitcoin::ecdsa::SerializedSignature::IntoIter = core::slice::iter::Iter<'a, u8>
+pub type &'a bitcoin::ecdsa::SerializedSignature::Item = &'a u8
+pub type &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = core::slice::iter::Iter<'a, bitcoin::taproot::TapNodeHash>
+pub type &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = &'a bitcoin::taproot::TapNodeHash
+pub type &'a bitcoin::taproot::serialized_signature::SerializedSignature::IntoIter = core::slice::iter::Iter<'a, u8>
+pub type &'a bitcoin::taproot::serialized_signature::SerializedSignature::Item = &'a u8
+pub type &'a mut bitcoin::blockdata::script::PushBytes::Error = bitcoin::blockdata::script::PushBytesError
+pub type &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = core::slice::iter::IterMut<'a, bitcoin::taproot::TapNodeHash>
+pub type &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = &'a mut bitcoin::taproot::TapNodeHash
+pub type alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>::Error = bitcoin::psbt::GetKeyError
+pub type alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>::Error = bitcoin::psbt::GetKeyError
+pub type bitcoin::CompressedPublicKey::Err = bitcoin::key::Error
+pub type bitcoin::CompressedPublicKey::Error = bitcoin::key::UncompressedPubkeyError
+pub type bitcoin::EcdsaSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::LegacySighash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::LegacySighash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::LegacySighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::LegacySighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::PrivateKey::Err = bitcoin::key::Error
+pub type bitcoin::PrivateKey::Output = [u8]
+pub type bitcoin::PubkeyHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::PubkeyHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::PubkeyHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::PubkeyHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::PublicKey::Err = bitcoin::key::Error
+pub type bitcoin::SegwitV0Sighash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::SegwitV0Sighash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::SegwitV0Sighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::SegwitV0Sighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::TapSighash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::TapSighash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::TapSighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::TapSighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::TapSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::WPubkeyHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::WPubkeyHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::WPubkeyHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::WPubkeyHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::Err = bitcoin::address::error::ParseError
+pub type bitcoin::address::AddressType::Err = bitcoin::address::error::UnknownAddressTypeError
+pub type bitcoin::bip152::ShortId::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip152::ShortId::Error = core::array::TryFromSliceError
+pub type bitcoin::bip152::ShortId::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip158::FilterHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip158::FilterHash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip158::FilterHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip158::FilterHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip158::FilterHeader::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip158::FilterHeader::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip158::FilterHeader::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip158::FilterHeader::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip32::ChainCode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::ChainCode::Error = core::array::TryFromSliceError
+pub type bitcoin::bip32::ChainCode::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::ChildNumber::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::DerivationPath::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::DerivationPath::Output = <alloc::vec::Vec<bitcoin::bip32::ChildNumber> as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::DerivationPathIterator<'a>::Item = bitcoin::bip32::DerivationPath
+pub type bitcoin::bip32::ExtendendPrivKey = bitcoin::bip32::Xpriv
+pub type bitcoin::bip32::ExtendendPubKey = bitcoin::bip32::Xpub
+pub type bitcoin::bip32::Fingerprint::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::Fingerprint::Error = core::array::TryFromSliceError
+pub type bitcoin::bip32::Fingerprint::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::KeySource = (bitcoin::bip32::Fingerprint, bitcoin::bip32::DerivationPath)
+pub type bitcoin::bip32::XKeyIdentifier::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip32::XKeyIdentifier::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip32::XKeyIdentifier::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::XKeyIdentifier::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip32::Xpriv::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::Xpriv::Error = bitcoin::psbt::GetKeyError
+pub type bitcoin::bip32::Xpub::Err = bitcoin::bip32::Error
+pub type bitcoin::blockdata::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::BlockHash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::BlockHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::BlockHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::TxMerkleNode::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::TxMerkleNode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::TxMerkleNode::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::WitnessCommitment::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::WitnessCommitment::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::WitnessCommitment::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::constants::ChainHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::constants::ChainHash::Error = core::array::TryFromSliceError
+pub type bitcoin::blockdata::constants::ChainHash::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::blockdata::fee_rate::FeeRate::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::fee_rate::FeeRate::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::fee_rate::FeeRate::Output = bitcoin_units::amount::Amount
+pub type bitcoin::blockdata::locktime::absolute::Height::Err = bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub type bitcoin::blockdata::locktime::absolute::Height::Error = bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub type bitcoin::blockdata::locktime::absolute::LockTime::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::absolute::LockTime::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::absolute::Time::Err = bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub type bitcoin::blockdata::locktime::absolute::Time::Error = bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub type bitcoin::blockdata::locktime::relative::Height::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Height::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Time::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Time::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::script::Bytes<'_>::Item = u8
+pub type bitcoin::blockdata::script::InstructionIndices<'a>::Item = core::result::Result<(usize, bitcoin::blockdata::script::Instruction<'a>), bitcoin::blockdata::script::Error>
+pub type bitcoin::blockdata::script::Instructions<'a>::Item = core::result::Result<bitcoin::blockdata::script::Instruction<'a>, bitcoin::blockdata::script::Error>
+pub type bitcoin::blockdata::script::PushBytes::Output = bitcoin::blockdata::script::PushBytes
+pub type bitcoin::blockdata::script::PushBytes::Output = u8
+pub type bitcoin::blockdata::script::PushBytes::Owned = bitcoin::blockdata::script::PushBytesBuf
+pub type bitcoin::blockdata::script::PushBytesBuf::Error = bitcoin::blockdata::script::PushBytesError
+pub type bitcoin::blockdata::script::PushBytesBuf::Target = bitcoin::blockdata::script::PushBytes
+pub type bitcoin::blockdata::script::Script::Output = bitcoin::blockdata::script::Script
+pub type bitcoin::blockdata::script::Script::Owned = bitcoin::blockdata::script::ScriptBuf
+pub type bitcoin::blockdata::script::ScriptBuf::Target = bitcoin::blockdata::script::Script
+pub type bitcoin::blockdata::script::ScriptHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::script::ScriptHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::script::ScriptHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::script::ScriptHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::script::WScriptHash::Bytes = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::script::WScriptHash::Engine = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::script::WScriptHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::script::WScriptHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Err = bitcoin::blockdata::script::witness_version::FromStrError
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Error = bitcoin::blockdata::script::witness_version::TryFromError
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Error = bitcoin::blockdata::script::witness_version::TryFromInstructionError
+pub type bitcoin::blockdata::transaction::OutPoint::Err = bitcoin::blockdata::transaction::ParseOutPointError
+pub type bitcoin::blockdata::transaction::Sequence::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::transaction::Sequence::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::transaction::Txid::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::transaction::Txid::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::transaction::Txid::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::transaction::Wtxid::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::transaction::Wtxid::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::transaction::Wtxid::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::weight::Weight::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::weight::Weight::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::weight::Weight::Output = bitcoin::blockdata::weight::Weight
+pub type bitcoin::blockdata::weight::Weight::Output = bitcoin_units::amount::Amount
+pub type bitcoin::blockdata::weight::Weight::Output = u64
+pub type bitcoin::blockdata::witness::Iter<'a>::Item = &'a [u8]
+pub type bitcoin::blockdata::witness::Witness::Output = [u8]
+pub type bitcoin::consensus::serde::ByteDecoder::DecodeError: bitcoin::consensus::serde::IntoDeError + core::fmt::Debug
+pub type bitcoin::consensus::serde::ByteDecoder::Decoder: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, Self::DecodeError>>
+pub type bitcoin::consensus::serde::ByteDecoder::InitError: bitcoin::consensus::serde::IntoDeError + core::fmt::Debug
+pub type bitcoin::consensus::serde::ByteEncoder::Encoder: bitcoin::consensus::serde::EncodeBytes + core::convert::From<Self>
+pub type bitcoin::consensus::serde::Hex<C>::DecodeError = bitcoin::consensus::serde::hex::DecodeError
+pub type bitcoin::consensus::serde::Hex<C>::Decoder = bitcoin::consensus::serde::hex::Decoder<'a>
+pub type bitcoin::consensus::serde::Hex<C>::Encoder = bitcoin::consensus::serde::hex::Encoder<C>
+pub type bitcoin::consensus::serde::Hex<C>::InitError = bitcoin::consensus::serde::hex::DecodeInitError
+pub type bitcoin::consensus::serde::hex::Decoder<'a>::Item = core::result::Result<u8, bitcoin::consensus::serde::hex::DecodeError>
+pub type bitcoin::ecdsa::SerializedSignature::Target = [u8]
+pub type bitcoin::ecdsa::Signature::Err = bitcoin::ecdsa::Error
+pub type bitcoin::key::TapTweak::TweakedAux
+pub type bitcoin::key::TapTweak::TweakedKey
+pub type bitcoin::key::UntweakedKeypair = secp256k1::key::Keypair
+pub type bitcoin::key::UntweakedKeypair::TweakedAux = bitcoin::key::TweakedKeypair
+pub type bitcoin::key::UntweakedKeypair::TweakedKey = bitcoin::key::TweakedKeypair
+pub type bitcoin::key::UntweakedPublicKey = secp256k1::key::XOnlyPublicKey
+pub type bitcoin::key::UntweakedPublicKey::TweakedAux = (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub type bitcoin::key::UntweakedPublicKey::TweakedKey = bitcoin::key::TweakedPublicKey
+pub type bitcoin::network::Network::Err = bitcoin::network::ParseNetworkError
+pub type bitcoin::network::Network::Error = bitcoin::network::UnknownChainHashError
+pub type bitcoin::network::Network::Error = bitcoin::p2p::UnknownMagicError
+pub type bitcoin::p2p::Magic::Err = bitcoin::p2p::ParseMagicError
+pub type bitcoin::p2p::ServiceFlags::Output = bitcoin::p2p::ServiceFlags
+pub type bitcoin::p2p::address::AddrV2Message::Iter = core::iter::sources::once::Once<core::net::socket_addr::SocketAddr>
+pub type bitcoin::p2p::address::Address::Iter = core::iter::sources::once::Once<core::net::socket_addr::SocketAddr>
+pub type bitcoin::p2p::message::CommandString::Err = bitcoin::p2p::message::CommandStringError
+pub type bitcoin::p2p::message::CommandString::Error = bitcoin::p2p::message::CommandStringError
+pub type bitcoin::pow::CompactTarget::Error = bitcoin::error::ParseIntError
+pub type bitcoin::pow::Work::Output = bitcoin::pow::Work
+pub type bitcoin::psbt::GetKey::Error: core::fmt::Debug
+pub type bitcoin::psbt::Psbt::Err = bitcoin::psbt::PsbtParseError
+pub type bitcoin::psbt::PsbtSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::psbt::SigningErrors = alloc::collections::btree::map::BTreeMap<usize, bitcoin::psbt::SignError>
+pub type bitcoin::psbt::SigningKeys = alloc::collections::btree::map::BTreeMap<usize, alloc::vec::Vec<bitcoin::PublicKey>>
+pub type bitcoin::psbt::raw::ProprietaryKey<Subtype>::Error = bitcoin::psbt::Error
+pub type bitcoin::psbt::raw::ProprietaryType = u8
+pub type bitcoin::sign_message::MessageSignature::Err = bitcoin::sign_message::MessageSignatureError
+pub type bitcoin::string::FromHexStr::Error
+pub type bitcoin::taproot::LeafNodes<'a>::Item = &'a bitcoin::taproot::LeafNode
+pub type bitcoin::taproot::NodeInfo::Error = bitcoin::taproot::IncompleteBuilderError
+pub type bitcoin::taproot::ScriptLeaves<'tree>::Item = bitcoin::taproot::ScriptLeaf<'tree>
+pub type bitcoin::taproot::Signature::Error = bitcoin::taproot::SigFromSliceError
+pub type bitcoin::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapLeafHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapLeafHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapLeafHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::TapNodeHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapNodeHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapNodeHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapNodeHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::TapTree::Error = bitcoin::taproot::HiddenNodesError
+pub type bitcoin::taproot::TapTree::Error = bitcoin::taproot::IncompleteBuilderError
+pub type bitcoin::taproot::TapTweakHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapTweakHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapTweakHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapTweakHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::merkle_branch::IntoIter::Item = bitcoin::taproot::TapNodeHash
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Error = bitcoin::taproot::TaprootError
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = bitcoin::taproot::merkle_branch::IntoIter
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = bitcoin::taproot::TapNodeHash
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Target = [bitcoin::taproot::TapNodeHash]
+pub type bitcoin::taproot::serialized_signature::IntoIter::Item = u8
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::IntoIter = bitcoin::taproot::serialized_signature::IntoIter
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::Item = u8
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::Target = [u8]
+pub type bitcoin_units::amount::Amount::Output = bitcoin::blockdata::fee_rate::FeeRate
+pub type std::collections::hash::map::HashMap<bitcoin::PublicKey, bitcoin::PrivateKey>::Error = bitcoin::psbt::GetKeyError
+pub type std::collections::hash::set::HashSet<bitcoin::bip32::Xpriv>::Error = bitcoin::psbt::GetKeyError
+pub type u64::Output = bitcoin::blockdata::weight::Weight
+pub use bitcoin::Amount
+pub use bitcoin::Denomination
+pub use bitcoin::SignedAmount
+pub use bitcoin::XOnlyPublicKey
+pub use bitcoin::amount::Amount
+pub use bitcoin::amount::CheckedSum
+pub use bitcoin::amount::Denomination
+pub use bitcoin::amount::Display
+pub use bitcoin::amount::ParseAmountError
+pub use bitcoin::amount::SignedAmount
+pub use bitcoin::amount::serde
+pub use bitcoin::key::Keypair
+pub use bitcoin::key::Parity
+pub use bitcoin::key::Secp256k1
+pub use bitcoin::key::Verification
+pub use bitcoin::key::XOnlyPublicKey
+pub use bitcoin::key::constants
+pub use bitcoin::key::rand
+pub use bitcoin::key::secp256k1

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -1,0 +1,9732 @@
+#[non_exhaustive] pub enum bitcoin::AddressType
+#[non_exhaustive] pub enum bitcoin::KnownHrp
+#[non_exhaustive] pub enum bitcoin::Network
+#[non_exhaustive] pub enum bitcoin::absolute::Error
+#[non_exhaustive] pub enum bitcoin::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::address::AddressType
+#[non_exhaustive] pub enum bitcoin::address::Error
+#[non_exhaustive] pub enum bitcoin::address::KnownHrp
+#[non_exhaustive] pub enum bitcoin::address::ParseError
+#[non_exhaustive] pub enum bitcoin::address::error::Error
+#[non_exhaustive] pub enum bitcoin::address::error::ParseError
+#[non_exhaustive] pub enum bitcoin::base58::Error
+#[non_exhaustive] pub enum bitcoin::bip152::Error
+#[non_exhaustive] pub enum bitcoin::bip158::Error
+#[non_exhaustive] pub enum bitcoin::bip32::Error
+#[non_exhaustive] pub enum bitcoin::block::Bip34Error
+#[non_exhaustive] pub enum bitcoin::block::ValidationError
+#[non_exhaustive] pub enum bitcoin::blockdata::block::Bip34Error
+#[non_exhaustive] pub enum bitcoin::blockdata::block::ValidationError
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::absolute::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::relative::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_version::TryFromInstructionError
+#[non_exhaustive] pub enum bitcoin::blockdata::transaction::ParseOutPointError
+#[non_exhaustive] pub enum bitcoin::consensus::encode::Error
+#[non_exhaustive] pub enum bitcoin::ecdsa::Error
+#[non_exhaustive] pub enum bitcoin::key::Error
+#[non_exhaustive] pub enum bitcoin::locktime::absolute::Error
+#[non_exhaustive] pub enum bitcoin::locktime::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::locktime::relative::Error
+#[non_exhaustive] pub enum bitcoin::merkle_tree::MerkleBlockError
+#[non_exhaustive] pub enum bitcoin::network::Network
+#[non_exhaustive] pub enum bitcoin::psbt::Error
+#[non_exhaustive] pub enum bitcoin::psbt::ExtractTxError
+#[non_exhaustive] pub enum bitcoin::psbt::GetKeyError
+#[non_exhaustive] pub enum bitcoin::psbt::IndexOutOfBoundsError
+#[non_exhaustive] pub enum bitcoin::psbt::KeyRequest
+#[non_exhaustive] pub enum bitcoin::psbt::OutputType
+#[non_exhaustive] pub enum bitcoin::psbt::SignError
+#[non_exhaustive] pub enum bitcoin::relative::Error
+#[non_exhaustive] pub enum bitcoin::script::Error
+#[non_exhaustive] pub enum bitcoin::script::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::script::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::script::witness_version::TryFromInstructionError
+#[non_exhaustive] pub enum bitcoin::sighash::AnnexError
+#[non_exhaustive] pub enum bitcoin::sighash::P2wpkhError
+#[non_exhaustive] pub enum bitcoin::sighash::PrevoutsIndexError
+#[non_exhaustive] pub enum bitcoin::sighash::TaprootError
+#[non_exhaustive] pub enum bitcoin::sign_message::MessageSignatureError
+#[non_exhaustive] pub enum bitcoin::string::FromHexError<E>
+#[non_exhaustive] pub enum bitcoin::taproot::HiddenNodesError
+#[non_exhaustive] pub enum bitcoin::taproot::IncompleteBuilderError
+#[non_exhaustive] pub enum bitcoin::taproot::SigFromSliceError
+#[non_exhaustive] pub enum bitcoin::taproot::TaprootBuilderError
+#[non_exhaustive] pub enum bitcoin::taproot::TaprootError
+#[non_exhaustive] pub enum bitcoin::transaction::ParseOutPointError
+#[non_exhaustive] pub enum bitcoin::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::witness_version::TryFromInstructionError
+#[non_exhaustive] pub struct bitcoin::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::address::UnknownAddressTypeError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::UnknownHrpError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::error::UnknownAddressTypeError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::error::UnknownHrpError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::bip152::TxIndexOutOfRangeError(_)
+#[non_exhaustive] pub struct bitcoin::blockdata::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::blockdata::script::witness_version::TryFromError
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::IndexOutOfBoundsError
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::InputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::OutputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::consensus::Params
+#[non_exhaustive] pub struct bitcoin::consensus::params::Params
+#[non_exhaustive] pub struct bitcoin::error::ParseIntError
+#[non_exhaustive] pub struct bitcoin::key::UncompressedPubkeyError
+#[non_exhaustive] pub struct bitcoin::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::network::ParseNetworkError(_)
+#[non_exhaustive] pub struct bitcoin::network::UnknownChainHashError(_)
+#[non_exhaustive] pub struct bitcoin::p2p::ParseMagicError
+#[non_exhaustive] pub struct bitcoin::p2p::UnknownMagicError(_)
+#[non_exhaustive] pub struct bitcoin::p2p::message::CommandStringError
+#[non_exhaustive] pub struct bitcoin::pow::TryFromError(_)
+#[non_exhaustive] pub struct bitcoin::script::witness_version::TryFromError
+#[non_exhaustive] pub struct bitcoin::sighash::InvalidSighashTypeError(pub u32)
+#[non_exhaustive] pub struct bitcoin::sighash::NonStandardSighashTypeError(pub u32)
+#[non_exhaustive] pub struct bitcoin::sighash::PrevoutsKindError
+#[non_exhaustive] pub struct bitcoin::sighash::PrevoutsSizeError
+#[non_exhaustive] pub struct bitcoin::sighash::SighashTypeParseError
+#[non_exhaustive] pub struct bitcoin::sighash::SingleMissingOutputError
+#[non_exhaustive] pub struct bitcoin::transaction::IndexOutOfBoundsError
+#[non_exhaustive] pub struct bitcoin::transaction::InputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::transaction::OutputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::witness_version::TryFromError
+#[repr(transparent)] pub struct bitcoin::Address<V> where V: bitcoin::address::NetworkValidation(_, _)
+#[repr(transparent)] pub struct bitcoin::Script(_)
+#[repr(transparent)] pub struct bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation(_, _)
+#[repr(transparent)] pub struct bitcoin::blockdata::script::PushBytes(_)
+#[repr(transparent)] pub struct bitcoin::blockdata::script::Script(_)
+#[repr(transparent)] pub struct bitcoin::script::PushBytes(_)
+#[repr(transparent)] pub struct bitcoin::script::Script(_)
+#[repr(u8)] pub enum bitcoin::WitnessVersion
+#[repr(u8)] pub enum bitcoin::blockdata::script::witness_version::WitnessVersion
+#[repr(u8)] pub enum bitcoin::script::witness_version::WitnessVersion
+#[repr(u8)] pub enum bitcoin::witness_version::WitnessVersion
+impl !core::marker::Sized for bitcoin::blockdata::script::PushBytes
+impl !core::marker::Sized for bitcoin::blockdata::script::Script
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Error
+impl alloc::borrow::ToOwned for bitcoin::blockdata::script::PushBytes
+impl alloc::borrow::ToOwned for bitcoin::blockdata::script::Script
+impl bitcoin::CompressedPublicKey
+impl bitcoin::EcdsaSighashType
+impl bitcoin::LegacySighash
+impl bitcoin::MerkleBlock
+impl bitcoin::PrivateKey
+impl bitcoin::PubkeyHash
+impl bitcoin::PublicKey
+impl bitcoin::SegwitV0Sighash
+impl bitcoin::TapSighash
+impl bitcoin::TapSighashType
+impl bitcoin::WPubkeyHash
+impl bitcoin::address::Address
+impl bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+impl bitcoin::address::NetworkValidation for bitcoin::address::NetworkChecked
+impl bitcoin::address::NetworkValidation for bitcoin::address::NetworkUnchecked
+impl bitcoin::bip152::BlockTransactions
+impl bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::bip152::ShortId
+impl bitcoin::bip158::BlockFilter
+impl bitcoin::bip158::BlockFilterReader
+impl bitcoin::bip158::FilterHash
+impl bitcoin::bip158::FilterHeader
+impl bitcoin::bip158::GcsFilterReader
+impl bitcoin::bip32::ChainCode
+impl bitcoin::bip32::ChildNumber
+impl bitcoin::bip32::DerivationPath
+impl bitcoin::bip32::Fingerprint
+impl bitcoin::bip32::IntoDerivationPath for alloc::string::String
+impl bitcoin::bip32::XKeyIdentifier
+impl bitcoin::bip32::Xpriv
+impl bitcoin::bip32::Xpub
+impl bitcoin::blockdata::block::Block
+impl bitcoin::blockdata::block::BlockHash
+impl bitcoin::blockdata::block::Header
+impl bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::blockdata::block::Version
+impl bitcoin::blockdata::block::WitnessCommitment
+impl bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::blockdata::constants::ChainHash
+impl bitcoin::blockdata::fee_rate::FeeRate
+impl bitcoin::blockdata::locktime::absolute::Height
+impl bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::blockdata::locktime::absolute::Time
+impl bitcoin::blockdata::locktime::relative::Height
+impl bitcoin::blockdata::locktime::relative::LockTime
+impl bitcoin::blockdata::locktime::relative::Time
+impl bitcoin::blockdata::opcodes::Opcode
+impl bitcoin::blockdata::script::Builder
+impl bitcoin::blockdata::script::PushBytes
+impl bitcoin::blockdata::script::PushBytesBuf
+impl bitcoin::blockdata::script::PushBytesErrorReport for bitcoin::blockdata::script::PushBytesError
+impl bitcoin::blockdata::script::PushBytesErrorReport for core::convert::Infallible
+impl bitcoin::blockdata::script::Script
+impl bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::blockdata::script::ScriptHash
+impl bitcoin::blockdata::script::WScriptHash
+impl bitcoin::blockdata::script::witness_program::WitnessProgram
+impl bitcoin::blockdata::script::witness_version::WitnessVersion
+impl bitcoin::blockdata::transaction::InputWeightPrediction
+impl bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::blockdata::transaction::Sequence
+impl bitcoin::blockdata::transaction::Transaction
+impl bitcoin::blockdata::transaction::TxIn
+impl bitcoin::blockdata::transaction::TxOut
+impl bitcoin::blockdata::transaction::Txid
+impl bitcoin::blockdata::transaction::Version
+impl bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::blockdata::weight::Weight
+impl bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Decodable for [u16; 8]
+impl bitcoin::consensus::encode::Decodable for [u8; 10]
+impl bitcoin::consensus::encode::Decodable for [u8; 12]
+impl bitcoin::consensus::encode::Decodable for [u8; 16]
+impl bitcoin::consensus::encode::Decodable for [u8; 2]
+impl bitcoin::consensus::encode::Decodable for [u8; 32]
+impl bitcoin::consensus::encode::Decodable for [u8; 33]
+impl bitcoin::consensus::encode::Decodable for [u8; 4]
+impl bitcoin::consensus::encode::Decodable for [u8; 6]
+impl bitcoin::consensus::encode::Decodable for [u8; 8]
+impl bitcoin::consensus::encode::Decodable for alloc::borrow::Cow<'static, str>
+impl bitcoin::consensus::encode::Decodable for alloc::boxed::Box<[u8]>
+impl bitcoin::consensus::encode::Decodable for alloc::string::String
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<alloc::vec::Vec<u8>>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip152::ShortId>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip158::FilterHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip158::FilterHeader>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::Header>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::consensus::encode::VarInt>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::taproot::TapLeafHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<u64>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<u8>
+impl bitcoin::consensus::encode::Decodable for bitcoin::MerkleBlock
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::BlockTransactions
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::BlockTransactionsRequest
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::PrefilledTransaction
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::ShortId
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip158::FilterHash
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip158::FilterHeader
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Block
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::BlockHash
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Header
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Version
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Transaction
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::TxIn
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::TxOut
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Txid
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Version
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::Decodable for bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Decodable for bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::encode::Decodable for bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::Magic
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::ServiceFlags
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::address::AddrV2
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::address::AddrV2Message
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::address::Address
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message::CommandString
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message::RawNetworkMessage
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_blockdata::Inventory
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_bloom::BloomFlags
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_bloom::FilterAdd
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_bloom::FilterLoad
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::CFCheckpt
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::CFHeaders
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::CFilter
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::GetCFCheckpt
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::GetCFHeaders
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_filter::GetCFilters
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_network::Reject
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_network::RejectReason
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::message_network::VersionMessage
+impl bitcoin::consensus::encode::Decodable for bitcoin::pow::CompactTarget
+impl bitcoin::consensus::encode::Decodable for bitcoin::taproot::TapLeafHash
+impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256::Hash
+impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256d::Hash
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Decodable for bool
+impl bitcoin::consensus::encode::Decodable for i16
+impl bitcoin::consensus::encode::Decodable for i32
+impl bitcoin::consensus::encode::Decodable for i64
+impl bitcoin::consensus::encode::Decodable for i8
+impl bitcoin::consensus::encode::Decodable for u16
+impl bitcoin::consensus::encode::Decodable for u32
+impl bitcoin::consensus::encode::Decodable for u64
+impl bitcoin::consensus::encode::Decodable for u8
+impl bitcoin::consensus::encode::Encodable for [u16; 8]
+impl bitcoin::consensus::encode::Encodable for [u8; 10]
+impl bitcoin::consensus::encode::Encodable for [u8; 12]
+impl bitcoin::consensus::encode::Encodable for [u8; 16]
+impl bitcoin::consensus::encode::Encodable for [u8; 2]
+impl bitcoin::consensus::encode::Encodable for [u8; 32]
+impl bitcoin::consensus::encode::Encodable for [u8; 33]
+impl bitcoin::consensus::encode::Encodable for [u8; 4]
+impl bitcoin::consensus::encode::Encodable for [u8; 6]
+impl bitcoin::consensus::encode::Encodable for [u8; 8]
+impl bitcoin::consensus::encode::Encodable for alloc::borrow::Cow<'static, str>
+impl bitcoin::consensus::encode::Encodable for alloc::boxed::Box<[u8]>
+impl bitcoin::consensus::encode::Encodable for alloc::string::String
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<alloc::vec::Vec<u8>>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip152::ShortId>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip158::FilterHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip158::FilterHeader>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::Header>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::consensus::encode::VarInt>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::taproot::TapLeafHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<u64>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<u8>
+impl bitcoin::consensus::encode::Encodable for bitcoin::MerkleBlock
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::BlockTransactions
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::BlockTransactionsRequest
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::PrefilledTransaction
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::ShortId
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip158::FilterHash
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip158::FilterHeader
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Block
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::BlockHash
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Header
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Version
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::script::Script
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Transaction
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::TxIn
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::TxOut
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Txid
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Version
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::Encodable for bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Encodable for bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::encode::Encodable for bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::Magic
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::ServiceFlags
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::address::AddrV2
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::address::AddrV2Message
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::address::Address
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message::CommandString
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message::NetworkMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message::RawNetworkMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_blockdata::Inventory
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_bloom::BloomFlags
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_bloom::FilterAdd
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_bloom::FilterLoad
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::CFCheckpt
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::CFHeaders
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::CFilter
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::GetCFCheckpt
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::GetCFHeaders
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_filter::GetCFilters
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_network::Reject
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_network::RejectReason
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::message_network::VersionMessage
+impl bitcoin::consensus::encode::Encodable for bitcoin::pow::CompactTarget
+impl bitcoin::consensus::encode::Encodable for bitcoin::taproot::TapLeafHash
+impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256::Hash
+impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256d::Hash
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Encodable for bool
+impl bitcoin::consensus::encode::Encodable for i16
+impl bitcoin::consensus::encode::Encodable for i32
+impl bitcoin::consensus::encode::Encodable for i64
+impl bitcoin::consensus::encode::Encodable for i8
+impl bitcoin::consensus::encode::Encodable for u16
+impl bitcoin::consensus::encode::Encodable for u32
+impl bitcoin::consensus::encode::Encodable for u64
+impl bitcoin::consensus::encode::Encodable for u8
+impl bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::params::Params
+impl bitcoin::ecdsa::SerializedSignature
+impl bitcoin::ecdsa::Signature
+impl bitcoin::error::ParseIntError
+impl bitcoin::key::TapTweak for bitcoin::key::UntweakedKeypair
+impl bitcoin::key::TapTweak for bitcoin::key::UntweakedPublicKey
+impl bitcoin::key::TweakedKeypair
+impl bitcoin::key::TweakedPublicKey
+impl bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::network::Network
+impl bitcoin::network::NetworkKind
+impl bitcoin::p2p::Magic
+impl bitcoin::p2p::ServiceFlags
+impl bitcoin::p2p::address::AddrV2Message
+impl bitcoin::p2p::address::Address
+impl bitcoin::p2p::message::CommandString
+impl bitcoin::p2p::message::NetworkMessage
+impl bitcoin::p2p::message::RawNetworkMessage
+impl bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl bitcoin::p2p::message_blockdata::Inventory
+impl bitcoin::p2p::message_network::VersionMessage
+impl bitcoin::pow::CompactTarget
+impl bitcoin::pow::Target
+impl bitcoin::pow::Work
+impl bitcoin::psbt::GetKey for alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>
+impl bitcoin::psbt::GetKey for alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>
+impl bitcoin::psbt::GetKey for bitcoin::bip32::Xpriv
+impl bitcoin::psbt::GetKey for std::collections::hash::map::HashMap<bitcoin::PublicKey, bitcoin::PrivateKey>
+impl bitcoin::psbt::GetKey for std::collections::hash::set::HashSet<bitcoin::bip32::Xpriv>
+impl bitcoin::psbt::Input
+impl bitcoin::psbt::Output
+impl bitcoin::psbt::OutputType
+impl bitcoin::psbt::Psbt
+impl bitcoin::psbt::PsbtSighashType
+impl bitcoin::sign_message::MessageSignature
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::Height
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::Time
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::string::FromHexStr for bitcoin::pow::CompactTarget
+impl bitcoin::taproot::ControlBlock
+impl bitcoin::taproot::FutureLeafVersion
+impl bitcoin::taproot::HiddenNodesError
+impl bitcoin::taproot::IncompleteBuilderError
+impl bitcoin::taproot::LeafNode
+impl bitcoin::taproot::LeafVersion
+impl bitcoin::taproot::NodeInfo
+impl bitcoin::taproot::Signature
+impl bitcoin::taproot::TapLeaf
+impl bitcoin::taproot::TapLeafHash
+impl bitcoin::taproot::TapNodeHash
+impl bitcoin::taproot::TapTree
+impl bitcoin::taproot::TapTweakHash
+impl bitcoin::taproot::TaprootBuilder
+impl bitcoin::taproot::TaprootSpendInfo
+impl bitcoin::taproot::merkle_branch::IntoIter
+impl bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl bitcoin::taproot::serialized_signature::IntoIter
+impl bitcoin::taproot::serialized_signature::SerializedSignature
+impl bitcoin_hashes::Hash for bitcoin::LegacySighash
+impl bitcoin_hashes::Hash for bitcoin::PubkeyHash
+impl bitcoin_hashes::Hash for bitcoin::SegwitV0Sighash
+impl bitcoin_hashes::Hash for bitcoin::TapSighash
+impl bitcoin_hashes::Hash for bitcoin::WPubkeyHash
+impl bitcoin_hashes::Hash for bitcoin::bip158::FilterHash
+impl bitcoin_hashes::Hash for bitcoin::bip158::FilterHeader
+impl bitcoin_hashes::Hash for bitcoin::bip32::XKeyIdentifier
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin::blockdata::script::ScriptHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::script::WScriptHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapLeafHash
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapNodeHash
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapTweakHash
+impl bitcoin_hashes::sha256t::Tag for bitcoin::TapSighashTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapBranchTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapLeafTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapTweakTag
+impl core::borrow::Borrow<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::borrow::Borrow<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::Borrow<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::borrow::Borrow<[u8; 4]> for bitcoin::p2p::Magic
+impl core::borrow::Borrow<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::borrow::Borrow<[u8]> for bitcoin::LegacySighash
+impl core::borrow::Borrow<[u8]> for bitcoin::PubkeyHash
+impl core::borrow::Borrow<[u8]> for bitcoin::SegwitV0Sighash
+impl core::borrow::Borrow<[u8]> for bitcoin::TapSighash
+impl core::borrow::Borrow<[u8]> for bitcoin::WPubkeyHash
+impl core::borrow::Borrow<[u8]> for bitcoin::bip152::ShortId
+impl core::borrow::Borrow<[u8]> for bitcoin::bip158::FilterHash
+impl core::borrow::Borrow<[u8]> for bitcoin::bip158::FilterHeader
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::ChainCode
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::Fingerprint
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::XKeyIdentifier
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::script::ScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::script::WScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::borrow::Borrow<[u8]> for bitcoin::p2p::Magic
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::borrow::Borrow<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::borrow::Borrow<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::borrow::BorrowMut<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::borrow::BorrowMut<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::borrow::BorrowMut<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::BorrowMut<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::borrow::BorrowMut<[u8; 4]> for bitcoin::p2p::Magic
+impl core::borrow::BorrowMut<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip152::ShortId
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip32::ChainCode
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip32::Fingerprint
+impl core::borrow::BorrowMut<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::BorrowMut<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::borrow::BorrowMut<[u8]> for bitcoin::p2p::Magic
+impl core::borrow::BorrowMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::borrow::BorrowMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::clone::Clone for bitcoin::CompressedPublicKey
+impl core::clone::Clone for bitcoin::EcdsaSighashType
+impl core::clone::Clone for bitcoin::LegacySighash
+impl core::clone::Clone for bitcoin::MerkleBlock
+impl core::clone::Clone for bitcoin::PrivateKey
+impl core::clone::Clone for bitcoin::PubkeyHash
+impl core::clone::Clone for bitcoin::PublicKey
+impl core::clone::Clone for bitcoin::SegwitV0Sighash
+impl core::clone::Clone for bitcoin::TapSighash
+impl core::clone::Clone for bitcoin::TapSighashTag
+impl core::clone::Clone for bitcoin::TapSighashType
+impl core::clone::Clone for bitcoin::WPubkeyHash
+impl core::clone::Clone for bitcoin::address::AddressType
+impl core::clone::Clone for bitcoin::address::KnownHrp
+impl core::clone::Clone for bitcoin::address::NetworkChecked
+impl core::clone::Clone for bitcoin::address::NetworkUnchecked
+impl core::clone::Clone for bitcoin::address::error::Error
+impl core::clone::Clone for bitcoin::address::error::ParseError
+impl core::clone::Clone for bitcoin::address::error::UnknownAddressTypeError
+impl core::clone::Clone for bitcoin::address::error::UnknownHrpError
+impl core::clone::Clone for bitcoin::base58::Error
+impl core::clone::Clone for bitcoin::bip152::BlockTransactions
+impl core::clone::Clone for bitcoin::bip152::BlockTransactionsRequest
+impl core::clone::Clone for bitcoin::bip152::Error
+impl core::clone::Clone for bitcoin::bip152::HeaderAndShortIds
+impl core::clone::Clone for bitcoin::bip152::PrefilledTransaction
+impl core::clone::Clone for bitcoin::bip152::ShortId
+impl core::clone::Clone for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::clone::Clone for bitcoin::bip158::BlockFilter
+impl core::clone::Clone for bitcoin::bip158::FilterHash
+impl core::clone::Clone for bitcoin::bip158::FilterHeader
+impl core::clone::Clone for bitcoin::bip32::ChainCode
+impl core::clone::Clone for bitcoin::bip32::ChildNumber
+impl core::clone::Clone for bitcoin::bip32::DerivationPath
+impl core::clone::Clone for bitcoin::bip32::Error
+impl core::clone::Clone for bitcoin::bip32::Fingerprint
+impl core::clone::Clone for bitcoin::bip32::XKeyIdentifier
+impl core::clone::Clone for bitcoin::bip32::Xpriv
+impl core::clone::Clone for bitcoin::bip32::Xpub
+impl core::clone::Clone for bitcoin::blockdata::block::Bip34Error
+impl core::clone::Clone for bitcoin::blockdata::block::Block
+impl core::clone::Clone for bitcoin::blockdata::block::BlockHash
+impl core::clone::Clone for bitcoin::blockdata::block::Header
+impl core::clone::Clone for bitcoin::blockdata::block::TxMerkleNode
+impl core::clone::Clone for bitcoin::blockdata::block::ValidationError
+impl core::clone::Clone for bitcoin::blockdata::block::Version
+impl core::clone::Clone for bitcoin::blockdata::block::WitnessCommitment
+impl core::clone::Clone for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::clone::Clone for bitcoin::blockdata::constants::ChainHash
+impl core::clone::Clone for bitcoin::blockdata::fee_rate::FeeRate
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Error
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Height
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Time
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Error
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Height
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::LockTime
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Time
+impl core::clone::Clone for bitcoin::blockdata::opcodes::Class
+impl core::clone::Clone for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::clone::Clone for bitcoin::blockdata::opcodes::Opcode
+impl core::clone::Clone for bitcoin::blockdata::script::Builder
+impl core::clone::Clone for bitcoin::blockdata::script::Error
+impl core::clone::Clone for bitcoin::blockdata::script::PushBytesBuf
+impl core::clone::Clone for bitcoin::blockdata::script::PushBytesError
+impl core::clone::Clone for bitcoin::blockdata::script::ScriptBuf
+impl core::clone::Clone for bitcoin::blockdata::script::ScriptHash
+impl core::clone::Clone for bitcoin::blockdata::script::WScriptHash
+impl core::clone::Clone for bitcoin::blockdata::script::witness_program::Error
+impl core::clone::Clone for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::clone::Clone for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::clone::Clone for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::clone::Clone for bitcoin::blockdata::transaction::InputsIndexError
+impl core::clone::Clone for bitcoin::blockdata::transaction::OutPoint
+impl core::clone::Clone for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::clone::Clone for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::clone::Clone for bitcoin::blockdata::transaction::Sequence
+impl core::clone::Clone for bitcoin::blockdata::transaction::Transaction
+impl core::clone::Clone for bitcoin::blockdata::transaction::TxIn
+impl core::clone::Clone for bitcoin::blockdata::transaction::TxOut
+impl core::clone::Clone for bitcoin::blockdata::transaction::Txid
+impl core::clone::Clone for bitcoin::blockdata::transaction::Version
+impl core::clone::Clone for bitcoin::blockdata::transaction::Wtxid
+impl core::clone::Clone for bitcoin::blockdata::weight::Weight
+impl core::clone::Clone for bitcoin::blockdata::witness::Witness
+impl core::clone::Clone for bitcoin::consensus::encode::CheckedData
+impl core::clone::Clone for bitcoin::consensus::encode::VarInt
+impl core::clone::Clone for bitcoin::consensus::params::Params
+impl core::clone::Clone for bitcoin::ecdsa::Error
+impl core::clone::Clone for bitcoin::ecdsa::SerializedSignature
+impl core::clone::Clone for bitcoin::ecdsa::Signature
+impl core::clone::Clone for bitcoin::error::ParseIntError
+impl core::clone::Clone for bitcoin::key::Error
+impl core::clone::Clone for bitcoin::key::SortKey
+impl core::clone::Clone for bitcoin::key::TweakedKeypair
+impl core::clone::Clone for bitcoin::key::TweakedPublicKey
+impl core::clone::Clone for bitcoin::key::UncompressedPubkeyError
+impl core::clone::Clone for bitcoin::merkle_tree::MerkleBlockError
+impl core::clone::Clone for bitcoin::merkle_tree::PartialMerkleTree
+impl core::clone::Clone for bitcoin::network::Network
+impl core::clone::Clone for bitcoin::network::NetworkKind
+impl core::clone::Clone for bitcoin::network::ParseNetworkError
+impl core::clone::Clone for bitcoin::network::UnknownChainHashError
+impl core::clone::Clone for bitcoin::p2p::Magic
+impl core::clone::Clone for bitcoin::p2p::ParseMagicError
+impl core::clone::Clone for bitcoin::p2p::ServiceFlags
+impl core::clone::Clone for bitcoin::p2p::UnknownMagicError
+impl core::clone::Clone for bitcoin::p2p::address::AddrV2
+impl core::clone::Clone for bitcoin::p2p::address::AddrV2Message
+impl core::clone::Clone for bitcoin::p2p::address::Address
+impl core::clone::Clone for bitcoin::p2p::message::CommandString
+impl core::clone::Clone for bitcoin::p2p::message::CommandStringError
+impl core::clone::Clone for bitcoin::p2p::message::NetworkMessage
+impl core::clone::Clone for bitcoin::p2p::message::RawNetworkMessage
+impl core::clone::Clone for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::clone::Clone for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::clone::Clone for bitcoin::p2p::message_blockdata::Inventory
+impl core::clone::Clone for bitcoin::p2p::message_bloom::BloomFlags
+impl core::clone::Clone for bitcoin::p2p::message_bloom::FilterAdd
+impl core::clone::Clone for bitcoin::p2p::message_bloom::FilterLoad
+impl core::clone::Clone for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::clone::Clone for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::clone::Clone for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::clone::Clone for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::clone::Clone for bitcoin::p2p::message_filter::CFCheckpt
+impl core::clone::Clone for bitcoin::p2p::message_filter::CFHeaders
+impl core::clone::Clone for bitcoin::p2p::message_filter::CFilter
+impl core::clone::Clone for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::clone::Clone for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::clone::Clone for bitcoin::p2p::message_filter::GetCFilters
+impl core::clone::Clone for bitcoin::p2p::message_network::Reject
+impl core::clone::Clone for bitcoin::p2p::message_network::RejectReason
+impl core::clone::Clone for bitcoin::p2p::message_network::VersionMessage
+impl core::clone::Clone for bitcoin::pow::CompactTarget
+impl core::clone::Clone for bitcoin::pow::Target
+impl core::clone::Clone for bitcoin::pow::TryFromError
+impl core::clone::Clone for bitcoin::pow::Work
+impl core::clone::Clone for bitcoin::psbt::ExtractTxError
+impl core::clone::Clone for bitcoin::psbt::GetKeyError
+impl core::clone::Clone for bitcoin::psbt::IndexOutOfBoundsError
+impl core::clone::Clone for bitcoin::psbt::Input
+impl core::clone::Clone for bitcoin::psbt::KeyRequest
+impl core::clone::Clone for bitcoin::psbt::Output
+impl core::clone::Clone for bitcoin::psbt::OutputType
+impl core::clone::Clone for bitcoin::psbt::Psbt
+impl core::clone::Clone for bitcoin::psbt::PsbtSighashType
+impl core::clone::Clone for bitcoin::psbt::SignError
+impl core::clone::Clone for bitcoin::psbt::SigningAlgorithm
+impl core::clone::Clone for bitcoin::psbt::raw::Key
+impl core::clone::Clone for bitcoin::sighash::AnnexError
+impl core::clone::Clone for bitcoin::sighash::InvalidSighashTypeError
+impl core::clone::Clone for bitcoin::sighash::NonStandardSighashTypeError
+impl core::clone::Clone for bitcoin::sighash::P2wpkhError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsIndexError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsKindError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsSizeError
+impl core::clone::Clone for bitcoin::sighash::SighashTypeParseError
+impl core::clone::Clone for bitcoin::sighash::SingleMissingOutputError
+impl core::clone::Clone for bitcoin::sighash::TaprootError
+impl core::clone::Clone for bitcoin::sign_message::MessageSignature
+impl core::clone::Clone for bitcoin::sign_message::MessageSignatureError
+impl core::clone::Clone for bitcoin::taproot::ControlBlock
+impl core::clone::Clone for bitcoin::taproot::FutureLeafVersion
+impl core::clone::Clone for bitcoin::taproot::HiddenNodesError
+impl core::clone::Clone for bitcoin::taproot::IncompleteBuilderError
+impl core::clone::Clone for bitcoin::taproot::LeafNode
+impl core::clone::Clone for bitcoin::taproot::LeafVersion
+impl core::clone::Clone for bitcoin::taproot::NodeInfo
+impl core::clone::Clone for bitcoin::taproot::SigFromSliceError
+impl core::clone::Clone for bitcoin::taproot::Signature
+impl core::clone::Clone for bitcoin::taproot::TapBranchTag
+impl core::clone::Clone for bitcoin::taproot::TapLeaf
+impl core::clone::Clone for bitcoin::taproot::TapLeafHash
+impl core::clone::Clone for bitcoin::taproot::TapLeafTag
+impl core::clone::Clone for bitcoin::taproot::TapNodeHash
+impl core::clone::Clone for bitcoin::taproot::TapTree
+impl core::clone::Clone for bitcoin::taproot::TapTweakHash
+impl core::clone::Clone for bitcoin::taproot::TapTweakTag
+impl core::clone::Clone for bitcoin::taproot::TaprootBuilder
+impl core::clone::Clone for bitcoin::taproot::TaprootBuilderError
+impl core::clone::Clone for bitcoin::taproot::TaprootError
+impl core::clone::Clone for bitcoin::taproot::TaprootSpendInfo
+impl core::clone::Clone for bitcoin::taproot::merkle_branch::IntoIter
+impl core::clone::Clone for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::clone::Clone for bitcoin::taproot::serialized_signature::IntoIter
+impl core::clone::Clone for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::Eq for bitcoin::CompressedPublicKey
+impl core::cmp::Eq for bitcoin::EcdsaSighashType
+impl core::cmp::Eq for bitcoin::LegacySighash
+impl core::cmp::Eq for bitcoin::MerkleBlock
+impl core::cmp::Eq for bitcoin::PrivateKey
+impl core::cmp::Eq for bitcoin::PubkeyHash
+impl core::cmp::Eq for bitcoin::PublicKey
+impl core::cmp::Eq for bitcoin::SegwitV0Sighash
+impl core::cmp::Eq for bitcoin::TapSighash
+impl core::cmp::Eq for bitcoin::TapSighashTag
+impl core::cmp::Eq for bitcoin::TapSighashType
+impl core::cmp::Eq for bitcoin::WPubkeyHash
+impl core::cmp::Eq for bitcoin::address::AddressType
+impl core::cmp::Eq for bitcoin::address::KnownHrp
+impl core::cmp::Eq for bitcoin::address::NetworkChecked
+impl core::cmp::Eq for bitcoin::address::NetworkUnchecked
+impl core::cmp::Eq for bitcoin::address::error::Error
+impl core::cmp::Eq for bitcoin::address::error::ParseError
+impl core::cmp::Eq for bitcoin::address::error::UnknownAddressTypeError
+impl core::cmp::Eq for bitcoin::address::error::UnknownHrpError
+impl core::cmp::Eq for bitcoin::base58::Error
+impl core::cmp::Eq for bitcoin::bip152::BlockTransactions
+impl core::cmp::Eq for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::Eq for bitcoin::bip152::Error
+impl core::cmp::Eq for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::Eq for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::Eq for bitcoin::bip152::ShortId
+impl core::cmp::Eq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::cmp::Eq for bitcoin::bip158::BlockFilter
+impl core::cmp::Eq for bitcoin::bip158::FilterHash
+impl core::cmp::Eq for bitcoin::bip158::FilterHeader
+impl core::cmp::Eq for bitcoin::bip32::ChainCode
+impl core::cmp::Eq for bitcoin::bip32::ChildNumber
+impl core::cmp::Eq for bitcoin::bip32::DerivationPath
+impl core::cmp::Eq for bitcoin::bip32::Error
+impl core::cmp::Eq for bitcoin::bip32::Fingerprint
+impl core::cmp::Eq for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::Eq for bitcoin::bip32::Xpriv
+impl core::cmp::Eq for bitcoin::bip32::Xpub
+impl core::cmp::Eq for bitcoin::blockdata::block::Bip34Error
+impl core::cmp::Eq for bitcoin::blockdata::block::Block
+impl core::cmp::Eq for bitcoin::blockdata::block::BlockHash
+impl core::cmp::Eq for bitcoin::blockdata::block::Header
+impl core::cmp::Eq for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::Eq for bitcoin::blockdata::block::ValidationError
+impl core::cmp::Eq for bitcoin::blockdata::block::Version
+impl core::cmp::Eq for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::Eq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Error
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Error
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::Class
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::Opcode
+impl core::cmp::Eq for bitcoin::blockdata::script::Builder
+impl core::cmp::Eq for bitcoin::blockdata::script::Error
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytes
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytesError
+impl core::cmp::Eq for bitcoin::blockdata::script::Script
+impl core::cmp::Eq for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::Eq for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::Eq for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_program::Error
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::Eq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::Eq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::Eq for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::Eq for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Txid
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Version
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::Eq for bitcoin::blockdata::weight::Weight
+impl core::cmp::Eq for bitcoin::blockdata::witness::Witness
+impl core::cmp::Eq for bitcoin::consensus::encode::CheckedData
+impl core::cmp::Eq for bitcoin::consensus::encode::VarInt
+impl core::cmp::Eq for bitcoin::ecdsa::Error
+impl core::cmp::Eq for bitcoin::ecdsa::SerializedSignature
+impl core::cmp::Eq for bitcoin::ecdsa::Signature
+impl core::cmp::Eq for bitcoin::error::ParseIntError
+impl core::cmp::Eq for bitcoin::key::Error
+impl core::cmp::Eq for bitcoin::key::SortKey
+impl core::cmp::Eq for bitcoin::key::TweakedKeypair
+impl core::cmp::Eq for bitcoin::key::TweakedPublicKey
+impl core::cmp::Eq for bitcoin::key::UncompressedPubkeyError
+impl core::cmp::Eq for bitcoin::merkle_tree::MerkleBlockError
+impl core::cmp::Eq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::cmp::Eq for bitcoin::network::Network
+impl core::cmp::Eq for bitcoin::network::NetworkKind
+impl core::cmp::Eq for bitcoin::network::ParseNetworkError
+impl core::cmp::Eq for bitcoin::network::UnknownChainHashError
+impl core::cmp::Eq for bitcoin::p2p::Magic
+impl core::cmp::Eq for bitcoin::p2p::ParseMagicError
+impl core::cmp::Eq for bitcoin::p2p::ServiceFlags
+impl core::cmp::Eq for bitcoin::p2p::UnknownMagicError
+impl core::cmp::Eq for bitcoin::p2p::address::AddrV2
+impl core::cmp::Eq for bitcoin::p2p::address::AddrV2Message
+impl core::cmp::Eq for bitcoin::p2p::address::Address
+impl core::cmp::Eq for bitcoin::p2p::message::CommandString
+impl core::cmp::Eq for bitcoin::p2p::message::CommandStringError
+impl core::cmp::Eq for bitcoin::p2p::message::NetworkMessage
+impl core::cmp::Eq for bitcoin::p2p::message::RawNetworkMessage
+impl core::cmp::Eq for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::cmp::Eq for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::cmp::Eq for bitcoin::p2p::message_blockdata::Inventory
+impl core::cmp::Eq for bitcoin::p2p::message_bloom::BloomFlags
+impl core::cmp::Eq for bitcoin::p2p::message_bloom::FilterAdd
+impl core::cmp::Eq for bitcoin::p2p::message_bloom::FilterLoad
+impl core::cmp::Eq for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::cmp::Eq for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::cmp::Eq for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::cmp::Eq for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::cmp::Eq for bitcoin::p2p::message_filter::CFCheckpt
+impl core::cmp::Eq for bitcoin::p2p::message_filter::CFHeaders
+impl core::cmp::Eq for bitcoin::p2p::message_filter::CFilter
+impl core::cmp::Eq for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::cmp::Eq for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::cmp::Eq for bitcoin::p2p::message_filter::GetCFilters
+impl core::cmp::Eq for bitcoin::p2p::message_network::Reject
+impl core::cmp::Eq for bitcoin::p2p::message_network::RejectReason
+impl core::cmp::Eq for bitcoin::p2p::message_network::VersionMessage
+impl core::cmp::Eq for bitcoin::pow::CompactTarget
+impl core::cmp::Eq for bitcoin::pow::Target
+impl core::cmp::Eq for bitcoin::pow::TryFromError
+impl core::cmp::Eq for bitcoin::pow::Work
+impl core::cmp::Eq for bitcoin::psbt::ExtractTxError
+impl core::cmp::Eq for bitcoin::psbt::GetKeyError
+impl core::cmp::Eq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::cmp::Eq for bitcoin::psbt::Input
+impl core::cmp::Eq for bitcoin::psbt::KeyRequest
+impl core::cmp::Eq for bitcoin::psbt::Output
+impl core::cmp::Eq for bitcoin::psbt::OutputType
+impl core::cmp::Eq for bitcoin::psbt::Psbt
+impl core::cmp::Eq for bitcoin::psbt::PsbtSighashType
+impl core::cmp::Eq for bitcoin::psbt::SignError
+impl core::cmp::Eq for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::Eq for bitcoin::psbt::raw::Key
+impl core::cmp::Eq for bitcoin::psbt::raw::Pair
+impl core::cmp::Eq for bitcoin::sighash::AnnexError
+impl core::cmp::Eq for bitcoin::sighash::InvalidSighashTypeError
+impl core::cmp::Eq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::cmp::Eq for bitcoin::sighash::P2wpkhError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsIndexError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsKindError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsSizeError
+impl core::cmp::Eq for bitcoin::sighash::SighashTypeParseError
+impl core::cmp::Eq for bitcoin::sighash::SingleMissingOutputError
+impl core::cmp::Eq for bitcoin::sighash::TaprootError
+impl core::cmp::Eq for bitcoin::sign_message::MessageSignature
+impl core::cmp::Eq for bitcoin::sign_message::MessageSignatureError
+impl core::cmp::Eq for bitcoin::taproot::ControlBlock
+impl core::cmp::Eq for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::Eq for bitcoin::taproot::HiddenNodesError
+impl core::cmp::Eq for bitcoin::taproot::IncompleteBuilderError
+impl core::cmp::Eq for bitcoin::taproot::LeafNode
+impl core::cmp::Eq for bitcoin::taproot::LeafVersion
+impl core::cmp::Eq for bitcoin::taproot::NodeInfo
+impl core::cmp::Eq for bitcoin::taproot::SigFromSliceError
+impl core::cmp::Eq for bitcoin::taproot::Signature
+impl core::cmp::Eq for bitcoin::taproot::TapBranchTag
+impl core::cmp::Eq for bitcoin::taproot::TapLeaf
+impl core::cmp::Eq for bitcoin::taproot::TapLeafHash
+impl core::cmp::Eq for bitcoin::taproot::TapLeafTag
+impl core::cmp::Eq for bitcoin::taproot::TapNodeHash
+impl core::cmp::Eq for bitcoin::taproot::TapTree
+impl core::cmp::Eq for bitcoin::taproot::TapTweakHash
+impl core::cmp::Eq for bitcoin::taproot::TapTweakTag
+impl core::cmp::Eq for bitcoin::taproot::TaprootBuilder
+impl core::cmp::Eq for bitcoin::taproot::TaprootBuilderError
+impl core::cmp::Eq for bitcoin::taproot::TaprootError
+impl core::cmp::Eq for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::Eq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::Eq for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::Ord for bitcoin::CompressedPublicKey
+impl core::cmp::Ord for bitcoin::LegacySighash
+impl core::cmp::Ord for bitcoin::PubkeyHash
+impl core::cmp::Ord for bitcoin::PublicKey
+impl core::cmp::Ord for bitcoin::SegwitV0Sighash
+impl core::cmp::Ord for bitcoin::TapSighash
+impl core::cmp::Ord for bitcoin::TapSighashTag
+impl core::cmp::Ord for bitcoin::TapSighashType
+impl core::cmp::Ord for bitcoin::WPubkeyHash
+impl core::cmp::Ord for bitcoin::address::AddressType
+impl core::cmp::Ord for bitcoin::address::KnownHrp
+impl core::cmp::Ord for bitcoin::address::NetworkChecked
+impl core::cmp::Ord for bitcoin::address::NetworkUnchecked
+impl core::cmp::Ord for bitcoin::bip152::BlockTransactions
+impl core::cmp::Ord for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::Ord for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::Ord for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::Ord for bitcoin::bip152::ShortId
+impl core::cmp::Ord for bitcoin::bip158::FilterHash
+impl core::cmp::Ord for bitcoin::bip158::FilterHeader
+impl core::cmp::Ord for bitcoin::bip32::ChainCode
+impl core::cmp::Ord for bitcoin::bip32::ChildNumber
+impl core::cmp::Ord for bitcoin::bip32::DerivationPath
+impl core::cmp::Ord for bitcoin::bip32::Fingerprint
+impl core::cmp::Ord for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::Ord for bitcoin::bip32::Xpub
+impl core::cmp::Ord for bitcoin::blockdata::block::BlockHash
+impl core::cmp::Ord for bitcoin::blockdata::block::Header
+impl core::cmp::Ord for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::Ord for bitcoin::blockdata::block::Version
+impl core::cmp::Ord for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::Ord for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::Ord for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::Ord for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::Ord for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::Ord for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::Ord for bitcoin::blockdata::script::PushBytes
+impl core::cmp::Ord for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::Ord for bitcoin::blockdata::script::Script
+impl core::cmp::Ord for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::Ord for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::Ord for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::Ord for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::Ord for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::Ord for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::Ord for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::Ord for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Txid
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Version
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::Ord for bitcoin::blockdata::weight::Weight
+impl core::cmp::Ord for bitcoin::blockdata::witness::Witness
+impl core::cmp::Ord for bitcoin::consensus::encode::VarInt
+impl core::cmp::Ord for bitcoin::key::SortKey
+impl core::cmp::Ord for bitcoin::key::TweakedKeypair
+impl core::cmp::Ord for bitcoin::key::TweakedPublicKey
+impl core::cmp::Ord for bitcoin::network::Network
+impl core::cmp::Ord for bitcoin::network::NetworkKind
+impl core::cmp::Ord for bitcoin::p2p::Magic
+impl core::cmp::Ord for bitcoin::p2p::ServiceFlags
+impl core::cmp::Ord for bitcoin::p2p::message_blockdata::Inventory
+impl core::cmp::Ord for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::cmp::Ord for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::cmp::Ord for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::cmp::Ord for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::cmp::Ord for bitcoin::pow::CompactTarget
+impl core::cmp::Ord for bitcoin::pow::Target
+impl core::cmp::Ord for bitcoin::pow::Work
+impl core::cmp::Ord for bitcoin::psbt::OutputType
+impl core::cmp::Ord for bitcoin::psbt::PsbtSighashType
+impl core::cmp::Ord for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::Ord for bitcoin::psbt::raw::Key
+impl core::cmp::Ord for bitcoin::taproot::ControlBlock
+impl core::cmp::Ord for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::Ord for bitcoin::taproot::LeafNode
+impl core::cmp::Ord for bitcoin::taproot::LeafVersion
+impl core::cmp::Ord for bitcoin::taproot::NodeInfo
+impl core::cmp::Ord for bitcoin::taproot::Signature
+impl core::cmp::Ord for bitcoin::taproot::TapBranchTag
+impl core::cmp::Ord for bitcoin::taproot::TapLeaf
+impl core::cmp::Ord for bitcoin::taproot::TapLeafHash
+impl core::cmp::Ord for bitcoin::taproot::TapLeafTag
+impl core::cmp::Ord for bitcoin::taproot::TapNodeHash
+impl core::cmp::Ord for bitcoin::taproot::TapTweakHash
+impl core::cmp::Ord for bitcoin::taproot::TapTweakTag
+impl core::cmp::Ord for bitcoin::taproot::TaprootBuilder
+impl core::cmp::Ord for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::Ord for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::Ord for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq for bitcoin::CompressedPublicKey
+impl core::cmp::PartialEq for bitcoin::EcdsaSighashType
+impl core::cmp::PartialEq for bitcoin::LegacySighash
+impl core::cmp::PartialEq for bitcoin::MerkleBlock
+impl core::cmp::PartialEq for bitcoin::PrivateKey
+impl core::cmp::PartialEq for bitcoin::PubkeyHash
+impl core::cmp::PartialEq for bitcoin::PublicKey
+impl core::cmp::PartialEq for bitcoin::SegwitV0Sighash
+impl core::cmp::PartialEq for bitcoin::TapSighash
+impl core::cmp::PartialEq for bitcoin::TapSighashTag
+impl core::cmp::PartialEq for bitcoin::TapSighashType
+impl core::cmp::PartialEq for bitcoin::WPubkeyHash
+impl core::cmp::PartialEq for bitcoin::address::AddressType
+impl core::cmp::PartialEq for bitcoin::address::KnownHrp
+impl core::cmp::PartialEq for bitcoin::address::NetworkChecked
+impl core::cmp::PartialEq for bitcoin::address::NetworkUnchecked
+impl core::cmp::PartialEq for bitcoin::address::error::Error
+impl core::cmp::PartialEq for bitcoin::address::error::ParseError
+impl core::cmp::PartialEq for bitcoin::address::error::UnknownAddressTypeError
+impl core::cmp::PartialEq for bitcoin::address::error::UnknownHrpError
+impl core::cmp::PartialEq for bitcoin::base58::Error
+impl core::cmp::PartialEq for bitcoin::bip152::BlockTransactions
+impl core::cmp::PartialEq for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::PartialEq for bitcoin::bip152::Error
+impl core::cmp::PartialEq for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::PartialEq for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::PartialEq for bitcoin::bip152::ShortId
+impl core::cmp::PartialEq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::cmp::PartialEq for bitcoin::bip158::BlockFilter
+impl core::cmp::PartialEq for bitcoin::bip158::FilterHash
+impl core::cmp::PartialEq for bitcoin::bip158::FilterHeader
+impl core::cmp::PartialEq for bitcoin::bip32::ChainCode
+impl core::cmp::PartialEq for bitcoin::bip32::ChildNumber
+impl core::cmp::PartialEq for bitcoin::bip32::DerivationPath
+impl core::cmp::PartialEq for bitcoin::bip32::Error
+impl core::cmp::PartialEq for bitcoin::bip32::Fingerprint
+impl core::cmp::PartialEq for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::PartialEq for bitcoin::bip32::Xpriv
+impl core::cmp::PartialEq for bitcoin::bip32::Xpub
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Bip34Error
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Block
+impl core::cmp::PartialEq for bitcoin::blockdata::block::BlockHash
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Header
+impl core::cmp::PartialEq for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin::blockdata::block::ValidationError
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Version
+impl core::cmp::PartialEq for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::PartialEq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::Class
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::Opcode
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Builder
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytes
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytesError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Script
+impl core::cmp::PartialEq for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialEq for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::PartialEq for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_program::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Txid
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Version
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin::blockdata::weight::Weight
+impl core::cmp::PartialEq for bitcoin::blockdata::witness::Witness
+impl core::cmp::PartialEq for bitcoin::consensus::encode::CheckedData
+impl core::cmp::PartialEq for bitcoin::consensus::encode::VarInt
+impl core::cmp::PartialEq for bitcoin::ecdsa::Error
+impl core::cmp::PartialEq for bitcoin::ecdsa::SerializedSignature
+impl core::cmp::PartialEq for bitcoin::ecdsa::Signature
+impl core::cmp::PartialEq for bitcoin::error::ParseIntError
+impl core::cmp::PartialEq for bitcoin::key::Error
+impl core::cmp::PartialEq for bitcoin::key::SortKey
+impl core::cmp::PartialEq for bitcoin::key::TweakedKeypair
+impl core::cmp::PartialEq for bitcoin::key::TweakedPublicKey
+impl core::cmp::PartialEq for bitcoin::key::UncompressedPubkeyError
+impl core::cmp::PartialEq for bitcoin::merkle_tree::MerkleBlockError
+impl core::cmp::PartialEq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::cmp::PartialEq for bitcoin::network::Network
+impl core::cmp::PartialEq for bitcoin::network::NetworkKind
+impl core::cmp::PartialEq for bitcoin::network::ParseNetworkError
+impl core::cmp::PartialEq for bitcoin::network::UnknownChainHashError
+impl core::cmp::PartialEq for bitcoin::p2p::Magic
+impl core::cmp::PartialEq for bitcoin::p2p::ParseMagicError
+impl core::cmp::PartialEq for bitcoin::p2p::ServiceFlags
+impl core::cmp::PartialEq for bitcoin::p2p::UnknownMagicError
+impl core::cmp::PartialEq for bitcoin::p2p::address::AddrV2
+impl core::cmp::PartialEq for bitcoin::p2p::address::AddrV2Message
+impl core::cmp::PartialEq for bitcoin::p2p::address::Address
+impl core::cmp::PartialEq for bitcoin::p2p::message::CommandString
+impl core::cmp::PartialEq for bitcoin::p2p::message::CommandStringError
+impl core::cmp::PartialEq for bitcoin::p2p::message::NetworkMessage
+impl core::cmp::PartialEq for bitcoin::p2p::message::RawNetworkMessage
+impl core::cmp::PartialEq for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::cmp::PartialEq for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::cmp::PartialEq for bitcoin::p2p::message_blockdata::Inventory
+impl core::cmp::PartialEq for bitcoin::p2p::message_bloom::BloomFlags
+impl core::cmp::PartialEq for bitcoin::p2p::message_bloom::FilterAdd
+impl core::cmp::PartialEq for bitcoin::p2p::message_bloom::FilterLoad
+impl core::cmp::PartialEq for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::cmp::PartialEq for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::cmp::PartialEq for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::cmp::PartialEq for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::CFCheckpt
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::CFHeaders
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::CFilter
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::cmp::PartialEq for bitcoin::p2p::message_filter::GetCFilters
+impl core::cmp::PartialEq for bitcoin::p2p::message_network::Reject
+impl core::cmp::PartialEq for bitcoin::p2p::message_network::RejectReason
+impl core::cmp::PartialEq for bitcoin::p2p::message_network::VersionMessage
+impl core::cmp::PartialEq for bitcoin::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin::pow::Target
+impl core::cmp::PartialEq for bitcoin::pow::TryFromError
+impl core::cmp::PartialEq for bitcoin::pow::Work
+impl core::cmp::PartialEq for bitcoin::psbt::ExtractTxError
+impl core::cmp::PartialEq for bitcoin::psbt::GetKeyError
+impl core::cmp::PartialEq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::cmp::PartialEq for bitcoin::psbt::Input
+impl core::cmp::PartialEq for bitcoin::psbt::KeyRequest
+impl core::cmp::PartialEq for bitcoin::psbt::Output
+impl core::cmp::PartialEq for bitcoin::psbt::OutputType
+impl core::cmp::PartialEq for bitcoin::psbt::Psbt
+impl core::cmp::PartialEq for bitcoin::psbt::PsbtSighashType
+impl core::cmp::PartialEq for bitcoin::psbt::SignError
+impl core::cmp::PartialEq for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::PartialEq for bitcoin::psbt::raw::Key
+impl core::cmp::PartialEq for bitcoin::psbt::raw::Pair
+impl core::cmp::PartialEq for bitcoin::sighash::AnnexError
+impl core::cmp::PartialEq for bitcoin::sighash::InvalidSighashTypeError
+impl core::cmp::PartialEq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::cmp::PartialEq for bitcoin::sighash::P2wpkhError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsIndexError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsKindError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsSizeError
+impl core::cmp::PartialEq for bitcoin::sighash::SighashTypeParseError
+impl core::cmp::PartialEq for bitcoin::sighash::SingleMissingOutputError
+impl core::cmp::PartialEq for bitcoin::sighash::TaprootError
+impl core::cmp::PartialEq for bitcoin::sign_message::MessageSignature
+impl core::cmp::PartialEq for bitcoin::sign_message::MessageSignatureError
+impl core::cmp::PartialEq for bitcoin::taproot::ControlBlock
+impl core::cmp::PartialEq for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::PartialEq for bitcoin::taproot::HiddenNodesError
+impl core::cmp::PartialEq for bitcoin::taproot::IncompleteBuilderError
+impl core::cmp::PartialEq for bitcoin::taproot::LeafNode
+impl core::cmp::PartialEq for bitcoin::taproot::LeafVersion
+impl core::cmp::PartialEq for bitcoin::taproot::NodeInfo
+impl core::cmp::PartialEq for bitcoin::taproot::SigFromSliceError
+impl core::cmp::PartialEq for bitcoin::taproot::Signature
+impl core::cmp::PartialEq for bitcoin::taproot::TapBranchTag
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeaf
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeafHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeafTag
+impl core::cmp::PartialEq for bitcoin::taproot::TapNodeHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapTree
+impl core::cmp::PartialEq for bitcoin::taproot::TapTweakHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapTweakTag
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootBuilder
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootBuilderError
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootError
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::PartialEq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::PartialEq for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialEq<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::Script
+impl core::cmp::PartialEq<bitcoin::taproot::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialOrd for bitcoin::CompressedPublicKey
+impl core::cmp::PartialOrd for bitcoin::LegacySighash
+impl core::cmp::PartialOrd for bitcoin::PubkeyHash
+impl core::cmp::PartialOrd for bitcoin::PublicKey
+impl core::cmp::PartialOrd for bitcoin::SegwitV0Sighash
+impl core::cmp::PartialOrd for bitcoin::TapSighash
+impl core::cmp::PartialOrd for bitcoin::TapSighashTag
+impl core::cmp::PartialOrd for bitcoin::TapSighashType
+impl core::cmp::PartialOrd for bitcoin::WPubkeyHash
+impl core::cmp::PartialOrd for bitcoin::address::AddressType
+impl core::cmp::PartialOrd for bitcoin::address::KnownHrp
+impl core::cmp::PartialOrd for bitcoin::address::NetworkChecked
+impl core::cmp::PartialOrd for bitcoin::address::NetworkUnchecked
+impl core::cmp::PartialOrd for bitcoin::bip152::BlockTransactions
+impl core::cmp::PartialOrd for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::PartialOrd for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::PartialOrd for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::PartialOrd for bitcoin::bip152::ShortId
+impl core::cmp::PartialOrd for bitcoin::bip158::FilterHash
+impl core::cmp::PartialOrd for bitcoin::bip158::FilterHeader
+impl core::cmp::PartialOrd for bitcoin::bip32::ChainCode
+impl core::cmp::PartialOrd for bitcoin::bip32::ChildNumber
+impl core::cmp::PartialOrd for bitcoin::bip32::DerivationPath
+impl core::cmp::PartialOrd for bitcoin::bip32::Fingerprint
+impl core::cmp::PartialOrd for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::PartialOrd for bitcoin::bip32::Xpub
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::Header
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::Version
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::PartialOrd for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::PushBytes
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::Script
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Version
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin::blockdata::weight::Weight
+impl core::cmp::PartialOrd for bitcoin::blockdata::witness::Witness
+impl core::cmp::PartialOrd for bitcoin::consensus::encode::VarInt
+impl core::cmp::PartialOrd for bitcoin::key::SortKey
+impl core::cmp::PartialOrd for bitcoin::key::TweakedKeypair
+impl core::cmp::PartialOrd for bitcoin::key::TweakedPublicKey
+impl core::cmp::PartialOrd for bitcoin::network::Network
+impl core::cmp::PartialOrd for bitcoin::network::NetworkKind
+impl core::cmp::PartialOrd for bitcoin::p2p::Magic
+impl core::cmp::PartialOrd for bitcoin::p2p::ServiceFlags
+impl core::cmp::PartialOrd for bitcoin::p2p::message_blockdata::Inventory
+impl core::cmp::PartialOrd for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::cmp::PartialOrd for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::cmp::PartialOrd for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::cmp::PartialOrd for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::cmp::PartialOrd for bitcoin::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin::pow::Target
+impl core::cmp::PartialOrd for bitcoin::pow::Work
+impl core::cmp::PartialOrd for bitcoin::psbt::OutputType
+impl core::cmp::PartialOrd for bitcoin::psbt::PsbtSighashType
+impl core::cmp::PartialOrd for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::PartialOrd for bitcoin::psbt::raw::Key
+impl core::cmp::PartialOrd for bitcoin::taproot::ControlBlock
+impl core::cmp::PartialOrd for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::PartialOrd for bitcoin::taproot::LeafNode
+impl core::cmp::PartialOrd for bitcoin::taproot::LeafVersion
+impl core::cmp::PartialOrd for bitcoin::taproot::NodeInfo
+impl core::cmp::PartialOrd for bitcoin::taproot::Signature
+impl core::cmp::PartialOrd for bitcoin::taproot::TapBranchTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeaf
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeafHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeafTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TapNodeHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapTweakHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapTweakTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TaprootBuilder
+impl core::cmp::PartialOrd for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::PartialOrd for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::PartialOrd for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialOrd<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::Script
+impl core::cmp::PartialOrd<bitcoin::taproot::serialized_signature::SerializedSignature> for [u8]
+impl core::convert::AsMut<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::AsMut<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::convert::AsMut<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsMut<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsMut<[u8; 4]> for bitcoin::p2p::Magic
+impl core::convert::AsMut<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::convert::AsMut<[u8]> for bitcoin::bip152::ShortId
+impl core::convert::AsMut<[u8]> for bitcoin::bip32::ChainCode
+impl core::convert::AsMut<[u8]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::Script
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsMut<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsMut<[u8]> for bitcoin::p2p::Magic
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 0]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 10]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 11]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 12]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 13]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 14]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 15]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 16]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 17]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 18]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 19]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 1]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 20]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 21]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 22]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 23]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 24]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 25]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 26]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 27]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 28]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 29]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 2]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 30]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 31]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 32]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 33]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 34]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 35]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 36]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 37]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 38]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 39]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 3]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 40]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 41]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 42]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 43]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 44]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 45]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 46]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 47]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 48]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 49]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 4]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 50]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 51]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 52]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 53]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 54]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 55]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 56]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 57]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 58]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 59]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 5]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 60]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 61]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 62]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 63]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 64]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 65]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 66]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 67]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 68]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 69]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 6]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 70]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 71]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 72]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 73]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 7]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 8]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 9]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::AsMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::Script
+impl core::convert::AsMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<[bitcoin::bip32::ChildNumber]> for bitcoin::bip32::ChildNumber
+impl core::convert::AsRef<[bitcoin::bip32::ChildNumber]> for bitcoin::bip32::DerivationPath
+impl core::convert::AsRef<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::AsRef<[u8; 20]> for bitcoin::PubkeyHash
+impl core::convert::AsRef<[u8; 20]> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<[u8; 20]> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::AsRef<[u8; 20]> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::LegacySighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::SegwitV0Sighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::TapSighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip158::FilterHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip158::FilterHeader
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapLeafHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapNodeHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapTweakHash
+impl core::convert::AsRef<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsRef<[u8; 4]> for bitcoin::p2p::Magic
+impl core::convert::AsRef<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::convert::AsRef<[u8]> for bitcoin::LegacySighash
+impl core::convert::AsRef<[u8]> for bitcoin::PubkeyHash
+impl core::convert::AsRef<[u8]> for bitcoin::SegwitV0Sighash
+impl core::convert::AsRef<[u8]> for bitcoin::TapSighash
+impl core::convert::AsRef<[u8]> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<[u8]> for bitcoin::bip152::ShortId
+impl core::convert::AsRef<[u8]> for bitcoin::bip158::FilterHash
+impl core::convert::AsRef<[u8]> for bitcoin::bip158::FilterHeader
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::ChainCode
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::Script
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsRef<[u8]> for bitcoin::p2p::Magic
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapLeafHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapNodeHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapTweakHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 0]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 10]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 11]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 12]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 13]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 14]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 15]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 16]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 17]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 18]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 19]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 1]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 20]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 21]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 22]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 23]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 24]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 25]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 26]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 27]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 28]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 29]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 2]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 30]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 31]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 32]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 33]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 34]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 35]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 36]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 37]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 38]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 39]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 3]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 40]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 41]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 42]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 43]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 44]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 45]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 46]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 47]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 48]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 49]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 4]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 50]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 51]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 52]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 53]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 54]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 55]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 56]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 57]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 58]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 59]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 5]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 60]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 61]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 62]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 63]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 64]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 65]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 66]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 67]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 68]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 69]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 6]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 70]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 71]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 72]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 73]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 7]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 8]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 9]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::PubkeyHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsRef<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::Script
+impl core::convert::AsRef<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<bitcoin::blockdata::transaction::Transaction> for bitcoin::bip152::PrefilledTransaction
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin::error::ParseIntError
+impl core::convert::AsRef<str> for bitcoin::p2p::message::CommandString
+impl core::convert::From<&[&[u8]]> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<&[alloc::vec::Vec<u8>]> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<&bitcoin::CompressedPublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<&bitcoin::CompressedPublicKey> for bitcoin::WPubkeyHash
+impl core::convert::From<&bitcoin::PublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<&bitcoin::bip32::Xpub> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<&bitcoin::blockdata::block::Block> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<&bitcoin::blockdata::block::Header> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<&bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<&bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<&bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<&bitcoin::network::Network> for &'static bitcoin::consensus::params::Params
+impl core::convert::From<&bitcoin::network::Network> for bitcoin::consensus::params::Params
+impl core::convert::From<&bitcoin::taproot::LeafNode> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<&bitcoin::taproot::TaprootSpendInfo> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 0]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 100]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 101]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 102]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 103]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 104]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 105]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 106]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 107]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 108]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 109]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 10]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 110]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 111]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 112]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 113]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 114]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 115]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 116]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 117]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 118]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 119]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 11]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 120]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 121]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 122]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 123]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 124]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 125]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 126]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 127]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 128]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 12]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 13]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 14]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 15]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 16]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 17]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 18]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 19]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 1]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 20]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 21]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 22]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 23]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 24]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 25]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 26]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 27]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 28]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 29]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 2]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 30]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 31]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 32]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 33]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 34]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 35]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 36]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 37]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 38]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 39]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 3]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 40]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 41]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 42]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 43]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 44]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 45]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 46]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 47]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 48]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 49]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 4]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 50]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 51]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 52]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 53]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 54]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 55]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 56]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 57]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 58]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 59]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 5]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 60]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 61]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 62]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 63]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 64]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 65]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 66]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 67]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 68]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 69]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 6]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 70]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 71]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 72]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 73]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 74]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 75]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 76]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 77]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 78]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 79]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 7]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 80]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 81]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 82]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 83]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 84]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 85]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 86]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 87]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 88]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 89]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 8]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 90]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 91]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 92]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 93]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 94]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 95]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 96]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 97]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 98]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 99]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 9]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[u8; 0]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 10]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 11]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 12]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 13]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 14]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 15]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 16]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 17]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 18]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 19]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 1]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 20]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 21]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 22]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 23]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 24]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 25]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 26]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 27]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 28]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 29]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 2]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 30]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 31]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 32]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 33]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 34]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 35]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 36]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 37]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 38]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 39]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 3]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 40]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 41]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 42]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 43]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 44]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 45]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 46]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 47]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 48]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 49]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 4]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 50]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 51]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 52]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 53]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 54]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 55]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 56]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 57]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 58]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 59]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 5]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 60]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 61]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 62]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 63]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 64]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 65]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 66]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 67]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 68]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 69]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 6]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 70]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 71]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 72]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 73]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 7]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 8]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 9]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<alloc::vec::Vec<bitcoin::bip32::ChildNumber>> for bitcoin::bip32::DerivationPath
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::Builder
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::From<bech32::segwit::DecodeError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::PublicKey
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::WPubkeyHash
+impl core::convert::From<bitcoin::CompressedPublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::EcdsaSighashType> for bitcoin::TapSighashType
+impl core::convert::From<bitcoin::EcdsaSighashType> for bitcoin::psbt::PsbtSighashType
+impl core::convert::From<bitcoin::LegacySighash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::PubkeyHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::PubkeyHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::PublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin::PublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::SegwitV0Sighash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::TapSighash> for bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+impl core::convert::From<bitcoin::TapSighashType> for bitcoin::psbt::PsbtSighashType
+impl core::convert::From<bitcoin::WPubkeyHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::WPubkeyHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::address::Address> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::From<bitcoin::address::error::UnknownHrpError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::bip32::Error
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::key::Error
+impl core::convert::From<bitcoin::bip158::FilterHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::bip158::FilterHeader> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::bip32::ChildNumber> for u32
+impl core::convert::From<bitcoin::bip32::DerivationPath> for alloc::vec::Vec<bitcoin::bip32::ChildNumber>
+impl core::convert::From<bitcoin::bip32::Error> for bitcoin::psbt::GetKeyError
+impl core::convert::From<bitcoin::bip32::XKeyIdentifier> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::bip32::Xpub> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<bitcoin::blockdata::block::Block> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin::blockdata::block::BlockHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::Header> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin::blockdata::block::TxMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::WitnessCommitment> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::WitnessMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::fee_rate::FeeRate> for u64
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::ConversionError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::Height> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::OperationError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::Time> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::relative::Height> for bitcoin::blockdata::locktime::relative::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::relative::Time> for bitcoin::blockdata::locktime::relative::LockTime
+impl core::convert::From<bitcoin::blockdata::script::PushBytesBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin::blockdata::script::Script>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<bitcoin::blockdata::script::ScriptHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::blockdata::script::ScriptHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::blockdata::script::WScriptHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::blockdata::script::WScriptHash> for bitcoin_hashes::sha256::Hash
+impl core::convert::From<bitcoin::blockdata::script::witness_program::Error> for bitcoin::address::error::Error
+impl core::convert::From<bitcoin::blockdata::script::witness_program::Error> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::Error
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bech32::primitives::gf32::Fe32
+impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bitcoin::blockdata::opcodes::Opcode
+impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::InputsIndexError
+impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::convert::From<bitcoin::blockdata::transaction::InputsIndexError> for bitcoin::sighash::P2wpkhError
+impl core::convert::From<bitcoin::blockdata::transaction::InputsIndexError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::blockdata::transaction::Sequence> for u32
+impl core::convert::From<bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<bitcoin::blockdata::transaction::Txid> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::From<bitcoin::blockdata::transaction::Txid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::transaction::Wtxid> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::From<bitcoin::blockdata::transaction::Wtxid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::weight::Weight> for u64
+impl core::convert::From<bitcoin::consensus::encode::Error> for bitcoin::psbt::Error
+impl core::convert::From<bitcoin::error::ParseIntError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::error::ParseIntError> for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::convert::From<bitcoin::error::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin::key::Error> for bitcoin::bip32::Error
+impl core::convert::From<bitcoin::key::TweakedKeypair> for bitcoin::key::TweakedPublicKey
+impl core::convert::From<bitcoin::key::TweakedKeypair> for secp256k1::key::Keypair
+impl core::convert::From<bitcoin::key::TweakedPublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::network::Network> for &'static bitcoin::consensus::params::Params
+impl core::convert::From<bitcoin::network::Network> for bitcoin::address::KnownHrp
+impl core::convert::From<bitcoin::network::Network> for bitcoin::consensus::params::Params
+impl core::convert::From<bitcoin::network::Network> for bitcoin::network::NetworkKind
+impl core::convert::From<bitcoin::network::Network> for bitcoin::p2p::Magic
+impl core::convert::From<bitcoin::p2p::ServiceFlags> for u64
+impl core::convert::From<bitcoin::pow::CompactTarget> for bitcoin::pow::Target
+impl core::convert::From<bitcoin::psbt::IndexOutOfBoundsError> for bitcoin::psbt::SignError
+impl core::convert::From<bitcoin::sighash::InvalidSighashTypeError> for bitcoin::taproot::SigFromSliceError
+impl core::convert::From<bitcoin::sighash::NonStandardSighashTypeError> for bitcoin::ecdsa::Error
+impl core::convert::From<bitcoin::sighash::P2wpkhError> for bitcoin::psbt::SignError
+impl core::convert::From<bitcoin::sighash::PrevoutsIndexError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::sighash::PrevoutsKindError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::sighash::PrevoutsSizeError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::taproot::LeafNode> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin::taproot::Signature> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::convert::From<bitcoin::taproot::TapLeafHash> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin::taproot::TapLeafHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+impl core::convert::From<bitcoin::taproot::TapNodeHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+impl core::convert::From<bitcoin::taproot::TapTree> for bitcoin::taproot::NodeInfo
+impl core::convert::From<bitcoin::taproot::TapTweakHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+impl core::convert::From<bitcoin::taproot::TaprootSpendInfo> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<bitcoin::taproot::merkle_branch::TaprootMerkleBranch> for alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+impl core::convert::From<bitcoin_hashes::FromSliceError> for bitcoin::psbt::Error
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::WPubkeyHash
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<bitcoin_hashes::sha256::Hash> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::LegacySighash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::SegwitV0Sighash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::bip158::FilterHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::bip158::FilterHeader
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>> for bitcoin::TapSighash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>> for bitcoin::taproot::TapLeafHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::bip158::Error
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::consensus::encode::Error
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::psbt::Error
+impl core::convert::From<hex_conservative::parse::HexToArrayError> for bitcoin::key::Error
+impl core::convert::From<hex_conservative::parse::HexToBytesError> for bitcoin::ecdsa::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::bip32::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::ecdsa::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::key::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::sign_message::MessageSignatureError
+impl core::convert::From<secp256k1::Error> for bitcoin::taproot::SigFromSliceError
+impl core::convert::From<secp256k1::key::PublicKey> for bitcoin::PublicKey
+impl core::convert::From<u16> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::From<u16> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u32> for bitcoin::bip32::ChildNumber
+impl core::convert::From<u32> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u64> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u64> for bitcoin::p2p::ServiceFlags
+impl core::convert::From<u8> for bitcoin::blockdata::opcodes::Opcode
+impl core::convert::From<u8> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<usize> for bitcoin::consensus::encode::VarInt
+impl core::convert::TryFrom<&[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<[bitcoin::taproot::TapNodeHash]>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::p2p::message::CommandString
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::p2p::message::CommandString
+impl core::convert::TryFrom<alloc::vec::Vec<bitcoin::taproot::TapNodeHash>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::TryFrom<bech32::primitives::gf32::Fe32> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::convert::TryFrom<bitcoin::PublicKey> for bitcoin::CompressedPublicKey
+impl core::convert::TryFrom<bitcoin::blockdata::constants::ChainHash> for bitcoin::network::Network
+impl core::convert::TryFrom<bitcoin::blockdata::opcodes::Opcode> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::convert::TryFrom<bitcoin::p2p::Magic> for bitcoin::network::Network
+impl core::convert::TryFrom<bitcoin::taproot::NodeInfo> for bitcoin::taproot::TapTree
+impl core::convert::TryFrom<bitcoin::taproot::TaprootBuilder> for bitcoin::taproot::NodeInfo
+impl core::convert::TryFrom<bitcoin::taproot::TaprootBuilder> for bitcoin::taproot::TapTree
+impl core::convert::TryFrom<bitcoin::taproot::serialized_signature::SerializedSignature> for bitcoin::taproot::Signature
+impl core::convert::TryFrom<u8> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::default::Default for bitcoin::TapSighashTag
+impl core::default::Default for bitcoin::bip152::ShortId
+impl core::default::Default for bitcoin::bip32::DerivationPath
+impl core::default::Default for bitcoin::bip32::Fingerprint
+impl core::default::Default for bitcoin::blockdata::block::Version
+impl core::default::Default for bitcoin::blockdata::locktime::relative::Height
+impl core::default::Default for bitcoin::blockdata::locktime::relative::Time
+impl core::default::Default for bitcoin::blockdata::script::Builder
+impl core::default::Default for bitcoin::blockdata::script::PushBytesBuf
+impl core::default::Default for bitcoin::blockdata::script::ScriptBuf
+impl core::default::Default for bitcoin::blockdata::transaction::OutPoint
+impl core::default::Default for bitcoin::blockdata::transaction::Sequence
+impl core::default::Default for bitcoin::blockdata::transaction::TxIn
+impl core::default::Default for bitcoin::blockdata::witness::Witness
+impl core::default::Default for bitcoin::p2p::ServiceFlags
+impl core::default::Default for bitcoin::pow::CompactTarget
+impl core::default::Default for bitcoin::psbt::Input
+impl core::default::Default for bitcoin::psbt::Output
+impl core::default::Default for bitcoin::taproot::TapBranchTag
+impl core::default::Default for bitcoin::taproot::TapLeafTag
+impl core::default::Default for bitcoin::taproot::TapTweakTag
+impl core::default::Default for bitcoin::taproot::TaprootBuilder
+impl core::default::Default for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::error::Error for bitcoin::address::error::Error
+impl core::error::Error for bitcoin::address::error::ParseError
+impl core::error::Error for bitcoin::address::error::UnknownAddressTypeError
+impl core::error::Error for bitcoin::address::error::UnknownHrpError
+impl core::error::Error for bitcoin::base58::Error
+impl core::error::Error for bitcoin::bip152::Error
+impl core::error::Error for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::error::Error for bitcoin::bip158::Error
+impl core::error::Error for bitcoin::bip32::Error
+impl core::error::Error for bitcoin::blockdata::block::Bip34Error
+impl core::error::Error for bitcoin::blockdata::block::ValidationError
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::Error
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::error::Error for bitcoin::blockdata::locktime::relative::Error
+impl core::error::Error for bitcoin::blockdata::script::Error
+impl core::error::Error for bitcoin::blockdata::script::PushBytesError
+impl core::error::Error for bitcoin::blockdata::script::witness_program::Error
+impl core::error::Error for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::error::Error for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::error::Error for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::error::Error for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::error::Error for bitcoin::blockdata::transaction::InputsIndexError
+impl core::error::Error for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::error::Error for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::error::Error for bitcoin::consensus::encode::Error
+impl core::error::Error for bitcoin::ecdsa::Error
+impl core::error::Error for bitcoin::error::ParseIntError
+impl core::error::Error for bitcoin::key::Error
+impl core::error::Error for bitcoin::key::UncompressedPubkeyError
+impl core::error::Error for bitcoin::merkle_tree::MerkleBlockError
+impl core::error::Error for bitcoin::network::ParseNetworkError
+impl core::error::Error for bitcoin::network::UnknownChainHashError
+impl core::error::Error for bitcoin::p2p::ParseMagicError
+impl core::error::Error for bitcoin::p2p::UnknownMagicError
+impl core::error::Error for bitcoin::p2p::message::CommandStringError
+impl core::error::Error for bitcoin::pow::TryFromError
+impl core::error::Error for bitcoin::psbt::Error
+impl core::error::Error for bitcoin::psbt::ExtractTxError
+impl core::error::Error for bitcoin::psbt::GetKeyError
+impl core::error::Error for bitcoin::psbt::IndexOutOfBoundsError
+impl core::error::Error for bitcoin::psbt::SignError
+impl core::error::Error for bitcoin::sighash::AnnexError
+impl core::error::Error for bitcoin::sighash::InvalidSighashTypeError
+impl core::error::Error for bitcoin::sighash::NonStandardSighashTypeError
+impl core::error::Error for bitcoin::sighash::P2wpkhError
+impl core::error::Error for bitcoin::sighash::PrevoutsIndexError
+impl core::error::Error for bitcoin::sighash::PrevoutsKindError
+impl core::error::Error for bitcoin::sighash::PrevoutsSizeError
+impl core::error::Error for bitcoin::sighash::SighashTypeParseError
+impl core::error::Error for bitcoin::sighash::SingleMissingOutputError
+impl core::error::Error for bitcoin::sighash::TaprootError
+impl core::error::Error for bitcoin::sign_message::MessageSignatureError
+impl core::error::Error for bitcoin::taproot::HiddenNodesError
+impl core::error::Error for bitcoin::taproot::IncompleteBuilderError
+impl core::error::Error for bitcoin::taproot::SigFromSliceError
+impl core::error::Error for bitcoin::taproot::TaprootBuilderError
+impl core::error::Error for bitcoin::taproot::TaprootError
+impl core::fmt::Debug for bitcoin::CompressedPublicKey
+impl core::fmt::Debug for bitcoin::EcdsaSighashType
+impl core::fmt::Debug for bitcoin::LegacySighash
+impl core::fmt::Debug for bitcoin::MerkleBlock
+impl core::fmt::Debug for bitcoin::PrivateKey
+impl core::fmt::Debug for bitcoin::PubkeyHash
+impl core::fmt::Debug for bitcoin::PublicKey
+impl core::fmt::Debug for bitcoin::SegwitV0Sighash
+impl core::fmt::Debug for bitcoin::TapSighash
+impl core::fmt::Debug for bitcoin::TapSighashType
+impl core::fmt::Debug for bitcoin::WPubkeyHash
+impl core::fmt::Debug for bitcoin::address::AddressType
+impl core::fmt::Debug for bitcoin::address::KnownHrp
+impl core::fmt::Debug for bitcoin::address::NetworkChecked
+impl core::fmt::Debug for bitcoin::address::NetworkUnchecked
+impl core::fmt::Debug for bitcoin::address::error::Error
+impl core::fmt::Debug for bitcoin::address::error::ParseError
+impl core::fmt::Debug for bitcoin::address::error::UnknownAddressTypeError
+impl core::fmt::Debug for bitcoin::address::error::UnknownHrpError
+impl core::fmt::Debug for bitcoin::base58::Error
+impl core::fmt::Debug for bitcoin::bip152::BlockTransactions
+impl core::fmt::Debug for bitcoin::bip152::BlockTransactionsRequest
+impl core::fmt::Debug for bitcoin::bip152::Error
+impl core::fmt::Debug for bitcoin::bip152::HeaderAndShortIds
+impl core::fmt::Debug for bitcoin::bip152::PrefilledTransaction
+impl core::fmt::Debug for bitcoin::bip152::ShortId
+impl core::fmt::Debug for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::fmt::Debug for bitcoin::bip158::BlockFilter
+impl core::fmt::Debug for bitcoin::bip158::Error
+impl core::fmt::Debug for bitcoin::bip158::FilterHash
+impl core::fmt::Debug for bitcoin::bip158::FilterHeader
+impl core::fmt::Debug for bitcoin::bip32::ChainCode
+impl core::fmt::Debug for bitcoin::bip32::ChildNumber
+impl core::fmt::Debug for bitcoin::bip32::DerivationPath
+impl core::fmt::Debug for bitcoin::bip32::Error
+impl core::fmt::Debug for bitcoin::bip32::Fingerprint
+impl core::fmt::Debug for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::Debug for bitcoin::bip32::Xpriv
+impl core::fmt::Debug for bitcoin::bip32::Xpub
+impl core::fmt::Debug for bitcoin::blockdata::block::Bip34Error
+impl core::fmt::Debug for bitcoin::blockdata::block::Block
+impl core::fmt::Debug for bitcoin::blockdata::block::BlockHash
+impl core::fmt::Debug for bitcoin::blockdata::block::Header
+impl core::fmt::Debug for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::Debug for bitcoin::blockdata::block::ValidationError
+impl core::fmt::Debug for bitcoin::blockdata::block::Version
+impl core::fmt::Debug for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::Debug for bitcoin::blockdata::fee_rate::FeeRate
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Error
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Time
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Error
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Height
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::LockTime
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Time
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::Class
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::Opcode
+impl core::fmt::Debug for bitcoin::blockdata::script::Builder
+impl core::fmt::Debug for bitcoin::blockdata::script::Error
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytes
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytesBuf
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytesError
+impl core::fmt::Debug for bitcoin::blockdata::script::Script
+impl core::fmt::Debug for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::Debug for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::Debug for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_program::Error
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::fmt::Debug for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::fmt::Debug for bitcoin::blockdata::transaction::InputsIndexError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::OutPoint
+impl core::fmt::Debug for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Transaction
+impl core::fmt::Debug for bitcoin::blockdata::transaction::TxIn
+impl core::fmt::Debug for bitcoin::blockdata::transaction::TxOut
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Txid
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Version
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::Debug for bitcoin::blockdata::weight::Weight
+impl core::fmt::Debug for bitcoin::blockdata::witness::Witness
+impl core::fmt::Debug for bitcoin::consensus::encode::CheckedData
+impl core::fmt::Debug for bitcoin::consensus::encode::Error
+impl core::fmt::Debug for bitcoin::consensus::encode::VarInt
+impl core::fmt::Debug for bitcoin::consensus::params::Params
+impl core::fmt::Debug for bitcoin::ecdsa::Error
+impl core::fmt::Debug for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::Debug for bitcoin::ecdsa::Signature
+impl core::fmt::Debug for bitcoin::error::ParseIntError
+impl core::fmt::Debug for bitcoin::key::Error
+impl core::fmt::Debug for bitcoin::key::SortKey
+impl core::fmt::Debug for bitcoin::key::TweakedKeypair
+impl core::fmt::Debug for bitcoin::key::TweakedPublicKey
+impl core::fmt::Debug for bitcoin::key::UncompressedPubkeyError
+impl core::fmt::Debug for bitcoin::merkle_tree::MerkleBlockError
+impl core::fmt::Debug for bitcoin::merkle_tree::PartialMerkleTree
+impl core::fmt::Debug for bitcoin::network::Network
+impl core::fmt::Debug for bitcoin::network::NetworkKind
+impl core::fmt::Debug for bitcoin::network::ParseNetworkError
+impl core::fmt::Debug for bitcoin::network::UnknownChainHashError
+impl core::fmt::Debug for bitcoin::p2p::Magic
+impl core::fmt::Debug for bitcoin::p2p::ParseMagicError
+impl core::fmt::Debug for bitcoin::p2p::ServiceFlags
+impl core::fmt::Debug for bitcoin::p2p::UnknownMagicError
+impl core::fmt::Debug for bitcoin::p2p::address::AddrV2
+impl core::fmt::Debug for bitcoin::p2p::address::AddrV2Message
+impl core::fmt::Debug for bitcoin::p2p::address::Address
+impl core::fmt::Debug for bitcoin::p2p::message::CommandString
+impl core::fmt::Debug for bitcoin::p2p::message::CommandStringError
+impl core::fmt::Debug for bitcoin::p2p::message::NetworkMessage
+impl core::fmt::Debug for bitcoin::p2p::message::RawNetworkMessage
+impl core::fmt::Debug for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::fmt::Debug for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::fmt::Debug for bitcoin::p2p::message_blockdata::Inventory
+impl core::fmt::Debug for bitcoin::p2p::message_bloom::BloomFlags
+impl core::fmt::Debug for bitcoin::p2p::message_bloom::FilterAdd
+impl core::fmt::Debug for bitcoin::p2p::message_bloom::FilterLoad
+impl core::fmt::Debug for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::fmt::Debug for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::fmt::Debug for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::fmt::Debug for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::fmt::Debug for bitcoin::p2p::message_filter::CFCheckpt
+impl core::fmt::Debug for bitcoin::p2p::message_filter::CFHeaders
+impl core::fmt::Debug for bitcoin::p2p::message_filter::CFilter
+impl core::fmt::Debug for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::fmt::Debug for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::fmt::Debug for bitcoin::p2p::message_filter::GetCFilters
+impl core::fmt::Debug for bitcoin::p2p::message_network::Reject
+impl core::fmt::Debug for bitcoin::p2p::message_network::RejectReason
+impl core::fmt::Debug for bitcoin::p2p::message_network::VersionMessage
+impl core::fmt::Debug for bitcoin::pow::CompactTarget
+impl core::fmt::Debug for bitcoin::pow::Target
+impl core::fmt::Debug for bitcoin::pow::TryFromError
+impl core::fmt::Debug for bitcoin::pow::Work
+impl core::fmt::Debug for bitcoin::psbt::Error
+impl core::fmt::Debug for bitcoin::psbt::ExtractTxError
+impl core::fmt::Debug for bitcoin::psbt::GetKeyError
+impl core::fmt::Debug for bitcoin::psbt::IndexOutOfBoundsError
+impl core::fmt::Debug for bitcoin::psbt::Input
+impl core::fmt::Debug for bitcoin::psbt::KeyRequest
+impl core::fmt::Debug for bitcoin::psbt::Output
+impl core::fmt::Debug for bitcoin::psbt::OutputType
+impl core::fmt::Debug for bitcoin::psbt::Psbt
+impl core::fmt::Debug for bitcoin::psbt::PsbtSighashType
+impl core::fmt::Debug for bitcoin::psbt::SignError
+impl core::fmt::Debug for bitcoin::psbt::SigningAlgorithm
+impl core::fmt::Debug for bitcoin::psbt::raw::Key
+impl core::fmt::Debug for bitcoin::psbt::raw::Pair
+impl core::fmt::Debug for bitcoin::sighash::AnnexError
+impl core::fmt::Debug for bitcoin::sighash::InvalidSighashTypeError
+impl core::fmt::Debug for bitcoin::sighash::NonStandardSighashTypeError
+impl core::fmt::Debug for bitcoin::sighash::P2wpkhError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsIndexError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsKindError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsSizeError
+impl core::fmt::Debug for bitcoin::sighash::SighashTypeParseError
+impl core::fmt::Debug for bitcoin::sighash::SingleMissingOutputError
+impl core::fmt::Debug for bitcoin::sighash::TaprootError
+impl core::fmt::Debug for bitcoin::sign_message::MessageSignature
+impl core::fmt::Debug for bitcoin::sign_message::MessageSignatureError
+impl core::fmt::Debug for bitcoin::taproot::ControlBlock
+impl core::fmt::Debug for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::Debug for bitcoin::taproot::HiddenNodesError
+impl core::fmt::Debug for bitcoin::taproot::IncompleteBuilderError
+impl core::fmt::Debug for bitcoin::taproot::LeafNode
+impl core::fmt::Debug for bitcoin::taproot::LeafVersion
+impl core::fmt::Debug for bitcoin::taproot::NodeInfo
+impl core::fmt::Debug for bitcoin::taproot::SigFromSliceError
+impl core::fmt::Debug for bitcoin::taproot::Signature
+impl core::fmt::Debug for bitcoin::taproot::TapLeaf
+impl core::fmt::Debug for bitcoin::taproot::TapLeafHash
+impl core::fmt::Debug for bitcoin::taproot::TapNodeHash
+impl core::fmt::Debug for bitcoin::taproot::TapTree
+impl core::fmt::Debug for bitcoin::taproot::TapTweakHash
+impl core::fmt::Debug for bitcoin::taproot::TaprootBuilder
+impl core::fmt::Debug for bitcoin::taproot::TaprootBuilderError
+impl core::fmt::Debug for bitcoin::taproot::TaprootError
+impl core::fmt::Debug for bitcoin::taproot::TaprootSpendInfo
+impl core::fmt::Debug for bitcoin::taproot::merkle_branch::IntoIter
+impl core::fmt::Debug for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::fmt::Debug for bitcoin::taproot::serialized_signature::IntoIter
+impl core::fmt::Debug for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::fmt::Display for bitcoin::CompressedPublicKey
+impl core::fmt::Display for bitcoin::EcdsaSighashType
+impl core::fmt::Display for bitcoin::LegacySighash
+impl core::fmt::Display for bitcoin::PrivateKey
+impl core::fmt::Display for bitcoin::PubkeyHash
+impl core::fmt::Display for bitcoin::PublicKey
+impl core::fmt::Display for bitcoin::SegwitV0Sighash
+impl core::fmt::Display for bitcoin::TapSighash
+impl core::fmt::Display for bitcoin::TapSighashType
+impl core::fmt::Display for bitcoin::WPubkeyHash
+impl core::fmt::Display for bitcoin::address::Address
+impl core::fmt::Display for bitcoin::address::AddressType
+impl core::fmt::Display for bitcoin::address::error::Error
+impl core::fmt::Display for bitcoin::address::error::ParseError
+impl core::fmt::Display for bitcoin::address::error::UnknownAddressTypeError
+impl core::fmt::Display for bitcoin::address::error::UnknownHrpError
+impl core::fmt::Display for bitcoin::base58::Error
+impl core::fmt::Display for bitcoin::bip152::Error
+impl core::fmt::Display for bitcoin::bip152::ShortId
+impl core::fmt::Display for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::fmt::Display for bitcoin::bip158::Error
+impl core::fmt::Display for bitcoin::bip158::FilterHash
+impl core::fmt::Display for bitcoin::bip158::FilterHeader
+impl core::fmt::Display for bitcoin::bip32::ChainCode
+impl core::fmt::Display for bitcoin::bip32::ChildNumber
+impl core::fmt::Display for bitcoin::bip32::DerivationPath
+impl core::fmt::Display for bitcoin::bip32::Error
+impl core::fmt::Display for bitcoin::bip32::Fingerprint
+impl core::fmt::Display for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::Display for bitcoin::bip32::Xpriv
+impl core::fmt::Display for bitcoin::bip32::Xpub
+impl core::fmt::Display for bitcoin::blockdata::block::Bip34Error
+impl core::fmt::Display for bitcoin::blockdata::block::BlockHash
+impl core::fmt::Display for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::Display for bitcoin::blockdata::block::ValidationError
+impl core::fmt::Display for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::Display for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::Display for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::Display for bitcoin::blockdata::fee_rate::FeeRate
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Error
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Height
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Time
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Error
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Height
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::LockTime
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Time
+impl core::fmt::Display for bitcoin::blockdata::opcodes::Opcode
+impl core::fmt::Display for bitcoin::blockdata::script::Builder
+impl core::fmt::Display for bitcoin::blockdata::script::Error
+impl core::fmt::Display for bitcoin::blockdata::script::PushBytesError
+impl core::fmt::Display for bitcoin::blockdata::script::Script
+impl core::fmt::Display for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::Display for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::Display for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::Display for bitcoin::blockdata::script::witness_program::Error
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::fmt::Display for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::fmt::Display for bitcoin::blockdata::transaction::InputsIndexError
+impl core::fmt::Display for bitcoin::blockdata::transaction::OutPoint
+impl core::fmt::Display for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::fmt::Display for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::fmt::Display for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::Display for bitcoin::blockdata::transaction::Txid
+impl core::fmt::Display for bitcoin::blockdata::transaction::Version
+impl core::fmt::Display for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::Display for bitcoin::blockdata::weight::Weight
+impl core::fmt::Display for bitcoin::consensus::encode::Error
+impl core::fmt::Display for bitcoin::ecdsa::Error
+impl core::fmt::Display for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::Display for bitcoin::ecdsa::Signature
+impl core::fmt::Display for bitcoin::error::ParseIntError
+impl core::fmt::Display for bitcoin::key::Error
+impl core::fmt::Display for bitcoin::key::TweakedPublicKey
+impl core::fmt::Display for bitcoin::key::UncompressedPubkeyError
+impl core::fmt::Display for bitcoin::merkle_tree::MerkleBlockError
+impl core::fmt::Display for bitcoin::network::Network
+impl core::fmt::Display for bitcoin::network::ParseNetworkError
+impl core::fmt::Display for bitcoin::network::UnknownChainHashError
+impl core::fmt::Display for bitcoin::p2p::Magic
+impl core::fmt::Display for bitcoin::p2p::ParseMagicError
+impl core::fmt::Display for bitcoin::p2p::ServiceFlags
+impl core::fmt::Display for bitcoin::p2p::UnknownMagicError
+impl core::fmt::Display for bitcoin::p2p::message::CommandString
+impl core::fmt::Display for bitcoin::p2p::message::CommandStringError
+impl core::fmt::Display for bitcoin::pow::Target
+impl core::fmt::Display for bitcoin::pow::TryFromError
+impl core::fmt::Display for bitcoin::pow::Work
+impl core::fmt::Display for bitcoin::psbt::Error
+impl core::fmt::Display for bitcoin::psbt::ExtractTxError
+impl core::fmt::Display for bitcoin::psbt::GetKeyError
+impl core::fmt::Display for bitcoin::psbt::IndexOutOfBoundsError
+impl core::fmt::Display for bitcoin::psbt::PsbtSighashType
+impl core::fmt::Display for bitcoin::psbt::SignError
+impl core::fmt::Display for bitcoin::psbt::raw::Key
+impl core::fmt::Display for bitcoin::sighash::AnnexError
+impl core::fmt::Display for bitcoin::sighash::InvalidSighashTypeError
+impl core::fmt::Display for bitcoin::sighash::NonStandardSighashTypeError
+impl core::fmt::Display for bitcoin::sighash::P2wpkhError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsIndexError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsKindError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsSizeError
+impl core::fmt::Display for bitcoin::sighash::SighashTypeParseError
+impl core::fmt::Display for bitcoin::sighash::SingleMissingOutputError
+impl core::fmt::Display for bitcoin::sighash::TaprootError
+impl core::fmt::Display for bitcoin::sign_message::MessageSignatureError
+impl core::fmt::Display for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::Display for bitcoin::taproot::HiddenNodesError
+impl core::fmt::Display for bitcoin::taproot::IncompleteBuilderError
+impl core::fmt::Display for bitcoin::taproot::LeafVersion
+impl core::fmt::Display for bitcoin::taproot::SigFromSliceError
+impl core::fmt::Display for bitcoin::taproot::TapLeafHash
+impl core::fmt::Display for bitcoin::taproot::TapNodeHash
+impl core::fmt::Display for bitcoin::taproot::TapTweakHash
+impl core::fmt::Display for bitcoin::taproot::TaprootBuilderError
+impl core::fmt::Display for bitcoin::taproot::TaprootError
+impl core::fmt::Display for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::fmt::LowerHex for bitcoin::LegacySighash
+impl core::fmt::LowerHex for bitcoin::PubkeyHash
+impl core::fmt::LowerHex for bitcoin::SegwitV0Sighash
+impl core::fmt::LowerHex for bitcoin::TapSighash
+impl core::fmt::LowerHex for bitcoin::WPubkeyHash
+impl core::fmt::LowerHex for bitcoin::bip152::ShortId
+impl core::fmt::LowerHex for bitcoin::bip158::FilterHash
+impl core::fmt::LowerHex for bitcoin::bip158::FilterHeader
+impl core::fmt::LowerHex for bitcoin::bip32::ChainCode
+impl core::fmt::LowerHex for bitcoin::bip32::Fingerprint
+impl core::fmt::LowerHex for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::LowerHex for bitcoin::blockdata::block::BlockHash
+impl core::fmt::LowerHex for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::LowerHex for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::LowerHex for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::LowerHex for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::LowerHex for bitcoin::blockdata::script::Script
+impl core::fmt::LowerHex for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::LowerHex for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::LowerHex for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Txid
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::LowerHex for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::LowerHex for bitcoin::key::TweakedPublicKey
+impl core::fmt::LowerHex for bitcoin::p2p::Magic
+impl core::fmt::LowerHex for bitcoin::p2p::ServiceFlags
+impl core::fmt::LowerHex for bitcoin::pow::CompactTarget
+impl core::fmt::LowerHex for bitcoin::pow::Target
+impl core::fmt::LowerHex for bitcoin::pow::Work
+impl core::fmt::LowerHex for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::LowerHex for bitcoin::taproot::LeafVersion
+impl core::fmt::LowerHex for bitcoin::taproot::TapLeafHash
+impl core::fmt::LowerHex for bitcoin::taproot::TapNodeHash
+impl core::fmt::LowerHex for bitcoin::taproot::TapTweakHash
+impl core::fmt::UpperHex for bitcoin::LegacySighash
+impl core::fmt::UpperHex for bitcoin::PubkeyHash
+impl core::fmt::UpperHex for bitcoin::SegwitV0Sighash
+impl core::fmt::UpperHex for bitcoin::TapSighash
+impl core::fmt::UpperHex for bitcoin::WPubkeyHash
+impl core::fmt::UpperHex for bitcoin::bip152::ShortId
+impl core::fmt::UpperHex for bitcoin::bip158::FilterHash
+impl core::fmt::UpperHex for bitcoin::bip158::FilterHeader
+impl core::fmt::UpperHex for bitcoin::bip32::ChainCode
+impl core::fmt::UpperHex for bitcoin::bip32::Fingerprint
+impl core::fmt::UpperHex for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::UpperHex for bitcoin::blockdata::block::BlockHash
+impl core::fmt::UpperHex for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::UpperHex for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::UpperHex for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::UpperHex for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::UpperHex for bitcoin::blockdata::script::Script
+impl core::fmt::UpperHex for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::UpperHex for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::UpperHex for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Txid
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::UpperHex for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::UpperHex for bitcoin::p2p::Magic
+impl core::fmt::UpperHex for bitcoin::p2p::ServiceFlags
+impl core::fmt::UpperHex for bitcoin::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin::pow::Target
+impl core::fmt::UpperHex for bitcoin::pow::Work
+impl core::fmt::UpperHex for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::UpperHex for bitcoin::taproot::LeafVersion
+impl core::fmt::UpperHex for bitcoin::taproot::TapLeafHash
+impl core::fmt::UpperHex for bitcoin::taproot::TapNodeHash
+impl core::fmt::UpperHex for bitcoin::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin::CompressedPublicKey
+impl core::hash::Hash for bitcoin::EcdsaSighashType
+impl core::hash::Hash for bitcoin::LegacySighash
+impl core::hash::Hash for bitcoin::PubkeyHash
+impl core::hash::Hash for bitcoin::PublicKey
+impl core::hash::Hash for bitcoin::SegwitV0Sighash
+impl core::hash::Hash for bitcoin::TapSighash
+impl core::hash::Hash for bitcoin::TapSighashTag
+impl core::hash::Hash for bitcoin::TapSighashType
+impl core::hash::Hash for bitcoin::WPubkeyHash
+impl core::hash::Hash for bitcoin::address::AddressType
+impl core::hash::Hash for bitcoin::address::KnownHrp
+impl core::hash::Hash for bitcoin::address::NetworkChecked
+impl core::hash::Hash for bitcoin::address::NetworkUnchecked
+impl core::hash::Hash for bitcoin::bip152::BlockTransactions
+impl core::hash::Hash for bitcoin::bip152::BlockTransactionsRequest
+impl core::hash::Hash for bitcoin::bip152::HeaderAndShortIds
+impl core::hash::Hash for bitcoin::bip152::PrefilledTransaction
+impl core::hash::Hash for bitcoin::bip152::ShortId
+impl core::hash::Hash for bitcoin::bip158::FilterHash
+impl core::hash::Hash for bitcoin::bip158::FilterHeader
+impl core::hash::Hash for bitcoin::bip32::ChainCode
+impl core::hash::Hash for bitcoin::bip32::ChildNumber
+impl core::hash::Hash for bitcoin::bip32::DerivationPath
+impl core::hash::Hash for bitcoin::bip32::Fingerprint
+impl core::hash::Hash for bitcoin::bip32::XKeyIdentifier
+impl core::hash::Hash for bitcoin::bip32::Xpub
+impl core::hash::Hash for bitcoin::blockdata::block::BlockHash
+impl core::hash::Hash for bitcoin::blockdata::block::Header
+impl core::hash::Hash for bitcoin::blockdata::block::TxMerkleNode
+impl core::hash::Hash for bitcoin::blockdata::block::Version
+impl core::hash::Hash for bitcoin::blockdata::block::WitnessCommitment
+impl core::hash::Hash for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::hash::Hash for bitcoin::blockdata::constants::ChainHash
+impl core::hash::Hash for bitcoin::blockdata::fee_rate::FeeRate
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::Height
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::Time
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::Height
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::LockTime
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::Time
+impl core::hash::Hash for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::hash::Hash for bitcoin::blockdata::script::PushBytes
+impl core::hash::Hash for bitcoin::blockdata::script::PushBytesBuf
+impl core::hash::Hash for bitcoin::blockdata::script::Script
+impl core::hash::Hash for bitcoin::blockdata::script::ScriptBuf
+impl core::hash::Hash for bitcoin::blockdata::script::ScriptHash
+impl core::hash::Hash for bitcoin::blockdata::script::WScriptHash
+impl core::hash::Hash for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::hash::Hash for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::hash::Hash for bitcoin::blockdata::transaction::OutPoint
+impl core::hash::Hash for bitcoin::blockdata::transaction::Sequence
+impl core::hash::Hash for bitcoin::blockdata::transaction::Transaction
+impl core::hash::Hash for bitcoin::blockdata::transaction::TxIn
+impl core::hash::Hash for bitcoin::blockdata::transaction::TxOut
+impl core::hash::Hash for bitcoin::blockdata::transaction::Txid
+impl core::hash::Hash for bitcoin::blockdata::transaction::Version
+impl core::hash::Hash for bitcoin::blockdata::transaction::Wtxid
+impl core::hash::Hash for bitcoin::blockdata::weight::Weight
+impl core::hash::Hash for bitcoin::blockdata::witness::Witness
+impl core::hash::Hash for bitcoin::ecdsa::SerializedSignature
+impl core::hash::Hash for bitcoin::ecdsa::Signature
+impl core::hash::Hash for bitcoin::key::SortKey
+impl core::hash::Hash for bitcoin::key::TweakedKeypair
+impl core::hash::Hash for bitcoin::key::TweakedPublicKey
+impl core::hash::Hash for bitcoin::network::Network
+impl core::hash::Hash for bitcoin::network::NetworkKind
+impl core::hash::Hash for bitcoin::p2p::Magic
+impl core::hash::Hash for bitcoin::p2p::ServiceFlags
+impl core::hash::Hash for bitcoin::p2p::address::AddrV2
+impl core::hash::Hash for bitcoin::p2p::address::AddrV2Message
+impl core::hash::Hash for bitcoin::p2p::address::Address
+impl core::hash::Hash for bitcoin::p2p::message_blockdata::Inventory
+impl core::hash::Hash for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::hash::Hash for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::hash::Hash for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::hash::Hash for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::hash::Hash for bitcoin::pow::CompactTarget
+impl core::hash::Hash for bitcoin::pow::Target
+impl core::hash::Hash for bitcoin::pow::Work
+impl core::hash::Hash for bitcoin::psbt::Input
+impl core::hash::Hash for bitcoin::psbt::Output
+impl core::hash::Hash for bitcoin::psbt::OutputType
+impl core::hash::Hash for bitcoin::psbt::Psbt
+impl core::hash::Hash for bitcoin::psbt::PsbtSighashType
+impl core::hash::Hash for bitcoin::psbt::SigningAlgorithm
+impl core::hash::Hash for bitcoin::psbt::raw::Key
+impl core::hash::Hash for bitcoin::taproot::ControlBlock
+impl core::hash::Hash for bitcoin::taproot::FutureLeafVersion
+impl core::hash::Hash for bitcoin::taproot::LeafNode
+impl core::hash::Hash for bitcoin::taproot::LeafVersion
+impl core::hash::Hash for bitcoin::taproot::NodeInfo
+impl core::hash::Hash for bitcoin::taproot::Signature
+impl core::hash::Hash for bitcoin::taproot::TapBranchTag
+impl core::hash::Hash for bitcoin::taproot::TapLeaf
+impl core::hash::Hash for bitcoin::taproot::TapLeafHash
+impl core::hash::Hash for bitcoin::taproot::TapLeafTag
+impl core::hash::Hash for bitcoin::taproot::TapNodeHash
+impl core::hash::Hash for bitcoin::taproot::TapTree
+impl core::hash::Hash for bitcoin::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin::taproot::TapTweakTag
+impl core::hash::Hash for bitcoin::taproot::TaprootBuilder
+impl core::hash::Hash for bitcoin::taproot::TaprootSpendInfo
+impl core::hash::Hash for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::hash::Hash for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::iter::traits::accum::Sum for bitcoin::blockdata::weight::Weight
+impl core::iter::traits::collect::FromIterator<bitcoin::bip32::ChildNumber> for bitcoin::bip32::DerivationPath
+impl core::iter::traits::collect::IntoIterator for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::iter::traits::collect::IntoIterator for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::iterator::Iterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::iterator::Iterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::InstructionIndices<'_>
+impl core::iter::traits::marker::FusedIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::marker::FusedIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Copy for bitcoin::CompressedPublicKey
+impl core::marker::Copy for bitcoin::EcdsaSighashType
+impl core::marker::Copy for bitcoin::LegacySighash
+impl core::marker::Copy for bitcoin::PrivateKey
+impl core::marker::Copy for bitcoin::PubkeyHash
+impl core::marker::Copy for bitcoin::PublicKey
+impl core::marker::Copy for bitcoin::SegwitV0Sighash
+impl core::marker::Copy for bitcoin::TapSighash
+impl core::marker::Copy for bitcoin::TapSighashTag
+impl core::marker::Copy for bitcoin::TapSighashType
+impl core::marker::Copy for bitcoin::WPubkeyHash
+impl core::marker::Copy for bitcoin::address::AddressType
+impl core::marker::Copy for bitcoin::address::KnownHrp
+impl core::marker::Copy for bitcoin::bip152::ShortId
+impl core::marker::Copy for bitcoin::bip158::FilterHash
+impl core::marker::Copy for bitcoin::bip158::FilterHeader
+impl core::marker::Copy for bitcoin::bip32::ChainCode
+impl core::marker::Copy for bitcoin::bip32::ChildNumber
+impl core::marker::Copy for bitcoin::bip32::Fingerprint
+impl core::marker::Copy for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Copy for bitcoin::bip32::Xpriv
+impl core::marker::Copy for bitcoin::bip32::Xpub
+impl core::marker::Copy for bitcoin::blockdata::block::BlockHash
+impl core::marker::Copy for bitcoin::blockdata::block::Header
+impl core::marker::Copy for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Copy for bitcoin::blockdata::block::Version
+impl core::marker::Copy for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Copy for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Copy for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Copy for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Copy for bitcoin::blockdata::opcodes::Class
+impl core::marker::Copy for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Copy for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Copy for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Copy for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Copy for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Copy for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Copy for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Copy for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Copy for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Copy for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Copy for bitcoin::blockdata::transaction::Txid
+impl core::marker::Copy for bitcoin::blockdata::transaction::Version
+impl core::marker::Copy for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Copy for bitcoin::blockdata::weight::Weight
+impl core::marker::Copy for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Copy for bitcoin::ecdsa::Signature
+impl core::marker::Copy for bitcoin::key::SortKey
+impl core::marker::Copy for bitcoin::key::TweakedKeypair
+impl core::marker::Copy for bitcoin::key::TweakedPublicKey
+impl core::marker::Copy for bitcoin::network::Network
+impl core::marker::Copy for bitcoin::network::NetworkKind
+impl core::marker::Copy for bitcoin::p2p::Magic
+impl core::marker::Copy for bitcoin::p2p::ServiceFlags
+impl core::marker::Copy for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::Copy for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::Copy for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::Copy for bitcoin::p2p::message_network::RejectReason
+impl core::marker::Copy for bitcoin::pow::CompactTarget
+impl core::marker::Copy for bitcoin::pow::Target
+impl core::marker::Copy for bitcoin::pow::Work
+impl core::marker::Copy for bitcoin::psbt::OutputType
+impl core::marker::Copy for bitcoin::psbt::PsbtSighashType
+impl core::marker::Copy for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Copy for bitcoin::sign_message::MessageSignature
+impl core::marker::Copy for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Copy for bitcoin::taproot::LeafVersion
+impl core::marker::Copy for bitcoin::taproot::Signature
+impl core::marker::Copy for bitcoin::taproot::TapBranchTag
+impl core::marker::Copy for bitcoin::taproot::TapLeafHash
+impl core::marker::Copy for bitcoin::taproot::TapLeafTag
+impl core::marker::Copy for bitcoin::taproot::TapNodeHash
+impl core::marker::Copy for bitcoin::taproot::TapTweakHash
+impl core::marker::Copy for bitcoin::taproot::TapTweakTag
+impl core::marker::Copy for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::Send for bitcoin::CompressedPublicKey
+impl core::marker::Send for bitcoin::EcdsaSighashType
+impl core::marker::Send for bitcoin::LegacySighash
+impl core::marker::Send for bitcoin::MerkleBlock
+impl core::marker::Send for bitcoin::PrivateKey
+impl core::marker::Send for bitcoin::PubkeyHash
+impl core::marker::Send for bitcoin::PublicKey
+impl core::marker::Send for bitcoin::SegwitV0Sighash
+impl core::marker::Send for bitcoin::TapSighash
+impl core::marker::Send for bitcoin::TapSighashTag
+impl core::marker::Send for bitcoin::TapSighashType
+impl core::marker::Send for bitcoin::WPubkeyHash
+impl core::marker::Send for bitcoin::address::AddressType
+impl core::marker::Send for bitcoin::address::KnownHrp
+impl core::marker::Send for bitcoin::address::NetworkChecked
+impl core::marker::Send for bitcoin::address::NetworkUnchecked
+impl core::marker::Send for bitcoin::address::error::Error
+impl core::marker::Send for bitcoin::address::error::ParseError
+impl core::marker::Send for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Send for bitcoin::address::error::UnknownHrpError
+impl core::marker::Send for bitcoin::base58::Error
+impl core::marker::Send for bitcoin::bip152::BlockTransactions
+impl core::marker::Send for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Send for bitcoin::bip152::Error
+impl core::marker::Send for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Send for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Send for bitcoin::bip152::ShortId
+impl core::marker::Send for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Send for bitcoin::bip158::BlockFilter
+impl core::marker::Send for bitcoin::bip158::BlockFilterReader
+impl core::marker::Send for bitcoin::bip158::Error
+impl core::marker::Send for bitcoin::bip158::FilterHash
+impl core::marker::Send for bitcoin::bip158::FilterHeader
+impl core::marker::Send for bitcoin::bip158::GcsFilterReader
+impl core::marker::Send for bitcoin::bip32::ChainCode
+impl core::marker::Send for bitcoin::bip32::ChildNumber
+impl core::marker::Send for bitcoin::bip32::DerivationPath
+impl core::marker::Send for bitcoin::bip32::Error
+impl core::marker::Send for bitcoin::bip32::Fingerprint
+impl core::marker::Send for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Send for bitcoin::bip32::Xpriv
+impl core::marker::Send for bitcoin::bip32::Xpub
+impl core::marker::Send for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Send for bitcoin::blockdata::block::Block
+impl core::marker::Send for bitcoin::blockdata::block::BlockHash
+impl core::marker::Send for bitcoin::blockdata::block::Header
+impl core::marker::Send for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Send for bitcoin::blockdata::block::ValidationError
+impl core::marker::Send for bitcoin::blockdata::block::Version
+impl core::marker::Send for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Send for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Send for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Send for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Send for bitcoin::blockdata::opcodes::Class
+impl core::marker::Send for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Send for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Send for bitcoin::blockdata::script::Builder
+impl core::marker::Send for bitcoin::blockdata::script::Error
+impl core::marker::Send for bitcoin::blockdata::script::PushBytes
+impl core::marker::Send for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Send for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Send for bitcoin::blockdata::script::Script
+impl core::marker::Send for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Send for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Send for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Send for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Send for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Send for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Send for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Send for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Send for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Send for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Send for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Send for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Send for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Send for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Send for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Send for bitcoin::blockdata::transaction::Txid
+impl core::marker::Send for bitcoin::blockdata::transaction::Version
+impl core::marker::Send for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Send for bitcoin::blockdata::weight::Weight
+impl core::marker::Send for bitcoin::blockdata::witness::Witness
+impl core::marker::Send for bitcoin::consensus::encode::CheckedData
+impl core::marker::Send for bitcoin::consensus::encode::Error
+impl core::marker::Send for bitcoin::consensus::encode::VarInt
+impl core::marker::Send for bitcoin::consensus::params::Params
+impl core::marker::Send for bitcoin::ecdsa::Error
+impl core::marker::Send for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Send for bitcoin::ecdsa::Signature
+impl core::marker::Send for bitcoin::error::ParseIntError
+impl core::marker::Send for bitcoin::key::Error
+impl core::marker::Send for bitcoin::key::SortKey
+impl core::marker::Send for bitcoin::key::TweakedKeypair
+impl core::marker::Send for bitcoin::key::TweakedPublicKey
+impl core::marker::Send for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Send for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Send for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Send for bitcoin::network::Network
+impl core::marker::Send for bitcoin::network::NetworkKind
+impl core::marker::Send for bitcoin::network::ParseNetworkError
+impl core::marker::Send for bitcoin::network::UnknownChainHashError
+impl core::marker::Send for bitcoin::p2p::Magic
+impl core::marker::Send for bitcoin::p2p::ParseMagicError
+impl core::marker::Send for bitcoin::p2p::ServiceFlags
+impl core::marker::Send for bitcoin::p2p::UnknownMagicError
+impl core::marker::Send for bitcoin::p2p::address::AddrV2
+impl core::marker::Send for bitcoin::p2p::address::AddrV2Message
+impl core::marker::Send for bitcoin::p2p::address::Address
+impl core::marker::Send for bitcoin::p2p::message::CommandString
+impl core::marker::Send for bitcoin::p2p::message::CommandStringError
+impl core::marker::Send for bitcoin::p2p::message::NetworkMessage
+impl core::marker::Send for bitcoin::p2p::message::RawNetworkMessage
+impl core::marker::Send for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::marker::Send for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::marker::Send for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::Send for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::Send for bitcoin::p2p::message_bloom::FilterAdd
+impl core::marker::Send for bitcoin::p2p::message_bloom::FilterLoad
+impl core::marker::Send for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::marker::Send for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::marker::Send for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::marker::Send for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::Send for bitcoin::p2p::message_filter::CFCheckpt
+impl core::marker::Send for bitcoin::p2p::message_filter::CFHeaders
+impl core::marker::Send for bitcoin::p2p::message_filter::CFilter
+impl core::marker::Send for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::marker::Send for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::marker::Send for bitcoin::p2p::message_filter::GetCFilters
+impl core::marker::Send for bitcoin::p2p::message_network::Reject
+impl core::marker::Send for bitcoin::p2p::message_network::RejectReason
+impl core::marker::Send for bitcoin::p2p::message_network::VersionMessage
+impl core::marker::Send for bitcoin::pow::CompactTarget
+impl core::marker::Send for bitcoin::pow::Target
+impl core::marker::Send for bitcoin::pow::TryFromError
+impl core::marker::Send for bitcoin::pow::Work
+impl core::marker::Send for bitcoin::psbt::Error
+impl core::marker::Send for bitcoin::psbt::ExtractTxError
+impl core::marker::Send for bitcoin::psbt::GetKeyError
+impl core::marker::Send for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Send for bitcoin::psbt::Input
+impl core::marker::Send for bitcoin::psbt::KeyRequest
+impl core::marker::Send for bitcoin::psbt::Output
+impl core::marker::Send for bitcoin::psbt::OutputType
+impl core::marker::Send for bitcoin::psbt::Psbt
+impl core::marker::Send for bitcoin::psbt::PsbtSighashType
+impl core::marker::Send for bitcoin::psbt::SignError
+impl core::marker::Send for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Send for bitcoin::psbt::raw::Key
+impl core::marker::Send for bitcoin::psbt::raw::Pair
+impl core::marker::Send for bitcoin::sighash::AnnexError
+impl core::marker::Send for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Send for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Send for bitcoin::sighash::P2wpkhError
+impl core::marker::Send for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Send for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Send for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Send for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Send for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Send for bitcoin::sighash::TaprootError
+impl core::marker::Send for bitcoin::sign_message::MessageSignature
+impl core::marker::Send for bitcoin::sign_message::MessageSignatureError
+impl core::marker::Send for bitcoin::taproot::ControlBlock
+impl core::marker::Send for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Send for bitcoin::taproot::HiddenNodesError
+impl core::marker::Send for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Send for bitcoin::taproot::LeafNode
+impl core::marker::Send for bitcoin::taproot::LeafVersion
+impl core::marker::Send for bitcoin::taproot::NodeInfo
+impl core::marker::Send for bitcoin::taproot::SigFromSliceError
+impl core::marker::Send for bitcoin::taproot::Signature
+impl core::marker::Send for bitcoin::taproot::TapBranchTag
+impl core::marker::Send for bitcoin::taproot::TapLeaf
+impl core::marker::Send for bitcoin::taproot::TapLeafHash
+impl core::marker::Send for bitcoin::taproot::TapLeafTag
+impl core::marker::Send for bitcoin::taproot::TapNodeHash
+impl core::marker::Send for bitcoin::taproot::TapTree
+impl core::marker::Send for bitcoin::taproot::TapTweakHash
+impl core::marker::Send for bitcoin::taproot::TapTweakTag
+impl core::marker::Send for bitcoin::taproot::TaprootBuilder
+impl core::marker::Send for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Send for bitcoin::taproot::TaprootError
+impl core::marker::Send for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Send for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Send for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Send for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Send for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::StructuralPartialEq for bitcoin::CompressedPublicKey
+impl core::marker::StructuralPartialEq for bitcoin::EcdsaSighashType
+impl core::marker::StructuralPartialEq for bitcoin::LegacySighash
+impl core::marker::StructuralPartialEq for bitcoin::MerkleBlock
+impl core::marker::StructuralPartialEq for bitcoin::PrivateKey
+impl core::marker::StructuralPartialEq for bitcoin::PubkeyHash
+impl core::marker::StructuralPartialEq for bitcoin::PublicKey
+impl core::marker::StructuralPartialEq for bitcoin::SegwitV0Sighash
+impl core::marker::StructuralPartialEq for bitcoin::TapSighash
+impl core::marker::StructuralPartialEq for bitcoin::TapSighashTag
+impl core::marker::StructuralPartialEq for bitcoin::TapSighashType
+impl core::marker::StructuralPartialEq for bitcoin::WPubkeyHash
+impl core::marker::StructuralPartialEq for bitcoin::address::AddressType
+impl core::marker::StructuralPartialEq for bitcoin::address::KnownHrp
+impl core::marker::StructuralPartialEq for bitcoin::address::NetworkChecked
+impl core::marker::StructuralPartialEq for bitcoin::address::NetworkUnchecked
+impl core::marker::StructuralPartialEq for bitcoin::address::error::Error
+impl core::marker::StructuralPartialEq for bitcoin::address::error::ParseError
+impl core::marker::StructuralPartialEq for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::StructuralPartialEq for bitcoin::address::error::UnknownHrpError
+impl core::marker::StructuralPartialEq for bitcoin::base58::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip152::BlockTransactions
+impl core::marker::StructuralPartialEq for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::StructuralPartialEq for bitcoin::bip152::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::StructuralPartialEq for bitcoin::bip152::PrefilledTransaction
+impl core::marker::StructuralPartialEq for bitcoin::bip152::ShortId
+impl core::marker::StructuralPartialEq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin::bip158::BlockFilter
+impl core::marker::StructuralPartialEq for bitcoin::bip158::FilterHash
+impl core::marker::StructuralPartialEq for bitcoin::bip158::FilterHeader
+impl core::marker::StructuralPartialEq for bitcoin::bip32::ChainCode
+impl core::marker::StructuralPartialEq for bitcoin::bip32::ChildNumber
+impl core::marker::StructuralPartialEq for bitcoin::bip32::DerivationPath
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Fingerprint
+impl core::marker::StructuralPartialEq for bitcoin::bip32::XKeyIdentifier
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Xpriv
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Xpub
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Bip34Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Block
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Header
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::ValidationError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Version
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::constants::ChainHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::Class
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Builder
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytes
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytesError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Script
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::ScriptHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::WScriptHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Sequence
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Transaction
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::TxIn
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::TxOut
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::weight::Weight
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::witness::Witness
+impl core::marker::StructuralPartialEq for bitcoin::consensus::encode::CheckedData
+impl core::marker::StructuralPartialEq for bitcoin::consensus::encode::VarInt
+impl core::marker::StructuralPartialEq for bitcoin::ecdsa::Error
+impl core::marker::StructuralPartialEq for bitcoin::ecdsa::Signature
+impl core::marker::StructuralPartialEq for bitcoin::error::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin::key::Error
+impl core::marker::StructuralPartialEq for bitcoin::key::SortKey
+impl core::marker::StructuralPartialEq for bitcoin::key::TweakedKeypair
+impl core::marker::StructuralPartialEq for bitcoin::key::TweakedPublicKey
+impl core::marker::StructuralPartialEq for bitcoin::key::UncompressedPubkeyError
+impl core::marker::StructuralPartialEq for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::StructuralPartialEq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::StructuralPartialEq for bitcoin::network::Network
+impl core::marker::StructuralPartialEq for bitcoin::network::NetworkKind
+impl core::marker::StructuralPartialEq for bitcoin::network::ParseNetworkError
+impl core::marker::StructuralPartialEq for bitcoin::network::UnknownChainHashError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::Magic
+impl core::marker::StructuralPartialEq for bitcoin::p2p::ParseMagicError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::ServiceFlags
+impl core::marker::StructuralPartialEq for bitcoin::p2p::UnknownMagicError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::address::AddrV2
+impl core::marker::StructuralPartialEq for bitcoin::p2p::address::AddrV2Message
+impl core::marker::StructuralPartialEq for bitcoin::p2p::address::Address
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message::CommandString
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message::CommandStringError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message::NetworkMessage
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message::RawNetworkMessage
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_bloom::FilterAdd
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_bloom::FilterLoad
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::CFCheckpt
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::CFHeaders
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::CFilter
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_filter::GetCFilters
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_network::Reject
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_network::RejectReason
+impl core::marker::StructuralPartialEq for bitcoin::p2p::message_network::VersionMessage
+impl core::marker::StructuralPartialEq for bitcoin::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin::pow::Target
+impl core::marker::StructuralPartialEq for bitcoin::pow::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin::pow::Work
+impl core::marker::StructuralPartialEq for bitcoin::psbt::ExtractTxError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::GetKeyError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Input
+impl core::marker::StructuralPartialEq for bitcoin::psbt::KeyRequest
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Output
+impl core::marker::StructuralPartialEq for bitcoin::psbt::OutputType
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Psbt
+impl core::marker::StructuralPartialEq for bitcoin::psbt::PsbtSighashType
+impl core::marker::StructuralPartialEq for bitcoin::psbt::SignError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::SigningAlgorithm
+impl core::marker::StructuralPartialEq for bitcoin::psbt::raw::Key
+impl core::marker::StructuralPartialEq for bitcoin::psbt::raw::Pair
+impl core::marker::StructuralPartialEq for bitcoin::sighash::AnnexError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::P2wpkhError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsKindError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::SighashTypeParseError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::TaprootError
+impl core::marker::StructuralPartialEq for bitcoin::sign_message::MessageSignature
+impl core::marker::StructuralPartialEq for bitcoin::sign_message::MessageSignatureError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::ControlBlock
+impl core::marker::StructuralPartialEq for bitcoin::taproot::FutureLeafVersion
+impl core::marker::StructuralPartialEq for bitcoin::taproot::HiddenNodesError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::LeafNode
+impl core::marker::StructuralPartialEq for bitcoin::taproot::LeafVersion
+impl core::marker::StructuralPartialEq for bitcoin::taproot::SigFromSliceError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::Signature
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapBranchTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeaf
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeafHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeafTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapNodeHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTree
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTweakHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTweakTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootBuilder
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootBuilderError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::StructuralPartialEq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Sync for bitcoin::CompressedPublicKey
+impl core::marker::Sync for bitcoin::EcdsaSighashType
+impl core::marker::Sync for bitcoin::LegacySighash
+impl core::marker::Sync for bitcoin::MerkleBlock
+impl core::marker::Sync for bitcoin::PrivateKey
+impl core::marker::Sync for bitcoin::PubkeyHash
+impl core::marker::Sync for bitcoin::PublicKey
+impl core::marker::Sync for bitcoin::SegwitV0Sighash
+impl core::marker::Sync for bitcoin::TapSighash
+impl core::marker::Sync for bitcoin::TapSighashTag
+impl core::marker::Sync for bitcoin::TapSighashType
+impl core::marker::Sync for bitcoin::WPubkeyHash
+impl core::marker::Sync for bitcoin::address::AddressType
+impl core::marker::Sync for bitcoin::address::KnownHrp
+impl core::marker::Sync for bitcoin::address::NetworkChecked
+impl core::marker::Sync for bitcoin::address::NetworkUnchecked
+impl core::marker::Sync for bitcoin::address::error::Error
+impl core::marker::Sync for bitcoin::address::error::ParseError
+impl core::marker::Sync for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Sync for bitcoin::address::error::UnknownHrpError
+impl core::marker::Sync for bitcoin::base58::Error
+impl core::marker::Sync for bitcoin::bip152::BlockTransactions
+impl core::marker::Sync for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Sync for bitcoin::bip152::Error
+impl core::marker::Sync for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Sync for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Sync for bitcoin::bip152::ShortId
+impl core::marker::Sync for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Sync for bitcoin::bip158::BlockFilter
+impl core::marker::Sync for bitcoin::bip158::BlockFilterReader
+impl core::marker::Sync for bitcoin::bip158::Error
+impl core::marker::Sync for bitcoin::bip158::FilterHash
+impl core::marker::Sync for bitcoin::bip158::FilterHeader
+impl core::marker::Sync for bitcoin::bip158::GcsFilterReader
+impl core::marker::Sync for bitcoin::bip32::ChainCode
+impl core::marker::Sync for bitcoin::bip32::ChildNumber
+impl core::marker::Sync for bitcoin::bip32::DerivationPath
+impl core::marker::Sync for bitcoin::bip32::Error
+impl core::marker::Sync for bitcoin::bip32::Fingerprint
+impl core::marker::Sync for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Sync for bitcoin::bip32::Xpriv
+impl core::marker::Sync for bitcoin::bip32::Xpub
+impl core::marker::Sync for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Sync for bitcoin::blockdata::block::Block
+impl core::marker::Sync for bitcoin::blockdata::block::BlockHash
+impl core::marker::Sync for bitcoin::blockdata::block::Header
+impl core::marker::Sync for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Sync for bitcoin::blockdata::block::ValidationError
+impl core::marker::Sync for bitcoin::blockdata::block::Version
+impl core::marker::Sync for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Sync for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Sync for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Sync for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Sync for bitcoin::blockdata::opcodes::Class
+impl core::marker::Sync for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Sync for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Sync for bitcoin::blockdata::script::Builder
+impl core::marker::Sync for bitcoin::blockdata::script::Error
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytes
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Sync for bitcoin::blockdata::script::Script
+impl core::marker::Sync for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Sync for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Sync for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Sync for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Sync for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Sync for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Sync for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Sync for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Sync for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Sync for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Sync for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Sync for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Sync for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Sync for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Sync for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Sync for bitcoin::blockdata::transaction::Txid
+impl core::marker::Sync for bitcoin::blockdata::transaction::Version
+impl core::marker::Sync for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Sync for bitcoin::blockdata::weight::Weight
+impl core::marker::Sync for bitcoin::blockdata::witness::Witness
+impl core::marker::Sync for bitcoin::consensus::encode::CheckedData
+impl core::marker::Sync for bitcoin::consensus::encode::Error
+impl core::marker::Sync for bitcoin::consensus::encode::VarInt
+impl core::marker::Sync for bitcoin::consensus::params::Params
+impl core::marker::Sync for bitcoin::ecdsa::Error
+impl core::marker::Sync for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Sync for bitcoin::ecdsa::Signature
+impl core::marker::Sync for bitcoin::error::ParseIntError
+impl core::marker::Sync for bitcoin::key::Error
+impl core::marker::Sync for bitcoin::key::SortKey
+impl core::marker::Sync for bitcoin::key::TweakedKeypair
+impl core::marker::Sync for bitcoin::key::TweakedPublicKey
+impl core::marker::Sync for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Sync for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Sync for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Sync for bitcoin::network::Network
+impl core::marker::Sync for bitcoin::network::NetworkKind
+impl core::marker::Sync for bitcoin::network::ParseNetworkError
+impl core::marker::Sync for bitcoin::network::UnknownChainHashError
+impl core::marker::Sync for bitcoin::p2p::Magic
+impl core::marker::Sync for bitcoin::p2p::ParseMagicError
+impl core::marker::Sync for bitcoin::p2p::ServiceFlags
+impl core::marker::Sync for bitcoin::p2p::UnknownMagicError
+impl core::marker::Sync for bitcoin::p2p::address::AddrV2
+impl core::marker::Sync for bitcoin::p2p::address::AddrV2Message
+impl core::marker::Sync for bitcoin::p2p::address::Address
+impl core::marker::Sync for bitcoin::p2p::message::CommandString
+impl core::marker::Sync for bitcoin::p2p::message::CommandStringError
+impl core::marker::Sync for bitcoin::p2p::message::NetworkMessage
+impl core::marker::Sync for bitcoin::p2p::message::RawNetworkMessage
+impl core::marker::Sync for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::marker::Sync for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::marker::Sync for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::Sync for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::Sync for bitcoin::p2p::message_bloom::FilterAdd
+impl core::marker::Sync for bitcoin::p2p::message_bloom::FilterLoad
+impl core::marker::Sync for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::marker::Sync for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::marker::Sync for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::marker::Sync for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::Sync for bitcoin::p2p::message_filter::CFCheckpt
+impl core::marker::Sync for bitcoin::p2p::message_filter::CFHeaders
+impl core::marker::Sync for bitcoin::p2p::message_filter::CFilter
+impl core::marker::Sync for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::marker::Sync for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::marker::Sync for bitcoin::p2p::message_filter::GetCFilters
+impl core::marker::Sync for bitcoin::p2p::message_network::Reject
+impl core::marker::Sync for bitcoin::p2p::message_network::RejectReason
+impl core::marker::Sync for bitcoin::p2p::message_network::VersionMessage
+impl core::marker::Sync for bitcoin::pow::CompactTarget
+impl core::marker::Sync for bitcoin::pow::Target
+impl core::marker::Sync for bitcoin::pow::TryFromError
+impl core::marker::Sync for bitcoin::pow::Work
+impl core::marker::Sync for bitcoin::psbt::Error
+impl core::marker::Sync for bitcoin::psbt::ExtractTxError
+impl core::marker::Sync for bitcoin::psbt::GetKeyError
+impl core::marker::Sync for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Sync for bitcoin::psbt::Input
+impl core::marker::Sync for bitcoin::psbt::KeyRequest
+impl core::marker::Sync for bitcoin::psbt::Output
+impl core::marker::Sync for bitcoin::psbt::OutputType
+impl core::marker::Sync for bitcoin::psbt::Psbt
+impl core::marker::Sync for bitcoin::psbt::PsbtSighashType
+impl core::marker::Sync for bitcoin::psbt::SignError
+impl core::marker::Sync for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Sync for bitcoin::psbt::raw::Key
+impl core::marker::Sync for bitcoin::psbt::raw::Pair
+impl core::marker::Sync for bitcoin::sighash::AnnexError
+impl core::marker::Sync for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Sync for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Sync for bitcoin::sighash::P2wpkhError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Sync for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Sync for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Sync for bitcoin::sighash::TaprootError
+impl core::marker::Sync for bitcoin::sign_message::MessageSignature
+impl core::marker::Sync for bitcoin::sign_message::MessageSignatureError
+impl core::marker::Sync for bitcoin::taproot::ControlBlock
+impl core::marker::Sync for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Sync for bitcoin::taproot::HiddenNodesError
+impl core::marker::Sync for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Sync for bitcoin::taproot::LeafNode
+impl core::marker::Sync for bitcoin::taproot::LeafVersion
+impl core::marker::Sync for bitcoin::taproot::NodeInfo
+impl core::marker::Sync for bitcoin::taproot::SigFromSliceError
+impl core::marker::Sync for bitcoin::taproot::Signature
+impl core::marker::Sync for bitcoin::taproot::TapBranchTag
+impl core::marker::Sync for bitcoin::taproot::TapLeaf
+impl core::marker::Sync for bitcoin::taproot::TapLeafHash
+impl core::marker::Sync for bitcoin::taproot::TapLeafTag
+impl core::marker::Sync for bitcoin::taproot::TapNodeHash
+impl core::marker::Sync for bitcoin::taproot::TapTree
+impl core::marker::Sync for bitcoin::taproot::TapTweakHash
+impl core::marker::Sync for bitcoin::taproot::TapTweakTag
+impl core::marker::Sync for bitcoin::taproot::TaprootBuilder
+impl core::marker::Sync for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Sync for bitcoin::taproot::TaprootError
+impl core::marker::Sync for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Sync for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Sync for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Sync for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Sync for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::Unpin for bitcoin::CompressedPublicKey
+impl core::marker::Unpin for bitcoin::EcdsaSighashType
+impl core::marker::Unpin for bitcoin::LegacySighash
+impl core::marker::Unpin for bitcoin::MerkleBlock
+impl core::marker::Unpin for bitcoin::PrivateKey
+impl core::marker::Unpin for bitcoin::PubkeyHash
+impl core::marker::Unpin for bitcoin::PublicKey
+impl core::marker::Unpin for bitcoin::SegwitV0Sighash
+impl core::marker::Unpin for bitcoin::TapSighash
+impl core::marker::Unpin for bitcoin::TapSighashTag
+impl core::marker::Unpin for bitcoin::TapSighashType
+impl core::marker::Unpin for bitcoin::WPubkeyHash
+impl core::marker::Unpin for bitcoin::address::AddressType
+impl core::marker::Unpin for bitcoin::address::KnownHrp
+impl core::marker::Unpin for bitcoin::address::NetworkChecked
+impl core::marker::Unpin for bitcoin::address::NetworkUnchecked
+impl core::marker::Unpin for bitcoin::address::error::Error
+impl core::marker::Unpin for bitcoin::address::error::ParseError
+impl core::marker::Unpin for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Unpin for bitcoin::address::error::UnknownHrpError
+impl core::marker::Unpin for bitcoin::base58::Error
+impl core::marker::Unpin for bitcoin::bip152::BlockTransactions
+impl core::marker::Unpin for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Unpin for bitcoin::bip152::Error
+impl core::marker::Unpin for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Unpin for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Unpin for bitcoin::bip152::ShortId
+impl core::marker::Unpin for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Unpin for bitcoin::bip158::BlockFilter
+impl core::marker::Unpin for bitcoin::bip158::BlockFilterReader
+impl core::marker::Unpin for bitcoin::bip158::Error
+impl core::marker::Unpin for bitcoin::bip158::FilterHash
+impl core::marker::Unpin for bitcoin::bip158::FilterHeader
+impl core::marker::Unpin for bitcoin::bip158::GcsFilterReader
+impl core::marker::Unpin for bitcoin::bip32::ChainCode
+impl core::marker::Unpin for bitcoin::bip32::ChildNumber
+impl core::marker::Unpin for bitcoin::bip32::DerivationPath
+impl core::marker::Unpin for bitcoin::bip32::Error
+impl core::marker::Unpin for bitcoin::bip32::Fingerprint
+impl core::marker::Unpin for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Unpin for bitcoin::bip32::Xpriv
+impl core::marker::Unpin for bitcoin::bip32::Xpub
+impl core::marker::Unpin for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Unpin for bitcoin::blockdata::block::Block
+impl core::marker::Unpin for bitcoin::blockdata::block::BlockHash
+impl core::marker::Unpin for bitcoin::blockdata::block::Header
+impl core::marker::Unpin for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Unpin for bitcoin::blockdata::block::ValidationError
+impl core::marker::Unpin for bitcoin::blockdata::block::Version
+impl core::marker::Unpin for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Unpin for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::Class
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Unpin for bitcoin::blockdata::script::Builder
+impl core::marker::Unpin for bitcoin::blockdata::script::Error
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytes
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Unpin for bitcoin::blockdata::script::Script
+impl core::marker::Unpin for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Unpin for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Unpin for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Unpin for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Unpin for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Unpin for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Unpin for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Unpin for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Txid
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Version
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Unpin for bitcoin::blockdata::weight::Weight
+impl core::marker::Unpin for bitcoin::blockdata::witness::Witness
+impl core::marker::Unpin for bitcoin::consensus::encode::CheckedData
+impl core::marker::Unpin for bitcoin::consensus::encode::Error
+impl core::marker::Unpin for bitcoin::consensus::encode::VarInt
+impl core::marker::Unpin for bitcoin::consensus::params::Params
+impl core::marker::Unpin for bitcoin::ecdsa::Error
+impl core::marker::Unpin for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Unpin for bitcoin::ecdsa::Signature
+impl core::marker::Unpin for bitcoin::error::ParseIntError
+impl core::marker::Unpin for bitcoin::key::Error
+impl core::marker::Unpin for bitcoin::key::SortKey
+impl core::marker::Unpin for bitcoin::key::TweakedKeypair
+impl core::marker::Unpin for bitcoin::key::TweakedPublicKey
+impl core::marker::Unpin for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Unpin for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Unpin for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Unpin for bitcoin::network::Network
+impl core::marker::Unpin for bitcoin::network::NetworkKind
+impl core::marker::Unpin for bitcoin::network::ParseNetworkError
+impl core::marker::Unpin for bitcoin::network::UnknownChainHashError
+impl core::marker::Unpin for bitcoin::p2p::Magic
+impl core::marker::Unpin for bitcoin::p2p::ParseMagicError
+impl core::marker::Unpin for bitcoin::p2p::ServiceFlags
+impl core::marker::Unpin for bitcoin::p2p::UnknownMagicError
+impl core::marker::Unpin for bitcoin::p2p::address::AddrV2
+impl core::marker::Unpin for bitcoin::p2p::address::AddrV2Message
+impl core::marker::Unpin for bitcoin::p2p::address::Address
+impl core::marker::Unpin for bitcoin::p2p::message::CommandString
+impl core::marker::Unpin for bitcoin::p2p::message::CommandStringError
+impl core::marker::Unpin for bitcoin::p2p::message::NetworkMessage
+impl core::marker::Unpin for bitcoin::p2p::message::RawNetworkMessage
+impl core::marker::Unpin for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::marker::Unpin for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::marker::Unpin for bitcoin::p2p::message_blockdata::Inventory
+impl core::marker::Unpin for bitcoin::p2p::message_bloom::BloomFlags
+impl core::marker::Unpin for bitcoin::p2p::message_bloom::FilterAdd
+impl core::marker::Unpin for bitcoin::p2p::message_bloom::FilterLoad
+impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::marker::Unpin for bitcoin::p2p::message_filter::CFCheckpt
+impl core::marker::Unpin for bitcoin::p2p::message_filter::CFHeaders
+impl core::marker::Unpin for bitcoin::p2p::message_filter::CFilter
+impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFilters
+impl core::marker::Unpin for bitcoin::p2p::message_network::Reject
+impl core::marker::Unpin for bitcoin::p2p::message_network::RejectReason
+impl core::marker::Unpin for bitcoin::p2p::message_network::VersionMessage
+impl core::marker::Unpin for bitcoin::pow::CompactTarget
+impl core::marker::Unpin for bitcoin::pow::Target
+impl core::marker::Unpin for bitcoin::pow::TryFromError
+impl core::marker::Unpin for bitcoin::pow::Work
+impl core::marker::Unpin for bitcoin::psbt::Error
+impl core::marker::Unpin for bitcoin::psbt::ExtractTxError
+impl core::marker::Unpin for bitcoin::psbt::GetKeyError
+impl core::marker::Unpin for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Unpin for bitcoin::psbt::Input
+impl core::marker::Unpin for bitcoin::psbt::KeyRequest
+impl core::marker::Unpin for bitcoin::psbt::Output
+impl core::marker::Unpin for bitcoin::psbt::OutputType
+impl core::marker::Unpin for bitcoin::psbt::Psbt
+impl core::marker::Unpin for bitcoin::psbt::PsbtSighashType
+impl core::marker::Unpin for bitcoin::psbt::SignError
+impl core::marker::Unpin for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Unpin for bitcoin::psbt::raw::Key
+impl core::marker::Unpin for bitcoin::psbt::raw::Pair
+impl core::marker::Unpin for bitcoin::sighash::AnnexError
+impl core::marker::Unpin for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Unpin for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Unpin for bitcoin::sighash::P2wpkhError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Unpin for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Unpin for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Unpin for bitcoin::sighash::TaprootError
+impl core::marker::Unpin for bitcoin::sign_message::MessageSignature
+impl core::marker::Unpin for bitcoin::sign_message::MessageSignatureError
+impl core::marker::Unpin for bitcoin::taproot::ControlBlock
+impl core::marker::Unpin for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Unpin for bitcoin::taproot::HiddenNodesError
+impl core::marker::Unpin for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Unpin for bitcoin::taproot::LeafNode
+impl core::marker::Unpin for bitcoin::taproot::LeafVersion
+impl core::marker::Unpin for bitcoin::taproot::NodeInfo
+impl core::marker::Unpin for bitcoin::taproot::SigFromSliceError
+impl core::marker::Unpin for bitcoin::taproot::Signature
+impl core::marker::Unpin for bitcoin::taproot::TapBranchTag
+impl core::marker::Unpin for bitcoin::taproot::TapLeaf
+impl core::marker::Unpin for bitcoin::taproot::TapLeafHash
+impl core::marker::Unpin for bitcoin::taproot::TapLeafTag
+impl core::marker::Unpin for bitcoin::taproot::TapNodeHash
+impl core::marker::Unpin for bitcoin::taproot::TapTree
+impl core::marker::Unpin for bitcoin::taproot::TapTweakHash
+impl core::marker::Unpin for bitcoin::taproot::TapTweakTag
+impl core::marker::Unpin for bitcoin::taproot::TaprootBuilder
+impl core::marker::Unpin for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Unpin for bitcoin::taproot::TaprootError
+impl core::marker::Unpin for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Unpin for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Unpin for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Unpin for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Unpin for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::ops::arith::Add for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Add for bitcoin::pow::Work
+impl core::ops::arith::AddAssign for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Div for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Div<bitcoin::blockdata::weight::Weight> for bitcoin_units::amount::Amount
+impl core::ops::arith::Div<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::DivAssign<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Mul<bitcoin::blockdata::fee_rate::FeeRate> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Mul<bitcoin::blockdata::weight::Weight> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::ops::arith::Mul<bitcoin::blockdata::weight::Weight> for u64
+impl core::ops::arith::Mul<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::MulAssign<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Sub for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Sub for bitcoin::pow::Work
+impl core::ops::arith::SubAssign for bitcoin::blockdata::weight::Weight
+impl core::ops::bit::BitOr for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitOrAssign for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitXor for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitXorAssign for bitcoin::p2p::ServiceFlags
+impl core::ops::deref::Deref for bitcoin::blockdata::script::PushBytesBuf
+impl core::ops::deref::Deref for bitcoin::blockdata::script::ScriptBuf
+impl core::ops::deref::Deref for bitcoin::ecdsa::SerializedSignature
+impl core::ops::deref::Deref for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::ops::deref::Deref for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::ops::deref::DerefMut for bitcoin::blockdata::script::PushBytesBuf
+impl core::ops::deref::DerefMut for bitcoin::blockdata::script::ScriptBuf
+impl core::ops::deref::DerefMut for bitcoin::ecdsa::SerializedSignature
+impl core::ops::deref::DerefMut for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::PrivateKey
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<usize> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<usize> for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::CompressedPublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::EcdsaSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::LegacySighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::MerkleBlock
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PrivateKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PubkeyHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::SegwitV0Sighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighashTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::WPubkeyHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::AddressType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::KnownHrp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::NetworkChecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::NetworkUnchecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::UnknownAddressTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::UnknownHrpError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::base58::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::BlockTransactions
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::BlockTransactionsRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::HeaderAndShortIds
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::PrefilledTransaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::ShortId
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilterReader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::FilterHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::FilterHeader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::GcsFilterReader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::ChainCode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::ChildNumber
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::DerivationPath
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Fingerprint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::XKeyIdentifier
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Xpriv
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Xpub
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Bip34Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Block
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::ValidationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::constants::ChainHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::Class
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::Opcode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Builder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytes
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytesBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Script
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::ScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::WScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_program::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::InputsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Sequence
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Transaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::TxIn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::TxOut
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::weight::Weight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::CheckedData
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::VarInt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::params::Params
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::SerializedSignature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::Signature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::error::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::SortKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::TweakedKeypair
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::TweakedPublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::UncompressedPubkeyError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::merkle_tree::MerkleBlockError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::merkle_tree::PartialMerkleTree
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::Network
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::NetworkKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::ParseNetworkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::UnknownChainHashError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::Magic
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::ParseMagicError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::ServiceFlags
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::UnknownMagicError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::AddrV2
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::AddrV2Message
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::Address
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::CommandString
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::CommandStringError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::NetworkMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::RawNetworkMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::Inventory
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::BloomFlags
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::FilterAdd
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::FilterLoad
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFCheckpt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFHeaders
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFilter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFilters
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::Reject
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::RejectReason
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::VersionMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::Target
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::Work
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::ExtractTxError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::GetKeyError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::IndexOutOfBoundsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Input
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::KeyRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Output
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::OutputType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Psbt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::PsbtSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SignError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SigningAlgorithm
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::Key
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::Pair
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::AnnexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::InvalidSighashTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::NonStandardSighashTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::P2wpkhError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsKindError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsSizeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SighashTypeParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SingleMissingOutputError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::TaprootError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sign_message::MessageSignature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sign_message::MessageSignatureError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ControlBlock
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::FutureLeafVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::HiddenNodesError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::IncompleteBuilderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::NodeInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::SigFromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::Signature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapBranchTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeaf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeafHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeafTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapNodeHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTree
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTweakHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTweakTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootBuilder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootBuilderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootSpendInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::merkle_branch::IntoIter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::serialized_signature::IntoIter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::CompressedPublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::EcdsaSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::LegacySighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::MerkleBlock
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PrivateKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PubkeyHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::SegwitV0Sighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighashTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::WPubkeyHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::AddressType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::KnownHrp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::NetworkChecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::NetworkUnchecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::UnknownAddressTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::UnknownHrpError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::base58::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::BlockTransactions
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::BlockTransactionsRequest
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::HeaderAndShortIds
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::PrefilledTransaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::ShortId
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilterReader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::FilterHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::FilterHeader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::GcsFilterReader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::ChainCode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::ChildNumber
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::DerivationPath
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Fingerprint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::XKeyIdentifier
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Xpriv
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Xpub
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Bip34Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Block
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::ValidationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::constants::ChainHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::fee_rate::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::Class
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::Opcode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Builder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytes
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytesBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytesError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Script
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::ScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::WScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_program::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::InputsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Sequence
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Transaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::TxIn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::TxOut
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::weight::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::CheckedData
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::VarInt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::params::Params
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::SerializedSignature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::Signature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::error::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::SortKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::TweakedKeypair
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::TweakedPublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::UncompressedPubkeyError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::merkle_tree::MerkleBlockError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::merkle_tree::PartialMerkleTree
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::Network
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::NetworkKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::ParseNetworkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::UnknownChainHashError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::Magic
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::ParseMagicError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::ServiceFlags
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::UnknownMagicError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::AddrV2
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::AddrV2Message
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::Address
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::CommandString
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::CommandStringError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::NetworkMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::RawNetworkMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::Inventory
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::BloomFlags
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::FilterAdd
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::FilterLoad
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFCheckpt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFHeaders
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFilter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFCheckpt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFHeaders
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFilters
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::Reject
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::RejectReason
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::VersionMessage
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::Target
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::Work
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::ExtractTxError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::GetKeyError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::IndexOutOfBoundsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Input
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::KeyRequest
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Output
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::OutputType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Psbt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::PsbtSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SignError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SigningAlgorithm
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::Key
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::Pair
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::AnnexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::InvalidSighashTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::NonStandardSighashTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::P2wpkhError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsKindError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsSizeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SighashTypeParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SingleMissingOutputError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::TaprootError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sign_message::MessageSignature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sign_message::MessageSignatureError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ControlBlock
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::FutureLeafVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::HiddenNodesError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::IncompleteBuilderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::NodeInfo
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::SigFromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::Signature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapBranchTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeaf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeafHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeafTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapNodeHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTree
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTweakHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTweakTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootBuilder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootBuilderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootSpendInfo
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::merkle_branch::IntoIter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::serialized_signature::IntoIter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::str::traits::FromStr for bitcoin::CompressedPublicKey
+impl core::str::traits::FromStr for bitcoin::EcdsaSighashType
+impl core::str::traits::FromStr for bitcoin::LegacySighash
+impl core::str::traits::FromStr for bitcoin::PrivateKey
+impl core::str::traits::FromStr for bitcoin::PubkeyHash
+impl core::str::traits::FromStr for bitcoin::PublicKey
+impl core::str::traits::FromStr for bitcoin::SegwitV0Sighash
+impl core::str::traits::FromStr for bitcoin::TapSighash
+impl core::str::traits::FromStr for bitcoin::TapSighashType
+impl core::str::traits::FromStr for bitcoin::WPubkeyHash
+impl core::str::traits::FromStr for bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+impl core::str::traits::FromStr for bitcoin::address::AddressType
+impl core::str::traits::FromStr for bitcoin::bip152::ShortId
+impl core::str::traits::FromStr for bitcoin::bip158::FilterHash
+impl core::str::traits::FromStr for bitcoin::bip158::FilterHeader
+impl core::str::traits::FromStr for bitcoin::bip32::ChainCode
+impl core::str::traits::FromStr for bitcoin::bip32::ChildNumber
+impl core::str::traits::FromStr for bitcoin::bip32::DerivationPath
+impl core::str::traits::FromStr for bitcoin::bip32::Fingerprint
+impl core::str::traits::FromStr for bitcoin::bip32::XKeyIdentifier
+impl core::str::traits::FromStr for bitcoin::bip32::Xpriv
+impl core::str::traits::FromStr for bitcoin::bip32::Xpub
+impl core::str::traits::FromStr for bitcoin::blockdata::block::BlockHash
+impl core::str::traits::FromStr for bitcoin::blockdata::block::TxMerkleNode
+impl core::str::traits::FromStr for bitcoin::blockdata::block::WitnessCommitment
+impl core::str::traits::FromStr for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin::blockdata::constants::ChainHash
+impl core::str::traits::FromStr for bitcoin::blockdata::fee_rate::FeeRate
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::Time
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::relative::Height
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::relative::Time
+impl core::str::traits::FromStr for bitcoin::blockdata::script::ScriptHash
+impl core::str::traits::FromStr for bitcoin::blockdata::script::WScriptHash
+impl core::str::traits::FromStr for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::OutPoint
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Sequence
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Txid
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Wtxid
+impl core::str::traits::FromStr for bitcoin::blockdata::weight::Weight
+impl core::str::traits::FromStr for bitcoin::ecdsa::Signature
+impl core::str::traits::FromStr for bitcoin::network::Network
+impl core::str::traits::FromStr for bitcoin::p2p::Magic
+impl core::str::traits::FromStr for bitcoin::p2p::message::CommandString
+impl core::str::traits::FromStr for bitcoin::psbt::PsbtSighashType
+impl core::str::traits::FromStr for bitcoin::taproot::TapLeafHash
+impl core::str::traits::FromStr for bitcoin::taproot::TapNodeHash
+impl core::str::traits::FromStr for bitcoin::taproot::TapTweakHash
+impl hex_conservative::parse::FromHex for bitcoin::bip152::ShortId
+impl hex_conservative::parse::FromHex for bitcoin::bip32::ChainCode
+impl hex_conservative::parse::FromHex for bitcoin::bip32::Fingerprint
+impl hex_conservative::parse::FromHex for bitcoin::blockdata::constants::ChainHash
+impl secp256k1::ThirtyTwoByteHash for bitcoin::LegacySighash
+impl secp256k1::ThirtyTwoByteHash for bitcoin::SegwitV0Sighash
+impl secp256k1::ThirtyTwoByteHash for bitcoin::TapSighash
+impl std::net::socket_addr::ToSocketAddrs for bitcoin::p2p::address::AddrV2Message
+impl std::net::socket_addr::ToSocketAddrs for bitcoin::p2p::address::Address
+impl<'a, R: bitcoin_io::BufRead + core::marker::Sized> bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, R: core::marker::Sized> core::marker::Send for bitcoin::bip158::BitStreamReader<'a, R> where R: core::marker::Send
+impl<'a, R: core::marker::Sized> core::marker::Sync for bitcoin::bip158::BitStreamReader<'a, R> where R: core::marker::Sync
+impl<'a, R: core::marker::Sized> core::marker::Unpin for bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, R: core::marker::Sized> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BitStreamReader<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for &'a T
+impl<'a, T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for &'a mut T
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> core::marker::Send for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Send for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Send for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Sync for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Sync for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Sync for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a> bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> bitcoin::bip32::IntoDerivationPath for &'a str
+impl<'a> bitcoin::blockdata::script::Instruction<'a>
+impl<'a> bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> bitcoin::blockdata::script::Instructions<'a>
+impl<'a> bitcoin::consensus::encode::Encodable for bitcoin::sighash::Annex<'a>
+impl<'a> bitcoin::sighash::Annex<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::clone::Clone for bitcoin::sighash::Annex<'a>
+impl<'a> core::cmp::Eq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::cmp::Eq for bitcoin::sighash::Annex<'a>
+impl<'a> core::cmp::PartialEq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::cmp::PartialEq for bitcoin::sighash::Annex<'a>
+impl<'a> core::convert::From<&'a [bitcoin::bip32::ChildNumber]> for bitcoin::bip32::DerivationPath
+impl<'a> core::convert::From<&'a [u8; 0]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 0]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 10]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 10]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 11]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 11]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 12]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 12]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 13]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 13]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 14]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 14]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 15]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 15]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 16]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 16]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 17]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 17]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 18]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 18]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 19]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 19]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 1]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 1]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 20]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 20]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 21]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 21]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 22]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 22]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 23]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 23]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 24]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 24]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 25]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 25]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 26]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 26]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 27]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 27]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 28]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 28]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 29]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 29]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 2]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 2]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 30]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 30]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 31]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 31]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 32]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 33]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 33]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 34]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 34]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 35]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 35]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 36]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 36]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 37]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 37]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 38]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 38]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 39]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 39]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 3]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 3]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 40]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 40]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 41]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 41]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 42]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 42]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 43]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 43]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 44]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 44]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 45]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 45]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 46]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 46]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 47]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 47]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 48]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 48]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 49]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 49]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 4]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 4]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::From<&'a [u8; 4]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 50]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 50]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 51]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 51]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 52]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 52]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 53]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 53]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 54]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 54]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 55]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 55]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 56]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 56]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 57]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 57]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 58]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 58]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 59]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 59]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 5]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 5]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 60]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 60]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 61]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 61]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 62]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 62]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 63]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 63]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 64]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 64]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 65]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 65]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 66]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 66]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 67]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 67]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 68]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 68]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 69]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 69]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 6]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 6]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::From<&'a [u8; 6]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 70]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 70]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 71]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 71]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 72]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 72]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 73]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 73]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 7]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 7]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 8]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 8]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 9]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 9]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::rc::Rc<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::sync::Arc<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::convert::From<&'a bitcoin::taproot::Signature> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl<'a> core::convert::From<&'a mut [u8; 0]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 10]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 11]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 12]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 13]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 14]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 15]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 16]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 17]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 18]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 19]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 1]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 20]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 21]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 22]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 23]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 24]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 25]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 26]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 27]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 28]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 29]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 2]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 30]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 31]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 32]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 33]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 34]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 35]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 36]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 37]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 38]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 39]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 3]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 40]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 41]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 42]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 43]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 44]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 45]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 46]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 47]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 48]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 49]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 4]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 50]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 51]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 52]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 53]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 54]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 55]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 56]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 57]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 58]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 59]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 5]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 60]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 61]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 62]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 63]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 64]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 65]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 66]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 67]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 68]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 69]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 6]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 70]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 71]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 72]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 73]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 7]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 8]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 9]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<[u8; 32]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::From<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::From<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::From<[u8; 6]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::convert::TryFrom<&'a [u8]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::TryFrom<&'a bitcoin::taproot::serialized_signature::SerializedSignature> for bitcoin::taproot::Signature
+impl<'a> core::convert::TryFrom<&'a mut [u8]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::TryFrom<&'a str> for bitcoin::p2p::message::CommandString
+impl<'a> core::convert::TryFrom<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::fmt::Debug for bitcoin::sighash::Annex<'a>
+impl<'a> core::hash::Hash for bitcoin::sighash::Annex<'a>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin::blockdata::weight::Weight> for bitcoin::blockdata::weight::Weight
+impl<'a> core::iter::traits::collect::Extend<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::iter::traits::collect::FromIterator<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::bip32::DerivationPath
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::blockdata::witness::Witness
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::ecdsa::SerializedSignature
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::taproot::serialized_signature::SerializedSignature
+impl<'a> core::iter::traits::collect::IntoIterator for &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl<'a> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Copy for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Send for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Send for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Send for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::marker::StructuralPartialEq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::StructuralPartialEq for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Sync for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Sync for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Sync for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::marker::Unpin for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Unpin for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Unpin for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::Annex<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::Annex<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafNodes<'a>
+impl<'leaf> bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::clone::Clone for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::Eq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::Ord for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::PartialEq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::PartialOrd for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::fmt::Debug for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::hash::Hash for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Send for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::StructuralPartialEq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Sync for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Unpin for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'s> bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::clone::Clone for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::Eq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::Ord for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::PartialEq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::PartialOrd for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::convert::From<bitcoin::sighash::ScriptPath<'s>> for bitcoin::taproot::TapLeafHash
+impl<'s> core::fmt::Debug for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::hash::Hash for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Send for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::StructuralPartialEq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Sync for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Unpin for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::ScriptPath<'s>
+impl<'tree> core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::iterator::Iterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::marker::FusedIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::marker::FusedIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Send for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Sync for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Unpin for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'u, T> core::clone::Clone for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::clone::Clone
+impl<'u, T> core::cmp::Eq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::Eq
+impl<'u, T> core::cmp::Ord for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::Ord
+impl<'u, T> core::cmp::PartialEq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::PartialEq
+impl<'u, T> core::cmp::PartialOrd for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::PartialOrd
+impl<'u, T> core::fmt::Debug for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::fmt::Debug
+impl<'u, T> core::hash::Hash for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::hash::Hash
+impl<'u, T> core::marker::Send for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Sync + core::marker::Send
+impl<'u, T> core::marker::StructuralPartialEq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>
+impl<'u, T> core::marker::Sync for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Sync
+impl<'u, T> core::marker::Unpin for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Unpin
+impl<'u, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::Prevouts<'u, T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<'u, T> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::Prevouts<'u, T> where T: core::panic::unwind_safe::UnwindSafe + core::panic::unwind_safe::RefUnwindSafe
+impl<E: core::clone::Clone> core::clone::Clone for bitcoin::string::FromHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for bitcoin::string::FromHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin::string::FromHexError<E>
+impl<E: core::error::Error + 'static> core::error::Error for bitcoin::sighash::SigningDataError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for bitcoin::sighash::SigningDataError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for bitcoin::string::FromHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for bitcoin::sighash::SigningDataError<E>
+impl<E: core::fmt::Display> core::fmt::Display for bitcoin::string::FromHexError<E>
+impl<E> !core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SigningDataError<E>
+impl<E> !core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SigningDataError<E>
+impl<E> bitcoin::sighash::EncodeSigningDataResult<E>
+impl<E> core::convert::From<E> for bitcoin::string::FromHexError<E>
+impl<E> core::convert::From<bitcoin_io::error::Error> for bitcoin::sighash::SigningDataError<E>
+impl<E> core::error::Error for bitcoin::string::FromHexError<E> where E: core::error::Error + 'static
+impl<E> core::marker::Send for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Send
+impl<E> core::marker::Send for bitcoin::sighash::SigningDataError<E> where E: core::marker::Send
+impl<E> core::marker::Send for bitcoin::string::FromHexError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for bitcoin::string::FromHexError<E>
+impl<E> core::marker::Sync for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for bitcoin::sighash::SigningDataError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for bitcoin::string::FromHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for bitcoin::sighash::SigningDataError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for bitcoin::string::FromHexError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::string::FromHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::string::FromHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::LegacySighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::PubkeyHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::SegwitV0Sighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::TapSighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::WPubkeyHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip158::FilterHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip158::FilterHeader
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip32::XKeyIdentifier
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::BlockHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::TxMerkleNode
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::WitnessCommitment
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::WitnessMerkleNode
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::script::ScriptHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::script::WScriptHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::transaction::Txid
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::transaction::Wtxid
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapLeafHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapNodeHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapTweakHash
+impl<I> core::ops::index::Index<I> for bitcoin::bip152::ShortId where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::ChainCode where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::DerivationPath where alloc::vec::Vec<bitcoin::bip32::ChildNumber>: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::Fingerprint where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::blockdata::constants::ChainHash where [u8]: core::ops::index::Index<I>
+impl<R: bitcoin_io::Read + core::marker::Sized> bitcoin::consensus::encode::ReadExt for R
+impl<R: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>> bitcoin::sighash::SighashCache<R>
+impl<R: core::borrow::BorrowMut<bitcoin::blockdata::transaction::Transaction>> bitcoin::sighash::SighashCache<R>
+impl<Subtype> bitcoin::consensus::encode::Decodable for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> bitcoin::consensus::encode::Encodable for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::clone::Clone for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::clone::Clone
+impl<Subtype> core::cmp::Eq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::Eq
+impl<Subtype> core::cmp::Ord for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::Ord
+impl<Subtype> core::cmp::PartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::PartialEq
+impl<Subtype> core::cmp::PartialOrd for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::PartialOrd
+impl<Subtype> core::convert::TryFrom<bitcoin::psbt::raw::Key> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::fmt::Debug for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::fmt::Debug
+impl<Subtype> core::hash::Hash for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::hash::Hash
+impl<Subtype> core::marker::Send for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Send
+impl<Subtype> core::marker::StructuralPartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::marker::Sync for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Sync
+impl<Subtype> core::marker::Unpin for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Unpin
+impl<Subtype> core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::panic::unwind_safe::RefUnwindSafe
+impl<Subtype> core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::panic::unwind_safe::UnwindSafe
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable, T6: bitcoin::consensus::encode::Decodable, T7: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5, T6, T7)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable, T6: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5, T6)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable, T6: bitcoin::consensus::encode::Encodable, T7: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5, T6, T7)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable, T6: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5, T6)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1)
+impl<T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for alloc::rc::Rc<T>
+impl<T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for alloc::sync::Arc<T>
+impl<T: core::fmt::Debug + core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>> core::fmt::Debug for bitcoin::sighash::SighashCache<T>
+impl<T> bitcoin::bip32::IntoDerivationPath for T where T: core::convert::Into<bitcoin::bip32::DerivationPath>
+impl<T> core::marker::Send for bitcoin::sighash::SighashCache<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin::sighash::SighashCache<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin::sighash::SighashCache<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SighashCache<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SighashCache<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<V: bitcoin::address::NetworkValidation> bitcoin::address::Address<V>
+impl<V: bitcoin::address::NetworkValidation> core::fmt::Debug for bitcoin::address::Address<V>
+impl<V> core::clone::Clone for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::clone::Clone
+impl<V> core::cmp::Eq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::Eq
+impl<V> core::cmp::Ord for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::Ord
+impl<V> core::cmp::PartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialEq
+impl<V> core::cmp::PartialOrd for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialOrd
+impl<V> core::hash::Hash for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::hash::Hash
+impl<V> core::marker::Send for bitcoin::address::Address<V>
+impl<V> core::marker::StructuralPartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation
+impl<V> core::marker::Sync for bitcoin::address::Address<V>
+impl<V> core::marker::Unpin for bitcoin::address::Address<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::Address<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for bitcoin::address::Address<V> where V: core::panic::unwind_safe::UnwindSafe
+impl<W: bitcoin_io::Write + core::marker::Sized> bitcoin::consensus::encode::WriteExt for W
+pub bitcoin::AddressType::P2pkh
+pub bitcoin::AddressType::P2sh
+pub bitcoin::AddressType::P2tr
+pub bitcoin::AddressType::P2wpkh
+pub bitcoin::AddressType::P2wsh
+pub bitcoin::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::EcdsaSighashType::All = 1
+pub bitcoin::EcdsaSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::EcdsaSighashType::None = 2
+pub bitcoin::EcdsaSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::EcdsaSighashType::Single = 3
+pub bitcoin::EcdsaSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::KnownHrp::Mainnet
+pub bitcoin::KnownHrp::Regtest
+pub bitcoin::KnownHrp::Testnets
+pub bitcoin::MerkleBlock::header: bitcoin::blockdata::block::Header
+pub bitcoin::MerkleBlock::txn: bitcoin::merkle_tree::PartialMerkleTree
+pub bitcoin::Network::Bitcoin
+pub bitcoin::Network::Regtest
+pub bitcoin::Network::Signet
+pub bitcoin::Network::Testnet
+pub bitcoin::NetworkKind::Main
+pub bitcoin::NetworkKind::Test
+pub bitcoin::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::OutPoint::vout: u32
+pub bitcoin::PrivateKey::compressed: bool
+pub bitcoin::PrivateKey::inner: secp256k1::key::SecretKey
+pub bitcoin::PrivateKey::network: bitcoin::network::NetworkKind
+pub bitcoin::Psbt::inputs: alloc::vec::Vec<bitcoin::psbt::Input>
+pub bitcoin::Psbt::outputs: alloc::vec::Vec<bitcoin::psbt::Output>
+pub bitcoin::Psbt::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::Psbt::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::Psbt::unsigned_tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::Psbt::version: u32
+pub bitcoin::Psbt::xpub: alloc::collections::btree::map::BTreeMap<bitcoin::bip32::Xpub, bitcoin::bip32::KeySource>
+pub bitcoin::PublicKey::compressed: bool
+pub bitcoin::PublicKey::inner: secp256k1::key::PublicKey
+pub bitcoin::TapSighashType::All = 1
+pub bitcoin::TapSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::TapSighashType::Default = 0
+pub bitcoin::TapSighashType::None = 2
+pub bitcoin::TapSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::TapSighashType::Single = 3
+pub bitcoin::TapSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::WitnessVersion::V0 = 0
+pub bitcoin::WitnessVersion::V1 = 1
+pub bitcoin::WitnessVersion::V10 = 10
+pub bitcoin::WitnessVersion::V11 = 11
+pub bitcoin::WitnessVersion::V12 = 12
+pub bitcoin::WitnessVersion::V13 = 13
+pub bitcoin::WitnessVersion::V14 = 14
+pub bitcoin::WitnessVersion::V15 = 15
+pub bitcoin::WitnessVersion::V16 = 16
+pub bitcoin::WitnessVersion::V2 = 2
+pub bitcoin::WitnessVersion::V3 = 3
+pub bitcoin::WitnessVersion::V4 = 4
+pub bitcoin::WitnessVersion::V5 = 5
+pub bitcoin::WitnessVersion::V6 = 6
+pub bitcoin::WitnessVersion::V7 = 7
+pub bitcoin::WitnessVersion::V8 = 8
+pub bitcoin::WitnessVersion::V9 = 9
+pub bitcoin::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::absolute::OperationError::InvalidComparison
+pub bitcoin::address::AddressType::P2pkh
+pub bitcoin::address::AddressType::P2sh
+pub bitcoin::address::AddressType::P2tr
+pub bitcoin::address::AddressType::P2wpkh
+pub bitcoin::address::AddressType::P2wsh
+pub bitcoin::address::Error::ExcessiveScriptSize
+pub bitcoin::address::Error::NetworkValidation
+pub bitcoin::address::Error::NetworkValidation::address: bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub bitcoin::address::Error::NetworkValidation::required: bitcoin::network::Network
+pub bitcoin::address::Error::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::Error::UnrecognizedScript
+pub bitcoin::address::Error::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::Error::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::KnownHrp::Mainnet
+pub bitcoin::address::KnownHrp::Regtest
+pub bitcoin::address::KnownHrp::Testnets
+pub bitcoin::address::ParseError::Base58(bitcoin::base58::Error)
+pub bitcoin::address::ParseError::Bech32(bech32::segwit::DecodeError)
+pub bitcoin::address::ParseError::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::ParseError::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::ParseError::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::error::Error::ExcessiveScriptSize
+pub bitcoin::address::error::Error::NetworkValidation
+pub bitcoin::address::error::Error::NetworkValidation::address: bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub bitcoin::address::error::Error::NetworkValidation::required: bitcoin::network::Network
+pub bitcoin::address::error::Error::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::error::Error::UnrecognizedScript
+pub bitcoin::address::error::Error::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::error::Error::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::error::ParseError::Base58(bitcoin::base58::Error)
+pub bitcoin::address::error::ParseError::Bech32(bech32::segwit::DecodeError)
+pub bitcoin::address::error::ParseError::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::error::ParseError::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::error::ParseError::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::base58::Error::BadByte(u8)
+pub bitcoin::base58::Error::BadChecksum(u32, u32)
+pub bitcoin::base58::Error::InvalidAddressVersion(u8)
+pub bitcoin::base58::Error::InvalidExtendedKeyVersion([u8; 4])
+pub bitcoin::base58::Error::InvalidLength(usize)
+pub bitcoin::base58::Error::TooShort(usize)
+pub bitcoin::bip152::BlockTransactions::block_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::bip152::BlockTransactions::transactions: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::bip152::BlockTransactionsRequest::block_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::bip152::BlockTransactionsRequest::indexes: alloc::vec::Vec<u64>
+pub bitcoin::bip152::Error::InvalidPrefill
+pub bitcoin::bip152::Error::UnknownVersion
+pub bitcoin::bip152::HeaderAndShortIds::header: bitcoin::blockdata::block::Header
+pub bitcoin::bip152::HeaderAndShortIds::nonce: u64
+pub bitcoin::bip152::HeaderAndShortIds::prefilled_txs: alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+pub bitcoin::bip152::HeaderAndShortIds::short_ids: alloc::vec::Vec<bitcoin::bip152::ShortId>
+pub bitcoin::bip152::PrefilledTransaction::idx: u16
+pub bitcoin::bip152::PrefilledTransaction::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::bip158::BlockFilter::content: alloc::vec::Vec<u8>
+pub bitcoin::bip158::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::bip158::Error::UtxoMissing(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::bip32::ChildNumber::Hardened
+pub bitcoin::bip32::ChildNumber::Hardened::index: u32
+pub bitcoin::bip32::ChildNumber::Normal
+pub bitcoin::bip32::ChildNumber::Normal::index: u32
+pub bitcoin::bip32::Error::Base58(bitcoin::base58::Error)
+pub bitcoin::bip32::Error::CannotDeriveFromHardenedKey
+pub bitcoin::bip32::Error::Hex(hex_conservative::parse::HexToArrayError)
+pub bitcoin::bip32::Error::InvalidChildNumber(u32)
+pub bitcoin::bip32::Error::InvalidChildNumberFormat
+pub bitcoin::bip32::Error::InvalidDerivationPathFormat
+pub bitcoin::bip32::Error::InvalidPublicKeyHexLength(usize)
+pub bitcoin::bip32::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::bip32::Error::UnknownVersion([u8; 4])
+pub bitcoin::bip32::Error::WrongExtendedKeyLength(usize)
+pub bitcoin::bip32::Xpriv::chain_code: bitcoin::bip32::ChainCode
+pub bitcoin::bip32::Xpriv::child_number: bitcoin::bip32::ChildNumber
+pub bitcoin::bip32::Xpriv::depth: u8
+pub bitcoin::bip32::Xpriv::network: bitcoin::network::NetworkKind
+pub bitcoin::bip32::Xpriv::parent_fingerprint: bitcoin::bip32::Fingerprint
+pub bitcoin::bip32::Xpriv::private_key: secp256k1::key::SecretKey
+pub bitcoin::bip32::Xpub::chain_code: bitcoin::bip32::ChainCode
+pub bitcoin::bip32::Xpub::child_number: bitcoin::bip32::ChildNumber
+pub bitcoin::bip32::Xpub::depth: u8
+pub bitcoin::bip32::Xpub::network: bitcoin::network::NetworkKind
+pub bitcoin::bip32::Xpub::parent_fingerprint: bitcoin::bip32::Fingerprint
+pub bitcoin::bip32::Xpub::public_key: secp256k1::key::PublicKey
+pub bitcoin::block::Bip34Error::NegativeHeight
+pub bitcoin::block::Bip34Error::NotPresent
+pub bitcoin::block::Bip34Error::UnexpectedPush(alloc::vec::Vec<u8>)
+pub bitcoin::block::Bip34Error::Unsupported
+pub bitcoin::block::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::block::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::block::Header::bits: bitcoin::pow::CompactTarget
+pub bitcoin::block::Header::merkle_root: bitcoin::blockdata::block::TxMerkleNode
+pub bitcoin::block::Header::nonce: u32
+pub bitcoin::block::Header::prev_blockhash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::block::Header::time: u32
+pub bitcoin::block::Header::version: bitcoin::blockdata::block::Version
+pub bitcoin::block::ValidationError::BadProofOfWork
+pub bitcoin::block::ValidationError::BadTarget
+pub bitcoin::blockdata::block::Bip34Error::NegativeHeight
+pub bitcoin::blockdata::block::Bip34Error::NotPresent
+pub bitcoin::blockdata::block::Bip34Error::UnexpectedPush(alloc::vec::Vec<u8>)
+pub bitcoin::blockdata::block::Bip34Error::Unsupported
+pub bitcoin::blockdata::block::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::blockdata::block::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::blockdata::block::Header::bits: bitcoin::pow::CompactTarget
+pub bitcoin::blockdata::block::Header::merkle_root: bitcoin::blockdata::block::TxMerkleNode
+pub bitcoin::blockdata::block::Header::nonce: u32
+pub bitcoin::blockdata::block::Header::prev_blockhash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::blockdata::block::Header::time: u32
+pub bitcoin::blockdata::block::Header::version: bitcoin::blockdata::block::Version
+pub bitcoin::blockdata::block::ValidationError::BadProofOfWork
+pub bitcoin::blockdata::block::ValidationError::BadTarget
+pub bitcoin::blockdata::locktime::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::blockdata::locktime::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::blockdata::locktime::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::locktime::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::blockdata::locktime::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::blockdata::locktime::absolute::OperationError::InvalidComparison
+pub bitcoin::blockdata::locktime::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::blockdata::locktime::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::blockdata::locktime::relative::Error::IntegerOverflow(u32)
+pub bitcoin::blockdata::locktime::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::blockdata::locktime::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::blockdata::opcodes::Class::IllegalOp
+pub bitcoin::blockdata::opcodes::Class::NoOp
+pub bitcoin::blockdata::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin::blockdata::opcodes::Class::PushBytes(u32)
+pub bitcoin::blockdata::opcodes::Class::PushNum(i32)
+pub bitcoin::blockdata::opcodes::Class::ReturnOp
+pub bitcoin::blockdata::opcodes::Class::SuccessOp
+pub bitcoin::blockdata::opcodes::ClassifyContext::Legacy
+pub bitcoin::blockdata::opcodes::ClassifyContext::TapScript
+pub bitcoin::blockdata::script::Error::EarlyEndOfScript
+pub bitcoin::blockdata::script::Error::NonMinimalPush
+pub bitcoin::blockdata::script::Error::NumericOverflow
+pub bitcoin::blockdata::script::Error::Serialization
+pub bitcoin::blockdata::script::Error::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::blockdata::script::Instruction::Op(bitcoin::blockdata::opcodes::Opcode)
+pub bitcoin::blockdata::script::Instruction::PushBytes(&'a bitcoin::blockdata::script::PushBytes)
+pub bitcoin::blockdata::script::witness_program::Error::InvalidLength(usize)
+pub bitcoin::blockdata::script::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::blockdata::script::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::blockdata::script::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::script::witness_version::TryFromError::invalid: u8
+pub bitcoin::blockdata::script::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::blockdata::script::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V9 = 9
+pub bitcoin::blockdata::transaction::IndexOutOfBoundsError::index: usize
+pub bitcoin::blockdata::transaction::IndexOutOfBoundsError::length: usize
+pub bitcoin::blockdata::transaction::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::blockdata::transaction::OutPoint::vout: u32
+pub bitcoin::blockdata::transaction::ParseOutPointError::Format
+pub bitcoin::blockdata::transaction::ParseOutPointError::TooLong
+pub bitcoin::blockdata::transaction::ParseOutPointError::Txid(hex_conservative::parse::HexToArrayError)
+pub bitcoin::blockdata::transaction::ParseOutPointError::Vout(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin::blockdata::transaction::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::blockdata::transaction::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::blockdata::transaction::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::blockdata::transaction::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::blockdata::transaction::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::blockdata::transaction::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::blockdata::transaction::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::blockdata::transaction::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::blockdata::transaction::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::blockdata::transaction::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::consensus::Params::allow_min_difficulty_blocks: bool
+pub bitcoin::consensus::Params::bip16_time: u32
+pub bitcoin::consensus::Params::bip34_height: u32
+pub bitcoin::consensus::Params::bip65_height: u32
+pub bitcoin::consensus::Params::bip66_height: u32
+pub bitcoin::consensus::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::Params::network: bitcoin::network::Network
+pub bitcoin::consensus::Params::no_pow_retargeting: bool
+pub bitcoin::consensus::Params::pow_limit: bitcoin::pow::Target
+pub bitcoin::consensus::Params::pow_target_spacing: u64
+pub bitcoin::consensus::Params::pow_target_timespan: u64
+pub bitcoin::consensus::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::encode::Error::InvalidChecksum
+pub bitcoin::consensus::encode::Error::InvalidChecksum::actual: [u8; 4]
+pub bitcoin::consensus::encode::Error::InvalidChecksum::expected: [u8; 4]
+pub bitcoin::consensus::encode::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::consensus::encode::Error::NonMinimalVarInt
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation::max: usize
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation::requested: usize
+pub bitcoin::consensus::encode::Error::ParseFailed(&'static str)
+pub bitcoin::consensus::encode::Error::UnsupportedSegwitFlag(u8)
+pub bitcoin::consensus::params::Params::allow_min_difficulty_blocks: bool
+pub bitcoin::consensus::params::Params::bip16_time: u32
+pub bitcoin::consensus::params::Params::bip34_height: u32
+pub bitcoin::consensus::params::Params::bip65_height: u32
+pub bitcoin::consensus::params::Params::bip66_height: u32
+pub bitcoin::consensus::params::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::params::Params::network: bitcoin::network::Network
+pub bitcoin::consensus::params::Params::no_pow_retargeting: bool
+pub bitcoin::consensus::params::Params::pow_limit: bitcoin::pow::Target
+pub bitcoin::consensus::params::Params::pow_target_spacing: u64
+pub bitcoin::consensus::params::Params::pow_target_timespan: u64
+pub bitcoin::consensus::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::ecdsa::Error::EmptySignature
+pub bitcoin::ecdsa::Error::Hex(hex_conservative::parse::HexToBytesError)
+pub bitcoin::ecdsa::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::ecdsa::Error::SighashType(bitcoin::sighash::NonStandardSighashTypeError)
+pub bitcoin::ecdsa::Signature::sighash_type: bitcoin::EcdsaSighashType
+pub bitcoin::ecdsa::Signature::signature: secp256k1::ecdsa::Signature
+pub bitcoin::key::Error::Base58(bitcoin::base58::Error)
+pub bitcoin::key::Error::Hex(hex_conservative::parse::HexToArrayError)
+pub bitcoin::key::Error::InvalidHexLength(usize)
+pub bitcoin::key::Error::InvalidKeyPrefix(u8)
+pub bitcoin::key::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::key::PrivateKey::compressed: bool
+pub bitcoin::key::PrivateKey::inner: secp256k1::key::SecretKey
+pub bitcoin::key::PrivateKey::network: bitcoin::network::NetworkKind
+pub bitcoin::key::PublicKey::compressed: bool
+pub bitcoin::key::PublicKey::inner: secp256k1::key::PublicKey
+pub bitcoin::locktime::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::locktime::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::locktime::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::locktime::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::locktime::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::locktime::absolute::OperationError::InvalidComparison
+pub bitcoin::locktime::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::locktime::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::locktime::relative::Error::IntegerOverflow(u32)
+pub bitcoin::locktime::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::locktime::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::merkle_tree::MerkleBlock::header: bitcoin::blockdata::block::Header
+pub bitcoin::merkle_tree::MerkleBlock::txn: bitcoin::merkle_tree::PartialMerkleTree
+pub bitcoin::merkle_tree::MerkleBlockError::BitsArrayOverflow
+pub bitcoin::merkle_tree::MerkleBlockError::HashesArrayOverflow
+pub bitcoin::merkle_tree::MerkleBlockError::IdenticalHashesFound
+pub bitcoin::merkle_tree::MerkleBlockError::MerkleRootMismatch
+pub bitcoin::merkle_tree::MerkleBlockError::NoTransactions
+pub bitcoin::merkle_tree::MerkleBlockError::NotAllBitsConsumed
+pub bitcoin::merkle_tree::MerkleBlockError::NotAllHashesConsumed
+pub bitcoin::merkle_tree::MerkleBlockError::NotEnoughBits
+pub bitcoin::merkle_tree::MerkleBlockError::TooManyHashes
+pub bitcoin::merkle_tree::MerkleBlockError::TooManyTransactions
+pub bitcoin::network::Network::Bitcoin
+pub bitcoin::network::Network::Regtest
+pub bitcoin::network::Network::Signet
+pub bitcoin::network::Network::Testnet
+pub bitcoin::network::NetworkKind::Main
+pub bitcoin::network::NetworkKind::Test
+pub bitcoin::opcodes::Class::IllegalOp
+pub bitcoin::opcodes::Class::NoOp
+pub bitcoin::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin::opcodes::Class::PushBytes(u32)
+pub bitcoin::opcodes::Class::PushNum(i32)
+pub bitcoin::opcodes::Class::ReturnOp
+pub bitcoin::opcodes::Class::SuccessOp
+pub bitcoin::opcodes::ClassifyContext::Legacy
+pub bitcoin::opcodes::ClassifyContext::TapScript
+pub bitcoin::p2p::Address::address: [u16; 8]
+pub bitcoin::p2p::Address::port: u16
+pub bitcoin::p2p::Address::services: bitcoin::p2p::ServiceFlags
+pub bitcoin::p2p::address::AddrV2::Cjdns(core::net::ip_addr::Ipv6Addr)
+pub bitcoin::p2p::address::AddrV2::I2p([u8; 32])
+pub bitcoin::p2p::address::AddrV2::Ipv4(core::net::ip_addr::Ipv4Addr)
+pub bitcoin::p2p::address::AddrV2::Ipv6(core::net::ip_addr::Ipv6Addr)
+pub bitcoin::p2p::address::AddrV2::TorV2([u8; 10])
+pub bitcoin::p2p::address::AddrV2::TorV3([u8; 32])
+pub bitcoin::p2p::address::AddrV2::Unknown(u8, alloc::vec::Vec<u8>)
+pub bitcoin::p2p::address::AddrV2Message::addr: bitcoin::p2p::address::AddrV2
+pub bitcoin::p2p::address::AddrV2Message::port: u16
+pub bitcoin::p2p::address::AddrV2Message::services: bitcoin::p2p::ServiceFlags
+pub bitcoin::p2p::address::AddrV2Message::time: u32
+pub bitcoin::p2p::address::Address::address: [u16; 8]
+pub bitcoin::p2p::address::Address::port: u16
+pub bitcoin::p2p::address::Address::services: bitcoin::p2p::ServiceFlags
+pub bitcoin::p2p::message::NetworkMessage::Addr(alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>)
+pub bitcoin::p2p::message::NetworkMessage::AddrV2(alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>)
+pub bitcoin::p2p::message::NetworkMessage::Alert(alloc::vec::Vec<u8>)
+pub bitcoin::p2p::message::NetworkMessage::Block(bitcoin::blockdata::block::Block)
+pub bitcoin::p2p::message::NetworkMessage::BlockTxn(bitcoin::p2p::message_compact_blocks::BlockTxn)
+pub bitcoin::p2p::message::NetworkMessage::CFCheckpt(bitcoin::p2p::message_filter::CFCheckpt)
+pub bitcoin::p2p::message::NetworkMessage::CFHeaders(bitcoin::p2p::message_filter::CFHeaders)
+pub bitcoin::p2p::message::NetworkMessage::CFilter(bitcoin::p2p::message_filter::CFilter)
+pub bitcoin::p2p::message::NetworkMessage::CmpctBlock(bitcoin::p2p::message_compact_blocks::CmpctBlock)
+pub bitcoin::p2p::message::NetworkMessage::FeeFilter(i64)
+pub bitcoin::p2p::message::NetworkMessage::FilterAdd(bitcoin::p2p::message_bloom::FilterAdd)
+pub bitcoin::p2p::message::NetworkMessage::FilterClear
+pub bitcoin::p2p::message::NetworkMessage::FilterLoad(bitcoin::p2p::message_bloom::FilterLoad)
+pub bitcoin::p2p::message::NetworkMessage::GetAddr
+pub bitcoin::p2p::message::NetworkMessage::GetBlockTxn(bitcoin::p2p::message_compact_blocks::GetBlockTxn)
+pub bitcoin::p2p::message::NetworkMessage::GetBlocks(bitcoin::p2p::message_blockdata::GetBlocksMessage)
+pub bitcoin::p2p::message::NetworkMessage::GetCFCheckpt(bitcoin::p2p::message_filter::GetCFCheckpt)
+pub bitcoin::p2p::message::NetworkMessage::GetCFHeaders(bitcoin::p2p::message_filter::GetCFHeaders)
+pub bitcoin::p2p::message::NetworkMessage::GetCFilters(bitcoin::p2p::message_filter::GetCFilters)
+pub bitcoin::p2p::message::NetworkMessage::GetData(alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>)
+pub bitcoin::p2p::message::NetworkMessage::GetHeaders(bitcoin::p2p::message_blockdata::GetHeadersMessage)
+pub bitcoin::p2p::message::NetworkMessage::Headers(alloc::vec::Vec<bitcoin::blockdata::block::Header>)
+pub bitcoin::p2p::message::NetworkMessage::Inv(alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>)
+pub bitcoin::p2p::message::NetworkMessage::MemPool
+pub bitcoin::p2p::message::NetworkMessage::MerkleBlock(bitcoin::MerkleBlock)
+pub bitcoin::p2p::message::NetworkMessage::NotFound(alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>)
+pub bitcoin::p2p::message::NetworkMessage::Ping(u64)
+pub bitcoin::p2p::message::NetworkMessage::Pong(u64)
+pub bitcoin::p2p::message::NetworkMessage::Reject(bitcoin::p2p::message_network::Reject)
+pub bitcoin::p2p::message::NetworkMessage::SendAddrV2
+pub bitcoin::p2p::message::NetworkMessage::SendCmpct(bitcoin::p2p::message_compact_blocks::SendCmpct)
+pub bitcoin::p2p::message::NetworkMessage::SendHeaders
+pub bitcoin::p2p::message::NetworkMessage::Tx(bitcoin::blockdata::transaction::Transaction)
+pub bitcoin::p2p::message::NetworkMessage::Unknown
+pub bitcoin::p2p::message::NetworkMessage::Unknown::command: bitcoin::p2p::message::CommandString
+pub bitcoin::p2p::message::NetworkMessage::Unknown::payload: alloc::vec::Vec<u8>
+pub bitcoin::p2p::message::NetworkMessage::Verack
+pub bitcoin::p2p::message::NetworkMessage::Version(bitcoin::p2p::message_network::VersionMessage)
+pub bitcoin::p2p::message::NetworkMessage::WtxidRelay
+pub bitcoin::p2p::message_blockdata::GetBlocksMessage::locator_hashes: alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+pub bitcoin::p2p::message_blockdata::GetBlocksMessage::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_blockdata::GetBlocksMessage::version: u32
+pub bitcoin::p2p::message_blockdata::GetHeadersMessage::locator_hashes: alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+pub bitcoin::p2p::message_blockdata::GetHeadersMessage::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_blockdata::GetHeadersMessage::version: u32
+pub bitcoin::p2p::message_blockdata::Inventory::Block(bitcoin::blockdata::block::BlockHash)
+pub bitcoin::p2p::message_blockdata::Inventory::CompactBlock(bitcoin::blockdata::block::BlockHash)
+pub bitcoin::p2p::message_blockdata::Inventory::Error
+pub bitcoin::p2p::message_blockdata::Inventory::Transaction(bitcoin::blockdata::transaction::Txid)
+pub bitcoin::p2p::message_blockdata::Inventory::Unknown
+pub bitcoin::p2p::message_blockdata::Inventory::Unknown::hash: [u8; 32]
+pub bitcoin::p2p::message_blockdata::Inventory::Unknown::inv_type: u32
+pub bitcoin::p2p::message_blockdata::Inventory::WTx(bitcoin::blockdata::transaction::Wtxid)
+pub bitcoin::p2p::message_blockdata::Inventory::WitnessBlock(bitcoin::blockdata::block::BlockHash)
+pub bitcoin::p2p::message_blockdata::Inventory::WitnessTransaction(bitcoin::blockdata::transaction::Txid)
+pub bitcoin::p2p::message_bloom::BloomFlags::All
+pub bitcoin::p2p::message_bloom::BloomFlags::None
+pub bitcoin::p2p::message_bloom::BloomFlags::PubkeyOnly
+pub bitcoin::p2p::message_bloom::FilterAdd::data: alloc::vec::Vec<u8>
+pub bitcoin::p2p::message_bloom::FilterLoad::filter: alloc::vec::Vec<u8>
+pub bitcoin::p2p::message_bloom::FilterLoad::flags: bitcoin::p2p::message_bloom::BloomFlags
+pub bitcoin::p2p::message_bloom::FilterLoad::hash_funcs: u32
+pub bitcoin::p2p::message_bloom::FilterLoad::tweak: u32
+pub bitcoin::p2p::message_compact_blocks::BlockTxn::transactions: bitcoin::bip152::BlockTransactions
+pub bitcoin::p2p::message_compact_blocks::CmpctBlock::compact_block: bitcoin::bip152::HeaderAndShortIds
+pub bitcoin::p2p::message_compact_blocks::GetBlockTxn::txs_request: bitcoin::bip152::BlockTransactionsRequest
+pub bitcoin::p2p::message_compact_blocks::SendCmpct::send_compact: bool
+pub bitcoin::p2p::message_compact_blocks::SendCmpct::version: u64
+pub bitcoin::p2p::message_filter::CFCheckpt::filter_headers: alloc::vec::Vec<bitcoin::bip158::FilterHeader>
+pub bitcoin::p2p::message_filter::CFCheckpt::filter_type: u8
+pub bitcoin::p2p::message_filter::CFCheckpt::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::CFHeaders::filter_hashes: alloc::vec::Vec<bitcoin::bip158::FilterHash>
+pub bitcoin::p2p::message_filter::CFHeaders::filter_type: u8
+pub bitcoin::p2p::message_filter::CFHeaders::previous_filter_header: bitcoin::bip158::FilterHeader
+pub bitcoin::p2p::message_filter::CFHeaders::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::CFilter::block_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::CFilter::filter: alloc::vec::Vec<u8>
+pub bitcoin::p2p::message_filter::CFilter::filter_type: u8
+pub bitcoin::p2p::message_filter::GetCFCheckpt::filter_type: u8
+pub bitcoin::p2p::message_filter::GetCFCheckpt::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::GetCFHeaders::filter_type: u8
+pub bitcoin::p2p::message_filter::GetCFHeaders::start_height: u32
+pub bitcoin::p2p::message_filter::GetCFHeaders::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_filter::GetCFilters::filter_type: u8
+pub bitcoin::p2p::message_filter::GetCFilters::start_height: u32
+pub bitcoin::p2p::message_filter::GetCFilters::stop_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::p2p::message_network::Reject::ccode: bitcoin::p2p::message_network::RejectReason
+pub bitcoin::p2p::message_network::Reject::hash: bitcoin_hashes::sha256d::Hash
+pub bitcoin::p2p::message_network::Reject::message: alloc::borrow::Cow<'static, str>
+pub bitcoin::p2p::message_network::Reject::reason: alloc::borrow::Cow<'static, str>
+pub bitcoin::p2p::message_network::RejectReason::Checkpoint = 67
+pub bitcoin::p2p::message_network::RejectReason::Duplicate = 18
+pub bitcoin::p2p::message_network::RejectReason::Dust = 65
+pub bitcoin::p2p::message_network::RejectReason::Fee = 66
+pub bitcoin::p2p::message_network::RejectReason::Invalid = 16
+pub bitcoin::p2p::message_network::RejectReason::Malformed = 1
+pub bitcoin::p2p::message_network::RejectReason::NonStandard = 64
+pub bitcoin::p2p::message_network::RejectReason::Obsolete = 17
+pub bitcoin::p2p::message_network::VersionMessage::nonce: u64
+pub bitcoin::p2p::message_network::VersionMessage::receiver: bitcoin::p2p::address::Address
+pub bitcoin::p2p::message_network::VersionMessage::relay: bool
+pub bitcoin::p2p::message_network::VersionMessage::sender: bitcoin::p2p::address::Address
+pub bitcoin::p2p::message_network::VersionMessage::services: bitcoin::p2p::ServiceFlags
+pub bitcoin::p2p::message_network::VersionMessage::start_height: i32
+pub bitcoin::p2p::message_network::VersionMessage::timestamp: i64
+pub bitcoin::p2p::message_network::VersionMessage::user_agent: alloc::string::String
+pub bitcoin::p2p::message_network::VersionMessage::version: u32
+pub bitcoin::psbt::Error::CombineInconsistentKeySources(alloc::boxed::Box<bitcoin::bip32::Xpub>)
+pub bitcoin::psbt::Error::ConsensusEncoding(bitcoin::consensus::encode::Error)
+pub bitcoin::psbt::Error::DuplicateKey(bitcoin::psbt::raw::Key)
+pub bitcoin::psbt::Error::FeeOverflow
+pub bitcoin::psbt::Error::InvalidControlBlock
+pub bitcoin::psbt::Error::InvalidEcdsaSignature(bitcoin::ecdsa::Error)
+pub bitcoin::psbt::Error::InvalidHash(bitcoin_hashes::FromSliceError)
+pub bitcoin::psbt::Error::InvalidKey(bitcoin::psbt::raw::Key)
+pub bitcoin::psbt::Error::InvalidLeafVersion
+pub bitcoin::psbt::Error::InvalidMagic
+pub bitcoin::psbt::Error::InvalidPreimageHashPair
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::hash: alloc::boxed::Box<[u8]>
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::hash_type: PsbtHash
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::preimage: alloc::boxed::Box<[u8]>
+pub bitcoin::psbt::Error::InvalidProprietaryKey
+pub bitcoin::psbt::Error::InvalidPublicKey(bitcoin::key::Error)
+pub bitcoin::psbt::Error::InvalidSecp256k1PublicKey(secp256k1::Error)
+pub bitcoin::psbt::Error::InvalidSeparator
+pub bitcoin::psbt::Error::InvalidTaprootSignature(bitcoin::taproot::SigFromSliceError)
+pub bitcoin::psbt::Error::InvalidXOnlyPublicKey
+pub bitcoin::psbt::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::psbt::Error::MissingUtxo
+pub bitcoin::psbt::Error::MustHaveUnsignedTx
+pub bitcoin::psbt::Error::NegativeFee
+pub bitcoin::psbt::Error::NoMorePairs
+pub bitcoin::psbt::Error::NonStandardSighashType(u32)
+pub bitcoin::psbt::Error::PartialDataConsumption
+pub bitcoin::psbt::Error::PsbtUtxoOutOfbounds
+pub bitcoin::psbt::Error::TapTree(bitcoin::taproot::IncompleteBuilderError)
+pub bitcoin::psbt::Error::Taproot(&'static str)
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx::actual: alloc::boxed::Box<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx::expected: alloc::boxed::Box<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Error::UnsignedTxHasScriptSigs
+pub bitcoin::psbt::Error::UnsignedTxHasScriptWitnesses
+pub bitcoin::psbt::Error::Version(&'static str)
+pub bitcoin::psbt::Error::XPubKey(&'static str)
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate::fee_rate: bitcoin::blockdata::fee_rate::FeeRate
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::ExtractTxError::MissingInputValue
+pub bitcoin::psbt::ExtractTxError::MissingInputValue::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::ExtractTxError::SendingTooMuch
+pub bitcoin::psbt::ExtractTxError::SendingTooMuch::psbt: bitcoin::psbt::Psbt
+pub bitcoin::psbt::GetKeyError::Bip32(bitcoin::bip32::Error)
+pub bitcoin::psbt::GetKeyError::NotSupported
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs::index: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs::length: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput::index: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput::length: usize
+pub bitcoin::psbt::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
+pub bitcoin::psbt::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::hash256_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::sha256d::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::non_witness_utxo: core::option::Option<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Input::partial_sigs: alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::ecdsa::Signature>
+pub bitcoin::psbt::Input::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::redeem_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::ripemd160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::ripemd160::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::sha256_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::sha256::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::sighash_type: core::option::Option<bitcoin::psbt::PsbtSighashType>
+pub bitcoin::psbt::Input::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
+pub bitcoin::psbt::Input::tap_key_origins: alloc::collections::btree::map::BTreeMap<secp256k1::key::XOnlyPublicKey, (alloc::vec::Vec<bitcoin::taproot::TapLeafHash>, bitcoin::bip32::KeySource)>
+pub bitcoin::psbt::Input::tap_key_sig: core::option::Option<bitcoin::taproot::Signature>
+pub bitcoin::psbt::Input::tap_merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>
+pub bitcoin::psbt::Input::tap_script_sigs: alloc::collections::btree::map::BTreeMap<(secp256k1::key::XOnlyPublicKey, bitcoin::taproot::TapLeafHash), bitcoin::taproot::Signature>
+pub bitcoin::psbt::Input::tap_scripts: alloc::collections::btree::map::BTreeMap<bitcoin::taproot::ControlBlock, (bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)>
+pub bitcoin::psbt::Input::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::witness_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::witness_utxo: core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::psbt::KeyRequest::Bip32(bitcoin::bip32::KeySource)
+pub bitcoin::psbt::KeyRequest::Pubkey(bitcoin::PublicKey)
+pub bitcoin::psbt::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::Output::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Output::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
+pub bitcoin::psbt::Output::tap_key_origins: alloc::collections::btree::map::BTreeMap<secp256k1::key::XOnlyPublicKey, (alloc::vec::Vec<bitcoin::taproot::TapLeafHash>, bitcoin::bip32::KeySource)>
+pub bitcoin::psbt::Output::tap_tree: core::option::Option<bitcoin::taproot::TapTree>
+pub bitcoin::psbt::Output::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Output::witness_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::OutputType::Bare
+pub bitcoin::psbt::OutputType::Sh
+pub bitcoin::psbt::OutputType::ShWpkh
+pub bitcoin::psbt::OutputType::ShWsh
+pub bitcoin::psbt::OutputType::Tr
+pub bitcoin::psbt::OutputType::Wpkh
+pub bitcoin::psbt::OutputType::Wsh
+pub bitcoin::psbt::Psbt::inputs: alloc::vec::Vec<bitcoin::psbt::Input>
+pub bitcoin::psbt::Psbt::outputs: alloc::vec::Vec<bitcoin::psbt::Output>
+pub bitcoin::psbt::Psbt::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Psbt::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Psbt::unsigned_tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::Psbt::version: u32
+pub bitcoin::psbt::Psbt::xpub: alloc::collections::btree::map::BTreeMap<bitcoin::bip32::Xpub, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::SignError::IndexOutOfBounds(bitcoin::psbt::IndexOutOfBoundsError)
+pub bitcoin::psbt::SignError::InvalidSighashType
+pub bitcoin::psbt::SignError::KeyNotFound
+pub bitcoin::psbt::SignError::MismatchedAlgoKey
+pub bitcoin::psbt::SignError::MissingInputUtxo
+pub bitcoin::psbt::SignError::MissingRedeemScript
+pub bitcoin::psbt::SignError::MissingSpendUtxo
+pub bitcoin::psbt::SignError::MissingWitnessScript
+pub bitcoin::psbt::SignError::NotEcdsa
+pub bitcoin::psbt::SignError::NotWpkh
+pub bitcoin::psbt::SignError::P2wpkhSighash(bitcoin::sighash::P2wpkhError)
+pub bitcoin::psbt::SignError::SegwitV0Sighash(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::psbt::SignError::UnknownOutputType
+pub bitcoin::psbt::SignError::Unsupported
+pub bitcoin::psbt::SignError::WrongSigningAlgorithm
+pub bitcoin::psbt::SigningAlgorithm::Ecdsa
+pub bitcoin::psbt::SigningAlgorithm::Schnorr
+pub bitcoin::psbt::raw::Key::key: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::Key::type_value: u8
+pub bitcoin::psbt::raw::Pair::key: bitcoin::psbt::raw::Key
+pub bitcoin::psbt::raw::Pair::value: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::key: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::prefix: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::subtype: Subtype
+pub bitcoin::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::relative::Error::IntegerOverflow(u32)
+pub bitcoin::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::script::Error::EarlyEndOfScript
+pub bitcoin::script::Error::NonMinimalPush
+pub bitcoin::script::Error::NumericOverflow
+pub bitcoin::script::Error::Serialization
+pub bitcoin::script::Error::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::script::Instruction::Op(bitcoin::blockdata::opcodes::Opcode)
+pub bitcoin::script::Instruction::PushBytes(&'a bitcoin::blockdata::script::PushBytes)
+pub bitcoin::script::witness_program::Error::InvalidLength(usize)
+pub bitcoin::script::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::script::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::script::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::script::witness_version::TryFromError::invalid: u8
+pub bitcoin::script::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::script::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::script::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::script::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::script::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::script::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::script::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::script::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::script::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::script::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::script::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::script::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::script::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::script::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::script::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::script::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::script::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::script::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::script::witness_version::WitnessVersion::V9 = 9
+pub bitcoin::sighash::AnnexError::Empty
+pub bitcoin::sighash::AnnexError::IncorrectPrefix(u8)
+pub bitcoin::sighash::EcdsaSighashType::All = 1
+pub bitcoin::sighash::EcdsaSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::sighash::EcdsaSighashType::None = 2
+pub bitcoin::sighash::EcdsaSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::sighash::EcdsaSighashType::Single = 3
+pub bitcoin::sighash::EcdsaSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::sighash::EncodeSigningDataResult::SighashSingleBug
+pub bitcoin::sighash::EncodeSigningDataResult::WriteResult(core::result::Result<(), E>)
+pub bitcoin::sighash::P2wpkhError::NotP2wpkhScript
+pub bitcoin::sighash::P2wpkhError::Sighash(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::sighash::Prevouts::All(&'u [T])
+pub bitcoin::sighash::Prevouts::One(usize, T)
+pub bitcoin::sighash::PrevoutsIndexError::InvalidAllIndex
+pub bitcoin::sighash::PrevoutsIndexError::InvalidOneIndex
+pub bitcoin::sighash::SighashTypeParseError::unrecognized: alloc::string::String
+pub bitcoin::sighash::SigningDataError::Io(bitcoin_io::error::Error)
+pub bitcoin::sighash::SigningDataError::Sighash(E)
+pub bitcoin::sighash::SingleMissingOutputError::input_index: usize
+pub bitcoin::sighash::SingleMissingOutputError::outputs_length: usize
+pub bitcoin::sighash::TapSighashType::All = 1
+pub bitcoin::sighash::TapSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::sighash::TapSighashType::Default = 0
+pub bitcoin::sighash::TapSighashType::None = 2
+pub bitcoin::sighash::TapSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::sighash::TapSighashType::Single = 3
+pub bitcoin::sighash::TapSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::sighash::TaprootError::InputsIndex(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::sighash::TaprootError::InvalidSighashType(u32)
+pub bitcoin::sighash::TaprootError::PrevoutsIndex(bitcoin::sighash::PrevoutsIndexError)
+pub bitcoin::sighash::TaprootError::PrevoutsKind(bitcoin::sighash::PrevoutsKindError)
+pub bitcoin::sighash::TaprootError::PrevoutsSize(bitcoin::sighash::PrevoutsSizeError)
+pub bitcoin::sighash::TaprootError::SingleMissingOutput(bitcoin::sighash::SingleMissingOutputError)
+pub bitcoin::sign_message::MessageSignature::compressed: bool
+pub bitcoin::sign_message::MessageSignature::signature: secp256k1::ecdsa::recovery::RecoverableSignature
+pub bitcoin::sign_message::MessageSignatureError::InvalidBase64
+pub bitcoin::sign_message::MessageSignatureError::InvalidEncoding(secp256k1::Error)
+pub bitcoin::sign_message::MessageSignatureError::InvalidLength
+pub bitcoin::sign_message::MessageSignatureError::UnsupportedAddressType(bitcoin::address::AddressType)
+pub bitcoin::string::FromHexError::MissingPrefix(alloc::string::String)
+pub bitcoin::string::FromHexError::ParseHex(E)
+pub bitcoin::taproot::ControlBlock::internal_key: bitcoin::key::UntweakedPublicKey
+pub bitcoin::taproot::ControlBlock::leaf_version: bitcoin::taproot::LeafVersion
+pub bitcoin::taproot::ControlBlock::merkle_branch: bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub bitcoin::taproot::ControlBlock::output_key_parity: secp256k1::key::Parity
+pub bitcoin::taproot::HiddenNodesError::HiddenParts(bitcoin::taproot::NodeInfo)
+pub bitcoin::taproot::IncompleteBuilderError::HiddenParts(bitcoin::taproot::TaprootBuilder)
+pub bitcoin::taproot::IncompleteBuilderError::NotFinalized(bitcoin::taproot::TaprootBuilder)
+pub bitcoin::taproot::LeafVersion::Future(bitcoin::taproot::FutureLeafVersion)
+pub bitcoin::taproot::LeafVersion::TapScript
+pub bitcoin::taproot::SigFromSliceError::InvalidSignatureSize(usize)
+pub bitcoin::taproot::SigFromSliceError::Secp256k1(secp256k1::Error)
+pub bitcoin::taproot::SigFromSliceError::SighashType(bitcoin::sighash::InvalidSighashTypeError)
+pub bitcoin::taproot::Signature::sighash_type: bitcoin::TapSighashType
+pub bitcoin::taproot::Signature::signature: secp256k1::schnorr::Signature
+pub bitcoin::taproot::TapLeaf::Hidden(bitcoin::taproot::TapNodeHash)
+pub bitcoin::taproot::TapLeaf::Script(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)
+pub bitcoin::taproot::TaprootBuilderError::EmptyTree
+pub bitcoin::taproot::TaprootBuilderError::InvalidInternalKey(secp256k1::Error)
+pub bitcoin::taproot::TaprootBuilderError::InvalidMerkleTreeDepth(usize)
+pub bitcoin::taproot::TaprootBuilderError::NodeNotInDfsOrder
+pub bitcoin::taproot::TaprootBuilderError::OverCompleteTree
+pub bitcoin::taproot::TaprootError::EmptyTree
+pub bitcoin::taproot::TaprootError::InvalidControlBlockSize(usize)
+pub bitcoin::taproot::TaprootError::InvalidInternalKey(secp256k1::Error)
+pub bitcoin::taproot::TaprootError::InvalidMerkleBranchSize(usize)
+pub bitcoin::taproot::TaprootError::InvalidMerkleTreeDepth(usize)
+pub bitcoin::taproot::TaprootError::InvalidTaprootLeafVersion(u8)
+pub bitcoin::transaction::IndexOutOfBoundsError::index: usize
+pub bitcoin::transaction::IndexOutOfBoundsError::length: usize
+pub bitcoin::transaction::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::transaction::OutPoint::vout: u32
+pub bitcoin::transaction::ParseOutPointError::Format
+pub bitcoin::transaction::ParseOutPointError::TooLong
+pub bitcoin::transaction::ParseOutPointError::Txid(hex_conservative::parse::HexToArrayError)
+pub bitcoin::transaction::ParseOutPointError::Vout(bitcoin::error::ParseIntError)
+pub bitcoin::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin::transaction::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::transaction::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::transaction::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::transaction::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::transaction::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::transaction::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::transaction::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::transaction::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::transaction::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::transaction::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::witness_program::Error::InvalidLength(usize)
+pub bitcoin::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::witness_version::TryFromError::invalid: u8
+pub bitcoin::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::witness_version::WitnessVersion::V9 = 9
+pub const bitcoin::LegacySighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::LegacySighash::LEN: usize
+pub const bitcoin::PubkeyHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::PubkeyHash::LEN: usize
+pub const bitcoin::SegwitV0Sighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::SegwitV0Sighash::LEN: usize
+pub const bitcoin::TapSighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::TapSighash::LEN: usize
+pub const bitcoin::WPubkeyHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::WPubkeyHash::LEN: usize
+pub const bitcoin::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::address::NetworkChecked::IS_CHECKED: bool
+pub const bitcoin::address::NetworkUnchecked::IS_CHECKED: bool
+pub const bitcoin::address::NetworkValidation::IS_CHECKED: bool
+pub const bitcoin::bip158::FilterHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip158::FilterHash::LEN: usize
+pub const bitcoin::bip158::FilterHeader::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip158::FilterHeader::LEN: usize
+pub const bitcoin::bip32::XKeyIdentifier::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip32::XKeyIdentifier::LEN: usize
+pub const bitcoin::blockdata::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::BlockHash::LEN: usize
+pub const bitcoin::blockdata::block::Header::SIZE: usize
+pub const bitcoin::blockdata::block::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::TxMerkleNode::LEN: usize
+pub const bitcoin::blockdata::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin::blockdata::block::Version::ONE: Self
+pub const bitcoin::blockdata::block::Version::TWO: Self
+pub const bitcoin::blockdata::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::WitnessCommitment::LEN: usize
+pub const bitcoin::blockdata::block::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::WitnessMerkleNode::LEN: usize
+pub const bitcoin::blockdata::constants::COINBASE_MATURITY: u32 = 100u32
+pub const bitcoin::blockdata::constants::ChainHash::BITCOIN: Self
+pub const bitcoin::blockdata::constants::ChainHash::REGTEST: Self
+pub const bitcoin::blockdata::constants::ChainHash::SIGNET: Self
+pub const bitcoin::blockdata::constants::ChainHash::TESTNET: Self
+pub const bitcoin::blockdata::constants::DIFFCHANGE_INTERVAL: u32 = 2_016u32
+pub const bitcoin::blockdata::constants::DIFFCHANGE_TIMESPAN: _
+pub const bitcoin::blockdata::constants::MAX_BLOCK_SIGOPS_COST: i64 = 80_000i64
+pub const bitcoin::blockdata::constants::MAX_SCRIPTNUM_VALUE: u32 = 2_147_483_648u32
+pub const bitcoin::blockdata::constants::MAX_SCRIPT_ELEMENT_SIZE: usize = 520usize
+pub const bitcoin::blockdata::constants::PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0u8
+pub const bitcoin::blockdata::constants::PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111u8
+pub const bitcoin::blockdata::constants::SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5u8
+pub const bitcoin::blockdata::constants::SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196u8
+pub const bitcoin::blockdata::constants::SUBSIDY_HALVING_INTERVAL: u32 = 210_000u32
+pub const bitcoin::blockdata::constants::TARGET_BLOCK_SPACING: u32 = 600u32
+pub const bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR: usize = 4usize
+pub const bitcoin::blockdata::fee_rate::FeeRate::BROADCAST_MIN: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::DUST: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::MAX: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::MIN: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::ZERO: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::locktime::absolute::Height::MAX: Self
+pub const bitcoin::blockdata::locktime::absolute::Height::MIN: Self
+pub const bitcoin::blockdata::locktime::absolute::Height::ZERO: Self
+pub const bitcoin::blockdata::locktime::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::blockdata::locktime::absolute::LockTime::SIZE: usize
+pub const bitcoin::blockdata::locktime::absolute::LockTime::ZERO: bitcoin::blockdata::locktime::absolute::LockTime
+pub const bitcoin::blockdata::locktime::absolute::Time::MAX: Self
+pub const bitcoin::blockdata::locktime::absolute::Time::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Height::MAX: Self
+pub const bitcoin::blockdata::locktime::relative::Height::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Height::ZERO: Self
+pub const bitcoin::blockdata::locktime::relative::Time::MAX: Self
+pub const bitcoin::blockdata::locktime::relative::Time::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Time::ZERO: Self
+pub const bitcoin::blockdata::opcodes::all::OP_0NOTEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_1ADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_1SUB: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DIV: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DROP: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_2MUL: _
+pub const bitcoin::blockdata::opcodes::all::OP_2OVER: _
+pub const bitcoin::blockdata::opcodes::all::OP_2ROT: _
+pub const bitcoin::blockdata::opcodes::all::OP_2SWAP: _
+pub const bitcoin::blockdata::opcodes::all::OP_3DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_ABS: _
+pub const bitcoin::blockdata::opcodes::all::OP_ADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_AND: _
+pub const bitcoin::blockdata::opcodes::all::OP_BOOLAND: _
+pub const bitcoin::blockdata::opcodes::all::OP_BOOLOR: _
+pub const bitcoin::blockdata::opcodes::all::OP_CAT: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKMULTISIG: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKMULTISIGVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIG: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIGADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIGVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_CLTV: _
+pub const bitcoin::blockdata::opcodes::all::OP_CODESEPARATOR: _
+pub const bitcoin::blockdata::opcodes::all::OP_CSV: _
+pub const bitcoin::blockdata::opcodes::all::OP_DEPTH: _
+pub const bitcoin::blockdata::opcodes::all::OP_DIV: _
+pub const bitcoin::blockdata::opcodes::all::OP_DROP: _
+pub const bitcoin::blockdata::opcodes::all::OP_DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_ELSE: _
+pub const bitcoin::blockdata::opcodes::all::OP_ENDIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_EQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_EQUALVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_FROMALTSTACK: _
+pub const bitcoin::blockdata::opcodes::all::OP_GREATERTHAN: _
+pub const bitcoin::blockdata::opcodes::all::OP_GREATERTHANOREQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_HASH160: _
+pub const bitcoin::blockdata::opcodes::all::OP_HASH256: _
+pub const bitcoin::blockdata::opcodes::all::OP_IF: _
+pub const bitcoin::blockdata::opcodes::all::OP_IFDUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_INVALIDOPCODE: _
+pub const bitcoin::blockdata::opcodes::all::OP_INVERT: _
+pub const bitcoin::blockdata::opcodes::all::OP_LEFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_LESSTHAN: _
+pub const bitcoin::blockdata::opcodes::all::OP_LESSTHANOREQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_LSHIFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_MAX: _
+pub const bitcoin::blockdata::opcodes::all::OP_MIN: _
+pub const bitcoin::blockdata::opcodes::all::OP_MOD: _
+pub const bitcoin::blockdata::opcodes::all::OP_MUL: _
+pub const bitcoin::blockdata::opcodes::all::OP_NEGATE: _
+pub const bitcoin::blockdata::opcodes::all::OP_NIP: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP10: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP1: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP4: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP5: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP6: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP7: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP8: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP9: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOT: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOTIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMEQUALVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMNOTEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_OR: _
+pub const bitcoin::blockdata::opcodes::all::OP_OVER: _
+pub const bitcoin::blockdata::opcodes::all::OP_PICK: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_0: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_10: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_11: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_12: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_13: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_14: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_15: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_16: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_17: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_18: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_19: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_20: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_21: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_22: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_23: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_24: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_25: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_26: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_27: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_28: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_29: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_30: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_31: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_32: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_33: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_34: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_35: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_36: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_37: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_38: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_39: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_3: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_40: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_41: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_42: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_43: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_44: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_45: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_46: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_47: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_48: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_49: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_50: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_51: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_52: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_53: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_54: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_55: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_56: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_57: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_58: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_59: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_5: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_60: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_61: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_62: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_63: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_64: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_65: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_66: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_67: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_68: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_69: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_6: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_70: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_71: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_72: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_73: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_74: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_75: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_7: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_8: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_9: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_10: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_11: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_12: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_13: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_14: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_15: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_16: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_3: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_5: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_6: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_7: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_8: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_9: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_NEG1: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED1: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED2: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_187: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_188: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_189: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_190: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_191: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_192: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_193: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_194: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_195: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_196: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_197: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_198: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_199: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_200: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_201: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_202: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_203: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_204: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_205: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_206: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_207: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_208: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_209: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_210: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_211: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_212: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_213: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_214: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_215: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_216: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_217: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_218: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_219: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_220: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_221: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_222: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_223: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_224: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_225: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_226: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_227: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_228: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_229: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_230: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_231: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_232: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_233: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_234: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_235: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_236: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_237: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_238: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_239: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_240: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_241: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_242: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_243: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_244: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_245: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_246: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_247: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_248: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_249: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_250: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_251: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_252: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_253: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_254: _
+pub const bitcoin::blockdata::opcodes::all::OP_RIGHT: _
+pub const bitcoin::blockdata::opcodes::all::OP_RIPEMD160: _
+pub const bitcoin::blockdata::opcodes::all::OP_ROLL: _
+pub const bitcoin::blockdata::opcodes::all::OP_ROT: _
+pub const bitcoin::blockdata::opcodes::all::OP_RSHIFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_SHA1: _
+pub const bitcoin::blockdata::opcodes::all::OP_SHA256: _
+pub const bitcoin::blockdata::opcodes::all::OP_SIZE: _
+pub const bitcoin::blockdata::opcodes::all::OP_SUB: _
+pub const bitcoin::blockdata::opcodes::all::OP_SUBSTR: _
+pub const bitcoin::blockdata::opcodes::all::OP_SWAP: _
+pub const bitcoin::blockdata::opcodes::all::OP_TOALTSTACK: _
+pub const bitcoin::blockdata::opcodes::all::OP_TUCK: _
+pub const bitcoin::blockdata::opcodes::all::OP_VER: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERNOTIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_WITHIN: _
+pub const bitcoin::blockdata::opcodes::all::OP_XOR: _
+pub const bitcoin::blockdata::script::ScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::script::ScriptHash::LEN: usize
+pub const bitcoin::blockdata::script::WScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::script::WScriptHash::LEN: usize
+pub const bitcoin::blockdata::script::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::blockdata::script::witness_program::MIN_SIZE: usize = 2usize
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2PKH_COMPRESSED_MAX: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2PKH_UNCOMPRESSED_MAX: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2TR_KEY_DEFAULT_SIGHASH: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2TR_KEY_NON_DEFAULT_SIGHASH: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2WPKH_MAX: Self
+pub const bitcoin::blockdata::transaction::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
+pub const bitcoin::blockdata::transaction::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
+pub const bitcoin::blockdata::transaction::Sequence::MAX: Self
+pub const bitcoin::blockdata::transaction::Sequence::ZERO: Self
+pub const bitcoin::blockdata::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::transaction::TxOut::NULL: Self
+pub const bitcoin::blockdata::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::transaction::Txid::LEN: usize
+pub const bitcoin::blockdata::transaction::Version::ONE: Self
+pub const bitcoin::blockdata::transaction::Version::TWO: Self
+pub const bitcoin::blockdata::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::transaction::Wtxid::LEN: usize
+pub const bitcoin::blockdata::weight::Weight::MAX: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MAX_BLOCK: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MIN: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MIN_TRANSACTION: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin::blockdata::weight::Weight::ZERO: bitcoin::blockdata::weight::Weight
+pub const bitcoin::consensus::encode::MAX_VEC_SIZE: usize = 4_000_000usize
+pub const bitcoin::constants::COINBASE_MATURITY: u32 = 100u32
+pub const bitcoin::constants::DIFFCHANGE_INTERVAL: u32 = 2_016u32
+pub const bitcoin::constants::DIFFCHANGE_TIMESPAN: _
+pub const bitcoin::constants::MAX_BLOCK_SIGOPS_COST: i64 = 80_000i64
+pub const bitcoin::constants::MAX_SCRIPTNUM_VALUE: u32 = 2_147_483_648u32
+pub const bitcoin::constants::MAX_SCRIPT_ELEMENT_SIZE: usize = 520usize
+pub const bitcoin::constants::PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0u8
+pub const bitcoin::constants::PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111u8
+pub const bitcoin::constants::SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5u8
+pub const bitcoin::constants::SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196u8
+pub const bitcoin::constants::SUBSIDY_HALVING_INTERVAL: u32 = 210_000u32
+pub const bitcoin::constants::TARGET_BLOCK_SPACING: u32 = 600u32
+pub const bitcoin::constants::WITNESS_SCALE_FACTOR: usize = 4usize
+pub const bitcoin::locktime::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::opcodes::all::OP_0NOTEQUAL: _
+pub const bitcoin::opcodes::all::OP_1ADD: _
+pub const bitcoin::opcodes::all::OP_1SUB: _
+pub const bitcoin::opcodes::all::OP_2DIV: _
+pub const bitcoin::opcodes::all::OP_2DROP: _
+pub const bitcoin::opcodes::all::OP_2DUP: _
+pub const bitcoin::opcodes::all::OP_2MUL: _
+pub const bitcoin::opcodes::all::OP_2OVER: _
+pub const bitcoin::opcodes::all::OP_2ROT: _
+pub const bitcoin::opcodes::all::OP_2SWAP: _
+pub const bitcoin::opcodes::all::OP_3DUP: _
+pub const bitcoin::opcodes::all::OP_ABS: _
+pub const bitcoin::opcodes::all::OP_ADD: _
+pub const bitcoin::opcodes::all::OP_AND: _
+pub const bitcoin::opcodes::all::OP_BOOLAND: _
+pub const bitcoin::opcodes::all::OP_BOOLOR: _
+pub const bitcoin::opcodes::all::OP_CAT: _
+pub const bitcoin::opcodes::all::OP_CHECKMULTISIG: _
+pub const bitcoin::opcodes::all::OP_CHECKMULTISIGVERIFY: _
+pub const bitcoin::opcodes::all::OP_CHECKSIG: _
+pub const bitcoin::opcodes::all::OP_CHECKSIGADD: _
+pub const bitcoin::opcodes::all::OP_CHECKSIGVERIFY: _
+pub const bitcoin::opcodes::all::OP_CLTV: _
+pub const bitcoin::opcodes::all::OP_CODESEPARATOR: _
+pub const bitcoin::opcodes::all::OP_CSV: _
+pub const bitcoin::opcodes::all::OP_DEPTH: _
+pub const bitcoin::opcodes::all::OP_DIV: _
+pub const bitcoin::opcodes::all::OP_DROP: _
+pub const bitcoin::opcodes::all::OP_DUP: _
+pub const bitcoin::opcodes::all::OP_ELSE: _
+pub const bitcoin::opcodes::all::OP_ENDIF: _
+pub const bitcoin::opcodes::all::OP_EQUAL: _
+pub const bitcoin::opcodes::all::OP_EQUALVERIFY: _
+pub const bitcoin::opcodes::all::OP_FROMALTSTACK: _
+pub const bitcoin::opcodes::all::OP_GREATERTHAN: _
+pub const bitcoin::opcodes::all::OP_GREATERTHANOREQUAL: _
+pub const bitcoin::opcodes::all::OP_HASH160: _
+pub const bitcoin::opcodes::all::OP_HASH256: _
+pub const bitcoin::opcodes::all::OP_IF: _
+pub const bitcoin::opcodes::all::OP_IFDUP: _
+pub const bitcoin::opcodes::all::OP_INVALIDOPCODE: _
+pub const bitcoin::opcodes::all::OP_INVERT: _
+pub const bitcoin::opcodes::all::OP_LEFT: _
+pub const bitcoin::opcodes::all::OP_LESSTHAN: _
+pub const bitcoin::opcodes::all::OP_LESSTHANOREQUAL: _
+pub const bitcoin::opcodes::all::OP_LSHIFT: _
+pub const bitcoin::opcodes::all::OP_MAX: _
+pub const bitcoin::opcodes::all::OP_MIN: _
+pub const bitcoin::opcodes::all::OP_MOD: _
+pub const bitcoin::opcodes::all::OP_MUL: _
+pub const bitcoin::opcodes::all::OP_NEGATE: _
+pub const bitcoin::opcodes::all::OP_NIP: _
+pub const bitcoin::opcodes::all::OP_NOP10: _
+pub const bitcoin::opcodes::all::OP_NOP1: _
+pub const bitcoin::opcodes::all::OP_NOP4: _
+pub const bitcoin::opcodes::all::OP_NOP5: _
+pub const bitcoin::opcodes::all::OP_NOP6: _
+pub const bitcoin::opcodes::all::OP_NOP7: _
+pub const bitcoin::opcodes::all::OP_NOP8: _
+pub const bitcoin::opcodes::all::OP_NOP9: _
+pub const bitcoin::opcodes::all::OP_NOP: _
+pub const bitcoin::opcodes::all::OP_NOT: _
+pub const bitcoin::opcodes::all::OP_NOTIF: _
+pub const bitcoin::opcodes::all::OP_NUMEQUAL: _
+pub const bitcoin::opcodes::all::OP_NUMEQUALVERIFY: _
+pub const bitcoin::opcodes::all::OP_NUMNOTEQUAL: _
+pub const bitcoin::opcodes::all::OP_OR: _
+pub const bitcoin::opcodes::all::OP_OVER: _
+pub const bitcoin::opcodes::all::OP_PICK: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_0: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_10: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_11: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_12: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_13: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_14: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_15: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_16: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_17: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_18: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_19: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_1: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_20: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_21: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_22: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_23: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_24: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_25: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_26: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_27: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_28: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_29: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_2: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_30: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_31: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_32: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_33: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_34: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_35: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_36: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_37: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_38: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_39: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_3: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_40: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_41: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_42: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_43: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_44: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_45: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_46: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_47: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_48: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_49: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_4: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_50: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_51: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_52: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_53: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_54: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_55: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_56: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_57: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_58: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_59: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_5: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_60: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_61: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_62: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_63: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_64: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_65: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_66: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_67: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_68: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_69: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_6: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_70: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_71: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_72: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_73: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_74: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_75: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_7: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_8: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_9: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA1: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA2: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA4: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_10: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_11: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_12: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_13: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_14: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_15: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_16: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_1: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_2: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_3: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_4: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_5: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_6: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_7: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_8: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_9: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_NEG1: _
+pub const bitcoin::opcodes::all::OP_RESERVED1: _
+pub const bitcoin::opcodes::all::OP_RESERVED2: _
+pub const bitcoin::opcodes::all::OP_RESERVED: _
+pub const bitcoin::opcodes::all::OP_RETURN: _
+pub const bitcoin::opcodes::all::OP_RETURN_187: _
+pub const bitcoin::opcodes::all::OP_RETURN_188: _
+pub const bitcoin::opcodes::all::OP_RETURN_189: _
+pub const bitcoin::opcodes::all::OP_RETURN_190: _
+pub const bitcoin::opcodes::all::OP_RETURN_191: _
+pub const bitcoin::opcodes::all::OP_RETURN_192: _
+pub const bitcoin::opcodes::all::OP_RETURN_193: _
+pub const bitcoin::opcodes::all::OP_RETURN_194: _
+pub const bitcoin::opcodes::all::OP_RETURN_195: _
+pub const bitcoin::opcodes::all::OP_RETURN_196: _
+pub const bitcoin::opcodes::all::OP_RETURN_197: _
+pub const bitcoin::opcodes::all::OP_RETURN_198: _
+pub const bitcoin::opcodes::all::OP_RETURN_199: _
+pub const bitcoin::opcodes::all::OP_RETURN_200: _
+pub const bitcoin::opcodes::all::OP_RETURN_201: _
+pub const bitcoin::opcodes::all::OP_RETURN_202: _
+pub const bitcoin::opcodes::all::OP_RETURN_203: _
+pub const bitcoin::opcodes::all::OP_RETURN_204: _
+pub const bitcoin::opcodes::all::OP_RETURN_205: _
+pub const bitcoin::opcodes::all::OP_RETURN_206: _
+pub const bitcoin::opcodes::all::OP_RETURN_207: _
+pub const bitcoin::opcodes::all::OP_RETURN_208: _
+pub const bitcoin::opcodes::all::OP_RETURN_209: _
+pub const bitcoin::opcodes::all::OP_RETURN_210: _
+pub const bitcoin::opcodes::all::OP_RETURN_211: _
+pub const bitcoin::opcodes::all::OP_RETURN_212: _
+pub const bitcoin::opcodes::all::OP_RETURN_213: _
+pub const bitcoin::opcodes::all::OP_RETURN_214: _
+pub const bitcoin::opcodes::all::OP_RETURN_215: _
+pub const bitcoin::opcodes::all::OP_RETURN_216: _
+pub const bitcoin::opcodes::all::OP_RETURN_217: _
+pub const bitcoin::opcodes::all::OP_RETURN_218: _
+pub const bitcoin::opcodes::all::OP_RETURN_219: _
+pub const bitcoin::opcodes::all::OP_RETURN_220: _
+pub const bitcoin::opcodes::all::OP_RETURN_221: _
+pub const bitcoin::opcodes::all::OP_RETURN_222: _
+pub const bitcoin::opcodes::all::OP_RETURN_223: _
+pub const bitcoin::opcodes::all::OP_RETURN_224: _
+pub const bitcoin::opcodes::all::OP_RETURN_225: _
+pub const bitcoin::opcodes::all::OP_RETURN_226: _
+pub const bitcoin::opcodes::all::OP_RETURN_227: _
+pub const bitcoin::opcodes::all::OP_RETURN_228: _
+pub const bitcoin::opcodes::all::OP_RETURN_229: _
+pub const bitcoin::opcodes::all::OP_RETURN_230: _
+pub const bitcoin::opcodes::all::OP_RETURN_231: _
+pub const bitcoin::opcodes::all::OP_RETURN_232: _
+pub const bitcoin::opcodes::all::OP_RETURN_233: _
+pub const bitcoin::opcodes::all::OP_RETURN_234: _
+pub const bitcoin::opcodes::all::OP_RETURN_235: _
+pub const bitcoin::opcodes::all::OP_RETURN_236: _
+pub const bitcoin::opcodes::all::OP_RETURN_237: _
+pub const bitcoin::opcodes::all::OP_RETURN_238: _
+pub const bitcoin::opcodes::all::OP_RETURN_239: _
+pub const bitcoin::opcodes::all::OP_RETURN_240: _
+pub const bitcoin::opcodes::all::OP_RETURN_241: _
+pub const bitcoin::opcodes::all::OP_RETURN_242: _
+pub const bitcoin::opcodes::all::OP_RETURN_243: _
+pub const bitcoin::opcodes::all::OP_RETURN_244: _
+pub const bitcoin::opcodes::all::OP_RETURN_245: _
+pub const bitcoin::opcodes::all::OP_RETURN_246: _
+pub const bitcoin::opcodes::all::OP_RETURN_247: _
+pub const bitcoin::opcodes::all::OP_RETURN_248: _
+pub const bitcoin::opcodes::all::OP_RETURN_249: _
+pub const bitcoin::opcodes::all::OP_RETURN_250: _
+pub const bitcoin::opcodes::all::OP_RETURN_251: _
+pub const bitcoin::opcodes::all::OP_RETURN_252: _
+pub const bitcoin::opcodes::all::OP_RETURN_253: _
+pub const bitcoin::opcodes::all::OP_RETURN_254: _
+pub const bitcoin::opcodes::all::OP_RIGHT: _
+pub const bitcoin::opcodes::all::OP_RIPEMD160: _
+pub const bitcoin::opcodes::all::OP_ROLL: _
+pub const bitcoin::opcodes::all::OP_ROT: _
+pub const bitcoin::opcodes::all::OP_RSHIFT: _
+pub const bitcoin::opcodes::all::OP_SHA1: _
+pub const bitcoin::opcodes::all::OP_SHA256: _
+pub const bitcoin::opcodes::all::OP_SIZE: _
+pub const bitcoin::opcodes::all::OP_SUB: _
+pub const bitcoin::opcodes::all::OP_SUBSTR: _
+pub const bitcoin::opcodes::all::OP_SWAP: _
+pub const bitcoin::opcodes::all::OP_TOALTSTACK: _
+pub const bitcoin::opcodes::all::OP_TUCK: _
+pub const bitcoin::opcodes::all::OP_VER: _
+pub const bitcoin::opcodes::all::OP_VERIF: _
+pub const bitcoin::opcodes::all::OP_VERIFY: _
+pub const bitcoin::opcodes::all::OP_VERNOTIF: _
+pub const bitcoin::opcodes::all::OP_WITHIN: _
+pub const bitcoin::opcodes::all::OP_XOR: _
+pub const bitcoin::p2p::Magic::BITCOIN: Self
+pub const bitcoin::p2p::Magic::REGTEST: Self
+pub const bitcoin::p2p::Magic::SIGNET: Self
+pub const bitcoin::p2p::Magic::TESTNET: Self
+pub const bitcoin::p2p::PROTOCOL_VERSION: u32 = 70_001u32
+pub const bitcoin::p2p::ServiceFlags::BLOOM: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::COMPACT_FILTERS: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::GETUTXO: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NETWORK: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NETWORK_LIMITED: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NONE: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::WITNESS: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::message::MAX_INV_SIZE: usize = 50_000usize
+pub const bitcoin::p2p::message::MAX_MSG_SIZE: usize = 5_000_000usize
+pub const bitcoin::policy::DEFAULT_BYTES_PER_SIGOP: u32 = 20u32
+pub const bitcoin::policy::DEFAULT_INCREMENTAL_RELAY_FEE: u32 = 1_000u32
+pub const bitcoin::policy::DEFAULT_MEMPOOL_EXPIRY: u32 = 336u32
+pub const bitcoin::policy::DEFAULT_MIN_RELAY_TX_FEE: u32 = 1_000u32
+pub const bitcoin::policy::DUST_RELAY_TX_FEE: u32 = 3_000u32
+pub const bitcoin::policy::MAX_STANDARD_TX_SIGOPS_COST: _
+pub const bitcoin::policy::MAX_STANDARD_TX_WEIGHT: u32 = 400_000u32
+pub const bitcoin::policy::MIN_STANDARD_TX_NONWITNESS_SIZE: u32 = 82u32
+pub const bitcoin::pow::Target::MAX: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_MAINNET: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_REGTEST: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_SIGNET: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_TESTNET: Self
+pub const bitcoin::pow::Target::ZERO: bitcoin::pow::Target
+pub const bitcoin::psbt::Psbt::DEFAULT_MAX_FEE_RATE: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::script::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::script::witness_program::MIN_SIZE: usize = 2usize
+pub const bitcoin::sign_message::BITCOIN_SIGNED_MSG_PREFIX: &[u8]
+pub const bitcoin::taproot::TAPROOT_ANNEX_PREFIX: u8 = 80u8
+pub const bitcoin::taproot::TAPROOT_CONTROL_BASE_SIZE: usize = 33usize
+pub const bitcoin::taproot::TAPROOT_CONTROL_MAX_NODE_COUNT: usize = 128usize
+pub const bitcoin::taproot::TAPROOT_CONTROL_MAX_SIZE: _
+pub const bitcoin::taproot::TAPROOT_CONTROL_NODE_SIZE: usize = 32usize
+pub const bitcoin::taproot::TAPROOT_LEAF_MASK: u8 = 254u8
+pub const bitcoin::taproot::TAPROOT_LEAF_TAPSCRIPT: u8 = 192u8
+pub const bitcoin::taproot::TapLeafHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapLeafHash::LEN: usize
+pub const bitcoin::taproot::TapNodeHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapNodeHash::LEN: usize
+pub const bitcoin::taproot::TapTweakHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapTweakHash::LEN: usize
+pub const bitcoin::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::witness_program::MIN_SIZE: usize = 2usize
+pub const fn bitcoin::blockdata::constants::ChainHash::using_genesis_block(network: bitcoin::network::Network) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_vb_unchecked(sat_vb: u64) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_kwu(self) -> u64
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin::blockdata::opcodes::Opcode::to_u8(self) -> u8
+pub const fn bitcoin::blockdata::script::ScriptBuf::new() -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::from_slice(input_script_len: usize, witness_element_lengths: &[usize]) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::ground_p2pkh_compressed(bytes_to_grind: usize) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::ground_p2wpkh(bytes_to_grind: usize) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::transaction::predict_weight_from_slices(inputs: &[bitcoin::blockdata::transaction::InputWeightPrediction], output_script_lens: &[usize]) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::weight::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_wu_usize(wu: usize) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_wu(self) -> u64
+pub const fn bitcoin::consensus::encode::VarInt::size(&self) -> usize
+pub const fn bitcoin::consensus::params::Params::new(network: bitcoin::network::Network) -> Self
+pub const fn bitcoin::network::Network::params(self) -> &'static bitcoin::consensus::params::Params
+pub const fn bitcoin::transaction::predict_weight_from_slices(inputs: &[bitcoin::blockdata::transaction::InputWeightPrediction], output_script_lens: &[usize]) -> bitcoin::blockdata::weight::Weight
+pub enum bitcoin::EcdsaSighashType
+pub enum bitcoin::NetworkKind
+pub enum bitcoin::TapSighashType
+pub enum bitcoin::absolute::LockTime
+pub enum bitcoin::address::NetworkChecked
+pub enum bitcoin::address::NetworkUnchecked
+pub enum bitcoin::bip32::ChildNumber
+pub enum bitcoin::blockdata::locktime::absolute::LockTime
+pub enum bitcoin::blockdata::locktime::relative::LockTime
+pub enum bitcoin::blockdata::opcodes::Class
+pub enum bitcoin::blockdata::opcodes::ClassifyContext
+pub enum bitcoin::blockdata::script::Instruction<'a>
+pub enum bitcoin::locktime::absolute::LockTime
+pub enum bitcoin::locktime::relative::LockTime
+pub enum bitcoin::network::NetworkKind
+pub enum bitcoin::opcodes::Class
+pub enum bitcoin::opcodes::ClassifyContext
+pub enum bitcoin::p2p::address::AddrV2
+pub enum bitcoin::p2p::message::NetworkMessage
+pub enum bitcoin::p2p::message_blockdata::Inventory
+pub enum bitcoin::p2p::message_bloom::BloomFlags
+pub enum bitcoin::p2p::message_network::RejectReason
+pub enum bitcoin::psbt::SigningAlgorithm
+pub enum bitcoin::relative::LockTime
+pub enum bitcoin::script::Instruction<'a>
+pub enum bitcoin::sighash::EcdsaSighashType
+pub enum bitcoin::sighash::EncodeSigningDataResult<E>
+pub enum bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>
+pub enum bitcoin::sighash::SigningDataError<E>
+pub enum bitcoin::sighash::TapSighashType
+pub enum bitcoin::taproot::LeafVersion
+pub enum bitcoin::taproot::TapLeaf
+pub extern crate bitcoin::hashes
+pub extern crate bitcoin::hex
+pub extern crate bitcoin::io
+pub extern crate bitcoin::secp256k1
+pub fn &'a T::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn &'a bitcoin::bip32::DerivationPath::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 0]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 10]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 11]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 12]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 13]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 14]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 15]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 16]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 17]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 18]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 19]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 1]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 20]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 21]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 22]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 23]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 24]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 25]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 26]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 27]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 28]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 29]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 2]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 30]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 31]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 32]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 33]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 34]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 35]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 36]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 37]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 38]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 39]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 3]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 40]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 41]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 42]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 43]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 44]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 45]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 46]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 47]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 48]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 49]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 4]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 50]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 51]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 52]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 53]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 54]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 55]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 56]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 57]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 58]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 59]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 5]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 60]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 61]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 62]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 63]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 64]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 65]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 66]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 67]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 68]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 69]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 6]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 70]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 71]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 72]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 73]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 7]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 8]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 9]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::try_from(bytes: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn &'a bitcoin::blockdata::witness::Witness::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::ecdsa::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::taproot::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn &'a mut T::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 0]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 10]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 11]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 12]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 13]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 14]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 15]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 16]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 17]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 18]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 19]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 1]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 20]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 21]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 22]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 23]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 24]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 25]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 26]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 27]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 28]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 29]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 2]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 30]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 31]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 32]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 33]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 34]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 35]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 36]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 37]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 38]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 39]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 3]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 40]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 41]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 42]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 43]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 44]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 45]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 46]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 47]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 48]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 49]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 4]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 50]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 51]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 52]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 53]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 54]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 55]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 56]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 57]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 58]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 59]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 5]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 60]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 61]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 62]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 63]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 64]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 65]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 66]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 67]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 68]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 69]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 6]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 70]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 71]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 72]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 73]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 7]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 8]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 9]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::try_from(bytes: &'a mut [u8]) -> core::result::Result<Self, Self::Error>
+pub fn &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn &'a str::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn &'static bitcoin::consensus::params::Params::from(value: &bitcoin::network::Network) -> Self
+pub fn &'static bitcoin::consensus::params::Params::from(value: bitcoin::network::Network) -> Self
+pub fn (T0, T1)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6, T7)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6, T7)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn R::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn R::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn R::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn R::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn R::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn R::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn R::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn R::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn R::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn R::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn T::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn W::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn [u16; 8]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u16; 8]::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 0]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 0]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 10]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 11]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 11]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 12]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 13]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 13]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 14]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 14]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 15]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 15]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 16]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 17]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 17]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 18]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 18]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 19]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 19]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 1]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 1]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 20]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 20]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 21]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 21]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 22]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 22]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 23]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 23]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 24]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 24]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 25]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 25]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 26]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 26]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 27]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 27]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 28]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 28]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 29]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 29]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 2]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 30]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 30]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 31]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 31]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 32]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 33]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 33]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 33]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 33]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 34]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 34]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 35]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 35]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 36]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 36]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 37]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 37]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 38]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 38]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 39]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 39]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 3]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 3]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 40]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 40]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 41]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 41]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 42]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 42]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 43]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 43]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 44]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 44]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 45]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 45]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 46]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 46]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 47]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 47]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 48]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 48]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 49]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 49]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 4]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 50]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 50]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 51]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 51]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 52]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 52]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 53]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 53]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 54]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 54]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 55]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 55]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 56]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 56]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 57]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 57]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 58]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 58]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 59]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 59]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 5]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 5]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 60]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 60]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 61]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 61]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 62]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 62]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 63]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 63]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 64]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 64]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 65]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 65]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 66]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 66]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 67]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 67]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 68]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 68]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 69]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 69]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 6]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 70]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 70]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 71]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 71]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 72]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 72]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 73]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 73]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 7]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 7]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 8]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 9]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 9]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8]::eq(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> bool
+pub fn [u8]::partial_cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn alloc::borrow::Cow<'_, bitcoin::blockdata::script::Script>::from(value: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::borrow::Cow<'static, str>::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<alloc::borrow::Cow<'static, str>, bitcoin::consensus::encode::Error>
+pub fn alloc::borrow::Cow<'static, str>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::boxed::Box<[u8]>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::boxed::Box<[u8]>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(value: alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>) -> Self
+pub fn alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn alloc::rc::Rc<T>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::rc::Rc<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::string::String::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<alloc::string::String, bitcoin::consensus::encode::Error>
+pub fn alloc::string::String::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::string::String::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn alloc::sync::Arc<T>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::sync::Arc<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<(u32, bitcoin::p2p::address::Address)>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<alloc::vec::Vec<u8>>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<alloc::vec::Vec<u8>>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::ShortId>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::ShortId>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHeader>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHeader>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip32::ChildNumber>::from(path: bitcoin::bip32::DerivationPath) -> Self
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::Header>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::Header>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::consensus::encode::VarInt>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::consensus::encode::VarInt>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::p2p::address::AddrV2Message>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::p2p::message_blockdata::Inventory>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapLeafHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapLeafHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapNodeHash>::from(branch: bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> Self
+pub fn alloc::vec::Vec<u64>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<u64>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<u8>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<u8>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<u8>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::vec::Vec<u8>::from(value: bitcoin::blockdata::script::PushBytesBuf) -> Self
+pub fn bech32::primitives::gf32::Fe32::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> Self
+pub fn bitcoin::CompressedPublicKey::clone(&self) -> bitcoin::CompressedPublicKey
+pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::cmp::Ordering
+pub fn bitcoin::CompressedPublicKey::eq(&self, other: &bitcoin::CompressedPublicKey) -> bool
+pub fn bitcoin::CompressedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPubkeyError>
+pub fn bitcoin::CompressedPublicKey::from_slice(data: &[u8]) -> core::result::Result<Self, secp256k1::Error>
+pub fn bitcoin::CompressedPublicKey::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::CompressedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::CompressedPublicKey::partial_cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::CompressedPublicKey::pubkey_hash(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::CompressedPublicKey::read_from<R: bitcoin_io::Read + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin::CompressedPublicKey::to_bytes(&self) -> [u8; 33]
+pub fn bitcoin::CompressedPublicKey::try_from(value: bitcoin::PublicKey) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::CompressedPublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), bitcoin::key::Error>
+pub fn bitcoin::CompressedPublicKey::wpubkey_hash(&self) -> bitcoin::WPubkeyHash
+pub fn bitcoin::CompressedPublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::EcdsaSighashType::clone(&self) -> bitcoin::EcdsaSighashType
+pub fn bitcoin::EcdsaSighashType::eq(&self, other: &bitcoin::EcdsaSighashType) -> bool
+pub fn bitcoin::EcdsaSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::EcdsaSighashType::from_consensus(n: u32) -> bitcoin::EcdsaSighashType
+pub fn bitcoin::EcdsaSighashType::from_standard(n: u32) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
+pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::LegacySighash::borrow(&self) -> &[u8]
+pub fn bitcoin::LegacySighash::clone(&self) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::cmp(&self, other: &bitcoin::LegacySighash) -> core::cmp::Ordering
+pub fn bitcoin::LegacySighash::engine() -> Self::Engine
+pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
+pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::LegacySighash::from_str(s: &str) -> core::result::Result<bitcoin::LegacySighash, Self::Err>
+pub fn bitcoin::LegacySighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::LegacySighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::LegacySighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::LegacySighash::partial_cmp(&self, other: &bitcoin::LegacySighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::LegacySighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::LegacySighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::MerkleBlock::clone(&self) -> bitcoin::MerkleBlock
+pub fn bitcoin::MerkleBlock::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::MerkleBlock::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::MerkleBlock::eq(&self, other: &bitcoin::MerkleBlock) -> bool
+pub fn bitcoin::MerkleBlock::extract_matches(&self, matches: &mut alloc::vec::Vec<bitcoin::blockdata::transaction::Txid>, indexes: &mut alloc::vec::Vec<u32>) -> core::result::Result<(), bitcoin::merkle_tree::MerkleBlockError>
+pub fn bitcoin::MerkleBlock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::MerkleBlock::from_block_with_predicate<F>(block: &bitcoin::blockdata::block::Block, match_txids: F) -> Self where F: core::ops::function::Fn(&bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::MerkleBlock::from_header_txids_with_predicate<F>(header: &bitcoin::blockdata::block::Header, block_txids: &[bitcoin::blockdata::transaction::Txid], match_txids: F) -> Self where F: core::ops::function::Fn(&bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::PrivateKey::clone(&self) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::eq(&self, other: &bitcoin::PrivateKey) -> bool
+pub fn bitcoin::PrivateKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PrivateKey::fmt_wif(&self, fmt: &mut dyn core::fmt::Write) -> core::fmt::Result
+pub fn bitcoin::PrivateKey::from_slice(data: &[u8], network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::from_str(s: &str) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::from_wif(wif: &str) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::index(&self, core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin::PrivateKey::new(key: secp256k1::key::SecretKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::new_uncompressed(key: secp256k1::key::SecretKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::public_key<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::PublicKey
+pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
+pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::PubkeyHash::borrow(&self) -> &[u8]
+pub fn bitcoin::PubkeyHash::clone(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::cmp(&self, other: &bitcoin::PubkeyHash) -> core::cmp::Ordering
+pub fn bitcoin::PubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::PubkeyHash::eq(&self, other: &bitcoin::PubkeyHash) -> bool
+pub fn bitcoin::PubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::PubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::PubkeyHash, Self::Err>
+pub fn bitcoin::PubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PubkeyHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::PubkeyHash::partial_cmp(&self, other: &bitcoin::PubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::PubkeyHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::PubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::PublicKey::clone(&self) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::cmp(&self, other: &bitcoin::PublicKey) -> core::cmp::Ordering
+pub fn bitcoin::PublicKey::eq(&self, other: &bitcoin::PublicKey) -> bool
+pub fn bitcoin::PublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PublicKey::from(pk: secp256k1::key::PublicKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from(value: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from_slice(data: &[u8]) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::Error>
+pub fn bitcoin::PublicKey::from_str(s: &str) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::Error>
+pub fn bitcoin::PublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PublicKey::new(key: impl core::convert::Into<secp256k1::key::PublicKey>) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::new_uncompressed(key: impl core::convert::Into<secp256k1::key::PublicKey>) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::partial_cmp(&self, other: &bitcoin::PublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::PublicKey::pubkey_hash(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::PublicKey::read_from<R: bitcoin_io::Read + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin::PublicKey::to_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::PublicKey::to_sort_key(self) -> bitcoin::key::SortKey
+pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), bitcoin::key::Error>
+pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPubkeyError>
+pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::SegwitV0Sighash::borrow(&self) -> &[u8]
+pub fn bitcoin::SegwitV0Sighash::clone(&self) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::cmp::Ordering
+pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
+pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
+pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::SegwitV0Sighash::from_str(s: &str) -> core::result::Result<bitcoin::SegwitV0Sighash, Self::Err>
+pub fn bitcoin::SegwitV0Sighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::SegwitV0Sighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::TapSighash::borrow(&self) -> &[u8]
+pub fn bitcoin::TapSighash::clone(&self) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::cmp(&self, other: &bitcoin::TapSighash) -> core::cmp::Ordering
+pub fn bitcoin::TapSighash::engine() -> Self::Engine
+pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
+pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::TapSighash::from_str(s: &str) -> core::result::Result<bitcoin::TapSighash, Self::Err>
+pub fn bitcoin::TapSighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::TapSighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::TapSighash::partial_cmp(&self, other: &bitcoin::TapSighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::TapSighash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin::TapSighashTag::clone(&self) -> bitcoin::TapSighashTag
+pub fn bitcoin::TapSighashTag::cmp(&self, other: &bitcoin::TapSighashTag) -> core::cmp::Ordering
+pub fn bitcoin::TapSighashTag::default() -> bitcoin::TapSighashTag
+pub fn bitcoin::TapSighashTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::TapSighashTag::eq(&self, other: &bitcoin::TapSighashTag) -> bool
+pub fn bitcoin::TapSighashTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighashTag::partial_cmp(&self, other: &bitcoin::TapSighashTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighashType::clone(&self) -> bitcoin::TapSighashType
+pub fn bitcoin::TapSighashType::cmp(&self, other: &bitcoin::TapSighashType) -> core::cmp::Ordering
+pub fn bitcoin::TapSighashType::eq(&self, other: &bitcoin::TapSighashType) -> bool
+pub fn bitcoin::TapSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::TapSighashType::from(s: bitcoin::EcdsaSighashType) -> Self
+pub fn bitcoin::TapSighashType::from_consensus_u8(sighash_type: u8) -> core::result::Result<Self, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::WPubkeyHash::borrow(&self) -> &[u8]
+pub fn bitcoin::WPubkeyHash::clone(&self) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::cmp(&self, other: &bitcoin::WPubkeyHash) -> core::cmp::Ordering
+pub fn bitcoin::WPubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::WPubkeyHash::eq(&self, other: &bitcoin::WPubkeyHash) -> bool
+pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::WPubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::WPubkeyHash, Self::Err>
+pub fn bitcoin::WPubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::WPubkeyHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::WPubkeyHash::partial_cmp(&self, other: &bitcoin::WPubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::WPubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bitcoin::address::AddressType>
+pub fn bitcoin::address::Address::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::Address::from_script(script: &bitcoin::blockdata::script::Script, network: bitcoin::network::Network) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::Address::from_witness_program(program: bitcoin::blockdata::script::witness_program::WitnessProgram, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: &bitcoin::PublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: &secp256k1::key::XOnlyPublicKey) -> bool
+pub fn bitcoin::address::Address::is_spend_standard(&self) -> bool
+pub fn bitcoin::address::Address::matches_script_pubkey(&self, script: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::address::Address::p2pkh(pk: impl core::convert::Into<bitcoin::PubkeyHash>, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2sh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::Address::p2shwpkh(pk: &bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2shwsh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2wpkh(pk: &bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
+pub fn bitcoin::address::Address::p2wsh(script: &bitcoin::blockdata::script::Script, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bitcoin::PubkeyHash>
+pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
+pub fn bitcoin::address::Address::script_pubkey(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::address::Address::to_qr_uri(&self) -> alloc::string::String
+pub fn bitcoin::address::Address<V>::as_unchecked(&self) -> &bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub fn bitcoin::address::Address<V>::clone(&self) -> bitcoin::address::Address<V>
+pub fn bitcoin::address::Address<V>::cmp(&self, other: &bitcoin::address::Address<V>) -> core::cmp::Ordering
+pub fn bitcoin::address::Address<V>::eq(&self, other: &bitcoin::address::Address<V>) -> bool
+pub fn bitcoin::address::Address<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::Address<V>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::Address<V>::partial_cmp(&self, other: &bitcoin::address::Address<V>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::assume_checked(self) -> bitcoin::address::Address
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::assume_checked_ref(&self) -> &bitcoin::address::Address
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::from_str(s: &str) -> core::result::Result<bitcoin::address::Address<bitcoin::address::NetworkUnchecked>, bitcoin::address::error::ParseError>
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::is_valid_for_network(&self, n: bitcoin::network::Network) -> bool
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::require_network(self, required: bitcoin::network::Network) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::AddressType::clone(&self) -> bitcoin::address::AddressType
+pub fn bitcoin::address::AddressType::cmp(&self, other: &bitcoin::address::AddressType) -> core::cmp::Ordering
+pub fn bitcoin::address::AddressType::eq(&self, other: &bitcoin::address::AddressType) -> bool
+pub fn bitcoin::address::AddressType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::AddressType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::address::AddressType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::AddressType::partial_cmp(&self, other: &bitcoin::address::AddressType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::KnownHrp::clone(&self) -> bitcoin::address::KnownHrp
+pub fn bitcoin::address::KnownHrp::cmp(&self, other: &bitcoin::address::KnownHrp) -> core::cmp::Ordering
+pub fn bitcoin::address::KnownHrp::eq(&self, other: &bitcoin::address::KnownHrp) -> bool
+pub fn bitcoin::address::KnownHrp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::KnownHrp::from(n: bitcoin::network::Network) -> Self
+pub fn bitcoin::address::KnownHrp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::KnownHrp::partial_cmp(&self, other: &bitcoin::address::KnownHrp) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::NetworkChecked::clone(&self) -> bitcoin::address::NetworkChecked
+pub fn bitcoin::address::NetworkChecked::cmp(&self, other: &bitcoin::address::NetworkChecked) -> core::cmp::Ordering
+pub fn bitcoin::address::NetworkChecked::eq(&self, other: &bitcoin::address::NetworkChecked) -> bool
+pub fn bitcoin::address::NetworkChecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::NetworkChecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::NetworkChecked::partial_cmp(&self, other: &bitcoin::address::NetworkChecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::NetworkUnchecked::clone(&self) -> bitcoin::address::NetworkUnchecked
+pub fn bitcoin::address::NetworkUnchecked::cmp(&self, other: &bitcoin::address::NetworkUnchecked) -> core::cmp::Ordering
+pub fn bitcoin::address::NetworkUnchecked::eq(&self, other: &bitcoin::address::NetworkUnchecked) -> bool
+pub fn bitcoin::address::NetworkUnchecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::NetworkUnchecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::NetworkUnchecked::partial_cmp(&self, other: &bitcoin::address::NetworkUnchecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::error::Error::clone(&self) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::Error::eq(&self, other: &bitcoin::address::error::Error) -> bool
+pub fn bitcoin::address::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::Error::from(e: bitcoin::blockdata::script::witness_program::Error) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::Error::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::address::error::ParseError::clone(&self) -> bitcoin::address::error::ParseError
+pub fn bitcoin::address::error::ParseError::eq(&self, other: &bitcoin::address::error::ParseError) -> bool
+pub fn bitcoin::address::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::ParseError::from(e: bech32::segwit::DecodeError) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::address::error::UnknownHrpError) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::base58::Error) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::blockdata::script::witness_program::Error) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::address::error::ParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::address::error::UnknownAddressTypeError::clone(&self) -> bitcoin::address::error::UnknownAddressTypeError
+pub fn bitcoin::address::error::UnknownAddressTypeError::eq(&self, other: &bitcoin::address::error::UnknownAddressTypeError) -> bool
+pub fn bitcoin::address::error::UnknownAddressTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::UnknownAddressTypeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::address::error::UnknownHrpError::clone(&self) -> bitcoin::address::error::UnknownHrpError
+pub fn bitcoin::address::error::UnknownHrpError::eq(&self, other: &bitcoin::address::error::UnknownHrpError) -> bool
+pub fn bitcoin::address::error::UnknownHrpError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::UnknownHrpError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::base58::Error::clone(&self) -> bitcoin::base58::Error
+pub fn bitcoin::base58::Error::eq(&self, other: &bitcoin::base58::Error) -> bool
+pub fn bitcoin::base58::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::base58::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::base58::decode(data: &str) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin::base58::Error>
+pub fn bitcoin::base58::decode_check(data: &str) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin::base58::Error>
+pub fn bitcoin::base58::encode(data: &[u8]) -> alloc::string::String
+pub fn bitcoin::base58::encode_check(data: &[u8]) -> alloc::string::String
+pub fn bitcoin::base58::encode_check_to_fmt(fmt: &mut core::fmt::Formatter<'_>, data: &[u8]) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactions::clone(&self) -> bitcoin::bip152::BlockTransactions
+pub fn bitcoin::bip152::BlockTransactions::cmp(&self, other: &bitcoin::bip152::BlockTransactions) -> core::cmp::Ordering
+pub fn bitcoin::bip152::BlockTransactions::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactions::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactions::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::BlockTransactions::eq(&self, other: &bitcoin::bip152::BlockTransactions) -> bool
+pub fn bitcoin::bip152::BlockTransactions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactions::from_request(request: &bitcoin::bip152::BlockTransactionsRequest, block: &bitcoin::blockdata::block::Block) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::bip152::TxIndexOutOfRangeError>
+pub fn bitcoin::bip152::BlockTransactions::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::BlockTransactions::partial_cmp(&self, other: &bitcoin::bip152::BlockTransactions) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::BlockTransactionsRequest::clone(&self) -> bitcoin::bip152::BlockTransactionsRequest
+pub fn bitcoin::bip152::BlockTransactionsRequest::cmp(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> core::cmp::Ordering
+pub fn bitcoin::bip152::BlockTransactionsRequest::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactionsRequest::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::BlockTransactionsRequest::eq(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> bool
+pub fn bitcoin::bip152::BlockTransactionsRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactionsRequest::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::BlockTransactionsRequest::partial_cmp(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::Error::clone(&self) -> bitcoin::bip152::Error
+pub fn bitcoin::bip152::Error::eq(&self, other: &bitcoin::bip152::Error) -> bool
+pub fn bitcoin::bip152::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::bip152::HeaderAndShortIds::clone(&self) -> bitcoin::bip152::HeaderAndShortIds
+pub fn bitcoin::bip152::HeaderAndShortIds::cmp(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> core::cmp::Ordering
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::eq(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> bool
+pub fn bitcoin::bip152::HeaderAndShortIds::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::HeaderAndShortIds::from_block(block: &bitcoin::blockdata::block::Block, nonce: u64, version: u32, prefill: &[usize]) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::bip152::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::HeaderAndShortIds::partial_cmp(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::PrefilledTransaction::as_ref(&self) -> &bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::bip152::PrefilledTransaction::clone(&self) -> bitcoin::bip152::PrefilledTransaction
+pub fn bitcoin::bip152::PrefilledTransaction::cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::cmp::Ordering
+pub fn bitcoin::bip152::PrefilledTransaction::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::PrefilledTransaction::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::PrefilledTransaction::eq(&self, other: &bitcoin::bip152::PrefilledTransaction) -> bool
+pub fn bitcoin::bip152::PrefilledTransaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::PrefilledTransaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::PrefilledTransaction::partial_cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8; 6]
+pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip152::ShortId::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip152::ShortId::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip152::ShortId::as_ref(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip152::ShortId::borrow(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::borrow(&self) -> &[u8]
+pub fn bitcoin::bip152::ShortId::borrow_mut(&mut self) -> &mut [u8; 6]
+pub fn bitcoin::bip152::ShortId::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip152::ShortId::calculate_siphash_keys(header: &bitcoin::blockdata::block::Header, nonce: u64) -> (u64, u64)
+pub fn bitcoin::bip152::ShortId::clone(&self) -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::ShortId::cmp(&self, other: &bitcoin::bip152::ShortId) -> core::cmp::Ordering
+pub fn bitcoin::bip152::ShortId::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::ShortId, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::ShortId::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::ShortId::default() -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::ShortId::eq(&self, other: &bitcoin::bip152::ShortId) -> bool
+pub fn bitcoin::bip152::ShortId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::ShortId::from(data: &'a [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from(data: [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip152::ShortId::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip152::ShortId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::ShortId::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip152::ShortId::is_empty(&self) -> bool
+pub fn bitcoin::bip152::ShortId::len(&self) -> usize
+pub fn bitcoin::bip152::ShortId::partial_cmp(&self, other: &bitcoin::bip152::ShortId) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::ShortId::to_bytes(self) -> [u8; 6]
+pub fn bitcoin::bip152::ShortId::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip152::ShortId::with_siphash_keys<T: core::convert::AsRef<[u8]>>(txid: &T, siphash_keys: (u64, u64)) -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::clone(&self) -> bitcoin::bip152::TxIndexOutOfRangeError
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::eq(&self, other: &bitcoin::bip152::TxIndexOutOfRangeError) -> bool
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::bip158::BitStreamReader<'a, R>::new(reader: &'a mut R) -> bitcoin::bip158::BitStreamReader<'a, R>
+pub fn bitcoin::bip158::BitStreamReader<'a, R>::read(&mut self, nbits: u8) -> core::result::Result<u64, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::flush(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::new(writer: &'a mut W) -> bitcoin::bip158::BitStreamWriter<'a, W>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::write(&mut self, data: u64, nbits: u8) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BlockFilter::clone(&self) -> bitcoin::bip158::BlockFilter
+pub fn bitcoin::bip158::BlockFilter::eq(&self, other: &bitcoin::bip158::BlockFilter) -> bool
+pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::BlockFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::new(content: &[u8]) -> bitcoin::bip158::BlockFilter
+pub fn bitcoin::bip158::BlockFilter::new_script_filter<M, S>(block: &bitcoin::blockdata::block::Block, script_for_coin: M) -> core::result::Result<bitcoin::bip158::BlockFilter, bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
+pub fn bitcoin::bip158::BlockFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::BlockFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: &bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_element(&mut self, data: &[u8])
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_input_scripts<M, S>(&mut self, script_for_coin: M) -> core::result::Result<(), bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_output_scripts(&mut self)
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::new(writer: &'a mut W, block: &'a bitcoin::blockdata::block::Block) -> bitcoin::bip158::BlockFilterWriter<'a, W>
+pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::bip158::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHash::borrow(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHash::clone(&self) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::cmp::Ordering
+pub fn bitcoin::bip158::FilterHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::FilterHash::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
+pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip158::FilterHash::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHash, Self::Err>
+pub fn bitcoin::bip158::FilterHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHeader::borrow(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHeader::clone(&self) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::cmp::Ordering
+pub fn bitcoin::bip158::FilterHeader::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip158::FilterHeader::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
+pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip158::FilterHeader::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHeader, Self::Err>
+pub fn bitcoin::bip158::FilterHeader::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHeader::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip158::FilterHeader::partial_cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip158::FilterHeader::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::GcsFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::GcsFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::GcsFilterReader::new(k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterReader
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::add_element(&mut self, element: &[u8])
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::new(writer: &'a mut W, k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterWriter<'a, W>
+pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::ChainCode::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip32::ChainCode::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip32::ChainCode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::ChainCode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::ChainCode::borrow_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::bip32::ChainCode::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::ChainCode::clone(&self) -> bitcoin::bip32::ChainCode
+pub fn bitcoin::bip32::ChainCode::cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::cmp::Ordering
+pub fn bitcoin::bip32::ChainCode::eq(&self, other: &bitcoin::bip32::ChainCode) -> bool
+pub fn bitcoin::bip32::ChainCode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::ChainCode::from(data: &'a [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from(data: [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip32::ChainCode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip32::ChainCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::ChainCode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::ChainCode::is_empty(&self) -> bool
+pub fn bitcoin::bip32::ChainCode::len(&self) -> usize
+pub fn bitcoin::bip32::ChainCode::partial_cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::ChainCode::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::bip32::ChainCode::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip32::ChildNumber::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
+pub fn bitcoin::bip32::ChildNumber::clone(&self) -> bitcoin::bip32::ChildNumber
+pub fn bitcoin::bip32::ChildNumber::cmp(&self, other: &bitcoin::bip32::ChildNumber) -> core::cmp::Ordering
+pub fn bitcoin::bip32::ChildNumber::eq(&self, other: &bitcoin::bip32::ChildNumber) -> bool
+pub fn bitcoin::bip32::ChildNumber::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::ChildNumber::from(number: u32) -> Self
+pub fn bitcoin::bip32::ChildNumber::from_hardened_idx(index: u32) -> core::result::Result<Self, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::from_normal_idx(index: u32) -> core::result::Result<Self, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::ChildNumber, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::ChildNumber::increment(self) -> core::result::Result<bitcoin::bip32::ChildNumber, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::is_hardened(&self) -> bool
+pub fn bitcoin::bip32::ChildNumber::is_normal(&self) -> bool
+pub fn bitcoin::bip32::ChildNumber::partial_cmp(&self, other: &bitcoin::bip32::ChildNumber) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::DerivationPath::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
+pub fn bitcoin::bip32::DerivationPath::child(&self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::children_from(&self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::clone(&self) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::cmp(&self, other: &bitcoin::bip32::DerivationPath) -> core::cmp::Ordering
+pub fn bitcoin::bip32::DerivationPath::default() -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::eq(&self, other: &bitcoin::bip32::DerivationPath) -> bool
+pub fn bitcoin::bip32::DerivationPath::extend<T: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, path: T) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::DerivationPath::from(numbers: &'a [bitcoin::bip32::ChildNumber]) -> Self
+pub fn bitcoin::bip32::DerivationPath::from(numbers: alloc::vec::Vec<bitcoin::bip32::ChildNumber>) -> Self
+pub fn bitcoin::bip32::DerivationPath::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::bip32::ChildNumber>
+pub fn bitcoin::bip32::DerivationPath::from_str(path: &str) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::DerivationPath::hardened_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::DerivationPath::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::DerivationPath::into_child(self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::is_empty(&self) -> bool
+pub fn bitcoin::bip32::DerivationPath::is_master(&self) -> bool
+pub fn bitcoin::bip32::DerivationPath::len(&self) -> usize
+pub fn bitcoin::bip32::DerivationPath::master() -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::normal_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::partial_cmp(&self, other: &bitcoin::bip32::DerivationPath) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::DerivationPath::to_u32_vec(&self) -> alloc::vec::Vec<u32>
+pub fn bitcoin::bip32::DerivationPathIterator<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::bip32::DerivationPathIterator<'a>::start_from(path: &'a bitcoin::bip32::DerivationPath, start: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPathIterator<'a>
+pub fn bitcoin::bip32::Error::clone(&self) -> bitcoin::bip32::Error
+pub fn bitcoin::bip32::Error::eq(&self, other: &bitcoin::bip32::Error) -> bool
+pub fn bitcoin::bip32::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Error::from(e: secp256k1::Error) -> bitcoin::bip32::Error
+pub fn bitcoin::bip32::Error::from(err: bitcoin::base58::Error) -> Self
+pub fn bitcoin::bip32::Error::from(err: bitcoin::key::Error) -> Self
+pub fn bitcoin::bip32::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::Fingerprint::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip32::Fingerprint::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip32::Fingerprint::as_ref(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::Fingerprint::borrow(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::Fingerprint::borrow_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::Fingerprint::clone(&self) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Fingerprint::cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::cmp::Ordering
+pub fn bitcoin::bip32::Fingerprint::default() -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Fingerprint::eq(&self, other: &bitcoin::bip32::Fingerprint) -> bool
+pub fn bitcoin::bip32::Fingerprint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Fingerprint::from(data: &'a [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from(data: [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip32::Fingerprint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip32::Fingerprint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::Fingerprint::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::Fingerprint::is_empty(&self) -> bool
+pub fn bitcoin::bip32::Fingerprint::len(&self) -> usize
+pub fn bitcoin::bip32::Fingerprint::partial_cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::Fingerprint::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip32::IntoDerivationPath::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::XKeyIdentifier::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::XKeyIdentifier::clone(&self) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::cmp::Ordering
+pub fn bitcoin::bip32::XKeyIdentifier::engine() -> Self::Engine
+pub fn bitcoin::bip32::XKeyIdentifier::eq(&self, other: &bitcoin::bip32::XKeyIdentifier) -> bool
+pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip32::XKeyIdentifier::from_str(s: &str) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, Self::Err>
+pub fn bitcoin::bip32::XKeyIdentifier::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::XKeyIdentifier::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::XKeyIdentifier::partial_cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip32::XKeyIdentifier::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::bip32::Xpriv::clone(&self) -> bitcoin::bip32::Xpriv
+pub fn bitcoin::bip32::Xpriv::decode(data: &[u8]) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::derive_priv<C: secp256k1::context::Signing, P: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, secp: &secp256k1::Secp256k1<C>, path: &P) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::encode(&self) -> [u8; 78]
+pub fn bitcoin::bip32::Xpriv::eq(&self, other: &bitcoin::bip32::Xpriv) -> bool
+pub fn bitcoin::bip32::Xpriv::fingerprint<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Xpriv::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpriv::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpriv::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn bitcoin::bip32::Xpriv::identifier<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::Xpriv::new_master(network: impl core::convert::Into<bitcoin::network::NetworkKind>, seed: &[u8]) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::to_keypair<C: secp256k1::context::Signing>(self, secp: &secp256k1::Secp256k1<C>) -> secp256k1::key::Keypair
+pub fn bitcoin::bip32::Xpriv::to_priv(self) -> bitcoin::PrivateKey
+pub fn bitcoin::bip32::Xpub::ckd_pub<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, i: bitcoin::bip32::ChildNumber) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::ckd_pub_tweak(&self, i: bitcoin::bip32::ChildNumber) -> core::result::Result<(secp256k1::key::SecretKey, bitcoin::bip32::ChainCode), bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::clone(&self) -> bitcoin::bip32::Xpub
+pub fn bitcoin::bip32::Xpub::cmp(&self, other: &bitcoin::bip32::Xpub) -> core::cmp::Ordering
+pub fn bitcoin::bip32::Xpub::decode(data: &[u8]) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::derive_pub<C: secp256k1::context::Verification, P: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, secp: &secp256k1::Secp256k1<C>, path: &P) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::encode(&self) -> [u8; 78]
+pub fn bitcoin::bip32::Xpub::eq(&self, other: &bitcoin::bip32::Xpub) -> bool
+pub fn bitcoin::bip32::Xpub::fingerprint(&self) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Xpub::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpub::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpub::from_priv<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::bip32::Xpriv) -> bitcoin::bip32::Xpub
+pub fn bitcoin::bip32::Xpub::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::Xpub::identifier(&self) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::Xpub::partial_cmp(&self, other: &bitcoin::bip32::Xpub) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::Xpub::to_pub(self) -> bitcoin::CompressedPublicKey
+pub fn bitcoin::bip32::Xpub::to_x_only_pub(self) -> secp256k1::key::XOnlyPublicKey
+pub fn bitcoin::blockdata::block::Bip34Error::clone(&self) -> bitcoin::blockdata::block::Bip34Error
+pub fn bitcoin::blockdata::block::Bip34Error::eq(&self, other: &bitcoin::blockdata::block::Bip34Error) -> bool
+pub fn bitcoin::blockdata::block::Bip34Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Bip34Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::block::Block::bip34_block_height(&self) -> core::result::Result<u64, bitcoin::blockdata::block::Bip34Error>
+pub fn bitcoin::blockdata::block::Block::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::Block::check_merkle_root(&self) -> bool
+pub fn bitcoin::blockdata::block::Block::check_witness_commitment(&self) -> bool
+pub fn bitcoin::blockdata::block::Block::clone(&self) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::blockdata::block::Block::coinbase(&self) -> core::option::Option<&bitcoin::blockdata::transaction::Transaction>
+pub fn bitcoin::blockdata::block::Block::compute_merkle_root(&self) -> core::option::Option<bitcoin::blockdata::block::TxMerkleNode>
+pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: &bitcoin::blockdata::block::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::Block::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Block::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Block::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Block::eq(&self, other: &bitcoin::blockdata::block::Block) -> bool
+pub fn bitcoin::blockdata::block::Block::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
+pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
+pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::BlockHash::clone(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::BlockHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::BlockHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::BlockHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::BlockHash::eq(&self, other: &bitcoin::blockdata::block::BlockHash) -> bool
+pub fn bitcoin::blockdata::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::BlockHash::from(block: &bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::BlockHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::BlockHash, Self::Err>
+pub fn bitcoin::blockdata::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::BlockHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::BlockHash::partial_cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::BlockHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::Header::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::Header::clone(&self) -> bitcoin::blockdata::block::Header
+pub fn bitcoin::blockdata::block::Header::cmp(&self, other: &bitcoin::blockdata::block::Header) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::Header::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Header, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Header::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Header, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Header::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Header::difficulty(&self, network: bitcoin::network::Network) -> u128
+pub fn bitcoin::blockdata::block::Header::difficulty_float(&self) -> f64
+pub fn bitcoin::blockdata::block::Header::eq(&self, other: &bitcoin::blockdata::block::Header) -> bool
+pub fn bitcoin::blockdata::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::Header::partial_cmp(&self, other: &bitcoin::blockdata::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
+pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
+pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
+pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::TxMerkleNode::clone(&self) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> bool
+pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::TxMerkleNode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::TxMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::ValidationError::clone(&self) -> bitcoin::blockdata::block::ValidationError
+pub fn bitcoin::blockdata::block::ValidationError::eq(&self, other: &bitcoin::blockdata::block::ValidationError) -> bool
+pub fn bitcoin::blockdata::block::ValidationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::ValidationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::block::Version::clone(&self) -> bitcoin::blockdata::block::Version
+pub fn bitcoin::blockdata::block::Version::cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::Version::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Version::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Version::default() -> bitcoin::blockdata::block::Version
+pub fn bitcoin::blockdata::block::Version::eq(&self, other: &bitcoin::blockdata::block::Version) -> bool
+pub fn bitcoin::blockdata::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Version::from_consensus(v: i32) -> Self
+pub fn bitcoin::blockdata::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::Version::is_signalling_soft_fork(&self, bit: u8) -> bool
+pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
+pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessCommitment::clone(&self) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
+pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::clone(&self) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> bool
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::blockdata::constants::ChainHash::as_ptr(&self) -> *const u8
+pub fn bitcoin::blockdata::constants::ChainHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::constants::ChainHash::clone(&self) -> bitcoin::blockdata::constants::ChainHash
+pub fn bitcoin::blockdata::constants::ChainHash::cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::constants::ChainHash::eq(&self, other: &bitcoin::blockdata::constants::ChainHash) -> bool
+pub fn bitcoin::blockdata::constants::ChainHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::constants::ChainHash::from(data: &'a [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from(data: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::blockdata::constants::ChainHash::from_genesis_block_hash(block_hash: bitcoin::blockdata::block::BlockHash) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::constants::ChainHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::constants::ChainHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::constants::ChainHash::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::constants::ChainHash::len(&self) -> usize
+pub fn bitcoin::blockdata::constants::ChainHash::partial_cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::constants::ChainHash::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::constants::genesis_block(network: bitcoin::network::Network) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin::blockdata::weight::Weight) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::clone(&self) -> bitcoin::blockdata::fee_rate::FeeRate
+pub fn bitcoin::blockdata::fee_rate::FeeRate::cmp(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::fee_rate::FeeRate::eq(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> bool
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fee_wu(self, weight: bitcoin::blockdata::weight::Weight) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_vb(sat_vb: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::fee_rate::FeeRate::mul(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::fee_rate::FeeRate::partial_cmp(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ConversionError
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::Error::clone(&self) -> bitcoin::blockdata::locktime::absolute::Error
+pub fn bitcoin::blockdata::locktime::absolute::Error::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Error) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::blockdata::locktime::absolute::ConversionError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::blockdata::locktime::absolute::OperationError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::error::ParseIntError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::Height::clone(&self) -> bitcoin::blockdata::locktime::absolute::Height
+pub fn bitcoin::blockdata::locktime::absolute::Height::cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::absolute::Height::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_consensus(n: u32) -> core::result::Result<bitcoin::blockdata::locktime::absolute::Height, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::Height::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::clone(&self) -> bitcoin::blockdata::locktime::absolute::LockTime
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::eq(&self, other: &bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from(h: bitcoin::blockdata::locktime::absolute::Height) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from(t: bitcoin::blockdata::locktime::absolute::Time) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_consensus(n: u32) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_height(n: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_time(n: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_block_height(&self) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_block_time(&self) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_implied_by(&self, other: bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_same_unit(&self, other: bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_satisfied_by(&self, height: bitcoin::blockdata::locktime::absolute::Height, time: bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::LockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::clone(&self) -> bitcoin::blockdata::locktime::absolute::OperationError
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::OperationError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::absolute::Time::clone(&self) -> bitcoin::blockdata::locktime::absolute::Time
+pub fn bitcoin::blockdata::locktime::absolute::Time::cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::absolute::Time::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_consensus(n: u32) -> core::result::Result<bitcoin::blockdata::locktime::absolute::Time, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::Time::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::Time::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Error::clone(&self) -> bitcoin::blockdata::locktime::relative::Error
+pub fn bitcoin::blockdata::locktime::relative::Error::eq(&self, other: &bitcoin::blockdata::locktime::relative::Error) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::locktime::relative::Height::clone(&self) -> bitcoin::blockdata::locktime::relative::Height
+pub fn bitcoin::blockdata::locktime::relative::Height::cmp(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::relative::Height::default() -> bitcoin::blockdata::locktime::relative::Height
+pub fn bitcoin::blockdata::locktime::relative::Height::eq(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Height::from(value: u16) -> Self
+pub fn bitcoin::blockdata::locktime::relative::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::relative::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::Height::partial_cmp(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::value(self) -> u16
+pub fn bitcoin::blockdata::locktime::relative::LockTime::clone(&self) -> bitcoin::blockdata::locktime::relative::LockTime
+pub fn bitcoin::blockdata::locktime::relative::LockTime::eq(&self, other: &bitcoin::blockdata::locktime::relative::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::LockTime::from(h: bitcoin::blockdata::locktime::relative::Height) -> Self
+pub fn bitcoin::blockdata::locktime::relative::LockTime::from(t: bitcoin::blockdata::locktime::relative::Time) -> Self
+pub fn bitcoin::blockdata::locktime::relative::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_implied_by(&self, other: bitcoin::blockdata::locktime::relative::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by(&self, h: bitcoin::blockdata::locktime::relative::Height, t: bitcoin::blockdata::locktime::relative::Time) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by_height(&self, h: bitcoin::blockdata::locktime::relative::Height) -> core::result::Result<bool, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by_time(&self, t: bitcoin::blockdata::locktime::relative::Time) -> core::result::Result<bool, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::clone(&self) -> bitcoin::blockdata::locktime::relative::Time
+pub fn bitcoin::blockdata::locktime::relative::Time::cmp(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::relative::Time::default() -> bitcoin::blockdata::locktime::relative::Time
+pub fn bitcoin::blockdata::locktime::relative::Time::eq(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin::blockdata::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::relative::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::Time::partial_cmp(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::value(self) -> u16
+pub fn bitcoin::blockdata::opcodes::Class::clone(&self) -> bitcoin::blockdata::opcodes::Class
+pub fn bitcoin::blockdata::opcodes::Class::eq(&self, other: &bitcoin::blockdata::opcodes::Class) -> bool
+pub fn bitcoin::blockdata::opcodes::Class::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::clone(&self) -> bitcoin::blockdata::opcodes::ClassifyContext
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::cmp(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::eq(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> bool
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::partial_cmp(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::opcodes::Opcode::classify(self, ctx: bitcoin::blockdata::opcodes::ClassifyContext) -> bitcoin::blockdata::opcodes::Class
+pub fn bitcoin::blockdata::opcodes::Opcode::clone(&self) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::opcodes::Opcode::eq(&self, other: &bitcoin::blockdata::opcodes::Opcode) -> bool
+pub fn bitcoin::blockdata::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::opcodes::Opcode::from(b: u8) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::opcodes::Opcode::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::script::Builder::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Builder::as_script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Builder::clone(&self) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::default() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::eq(&self, other: &bitcoin::blockdata::script::Builder) -> bool
+pub fn bitcoin::blockdata::script::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::script::Builder::from(v: alloc::vec::Vec<u8>) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::Builder::into_script(self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Builder::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::Builder::len(&self) -> usize
+pub fn bitcoin::blockdata::script::Builder::new() -> Self
+pub fn bitcoin::blockdata::script::Builder::push_int(self, data: i64) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_key(self, key: &bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_lock_time(self, lock_time: bitcoin::blockdata::locktime::absolute::LockTime) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_opcode(self, data: bitcoin::blockdata::opcodes::Opcode) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_sequence(self, sequence: bitcoin::blockdata::transaction::Sequence) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(self, data: T) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_verify(self) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: &secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Bytes<'_>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::nth_back(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::Error::clone(&self) -> bitcoin::blockdata::script::Error
+pub fn bitcoin::blockdata::script::Error::eq(&self, other: &bitcoin::blockdata::script::Error) -> bool
+pub fn bitcoin::blockdata::script::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::Instruction<'a>::clone(&self) -> bitcoin::blockdata::script::Instruction<'a>
+pub fn bitcoin::blockdata::script::Instruction<'a>::eq(&self, other: &bitcoin::blockdata::script::Instruction<'a>) -> bool
+pub fn bitcoin::blockdata::script::Instruction<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Instruction<'a>::opcode(&self) -> core::option::Option<bitcoin::blockdata::opcodes::Opcode>
+pub fn bitcoin::blockdata::script::Instruction<'a>::push_bytes(&self) -> core::option::Option<&bitcoin::blockdata::script::PushBytes>
+pub fn bitcoin::blockdata::script::Instruction<'a>::script_num(&self) -> core::option::Option<i64>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::as_script(&self) -> &'a bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::clone(&self) -> bitcoin::blockdata::script::InstructionIndices<'a>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::Instructions<'a>::as_script(&self) -> &'a bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Instructions<'a>::clone(&self) -> bitcoin::blockdata::script::Instructions<'a>
+pub fn bitcoin::blockdata::script::Instructions<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Instructions<'a>::next(&mut self) -> core::option::Option<core::result::Result<bitcoin::blockdata::script::Instruction<'a>, bitcoin::blockdata::script::Error>>
+pub fn bitcoin::blockdata::script::Instructions<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::PushBytes::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytes::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytes::cmp(&self, other: &bitcoin::blockdata::script::PushBytes) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::PushBytes::empty() -> &'static Self
+pub fn bitcoin::blockdata::script::PushBytes::eq(&self, other: &bitcoin::blockdata::script::PushBytes) -> bool
+pub fn bitcoin::blockdata::script::PushBytes::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytes::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::PushBytes::len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytes::partial_cmp(&self, other: &bitcoin::blockdata::script::PushBytes) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::PushBytes::to_owned(&self) -> Self::Owned
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_mut_push_bytes(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_push_bytes(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::borrow(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::borrow_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::capacity(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesBuf::clear(&mut self)
+pub fn bitcoin::blockdata::script::PushBytesBuf::clone(&self) -> bitcoin::blockdata::script::PushBytesBuf
+pub fn bitcoin::blockdata::script::PushBytesBuf::cmp(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::PushBytesBuf::default() -> bitcoin::blockdata::script::PushBytesBuf
+pub fn bitcoin::blockdata::script::PushBytesBuf::deref(&self) -> &Self::Target
+pub fn bitcoin::blockdata::script::PushBytesBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::blockdata::script::PushBytesBuf::eq(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> bool
+pub fn bitcoin::blockdata::script::PushBytesBuf::extend_from_slice(&mut self, bytes: &[u8]) -> core::result::Result<(), bitcoin::blockdata::script::PushBytesError>
+pub fn bitcoin::blockdata::script::PushBytesBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 0]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 10]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 11]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 12]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 13]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 14]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 15]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 16]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 17]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 18]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 19]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 1]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 20]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 21]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 22]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 23]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 24]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 25]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 26]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 27]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 28]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 29]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 2]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 30]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 31]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 32]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 33]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 34]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 35]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 36]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 37]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 38]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 39]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 3]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 40]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 41]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 42]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 43]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 44]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 45]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 46]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 47]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 48]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 49]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 4]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 50]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 51]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 52]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 53]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 54]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 55]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 56]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 57]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 58]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 59]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 5]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 60]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 61]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 62]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 63]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 64]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 65]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 66]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 67]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 68]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 69]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 6]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 70]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 71]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 72]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 73]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 7]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 8]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 9]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 0]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 10]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 11]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 12]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 13]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 14]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 15]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 16]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 17]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 18]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 19]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 1]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 20]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 21]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 22]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 23]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 24]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 25]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 26]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 27]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 28]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 29]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 2]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 30]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 31]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 33]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 34]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 35]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 36]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 37]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 38]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 39]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 3]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 40]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 41]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 42]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 43]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 44]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 45]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 46]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 47]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 48]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 49]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 4]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 50]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 51]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 52]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 53]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 54]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 55]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 56]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 57]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 58]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 59]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 5]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 60]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 61]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 62]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 63]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 64]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 65]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 66]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 67]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 68]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 69]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 6]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 70]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 71]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 72]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 73]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 7]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 8]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 9]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::PushBytesBuf::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::PushBytesBuf::len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesBuf::new() -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::PushBytesBuf::pop(&mut self) -> core::option::Option<u8>
+pub fn bitcoin::blockdata::script::PushBytesBuf::push(&mut self, byte: u8) -> core::result::Result<(), bitcoin::blockdata::script::PushBytesError>
+pub fn bitcoin::blockdata::script::PushBytesBuf::remove(&mut self, index: usize) -> u8
+pub fn bitcoin::blockdata::script::PushBytesBuf::reserve(&mut self, additional_capacity: usize)
+pub fn bitcoin::blockdata::script::PushBytesBuf::truncate(&mut self, len: usize)
+pub fn bitcoin::blockdata::script::PushBytesBuf::try_from(vec: alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::PushBytesBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin::blockdata::script::PushBytesError::clone(&self) -> bitcoin::blockdata::script::PushBytesError
+pub fn bitcoin::blockdata::script::PushBytesError::eq(&self, other: &bitcoin::blockdata::script::PushBytesError) -> bool
+pub fn bitcoin::blockdata::script::PushBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytesError::input_len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::PushBytesErrorReport::input_len(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Script::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::Script::as_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::Script::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Script::as_ref(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::builder() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Script::bytes(&self) -> bitcoin::blockdata::script::Bytes<'_>
+pub fn bitcoin::blockdata::script::Script::cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::Script::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::script::Script::count_sigops(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::count_sigops_legacy(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::eq(&self, other: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::blockdata::script::Script::eq(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> bool
+pub fn bitcoin::blockdata::script::Script::first_opcode(&self) -> core::option::Option<bitcoin::blockdata::opcodes::Opcode>
+pub fn bitcoin::blockdata::script::Script::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Script::fmt_asm(&self, f: &mut dyn core::fmt::Write) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Script::from_bytes(bytes: &[u8]) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::from_bytes_mut(bytes: &mut [u8]) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::Script::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::instruction_indices(&self) -> bitcoin::blockdata::script::InstructionIndices<'_>
+pub fn bitcoin::blockdata::script::Script::instruction_indices_minimal(&self) -> bitcoin::blockdata::script::InstructionIndices<'_>
+pub fn bitcoin::blockdata::script::Script::instructions(&self) -> bitcoin::blockdata::script::Instructions<'_>
+pub fn bitcoin::blockdata::script::Script::instructions_minimal(&self) -> bitcoin::blockdata::script::Instructions<'_>
+pub fn bitcoin::blockdata::script::Script::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_multisig(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_op_return(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2pk(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2pkh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2sh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2tr(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2wpkh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2wsh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_provably_unspendable(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_push_only(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_witness_program(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::len(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::minimal_non_dust(&self) -> bitcoin_units::amount::Amount
+pub fn bitcoin::blockdata::script::Script::minimal_non_dust_custom(&self, dust_relay_fee: bitcoin::blockdata::fee_rate::FeeRate) -> bitcoin_units::amount::Amount
+pub fn bitcoin::blockdata::script::Script::new() -> &'static bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::p2pk_public_key(&self) -> core::option::Option<bitcoin::PublicKey>
+pub fn bitcoin::blockdata::script::Script::p2wpkh_script_code(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub fn bitcoin::blockdata::script::Script::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::Script::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::Script::script_hash(&self) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::Script::tapscript_leaf_hash(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::blockdata::script::Script::to_asm_string(&self) -> alloc::string::String
+pub fn bitcoin::blockdata::script::Script::to_bytes(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::Script::to_hex_string(&self) -> alloc::string::String
+pub fn bitcoin::blockdata::script::Script::to_owned(&self) -> Self::Owned
+pub fn bitcoin::blockdata::script::Script::to_p2sh(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::to_p2tr<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::to_p2wsh(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::witness_version(&self) -> core::option::Option<bitcoin::blockdata::script::witness_version::WitnessVersion>
+pub fn bitcoin::blockdata::script::Script::wscript_hash(&self) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut_script(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptBuf::as_ref(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::borrow(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::borrow_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::builder() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::ScriptBuf::clone(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::ScriptBuf::cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::ScriptBuf::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::script::ScriptBuf::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::script::ScriptBuf::default() -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::ScriptBuf::deref(&self) -> &Self::Target
+pub fn bitcoin::blockdata::script::ScriptBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::blockdata::script::ScriptBuf::eq(&self, other: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::blockdata::script::ScriptBuf::eq(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> bool
+pub fn bitcoin::blockdata::script::ScriptBuf::extend<T>(&mut self, iter: T) where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::script::Instruction<'a>>
+pub fn bitcoin::blockdata::script::ScriptBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::ScriptBuf::from(a: bitcoin::address::Address) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(v: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(value: alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::parse::HexToBytesError>
+pub fn bitcoin::blockdata::script::ScriptBuf::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::script::Instruction<'a>>
+pub fn bitcoin::blockdata::script::ScriptBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: &bitcoin::PublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: &bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: &bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_witness_program(witness_program: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptBuf::push_instruction(&mut self, instruction: bitcoin::blockdata::script::Instruction<'_>)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_instruction_no_opt(&mut self, instruction: bitcoin::blockdata::script::Instruction<'_>)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_opcode(&mut self, data: bitcoin::blockdata::opcodes::Opcode)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(&mut self, data: T)
+pub fn bitcoin::blockdata::script::ScriptBuf::reserve(&mut self, additional_len: usize)
+pub fn bitcoin::blockdata::script::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
+pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
+pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::ScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptHash::clone(&self) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::ScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::ScriptHash::eq(&self, other: &bitcoin::blockdata::script::ScriptHash) -> bool
+pub fn bitcoin::blockdata::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::script::ScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::WScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::WScriptHash::clone(&self) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::WScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::WScriptHash::eq(&self, other: &bitcoin::blockdata::script::WScriptHash) -> bool
+pub fn bitcoin::blockdata::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::script::WScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::WScriptHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::script::WScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::script::WScriptHash::to_raw_hash(self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin::blockdata::script::read_scriptbool(v: &[u8]) -> bool
+pub fn bitcoin::blockdata::script::read_scriptint(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::blockdata::script::read_scriptint_non_minimal(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::blockdata::script::witness_program::Error::clone(&self) -> bitcoin::blockdata::script::witness_program::Error
+pub fn bitcoin::blockdata::script::witness_program::Error::eq(&self, other: &bitcoin::blockdata::script::witness_program::Error) -> bool
+pub fn bitcoin::blockdata::script::witness_program::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_program::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::clone(&self) -> bitcoin::blockdata::script::witness_program::WitnessProgram
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::eq(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2tr(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wpkh(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wsh(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::new(version: bitcoin::blockdata::script::witness_version::WitnessVersion, bytes: &[u8]) -> core::result::Result<Self, bitcoin::blockdata::script::witness_program::Error>
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wsh(script: &bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::program(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::version(&self) -> bitcoin::blockdata::script::witness_version::WitnessVersion
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::clone(&self) -> bitcoin::blockdata::script::witness_version::FromStrError
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::eq(&self, other: &bitcoin::blockdata::script::witness_version::FromStrError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::from(e: bitcoin::error::ParseIntError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::clone(&self) -> bitcoin::blockdata::script::witness_version::TryFromError
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::eq(&self, other: &bitcoin::blockdata::script::witness_version::TryFromError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::clone(&self) -> bitcoin::blockdata::script::witness_version::TryFromInstructionError
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::eq(&self, other: &bitcoin::blockdata::script::witness_version::TryFromInstructionError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::clone(&self) -> bitcoin::blockdata::script::witness_version::WitnessVersion
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::eq(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> bool
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_fe(self) -> bech32::primitives::gf32::Fe32
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_num(self) -> u8
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(instruction: bitcoin::blockdata::script::Instruction<'_>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(opcode: bitcoin::blockdata::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(value: bech32::primitives::gf32::Fe32) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::clone(&self) -> bitcoin::blockdata::transaction::IndexOutOfBoundsError
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::eq(&self, other: &bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> bool
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::clone(&self) -> bitcoin::blockdata::transaction::InputWeightPrediction
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::new<T>(input_script_len: usize, witness_element_lengths: T) -> Self where T: core::iter::traits::collect::IntoIterator, <T as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<usize>
+pub fn bitcoin::blockdata::transaction::InputsIndexError::clone(&self) -> bitcoin::blockdata::transaction::InputsIndexError
+pub fn bitcoin::blockdata::transaction::InputsIndexError::eq(&self, other: &bitcoin::blockdata::transaction::InputsIndexError) -> bool
+pub fn bitcoin::blockdata::transaction::InputsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::InputsIndexError::from(e: bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::blockdata::transaction::InputsIndexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::transaction::OutPoint::clone(&self) -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::cmp(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::OutPoint::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::OutPoint::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::OutPoint::default() -> Self
+pub fn bitcoin::blockdata::transaction::OutPoint::eq(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> bool
+pub fn bitcoin::blockdata::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::OutPoint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::OutPoint::is_null(&self) -> bool
+pub fn bitcoin::blockdata::transaction::OutPoint::new(txid: bitcoin::blockdata::transaction::Txid, vout: u32) -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::null() -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::partial_cmp(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::clone(&self) -> bitcoin::blockdata::transaction::OutputsIndexError
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::eq(&self, other: &bitcoin::blockdata::transaction::OutputsIndexError) -> bool
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::from(e: bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::clone(&self) -> bitcoin::blockdata::transaction::ParseOutPointError
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::eq(&self, other: &bitcoin::blockdata::transaction::ParseOutPointError) -> bool
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::blockdata::transaction::Sequence::clone(&self) -> bitcoin::blockdata::transaction::Sequence
+pub fn bitcoin::blockdata::transaction::Sequence::cmp(&self, other: &bitcoin::blockdata::transaction::Sequence) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Sequence::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::default() -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::enables_absolute_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::eq(&self, other: &bitcoin::blockdata::transaction::Sequence) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Sequence::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_consensus(n: u32) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_height(height: u16) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::transaction::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Sequence::is_final(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_height_locked(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_rbf(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_relative_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_time_locked(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Sequence) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Sequence::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::transaction::Sequence::to_relative_lock_time(&self) -> core::option::Option<bitcoin::blockdata::locktime::relative::LockTime>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::base_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::clone(&self) -> bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::blockdata::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Transaction::compute_txid(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Transaction::compute_wtxid(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Transaction::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::eq(&self, other: &bitcoin::blockdata::transaction::Transaction) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Transaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Transaction::is_absolute_timelock_satisfied(&self, height: bitcoin::blockdata::locktime::absolute::Height, time: bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_coinbase(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_explicitly_rbf(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_lock_time_enabled(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Transaction::script_pubkey_lens(&self) -> impl core::iter::traits::iterator::Iterator<Item = usize> + '_
+pub fn bitcoin::blockdata::transaction::Transaction::total_sigop_cost<S>(&self, spent: S) -> usize where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub fn bitcoin::blockdata::transaction::Transaction::total_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::tx_in(&self, input_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxIn, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::blockdata::transaction::Transaction::tx_out(&self, output_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::blockdata::transaction::OutputsIndexError>
+pub fn bitcoin::blockdata::transaction::Transaction::txid(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Transaction::vsize(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::Transaction::wtxid(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::TxIn::base_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxIn::clone(&self) -> bitcoin::blockdata::transaction::TxIn
+pub fn bitcoin::blockdata::transaction::TxIn::cmp(&self, other: &bitcoin::blockdata::transaction::TxIn) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::TxIn::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxIn::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::TxIn::default() -> bitcoin::blockdata::transaction::TxIn
+pub fn bitcoin::blockdata::transaction::TxIn::enables_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::TxIn::eq(&self, other: &bitcoin::blockdata::transaction::TxIn) -> bool
+pub fn bitcoin::blockdata::transaction::TxIn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::TxIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::TxIn::legacy_weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::TxIn::partial_cmp(&self, other: &bitcoin::blockdata::transaction::TxIn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::TxIn::segwit_weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::TxIn::total_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxOut::clone(&self) -> bitcoin::blockdata::transaction::TxOut
+pub fn bitcoin::blockdata::transaction::TxOut::cmp(&self, other: &bitcoin::blockdata::transaction::TxOut) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::transaction::TxOut, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::transaction::TxOut, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::eq(&self, other: &bitcoin::blockdata::transaction::TxOut) -> bool
+pub fn bitcoin::blockdata::transaction::TxOut::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::TxOut::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::TxOut::minimal_non_dust(script_pubkey: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn bitcoin::blockdata::transaction::TxOut::minimal_non_dust_custom(script_pubkey: bitcoin::blockdata::script::ScriptBuf, dust_relay_fee: bitcoin::blockdata::fee_rate::FeeRate) -> Self
+pub fn bitcoin::blockdata::transaction::TxOut::partial_cmp(&self, other: &bitcoin::blockdata::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Txid::clone(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Txid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Txid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Txid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Txid::eq(&self, other: &bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::transaction::Txid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Txid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Txid::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::transaction::Txid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::transaction::Txid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Version::clone(&self) -> bitcoin::blockdata::transaction::Version
+pub fn bitcoin::blockdata::transaction::Version::cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Version::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Version::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Version::eq(&self, other: &bitcoin::blockdata::transaction::Version) -> bool
+pub fn bitcoin::blockdata::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Version::is_standard(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Version::non_standard(version: i32) -> bitcoin::blockdata::transaction::Version
+pub fn bitcoin::blockdata::transaction::Version::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::transaction::Wtxid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Wtxid::clone(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Wtxid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Wtxid::eq(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> bool
+pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::transaction::Wtxid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Wtxid::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::transaction::Wtxid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::transaction::Wtxid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::effective_value(fee_rate: bitcoin::blockdata::fee_rate::FeeRate, satisfaction_weight: bitcoin::blockdata::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin::blockdata::transaction::predict_weight<I, O>(inputs: I, output_script_lens: O) -> bitcoin::blockdata::weight::Weight where I: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::transaction::InputWeightPrediction>, O: core::iter::traits::collect::IntoIterator<Item = usize>
+pub fn bitcoin::blockdata::weight::Weight::add(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::add_assign(&mut self, rhs: Self)
+pub fn bitcoin::blockdata::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::clone(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::weight::Weight::cmp(&self, other: &bitcoin::blockdata::weight::Weight) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::weight::Weight::div(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin::blockdata::weight::Weight::eq(&self, other: &bitcoin::blockdata::weight::Weight) -> bool
+pub fn bitcoin::blockdata::weight::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::weight::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::weight::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::weight::Weight::mul(self, rhs: bitcoin::blockdata::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin::blockdata::weight::Weight::partial_cmp(&self, other: &bitcoin::blockdata::weight::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::weight::Weight::scale_by_witness_factor(self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::sub(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin::blockdata::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin::blockdata::weight::Weight>
+pub fn bitcoin::blockdata::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::witness::Iter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::witness::Witness::clear(&mut self)
+pub fn bitcoin::blockdata::witness::Witness::clone(&self) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::witness::Witness::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::witness::Witness::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::witness::Witness::default() -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::eq(&self, other: &bitcoin::blockdata::witness::Witness) -> bool
+pub fn bitcoin::blockdata::witness::Witness::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::witness::Witness::from(slice: &[&[u8]]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(slice: &[alloc::vec::Vec<u8>]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(vec: alloc::vec::Vec<&[u8]>) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(vec: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from_slice<T: core::convert::AsRef<[u8]>>(slice: &[T]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::witness::Witness::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin::blockdata::witness::Witness::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::witness::Witness::iter(&self) -> bitcoin::blockdata::witness::Iter<'_>
+pub fn bitcoin::blockdata::witness::Witness::last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::len(&self) -> usize
+pub fn bitcoin::blockdata::witness::Witness::new() -> Self
+pub fn bitcoin::blockdata::witness::Witness::nth(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::p2tr_key_spend(signature: &bitcoin::taproot::Signature) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: &secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::partial_cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
+pub fn bitcoin::blockdata::witness::Witness::push_ecdsa_signature(&mut self, signature: &bitcoin::ecdsa::Signature)
+pub fn bitcoin::blockdata::witness::Witness::second_to_last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::size(&self) -> usize
+pub fn bitcoin::blockdata::witness::Witness::tapscript(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
+pub fn bitcoin::consensus::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::Encodable::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::ReadExt::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::WriteExt::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::deserialize<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<T, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::deserialize_partial<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<(T, usize), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::CheckedData::checksum(&self) -> [u8; 4]
+pub fn bitcoin::consensus::encode::CheckedData::clone(&self) -> bitcoin::consensus::encode::CheckedData
+pub fn bitcoin::consensus::encode::CheckedData::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::CheckedData::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::CheckedData::data(&self) -> &[u8]
+pub fn bitcoin::consensus::encode::CheckedData::eq(&self, other: &bitcoin::consensus::encode::CheckedData) -> bool
+pub fn bitcoin::consensus::encode::CheckedData::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::CheckedData::into_data(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::consensus::encode::CheckedData::new(data: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::consensus::encode::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::Encodable::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::Error::from(error: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::consensus::encode::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::consensus::encode::ReadExt::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::VarInt::clone(&self) -> bitcoin::consensus::encode::VarInt
+pub fn bitcoin::consensus::encode::VarInt::cmp(&self, other: &bitcoin::consensus::encode::VarInt) -> core::cmp::Ordering
+pub fn bitcoin::consensus::encode::VarInt::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::VarInt::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::VarInt::eq(&self, other: &bitcoin::consensus::encode::VarInt) -> bool
+pub fn bitcoin::consensus::encode::VarInt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::VarInt::from(x: u16) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u32) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u64) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u8) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: usize) -> Self
+pub fn bitcoin::consensus::encode::VarInt::partial_cmp(&self, other: &bitcoin::consensus::encode::VarInt) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::consensus::encode::WriteExt::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::deserialize<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<T, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::deserialize_partial<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<(T, usize), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::serialize<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::vec::Vec<u8>
+pub fn bitcoin::consensus::encode::serialize_hex<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::string::String
+pub fn bitcoin::consensus::params::Params::clone(&self) -> bitcoin::consensus::params::Params
+pub fn bitcoin::consensus::params::Params::difficulty_adjustment_interval(&self) -> u64
+pub fn bitcoin::consensus::params::Params::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::params::Params::from(value: &bitcoin::network::Network) -> Self
+pub fn bitcoin::consensus::params::Params::from(value: bitcoin::network::Network) -> Self
+pub fn bitcoin::consensus::serialize<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::vec::Vec<u8>
+pub fn bitcoin::constants::genesis_block(network: bitcoin::network::Network) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::ecdsa::Error::clone(&self) -> bitcoin::ecdsa::Error
+pub fn bitcoin::ecdsa::Error::eq(&self, other: &bitcoin::ecdsa::Error) -> bool
+pub fn bitcoin::ecdsa::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::Error::from(e: secp256k1::Error) -> bitcoin::ecdsa::Error
+pub fn bitcoin::ecdsa::Error::from(err: bitcoin::sighash::NonStandardSighashTypeError) -> Self
+pub fn bitcoin::ecdsa::Error::from(err: hex_conservative::parse::HexToBytesError) -> Self
+pub fn bitcoin::ecdsa::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::ecdsa::SerializedSignature::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::ecdsa::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn bitcoin::ecdsa::SerializedSignature::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::ecdsa::SerializedSignature::borrow(&self) -> &[u8]
+pub fn bitcoin::ecdsa::SerializedSignature::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::ecdsa::SerializedSignature::clone(&self) -> bitcoin::ecdsa::SerializedSignature
+pub fn bitcoin::ecdsa::SerializedSignature::deref(&self) -> &Self::Target
+pub fn bitcoin::ecdsa::SerializedSignature::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::ecdsa::SerializedSignature::eq(&self, other: &bitcoin::ecdsa::SerializedSignature) -> bool
+pub fn bitcoin::ecdsa::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::ecdsa::SerializedSignature::iter(&self) -> core::slice::iter::Iter<'_, u8>
+pub fn bitcoin::ecdsa::SerializedSignature::write_to<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::ecdsa::Signature::clone(&self) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::eq(&self, other: &bitcoin::ecdsa::Signature) -> bool
+pub fn bitcoin::ecdsa::Signature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::Signature::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin::ecdsa::Error>
+pub fn bitcoin::ecdsa::Signature::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::ecdsa::Signature::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::ecdsa::Signature::serialize(&self) -> bitcoin::ecdsa::SerializedSignature
+pub fn bitcoin::ecdsa::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::ecdsa::Signature::sighash_all(signature: secp256k1::ecdsa::Signature) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::to_vec(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::error::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin::error::ParseIntError::clone(&self) -> bitcoin::error::ParseIntError
+pub fn bitcoin::error::ParseIntError::eq(&self, other: &bitcoin::error::ParseIntError) -> bool
+pub fn bitcoin::error::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::error::ParseIntError::input(&self) -> &str
+pub fn bitcoin::error::ParseIntError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::key::Error::clone(&self) -> bitcoin::key::Error
+pub fn bitcoin::key::Error::eq(&self, other: &bitcoin::key::Error) -> bool
+pub fn bitcoin::key::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::Error::from(e: bitcoin::base58::Error) -> bitcoin::key::Error
+pub fn bitcoin::key::Error::from(e: hex_conservative::parse::HexToArrayError) -> Self
+pub fn bitcoin::key::Error::from(e: secp256k1::Error) -> bitcoin::key::Error
+pub fn bitcoin::key::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::key::SortKey::clone(&self) -> bitcoin::key::SortKey
+pub fn bitcoin::key::SortKey::cmp(&self, other: &bitcoin::key::SortKey) -> core::cmp::Ordering
+pub fn bitcoin::key::SortKey::eq(&self, other: &bitcoin::key::SortKey) -> bool
+pub fn bitcoin::key::SortKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::SortKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::SortKey::partial_cmp(&self, other: &bitcoin::key::SortKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TapTweak::dangerous_assume_tweaked(self) -> Self::TweakedKey
+pub fn bitcoin::key::TapTweak::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self::TweakedAux
+pub fn bitcoin::key::TweakedKeypair::clone(&self) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::TweakedKeypair::cmp(&self, other: &bitcoin::key::TweakedKeypair) -> core::cmp::Ordering
+pub fn bitcoin::key::TweakedKeypair::dangerous_assume_tweaked(pair: secp256k1::key::Keypair) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::TweakedKeypair::eq(&self, other: &bitcoin::key::TweakedKeypair) -> bool
+pub fn bitcoin::key::TweakedKeypair::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::TweakedKeypair::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::TweakedKeypair::partial_cmp(&self, other: &bitcoin::key::TweakedKeypair) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TweakedKeypair::public_parts(&self) -> (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub fn bitcoin::key::TweakedKeypair::to_inner(self) -> secp256k1::key::Keypair
+pub fn bitcoin::key::TweakedPublicKey::clone(&self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::TweakedPublicKey::cmp(&self, other: &bitcoin::key::TweakedPublicKey) -> core::cmp::Ordering
+pub fn bitcoin::key::TweakedPublicKey::dangerous_assume_tweaked(key: secp256k1::key::XOnlyPublicKey) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::TweakedPublicKey::eq(&self, other: &bitcoin::key::TweakedPublicKey) -> bool
+pub fn bitcoin::key::TweakedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::TweakedPublicKey::from(pair: bitcoin::key::TweakedKeypair) -> Self
+pub fn bitcoin::key::TweakedPublicKey::from_keypair(keypair: bitcoin::key::TweakedKeypair) -> Self
+pub fn bitcoin::key::TweakedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::TweakedPublicKey::partial_cmp(&self, other: &bitcoin::key::TweakedPublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TweakedPublicKey::serialize(&self) -> [u8; 32]
+pub fn bitcoin::key::TweakedPublicKey::to_inner(self) -> secp256k1::key::XOnlyPublicKey
+pub fn bitcoin::key::UncompressedPubkeyError::clone(&self) -> bitcoin::key::UncompressedPubkeyError
+pub fn bitcoin::key::UncompressedPubkeyError::eq(&self, other: &bitcoin::key::UncompressedPubkeyError) -> bool
+pub fn bitcoin::key::UncompressedPubkeyError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::UncompressedPubkeyError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::key::UntweakedKeypair::dangerous_assume_tweaked(self) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::UntweakedKeypair::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::UntweakedPublicKey::dangerous_assume_tweaked(self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::UntweakedPublicKey::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub fn bitcoin::merkle_tree::MerkleBlockError::clone(&self) -> bitcoin::merkle_tree::MerkleBlockError
+pub fn bitcoin::merkle_tree::MerkleBlockError::eq(&self, other: &bitcoin::merkle_tree::MerkleBlockError) -> bool
+pub fn bitcoin::merkle_tree::MerkleBlockError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::merkle_tree::MerkleBlockError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::bits(&self) -> &alloc::vec::Vec<bool>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::clone(&self) -> bitcoin::merkle_tree::PartialMerkleTree
+pub fn bitcoin::merkle_tree::PartialMerkleTree::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::eq(&self, other: &bitcoin::merkle_tree::PartialMerkleTree) -> bool
+pub fn bitcoin::merkle_tree::PartialMerkleTree::extract_matches(&self, matches: &mut alloc::vec::Vec<bitcoin::blockdata::transaction::Txid>, indexes: &mut alloc::vec::Vec<u32>) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin::merkle_tree::MerkleBlockError>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::merkle_tree::PartialMerkleTree::from_txids(txids: &[bitcoin::blockdata::transaction::Txid], matches: &[bool]) -> Self
+pub fn bitcoin::merkle_tree::PartialMerkleTree::hashes(&self) -> &alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::num_transactions(&self) -> u32
+pub fn bitcoin::merkle_tree::calculate_root<T, I>(hashes: I) -> core::option::Option<T> where T: bitcoin_hashes::Hash + bitcoin::consensus::encode::Encodable, <T as bitcoin_hashes::Hash>::Engine: bitcoin_io::Write, I: core::iter::traits::iterator::Iterator<Item = T>
+pub fn bitcoin::merkle_tree::calculate_root_inline<T>(hashes: &mut [T]) -> core::option::Option<T> where T: bitcoin_hashes::Hash + bitcoin::consensus::encode::Encodable, <T as bitcoin_hashes::Hash>::Engine: bitcoin_io::Write
+pub fn bitcoin::network::Network::chain_hash(self) -> bitcoin::blockdata::constants::ChainHash
+pub fn bitcoin::network::Network::clone(&self) -> bitcoin::network::Network
+pub fn bitcoin::network::Network::cmp(&self, other: &bitcoin::network::Network) -> core::cmp::Ordering
+pub fn bitcoin::network::Network::eq(&self, other: &bitcoin::network::Network) -> bool
+pub fn bitcoin::network::Network::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::Network::from_chain_hash(chain_hash: bitcoin::blockdata::constants::ChainHash) -> core::option::Option<bitcoin::network::Network>
+pub fn bitcoin::network::Network::from_core_arg(core_arg: &str) -> core::result::Result<Self, bitcoin::network::ParseNetworkError>
+pub fn bitcoin::network::Network::from_magic(magic: bitcoin::p2p::Magic) -> core::option::Option<bitcoin::network::Network>
+pub fn bitcoin::network::Network::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::network::Network::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::network::Network::magic(self) -> bitcoin::p2p::Magic
+pub fn bitcoin::network::Network::partial_cmp(&self, other: &bitcoin::network::Network) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::network::Network::to_core_arg(self) -> &'static str
+pub fn bitcoin::network::Network::try_from(chain_hash: bitcoin::blockdata::constants::ChainHash) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::network::Network::try_from(magic: bitcoin::p2p::Magic) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::network::NetworkKind::clone(&self) -> bitcoin::network::NetworkKind
+pub fn bitcoin::network::NetworkKind::cmp(&self, other: &bitcoin::network::NetworkKind) -> core::cmp::Ordering
+pub fn bitcoin::network::NetworkKind::eq(&self, other: &bitcoin::network::NetworkKind) -> bool
+pub fn bitcoin::network::NetworkKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::NetworkKind::from(n: bitcoin::network::Network) -> Self
+pub fn bitcoin::network::NetworkKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::network::NetworkKind::is_mainnet(&self) -> bool
+pub fn bitcoin::network::NetworkKind::partial_cmp(&self, other: &bitcoin::network::NetworkKind) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::network::ParseNetworkError::clone(&self) -> bitcoin::network::ParseNetworkError
+pub fn bitcoin::network::ParseNetworkError::eq(&self, other: &bitcoin::network::ParseNetworkError) -> bool
+pub fn bitcoin::network::ParseNetworkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::ParseNetworkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::network::ParseNetworkError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::network::UnknownChainHashError::clone(&self) -> bitcoin::network::UnknownChainHashError
+pub fn bitcoin::network::UnknownChainHashError::eq(&self, other: &bitcoin::network::UnknownChainHashError) -> bool
+pub fn bitcoin::network::UnknownChainHashError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::UnknownChainHashError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::p2p::Magic::as_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::p2p::Magic::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::p2p::Magic::as_ref(&self) -> &[u8; 4]
+pub fn bitcoin::p2p::Magic::as_ref(&self) -> &[u8]
+pub fn bitcoin::p2p::Magic::borrow(&self) -> &[u8; 4]
+pub fn bitcoin::p2p::Magic::borrow(&self) -> &[u8]
+pub fn bitcoin::p2p::Magic::borrow_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::p2p::Magic::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::p2p::Magic::clone(&self) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::cmp(&self, other: &bitcoin::p2p::Magic) -> core::cmp::Ordering
+pub fn bitcoin::p2p::Magic::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::Magic::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::Magic::eq(&self, other: &bitcoin::p2p::Magic) -> bool
+pub fn bitcoin::p2p::Magic::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::p2p::Magic::from(network: bitcoin::network::Network) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::from_bytes(bytes: [u8; 4]) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::from_str(s: &str) -> core::result::Result<bitcoin::p2p::Magic, Self::Err>
+pub fn bitcoin::p2p::Magic::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::Magic::partial_cmp(&self, other: &bitcoin::p2p::Magic) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::Magic::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::p2p::ParseMagicError::clone(&self) -> bitcoin::p2p::ParseMagicError
+pub fn bitcoin::p2p::ParseMagicError::eq(&self, other: &bitcoin::p2p::ParseMagicError) -> bool
+pub fn bitcoin::p2p::ParseMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::ParseMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::p2p::ParseMagicError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::p2p::ServiceFlags::add(&mut self, other: bitcoin::p2p::ServiceFlags) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::bitor(self, rhs: Self) -> Self
+pub fn bitcoin::p2p::ServiceFlags::bitor_assign(&mut self, rhs: Self)
+pub fn bitcoin::p2p::ServiceFlags::bitxor(self, rhs: Self) -> Self
+pub fn bitcoin::p2p::ServiceFlags::bitxor_assign(&mut self, rhs: Self)
+pub fn bitcoin::p2p::ServiceFlags::clone(&self) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::cmp(&self, other: &bitcoin::p2p::ServiceFlags) -> core::cmp::Ordering
+pub fn bitcoin::p2p::ServiceFlags::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::ServiceFlags::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::ServiceFlags::default() -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::eq(&self, other: &bitcoin::p2p::ServiceFlags) -> bool
+pub fn bitcoin::p2p::ServiceFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::ServiceFlags::from(f: u64) -> Self
+pub fn bitcoin::p2p::ServiceFlags::has(self, flags: bitcoin::p2p::ServiceFlags) -> bool
+pub fn bitcoin::p2p::ServiceFlags::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::ServiceFlags::partial_cmp(&self, other: &bitcoin::p2p::ServiceFlags) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::ServiceFlags::remove(&mut self, other: bitcoin::p2p::ServiceFlags) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::to_u64(self) -> u64
+pub fn bitcoin::p2p::UnknownMagicError::clone(&self) -> bitcoin::p2p::UnknownMagicError
+pub fn bitcoin::p2p::UnknownMagicError::eq(&self, other: &bitcoin::p2p::UnknownMagicError) -> bool
+pub fn bitcoin::p2p::UnknownMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::UnknownMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::p2p::UnknownMagicError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::p2p::address::AddrV2::clone(&self) -> bitcoin::p2p::address::AddrV2
+pub fn bitcoin::p2p::address::AddrV2::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::address::AddrV2::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::AddrV2::eq(&self, other: &bitcoin::p2p::address::AddrV2) -> bool
+pub fn bitcoin::p2p::address::AddrV2::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::address::AddrV2::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::address::AddrV2Message::clone(&self) -> bitcoin::p2p::address::AddrV2Message
+pub fn bitcoin::p2p::address::AddrV2Message::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::address::AddrV2Message::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::AddrV2Message::eq(&self, other: &bitcoin::p2p::address::AddrV2Message) -> bool
+pub fn bitcoin::p2p::address::AddrV2Message::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::address::AddrV2Message::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::address::AddrV2Message::socket_addr(&self) -> core::result::Result<core::net::socket_addr::SocketAddr, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::AddrV2Message::to_socket_addrs(&self) -> core::result::Result<Self::Iter, std::io::error::Error>
+pub fn bitcoin::p2p::address::Address::clone(&self) -> bitcoin::p2p::address::Address
+pub fn bitcoin::p2p::address::Address::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::address::Address::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::Address::eq(&self, other: &bitcoin::p2p::address::Address) -> bool
+pub fn bitcoin::p2p::address::Address::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::address::Address::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::address::Address::new(socket: &core::net::socket_addr::SocketAddr, services: bitcoin::p2p::ServiceFlags) -> bitcoin::p2p::address::Address
+pub fn bitcoin::p2p::address::Address::socket_addr(&self) -> core::result::Result<core::net::socket_addr::SocketAddr, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::address::Address::to_socket_addrs(&self) -> core::result::Result<Self::Iter, std::io::error::Error>
+pub fn bitcoin::p2p::message::CommandString::as_ref(&self) -> &str
+pub fn bitcoin::p2p::message::CommandString::clone(&self) -> bitcoin::p2p::message::CommandString
+pub fn bitcoin::p2p::message::CommandString::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message::CommandString::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message::CommandString::eq(&self, other: &bitcoin::p2p::message::CommandString) -> bool
+pub fn bitcoin::p2p::message::CommandString::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::CommandString::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::p2p::message::CommandString::try_from(value: &'a str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::p2p::message::CommandString::try_from(value: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::p2p::message::CommandString::try_from(value: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::p2p::message::CommandString::try_from_static(s: &'static str) -> core::result::Result<bitcoin::p2p::message::CommandString, bitcoin::p2p::message::CommandStringError>
+pub fn bitcoin::p2p::message::CommandStringError::clone(&self) -> bitcoin::p2p::message::CommandStringError
+pub fn bitcoin::p2p::message::CommandStringError::eq(&self, other: &bitcoin::p2p::message::CommandStringError) -> bool
+pub fn bitcoin::p2p::message::CommandStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::CommandStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::p2p::message::NetworkMessage::clone(&self) -> bitcoin::p2p::message::NetworkMessage
+pub fn bitcoin::p2p::message::NetworkMessage::cmd(&self) -> &'static str
+pub fn bitcoin::p2p::message::NetworkMessage::command(&self) -> bitcoin::p2p::message::CommandString
+pub fn bitcoin::p2p::message::NetworkMessage::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message::NetworkMessage::eq(&self, other: &bitcoin::p2p::message::NetworkMessage) -> bool
+pub fn bitcoin::p2p::message::NetworkMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::RawNetworkMessage::clone(&self) -> bitcoin::p2p::message::RawNetworkMessage
+pub fn bitcoin::p2p::message::RawNetworkMessage::cmd(&self) -> &'static str
+pub fn bitcoin::p2p::message::RawNetworkMessage::command(&self) -> bitcoin::p2p::message::CommandString
+pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message::RawNetworkMessage::eq(&self, other: &bitcoin::p2p::message::RawNetworkMessage) -> bool
+pub fn bitcoin::p2p::message::RawNetworkMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::RawNetworkMessage::magic(&self) -> &bitcoin::p2p::Magic
+pub fn bitcoin::p2p::message::RawNetworkMessage::new(magic: bitcoin::p2p::Magic, payload: bitcoin::p2p::message::NetworkMessage) -> Self
+pub fn bitcoin::p2p::message::RawNetworkMessage::payload(&self) -> &bitcoin::p2p::message::NetworkMessage
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::clone(&self) -> bitcoin::p2p::message_blockdata::GetBlocksMessage
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_blockdata::GetBlocksMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_blockdata::GetBlocksMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::eq(&self, other: &bitcoin::p2p::message_blockdata::GetBlocksMessage) -> bool
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::new(locator_hashes: alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>, stop_hash: bitcoin::blockdata::block::BlockHash) -> bitcoin::p2p::message_blockdata::GetBlocksMessage
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::clone(&self) -> bitcoin::p2p::message_blockdata::GetHeadersMessage
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_blockdata::GetHeadersMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_blockdata::GetHeadersMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::eq(&self, other: &bitcoin::p2p::message_blockdata::GetHeadersMessage) -> bool
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::new(locator_hashes: alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>, stop_hash: bitcoin::blockdata::block::BlockHash) -> bitcoin::p2p::message_blockdata::GetHeadersMessage
+pub fn bitcoin::p2p::message_blockdata::Inventory::clone(&self) -> bitcoin::p2p::message_blockdata::Inventory
+pub fn bitcoin::p2p::message_blockdata::Inventory::cmp(&self, other: &bitcoin::p2p::message_blockdata::Inventory) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_blockdata::Inventory::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_blockdata::Inventory::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_blockdata::Inventory::eq(&self, other: &bitcoin::p2p::message_blockdata::Inventory) -> bool
+pub fn bitcoin::p2p::message_blockdata::Inventory::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_blockdata::Inventory::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_blockdata::Inventory::network_hash(&self) -> core::option::Option<[u8; 32]>
+pub fn bitcoin::p2p::message_blockdata::Inventory::partial_cmp(&self, other: &bitcoin::p2p::message_blockdata::Inventory) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_bloom::BloomFlags::clone(&self) -> bitcoin::p2p::message_bloom::BloomFlags
+pub fn bitcoin::p2p::message_bloom::BloomFlags::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::BloomFlags::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_bloom::BloomFlags::eq(&self, other: &bitcoin::p2p::message_bloom::BloomFlags) -> bool
+pub fn bitcoin::p2p::message_bloom::BloomFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_bloom::FilterAdd::clone(&self) -> bitcoin::p2p::message_bloom::FilterAdd
+pub fn bitcoin::p2p::message_bloom::FilterAdd::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_bloom::FilterAdd, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::FilterAdd::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_bloom::FilterAdd, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::FilterAdd::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_bloom::FilterAdd::eq(&self, other: &bitcoin::p2p::message_bloom::FilterAdd) -> bool
+pub fn bitcoin::p2p::message_bloom::FilterAdd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_bloom::FilterLoad::clone(&self) -> bitcoin::p2p::message_bloom::FilterLoad
+pub fn bitcoin::p2p::message_bloom::FilterLoad::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_bloom::FilterLoad, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::FilterLoad::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_bloom::FilterLoad, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_bloom::FilterLoad::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_bloom::FilterLoad::eq(&self, other: &bitcoin::p2p::message_bloom::FilterLoad) -> bool
+pub fn bitcoin::p2p::message_bloom::FilterLoad::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::clone(&self) -> bitcoin::p2p::message_compact_blocks::BlockTxn
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::cmp(&self, other: &bitcoin::p2p::message_compact_blocks::BlockTxn) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::BlockTxn, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::BlockTxn, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::eq(&self, other: &bitcoin::p2p::message_compact_blocks::BlockTxn) -> bool
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::partial_cmp(&self, other: &bitcoin::p2p::message_compact_blocks::BlockTxn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::clone(&self) -> bitcoin::p2p::message_compact_blocks::CmpctBlock
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::cmp(&self, other: &bitcoin::p2p::message_compact_blocks::CmpctBlock) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::CmpctBlock, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::CmpctBlock, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::eq(&self, other: &bitcoin::p2p::message_compact_blocks::CmpctBlock) -> bool
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::partial_cmp(&self, other: &bitcoin::p2p::message_compact_blocks::CmpctBlock) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::clone(&self) -> bitcoin::p2p::message_compact_blocks::GetBlockTxn
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::cmp(&self, other: &bitcoin::p2p::message_compact_blocks::GetBlockTxn) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::GetBlockTxn, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::GetBlockTxn, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::eq(&self, other: &bitcoin::p2p::message_compact_blocks::GetBlockTxn) -> bool
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::partial_cmp(&self, other: &bitcoin::p2p::message_compact_blocks::GetBlockTxn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::clone(&self) -> bitcoin::p2p::message_compact_blocks::SendCmpct
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::cmp(&self, other: &bitcoin::p2p::message_compact_blocks::SendCmpct) -> core::cmp::Ordering
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::SendCmpct, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_compact_blocks::SendCmpct, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::eq(&self, other: &bitcoin::p2p::message_compact_blocks::SendCmpct) -> bool
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::partial_cmp(&self, other: &bitcoin::p2p::message_compact_blocks::SendCmpct) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::message_filter::CFCheckpt::clone(&self) -> bitcoin::p2p::message_filter::CFCheckpt
+pub fn bitcoin::p2p::message_filter::CFCheckpt::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFCheckpt, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFCheckpt::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFCheckpt, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFCheckpt::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::CFCheckpt::eq(&self, other: &bitcoin::p2p::message_filter::CFCheckpt) -> bool
+pub fn bitcoin::p2p::message_filter::CFCheckpt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::CFHeaders::clone(&self) -> bitcoin::p2p::message_filter::CFHeaders
+pub fn bitcoin::p2p::message_filter::CFHeaders::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFHeaders, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFHeaders::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFHeaders, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFHeaders::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::CFHeaders::eq(&self, other: &bitcoin::p2p::message_filter::CFHeaders) -> bool
+pub fn bitcoin::p2p::message_filter::CFHeaders::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::CFilter::clone(&self) -> bitcoin::p2p::message_filter::CFilter
+pub fn bitcoin::p2p::message_filter::CFilter::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFilter, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFilter::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::CFilter, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::CFilter::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::CFilter::eq(&self, other: &bitcoin::p2p::message_filter::CFilter) -> bool
+pub fn bitcoin::p2p::message_filter::CFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::clone(&self) -> bitcoin::p2p::message_filter::GetCFCheckpt
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFCheckpt, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFCheckpt, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::eq(&self, other: &bitcoin::p2p::message_filter::GetCFCheckpt) -> bool
+pub fn bitcoin::p2p::message_filter::GetCFCheckpt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::clone(&self) -> bitcoin::p2p::message_filter::GetCFHeaders
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFHeaders, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFHeaders, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::eq(&self, other: &bitcoin::p2p::message_filter::GetCFHeaders) -> bool
+pub fn bitcoin::p2p::message_filter::GetCFHeaders::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_filter::GetCFilters::clone(&self) -> bitcoin::p2p::message_filter::GetCFilters
+pub fn bitcoin::p2p::message_filter::GetCFilters::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFilters, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFilters::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_filter::GetCFilters, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_filter::GetCFilters::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_filter::GetCFilters::eq(&self, other: &bitcoin::p2p::message_filter::GetCFilters) -> bool
+pub fn bitcoin::p2p::message_filter::GetCFilters::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_network::Reject::clone(&self) -> bitcoin::p2p::message_network::Reject
+pub fn bitcoin::p2p::message_network::Reject::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_network::Reject, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::Reject::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_network::Reject, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::Reject::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_network::Reject::eq(&self, other: &bitcoin::p2p::message_network::Reject) -> bool
+pub fn bitcoin::p2p::message_network::Reject::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_network::RejectReason::clone(&self) -> bitcoin::p2p::message_network::RejectReason
+pub fn bitcoin::p2p::message_network::RejectReason::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::RejectReason::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_network::RejectReason::eq(&self, other: &bitcoin::p2p::message_network::RejectReason) -> bool
+pub fn bitcoin::p2p::message_network::RejectReason::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_network::VersionMessage::clone(&self) -> bitcoin::p2p::message_network::VersionMessage
+pub fn bitcoin::p2p::message_network::VersionMessage::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_network::VersionMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::VersionMessage::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::p2p::message_network::VersionMessage, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::message_network::VersionMessage::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::message_network::VersionMessage::eq(&self, other: &bitcoin::p2p::message_network::VersionMessage) -> bool
+pub fn bitcoin::p2p::message_network::VersionMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message_network::VersionMessage::new(services: bitcoin::p2p::ServiceFlags, timestamp: i64, receiver: bitcoin::p2p::address::Address, sender: bitcoin::p2p::address::Address, nonce: u64, user_agent: alloc::string::String, start_height: i32) -> bitcoin::p2p::message_network::VersionMessage
+pub fn bitcoin::policy::get_virtual_tx_size(weight: i64, n_sigops: i64) -> i64
+pub fn bitcoin::pow::CompactTarget::clone(&self) -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTarget::cmp(&self, other: &bitcoin::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin::pow::CompactTarget::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::pow::CompactTarget::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::pow::CompactTarget::default() -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTarget::eq(&self, other: &bitcoin::pow::CompactTarget) -> bool
+pub fn bitcoin::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin::pow::CompactTarget::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::CompactTarget::partial_cmp(&self, other: &bitcoin::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin::pow::Target::clone(&self) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::cmp(&self, other: &bitcoin::pow::Target) -> core::cmp::Ordering
+pub fn bitcoin::pow::Target::difficulty(&self, network: bitcoin::network::Network) -> u128
+pub fn bitcoin::pow::Target::difficulty_float(&self) -> f64
+pub fn bitcoin::pow::Target::eq(&self, other: &bitcoin::pow::Target) -> bool
+pub fn bitcoin::pow::Target::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::Target::from(c: bitcoin::pow::CompactTarget) -> Self
+pub fn bitcoin::pow::Target::from_be_bytes(bytes: [u8; 32]) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::from_compact(c: bitcoin::pow::CompactTarget) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::from_le_bytes(bytes: [u8; 32]) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::Target::is_met_by(&self, hash: bitcoin::blockdata::block::BlockHash) -> bool
+pub fn bitcoin::pow::Target::max_difficulty_transition_threshold(&self) -> Self
+pub fn bitcoin::pow::Target::min_difficulty_transition_threshold(&self) -> Self
+pub fn bitcoin::pow::Target::partial_cmp(&self, other: &bitcoin::pow::Target) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::Target::to_be_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Target::to_compact_lossy(self) -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::Target::to_le_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Target::to_work(self) -> bitcoin::pow::Work
+pub fn bitcoin::pow::TryFromError::clone(&self) -> bitcoin::pow::TryFromError
+pub fn bitcoin::pow::TryFromError::eq(&self, other: &bitcoin::pow::TryFromError) -> bool
+pub fn bitcoin::pow::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::TryFromError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::pow::Work::add(self, rhs: Self) -> Self
+pub fn bitcoin::pow::Work::clone(&self) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::cmp(&self, other: &bitcoin::pow::Work) -> core::cmp::Ordering
+pub fn bitcoin::pow::Work::eq(&self, other: &bitcoin::pow::Work) -> bool
+pub fn bitcoin::pow::Work::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::Work::from_be_bytes(bytes: [u8; 32]) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::from_le_bytes(bytes: [u8; 32]) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::Work::log2(self) -> f64
+pub fn bitcoin::pow::Work::partial_cmp(&self, other: &bitcoin::pow::Work) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::Work::sub(self, rhs: Self) -> Self
+pub fn bitcoin::pow::Work::to_be_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Work::to_le_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Work::to_target(self) -> bitcoin::pow::Target
+pub fn bitcoin::psbt::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Error::from(e: bitcoin::consensus::encode::Error) -> Self
+pub fn bitcoin::psbt::Error::from(e: bitcoin_hashes::FromSliceError) -> bitcoin::psbt::Error
+pub fn bitcoin::psbt::Error::from(e: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::psbt::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::ExtractTxError::clone(&self) -> bitcoin::psbt::ExtractTxError
+pub fn bitcoin::psbt::ExtractTxError::eq(&self, other: &bitcoin::psbt::ExtractTxError) -> bool
+pub fn bitcoin::psbt::ExtractTxError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::ExtractTxError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::GetKey::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn bitcoin::psbt::GetKeyError::clone(&self) -> bitcoin::psbt::GetKeyError
+pub fn bitcoin::psbt::GetKeyError::eq(&self, other: &bitcoin::psbt::GetKeyError) -> bool
+pub fn bitcoin::psbt::GetKeyError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::GetKeyError::from(e: bitcoin::bip32::Error) -> Self
+pub fn bitcoin::psbt::GetKeyError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::IndexOutOfBoundsError::clone(&self) -> bitcoin::psbt::IndexOutOfBoundsError
+pub fn bitcoin::psbt::IndexOutOfBoundsError::eq(&self, other: &bitcoin::psbt::IndexOutOfBoundsError) -> bool
+pub fn bitcoin::psbt::IndexOutOfBoundsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::IndexOutOfBoundsError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::Input::clone(&self) -> bitcoin::psbt::Input
+pub fn bitcoin::psbt::Input::combine(&mut self, other: Self)
+pub fn bitcoin::psbt::Input::default() -> bitcoin::psbt::Input
+pub fn bitcoin::psbt::Input::ecdsa_hash_ty(&self) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::psbt::Input::eq(&self, other: &bitcoin::psbt::Input) -> bool
+pub fn bitcoin::psbt::Input::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Input::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::Input::taproot_hash_ty(&self) -> core::result::Result<bitcoin::TapSighashType, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::psbt::KeyRequest::clone(&self) -> bitcoin::psbt::KeyRequest
+pub fn bitcoin::psbt::KeyRequest::eq(&self, other: &bitcoin::psbt::KeyRequest) -> bool
+pub fn bitcoin::psbt::KeyRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Output::clone(&self) -> bitcoin::psbt::Output
+pub fn bitcoin::psbt::Output::combine(&mut self, other: Self)
+pub fn bitcoin::psbt::Output::default() -> bitcoin::psbt::Output
+pub fn bitcoin::psbt::Output::eq(&self, other: &bitcoin::psbt::Output) -> bool
+pub fn bitcoin::psbt::Output::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Output::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::OutputType::clone(&self) -> bitcoin::psbt::OutputType
+pub fn bitcoin::psbt::OutputType::cmp(&self, other: &bitcoin::psbt::OutputType) -> core::cmp::Ordering
+pub fn bitcoin::psbt::OutputType::eq(&self, other: &bitcoin::psbt::OutputType) -> bool
+pub fn bitcoin::psbt::OutputType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::OutputType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::OutputType::partial_cmp(&self, other: &bitcoin::psbt::OutputType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::OutputType::signing_algorithm(&self) -> bitcoin::psbt::SigningAlgorithm
+pub fn bitcoin::psbt::Psbt::clone(&self) -> bitcoin::psbt::Psbt
+pub fn bitcoin::psbt::Psbt::combine(&mut self, other: Self) -> core::result::Result<(), bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::deserialize(bytes: &[u8]) -> core::result::Result<Self, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::eq(&self, other: &bitcoin::psbt::Psbt) -> bool
+pub fn bitcoin::psbt::Psbt::extract_tx(self) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::extract_tx_fee_rate_limit(self) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::extract_tx_unchecked_fee_rate(self) -> bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::psbt::Psbt::extract_tx_with_fee_rate_limit(self, max_fee_rate: bitcoin::blockdata::fee_rate::FeeRate) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::fee(&self) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Psbt::from_unsigned_tx(tx: bitcoin::blockdata::transaction::Transaction) -> core::result::Result<Self, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::Psbt::iter_funding_utxos(&self) -> impl core::iter::traits::iterator::Iterator<Item = core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::psbt::Error>>
+pub fn bitcoin::psbt::Psbt::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::psbt::Psbt::serialize_hex(&self) -> alloc::string::String
+pub fn bitcoin::psbt::Psbt::sighash_ecdsa<T: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>>(&self, input_index: usize, cache: &mut bitcoin::sighash::SighashCache<T>) -> core::result::Result<(secp256k1::Message, bitcoin::EcdsaSighashType), bitcoin::psbt::SignError>
+pub fn bitcoin::psbt::Psbt::sign<C, K>(&mut self, k: &K, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<bitcoin::psbt::SigningKeys, (bitcoin::psbt::SigningKeys, bitcoin::psbt::SigningErrors)> where C: secp256k1::context::Signing, K: bitcoin::psbt::GetKey
+pub fn bitcoin::psbt::Psbt::spend_utxo(&self, input_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::psbt::SignError>
+pub fn bitcoin::psbt::PsbtSighashType::clone(&self) -> bitcoin::psbt::PsbtSighashType
+pub fn bitcoin::psbt::PsbtSighashType::cmp(&self, other: &bitcoin::psbt::PsbtSighashType) -> core::cmp::Ordering
+pub fn bitcoin::psbt::PsbtSighashType::ecdsa_hash_ty(self) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::psbt::PsbtSighashType::eq(&self, other: &bitcoin::psbt::PsbtSighashType) -> bool
+pub fn bitcoin::psbt::PsbtSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::PsbtSighashType::from(ecdsa_hash_ty: bitcoin::EcdsaSighashType) -> Self
+pub fn bitcoin::psbt::PsbtSighashType::from(taproot_hash_ty: bitcoin::TapSighashType) -> Self
+pub fn bitcoin::psbt::PsbtSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::psbt::PsbtSighashType::from_u32(n: u32) -> bitcoin::psbt::PsbtSighashType
+pub fn bitcoin::psbt::PsbtSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::PsbtSighashType::partial_cmp(&self, other: &bitcoin::psbt::PsbtSighashType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::PsbtSighashType::taproot_hash_ty(self) -> core::result::Result<bitcoin::TapSighashType, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::psbt::PsbtSighashType::to_u32(self) -> u32
+pub fn bitcoin::psbt::SignError::clone(&self) -> bitcoin::psbt::SignError
+pub fn bitcoin::psbt::SignError::eq(&self, other: &bitcoin::psbt::SignError) -> bool
+pub fn bitcoin::psbt::SignError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::SignError::from(e: bitcoin::psbt::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::psbt::SignError::from(e: bitcoin::sighash::P2wpkhError) -> Self
+pub fn bitcoin::psbt::SignError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::psbt::SigningAlgorithm::clone(&self) -> bitcoin::psbt::SigningAlgorithm
+pub fn bitcoin::psbt::SigningAlgorithm::cmp(&self, other: &bitcoin::psbt::SigningAlgorithm) -> core::cmp::Ordering
+pub fn bitcoin::psbt::SigningAlgorithm::eq(&self, other: &bitcoin::psbt::SigningAlgorithm) -> bool
+pub fn bitcoin::psbt::SigningAlgorithm::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::SigningAlgorithm::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::SigningAlgorithm::partial_cmp(&self, other: &bitcoin::psbt::SigningAlgorithm) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::Key::clone(&self) -> bitcoin::psbt::raw::Key
+pub fn bitcoin::psbt::raw::Key::cmp(&self, other: &bitcoin::psbt::raw::Key) -> core::cmp::Ordering
+pub fn bitcoin::psbt::raw::Key::eq(&self, other: &bitcoin::psbt::raw::Key) -> bool
+pub fn bitcoin::psbt::raw::Key::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::Key::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::raw::Key::partial_cmp(&self, other: &bitcoin::psbt::raw::Key) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::Pair::eq(&self, other: &bitcoin::psbt::raw::Pair) -> bool
+pub fn bitcoin::psbt::raw::Pair::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::clone(&self) -> bitcoin::psbt::raw::ProprietaryKey<Subtype>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::cmp(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> core::cmp::Ordering
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::eq(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> bool
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::partial_cmp(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::to_key(&self) -> bitcoin::psbt::raw::Key
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::try_from(key: bitcoin::psbt::raw::Key) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::script::PushBytesErrorReport::input_len(&self) -> usize
+pub fn bitcoin::script::read_scriptbool(v: &[u8]) -> bool
+pub fn bitcoin::script::read_scriptint(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::script::read_scriptint_non_minimal(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
+pub fn bitcoin::sighash::Annex<'a>::as_bytes(&self) -> &[u8]
+pub fn bitcoin::sighash::Annex<'a>::clone(&self) -> bitcoin::sighash::Annex<'a>
+pub fn bitcoin::sighash::Annex<'a>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::sighash::Annex<'a>::eq(&self, other: &bitcoin::sighash::Annex<'a>) -> bool
+pub fn bitcoin::sighash::Annex<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::Annex<'a>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::Annex<'a>::new(annex_bytes: &'a [u8]) -> core::result::Result<Self, bitcoin::sighash::AnnexError>
+pub fn bitcoin::sighash::AnnexError::clone(&self) -> bitcoin::sighash::AnnexError
+pub fn bitcoin::sighash::AnnexError::eq(&self, other: &bitcoin::sighash::AnnexError) -> bool
+pub fn bitcoin::sighash::AnnexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::AnnexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::EncodeSigningDataResult<E>::is_sighash_single_bug(self) -> core::result::Result<bool, E>
+pub fn bitcoin::sighash::EncodeSigningDataResult<E>::map_err<E2, F>(self, f: F) -> bitcoin::sighash::EncodeSigningDataResult<E2> where F: core::ops::function::FnOnce(E) -> E2
+pub fn bitcoin::sighash::InvalidSighashTypeError::clone(&self) -> bitcoin::sighash::InvalidSighashTypeError
+pub fn bitcoin::sighash::InvalidSighashTypeError::eq(&self, other: &bitcoin::sighash::InvalidSighashTypeError) -> bool
+pub fn bitcoin::sighash::InvalidSighashTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::InvalidSighashTypeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::NonStandardSighashTypeError::clone(&self) -> bitcoin::sighash::NonStandardSighashTypeError
+pub fn bitcoin::sighash::NonStandardSighashTypeError::eq(&self, other: &bitcoin::sighash::NonStandardSighashTypeError) -> bool
+pub fn bitcoin::sighash::NonStandardSighashTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::NonStandardSighashTypeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::P2wpkhError::clone(&self) -> bitcoin::sighash::P2wpkhError
+pub fn bitcoin::sighash::P2wpkhError::eq(&self, other: &bitcoin::sighash::P2wpkhError) -> bool
+pub fn bitcoin::sighash::P2wpkhError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::P2wpkhError::from(value: bitcoin::blockdata::transaction::InputsIndexError) -> Self
+pub fn bitcoin::sighash::P2wpkhError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::Prevouts<'u, T>::clone(&self) -> bitcoin::sighash::Prevouts<'u, T>
+pub fn bitcoin::sighash::Prevouts<'u, T>::cmp(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> core::cmp::Ordering
+pub fn bitcoin::sighash::Prevouts<'u, T>::eq(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> bool
+pub fn bitcoin::sighash::Prevouts<'u, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::Prevouts<'u, T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::Prevouts<'u, T>::partial_cmp(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::sighash::PrevoutsIndexError::clone(&self) -> bitcoin::sighash::PrevoutsIndexError
+pub fn bitcoin::sighash::PrevoutsIndexError::eq(&self, other: &bitcoin::sighash::PrevoutsIndexError) -> bool
+pub fn bitcoin::sighash::PrevoutsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::PrevoutsIndexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::PrevoutsKindError::clone(&self) -> bitcoin::sighash::PrevoutsKindError
+pub fn bitcoin::sighash::PrevoutsKindError::eq(&self, other: &bitcoin::sighash::PrevoutsKindError) -> bool
+pub fn bitcoin::sighash::PrevoutsKindError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::PrevoutsKindError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::PrevoutsSizeError::clone(&self) -> bitcoin::sighash::PrevoutsSizeError
+pub fn bitcoin::sighash::PrevoutsSizeError::eq(&self, other: &bitcoin::sighash::PrevoutsSizeError) -> bool
+pub fn bitcoin::sighash::PrevoutsSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::PrevoutsSizeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::ScriptPath<'s>::clone(&self) -> bitcoin::sighash::ScriptPath<'s>
+pub fn bitcoin::sighash::ScriptPath<'s>::cmp(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> core::cmp::Ordering
+pub fn bitcoin::sighash::ScriptPath<'s>::eq(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> bool
+pub fn bitcoin::sighash::ScriptPath<'s>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::ScriptPath<'s>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::ScriptPath<'s>::leaf_hash(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::sighash::ScriptPath<'s>::new(script: &'s bitcoin::blockdata::script::Script, leaf_version: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::sighash::ScriptPath<'s>::partial_cmp(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::sighash::ScriptPath<'s>::with_defaults(script: &'s bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::sighash::SighashCache<R>::into_transaction(self) -> R
+pub fn bitcoin::sighash::SighashCache<R>::legacy_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized, U: core::convert::Into<u32>>(&self, writer: &mut W, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, sighash_type: U) -> bitcoin::sighash::EncodeSigningDataResult<bitcoin::sighash::SigningDataError<bitcoin::blockdata::transaction::InputsIndexError>>
+pub fn bitcoin::sighash::SighashCache<R>::legacy_signature_hash(&self, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, sighash_type: u32) -> core::result::Result<bitcoin::LegacySighash, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::sighash::SighashCache<R>::new(tx: R) -> Self
+pub fn bitcoin::sighash::SighashCache<R>::p2wpkh_signature_hash(&mut self, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin::sighash::P2wpkhError>
+pub fn bitcoin::sighash::SighashCache<R>::p2wsh_signature_hash(&mut self, input_index: usize, witness_script: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::sighash::SighashCache<R>::segwit_v0_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized>(&mut self, writer: &mut W, input_index: usize, script_code: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<(), bitcoin::sighash::SigningDataError<bitcoin::blockdata::transaction::InputsIndexError>>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized, T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, writer: &mut W, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, annex: core::option::Option<bitcoin::sighash::Annex<'_>>, leaf_hash_code_separator: core::option::Option<(bitcoin::taproot::TapLeafHash, u32)>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<(), bitcoin::sighash::SigningDataError<bitcoin::sighash::TaprootError>>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_key_spend_signature_hash<T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_script_spend_signature_hash<S: core::convert::Into<bitcoin::taproot::TapLeafHash>, T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, leaf_hash: S, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_signature_hash<T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, annex: core::option::Option<bitcoin::sighash::Annex<'_>>, leaf_hash_code_separator: core::option::Option<(bitcoin::taproot::TapLeafHash, u32)>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::transaction(&self) -> &bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::sighash::SighashCache<R>::witness_mut(&mut self, input_index: usize) -> core::option::Option<&mut bitcoin::blockdata::witness::Witness>
+pub fn bitcoin::sighash::SighashCache<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SighashTypeParseError::clone(&self) -> bitcoin::sighash::SighashTypeParseError
+pub fn bitcoin::sighash::SighashTypeParseError::eq(&self, other: &bitcoin::sighash::SighashTypeParseError) -> bool
+pub fn bitcoin::sighash::SighashTypeParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SighashTypeParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::SigningDataError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SigningDataError<E>::from(value: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::sighash::SigningDataError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::SingleMissingOutputError::clone(&self) -> bitcoin::sighash::SingleMissingOutputError
+pub fn bitcoin::sighash::SingleMissingOutputError::eq(&self, other: &bitcoin::sighash::SingleMissingOutputError) -> bool
+pub fn bitcoin::sighash::SingleMissingOutputError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SingleMissingOutputError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sighash::TaprootError::clone(&self) -> bitcoin::sighash::TaprootError
+pub fn bitcoin::sighash::TaprootError::eq(&self, other: &bitcoin::sighash::TaprootError) -> bool
+pub fn bitcoin::sighash::TaprootError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::blockdata::transaction::InputsIndexError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsIndexError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsKindError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsSizeError) -> Self
+pub fn bitcoin::sighash::TaprootError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sign_message::MessageSignature::clone(&self) -> bitcoin::sign_message::MessageSignature
+pub fn bitcoin::sign_message::MessageSignature::eq(&self, other: &bitcoin::sign_message::MessageSignature) -> bool
+pub fn bitcoin::sign_message::MessageSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sign_message::MessageSignature::from_slice(bytes: &[u8]) -> core::result::Result<bitcoin::sign_message::MessageSignature, bitcoin::sign_message::MessageSignatureError>
+pub fn bitcoin::sign_message::MessageSignature::is_signed_by_address<C: secp256k1::context::Verification>(&self, secp_ctx: &secp256k1::Secp256k1<C>, address: &bitcoin::address::Address, msg_hash: bitcoin_hashes::sha256d::Hash) -> core::result::Result<bool, bitcoin::sign_message::MessageSignatureError>
+pub fn bitcoin::sign_message::MessageSignature::new(signature: secp256k1::ecdsa::recovery::RecoverableSignature, compressed: bool) -> bitcoin::sign_message::MessageSignature
+pub fn bitcoin::sign_message::MessageSignature::recover_pubkey<C: secp256k1::context::Verification>(&self, secp_ctx: &secp256k1::Secp256k1<C>, msg_hash: bitcoin_hashes::sha256d::Hash) -> core::result::Result<bitcoin::PublicKey, bitcoin::sign_message::MessageSignatureError>
+pub fn bitcoin::sign_message::MessageSignature::serialize(&self) -> [u8; 65]
+pub fn bitcoin::sign_message::MessageSignatureError::clone(&self) -> bitcoin::sign_message::MessageSignatureError
+pub fn bitcoin::sign_message::MessageSignatureError::eq(&self, other: &bitcoin::sign_message::MessageSignatureError) -> bool
+pub fn bitcoin::sign_message::MessageSignatureError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sign_message::MessageSignatureError::from(e: secp256k1::Error) -> bitcoin::sign_message::MessageSignatureError
+pub fn bitcoin::sign_message::MessageSignatureError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::sign_message::signed_msg_hash(msg: &str) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::string::FromHexError<E>::clone(&self) -> bitcoin::string::FromHexError<E>
+pub fn bitcoin::string::FromHexError<E>::eq(&self, other: &bitcoin::string::FromHexError<E>) -> bool
+pub fn bitcoin::string::FromHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::string::FromHexError<E>::from(e: E) -> Self
+pub fn bitcoin::string::FromHexError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::string::FromHexStr::from_hex_str<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, bitcoin::string::FromHexError<Self::Error>>
+pub fn bitcoin::string::FromHexStr::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::ControlBlock::clone(&self) -> bitcoin::taproot::ControlBlock
+pub fn bitcoin::taproot::ControlBlock::cmp(&self, other: &bitcoin::taproot::ControlBlock) -> core::cmp::Ordering
+pub fn bitcoin::taproot::ControlBlock::decode(sl: &[u8]) -> core::result::Result<bitcoin::taproot::ControlBlock, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::ControlBlock::encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> bitcoin_io::Result<usize>
+pub fn bitcoin::taproot::ControlBlock::eq(&self, other: &bitcoin::taproot::ControlBlock) -> bool
+pub fn bitcoin::taproot::ControlBlock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::ControlBlock::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::ControlBlock::partial_cmp(&self, other: &bitcoin::taproot::ControlBlock) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::ControlBlock::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::ControlBlock::size(&self) -> usize
+pub fn bitcoin::taproot::ControlBlock::verify_taproot_commitment<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, output_key: secp256k1::key::XOnlyPublicKey, script: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::taproot::FutureLeafVersion::clone(&self) -> bitcoin::taproot::FutureLeafVersion
+pub fn bitcoin::taproot::FutureLeafVersion::cmp(&self, other: &bitcoin::taproot::FutureLeafVersion) -> core::cmp::Ordering
+pub fn bitcoin::taproot::FutureLeafVersion::eq(&self, other: &bitcoin::taproot::FutureLeafVersion) -> bool
+pub fn bitcoin::taproot::FutureLeafVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::FutureLeafVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::FutureLeafVersion::partial_cmp(&self, other: &bitcoin::taproot::FutureLeafVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::FutureLeafVersion::to_consensus(self) -> u8
+pub fn bitcoin::taproot::HiddenNodesError::clone(&self) -> bitcoin::taproot::HiddenNodesError
+pub fn bitcoin::taproot::HiddenNodesError::eq(&self, other: &bitcoin::taproot::HiddenNodesError) -> bool
+pub fn bitcoin::taproot::HiddenNodesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::HiddenNodesError::into_node_info(self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::HiddenNodesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::IncompleteBuilderError::clone(&self) -> bitcoin::taproot::IncompleteBuilderError
+pub fn bitcoin::taproot::IncompleteBuilderError::eq(&self, other: &bitcoin::taproot::IncompleteBuilderError) -> bool
+pub fn bitcoin::taproot::IncompleteBuilderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::IncompleteBuilderError::into_builder(self) -> bitcoin::taproot::TaprootBuilder
+pub fn bitcoin::taproot::IncompleteBuilderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::LeafNode::clone(&self) -> bitcoin::taproot::LeafNode
+pub fn bitcoin::taproot::LeafNode::cmp(&self, other: &bitcoin::taproot::LeafNode) -> core::cmp::Ordering
+pub fn bitcoin::taproot::LeafNode::depth(&self) -> u8
+pub fn bitcoin::taproot::LeafNode::eq(&self, other: &bitcoin::taproot::LeafNode) -> bool
+pub fn bitcoin::taproot::LeafNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::LeafNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::LeafNode::leaf(&self) -> &bitcoin::taproot::TapLeaf
+pub fn bitcoin::taproot::LeafNode::leaf_hash(&self) -> core::option::Option<bitcoin::taproot::TapLeafHash>
+pub fn bitcoin::taproot::LeafNode::leaf_version(&self) -> core::option::Option<bitcoin::taproot::LeafVersion>
+pub fn bitcoin::taproot::LeafNode::merkle_branch(&self) -> &bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::LeafNode::new_hidden(hash: bitcoin::taproot::TapNodeHash) -> Self
+pub fn bitcoin::taproot::LeafNode::new_script(script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::taproot::LeafNode::node_hash(&self) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::LeafNode::partial_cmp(&self, other: &bitcoin::taproot::LeafNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::LeafNode::script(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::taproot::LeafNodes<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::LeafNodes<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::LeafNodes<'tree>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::LeafVersion::clone(&self) -> bitcoin::taproot::LeafVersion
+pub fn bitcoin::taproot::LeafVersion::cmp(&self, other: &bitcoin::taproot::LeafVersion) -> core::cmp::Ordering
+pub fn bitcoin::taproot::LeafVersion::eq(&self, other: &bitcoin::taproot::LeafVersion) -> bool
+pub fn bitcoin::taproot::LeafVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::LeafVersion::from_consensus(version: u8) -> core::result::Result<Self, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::LeafVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::LeafVersion::partial_cmp(&self, other: &bitcoin::taproot::LeafVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::LeafVersion::to_consensus(self) -> u8
+pub fn bitcoin::taproot::NodeInfo::clone(&self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::NodeInfo::cmp(&self, other: &bitcoin::taproot::NodeInfo) -> core::cmp::Ordering
+pub fn bitcoin::taproot::NodeInfo::combine(a: Self, b: Self) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::NodeInfo::eq(&self, other: &Self) -> bool
+pub fn bitcoin::taproot::NodeInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::NodeInfo::from(tree: bitcoin::taproot::TapTree) -> Self
+pub fn bitcoin::taproot::NodeInfo::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::taproot::NodeInfo::leaf_nodes(&self) -> bitcoin::taproot::LeafNodes<'_>
+pub fn bitcoin::taproot::NodeInfo::new_hidden_node(hash: bitcoin::taproot::TapNodeHash) -> Self
+pub fn bitcoin::taproot::NodeInfo::new_leaf_with_ver(script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::taproot::NodeInfo::partial_cmp(&self, other: &bitcoin::taproot::NodeInfo) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::NodeInfo::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::clone(&self) -> bitcoin::taproot::ScriptLeaf<'leaf>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::cmp(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> core::cmp::Ordering
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::eq(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> bool
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::from_leaf_node(leaf_node: &'leaf bitcoin::taproot::LeafNode) -> core::option::Option<Self>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::merkle_branch(&self) -> &bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::partial_cmp(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::version(&self) -> bitcoin::taproot::LeafVersion
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::SigFromSliceError::clone(&self) -> bitcoin::taproot::SigFromSliceError
+pub fn bitcoin::taproot::SigFromSliceError::eq(&self, other: &bitcoin::taproot::SigFromSliceError) -> bool
+pub fn bitcoin::taproot::SigFromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::SigFromSliceError::from(e: secp256k1::Error) -> Self
+pub fn bitcoin::taproot::SigFromSliceError::from(err: bitcoin::sighash::InvalidSighashTypeError) -> Self
+pub fn bitcoin::taproot::SigFromSliceError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::Signature::clone(&self) -> bitcoin::taproot::Signature
+pub fn bitcoin::taproot::Signature::cmp(&self, other: &bitcoin::taproot::Signature) -> core::cmp::Ordering
+pub fn bitcoin::taproot::Signature::eq(&self, other: &bitcoin::taproot::Signature) -> bool
+pub fn bitcoin::taproot::Signature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::Signature::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin::taproot::SigFromSliceError>
+pub fn bitcoin::taproot::Signature::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::Signature::partial_cmp(&self, other: &bitcoin::taproot::Signature) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::Signature::serialize(self) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::taproot::Signature::to_vec(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::Signature::try_from(value: &'a bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::Signature::try_from(value: bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapBranchTag::clone(&self) -> bitcoin::taproot::TapBranchTag
+pub fn bitcoin::taproot::TapBranchTag::cmp(&self, other: &bitcoin::taproot::TapBranchTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapBranchTag::default() -> bitcoin::taproot::TapBranchTag
+pub fn bitcoin::taproot::TapBranchTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapBranchTag::eq(&self, other: &bitcoin::taproot::TapBranchTag) -> bool
+pub fn bitcoin::taproot::TapBranchTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapBranchTag::partial_cmp(&self, other: &bitcoin::taproot::TapBranchTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeaf::as_hidden(&self) -> core::option::Option<&bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::TapLeaf::as_script(&self) -> core::option::Option<(&bitcoin::blockdata::script::Script, bitcoin::taproot::LeafVersion)>
+pub fn bitcoin::taproot::TapLeaf::clone(&self) -> bitcoin::taproot::TapLeaf
+pub fn bitcoin::taproot::TapLeaf::cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeaf::eq(&self, other: &bitcoin::taproot::TapLeaf) -> bool
+pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapLeafHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapLeafHash::clone(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeafHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::taproot::TapLeafHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::taproot::TapLeafHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLeafHash) -> bool
+pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapLeafHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapLeafHash, Self::Err>
+pub fn bitcoin::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapLeafHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin::taproot::TapLeafTag::clone(&self) -> bitcoin::taproot::TapLeafTag
+pub fn bitcoin::taproot::TapLeafTag::cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeafTag::default() -> bitcoin::taproot::TapLeafTag
+pub fn bitcoin::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeafTag) -> bool
+pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapNodeHash::assume_hidden(hash: [u8; 32]) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapNodeHash::clone(&self) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapNodeHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapNodeHash::eq(&self, other: &bitcoin::taproot::TapNodeHash) -> bool
+pub fn bitcoin::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapNodeHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapNodeHash, Self::Err>
+pub fn bitcoin::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapNodeHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapNodeHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin::taproot::TapTree::clone(&self) -> bitcoin::taproot::TapTree
+pub fn bitcoin::taproot::TapTree::eq(&self, other: &bitcoin::taproot::TapTree) -> bool
+pub fn bitcoin::taproot::TapTree::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapTree::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTree::into_node_info(self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::TapTree::node_info(&self) -> &bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::TapTree::script_leaves(&self) -> bitcoin::taproot::ScriptLeaves<'_>
+pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapTweakHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapTweakHash::clone(&self) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapTweakHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapTweakHash::eq(&self, other: &bitcoin::taproot::TapTweakHash) -> bool
+pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapTweakHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapTweakHash, Self::Err>
+pub fn bitcoin::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapTweakHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin::taproot::TapTweakHash::to_scalar(self) -> secp256k1::scalar::Scalar
+pub fn bitcoin::taproot::TapTweakTag::clone(&self) -> bitcoin::taproot::TapTweakTag
+pub fn bitcoin::taproot::TapTweakTag::cmp(&self, other: &bitcoin::taproot::TapTweakTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapTweakTag::default() -> bitcoin::taproot::TapTweakTag
+pub fn bitcoin::taproot::TapTweakTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapTweakTag::eq(&self, other: &bitcoin::taproot::TapTweakTag) -> bool
+pub fn bitcoin::taproot::TapTweakTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakTag::partial_cmp(&self, other: &bitcoin::taproot::TapTweakTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootBuilder::add_hidden_node(self, depth: u8, hash: bitcoin::taproot::TapNodeHash) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::add_leaf(self, depth: u8, script: bitcoin::blockdata::script::ScriptBuf) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::add_leaf_with_ver(self, depth: u8, script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::clone(&self) -> bitcoin::taproot::TaprootBuilder
+pub fn bitcoin::taproot::TaprootBuilder::cmp(&self, other: &bitcoin::taproot::TaprootBuilder) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TaprootBuilder::default() -> Self
+pub fn bitcoin::taproot::TaprootBuilder::eq(&self, other: &bitcoin::taproot::TaprootBuilder) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::finalize<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey) -> core::result::Result<bitcoin::taproot::TaprootSpendInfo, bitcoin::taproot::TaprootBuilder>
+pub fn bitcoin::taproot::TaprootBuilder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootBuilder::has_hidden_nodes(&self) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TaprootBuilder::is_finalizable(&self) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::new() -> Self
+pub fn bitcoin::taproot::TaprootBuilder::partial_cmp(&self, other: &bitcoin::taproot::TaprootBuilder) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootBuilder::try_into_node_info(self) -> core::result::Result<bitcoin::taproot::NodeInfo, bitcoin::taproot::IncompleteBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::try_into_taptree(self) -> core::result::Result<bitcoin::taproot::TapTree, bitcoin::taproot::IncompleteBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::with_capacity(size: usize) -> Self
+pub fn bitcoin::taproot::TaprootBuilder::with_huffman_tree<I>(script_weights: I) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, bitcoin::blockdata::script::ScriptBuf)>
+pub fn bitcoin::taproot::TaprootBuilderError::clone(&self) -> bitcoin::taproot::TaprootBuilderError
+pub fn bitcoin::taproot::TaprootBuilderError::eq(&self, other: &bitcoin::taproot::TaprootBuilderError) -> bool
+pub fn bitcoin::taproot::TaprootBuilderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootBuilderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::TaprootError::clone(&self) -> bitcoin::taproot::TaprootError
+pub fn bitcoin::taproot::TaprootError::eq(&self, other: &bitcoin::taproot::TaprootError) -> bool
+pub fn bitcoin::taproot::TaprootError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin::taproot::TaprootSpendInfo::clone(&self) -> bitcoin::taproot::TaprootSpendInfo
+pub fn bitcoin::taproot::TaprootSpendInfo::cmp(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TaprootSpendInfo::control_block(&self, script_ver: &(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)) -> core::option::Option<bitcoin::taproot::ControlBlock>
+pub fn bitcoin::taproot::TaprootSpendInfo::eq(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> bool
+pub fn bitcoin::taproot::TaprootSpendInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootSpendInfo::from_node_info<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, node: bitcoin::taproot::NodeInfo) -> bitcoin::taproot::TaprootSpendInfo
+pub fn bitcoin::taproot::TaprootSpendInfo::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TaprootSpendInfo::internal_key(&self) -> bitcoin::key::UntweakedPublicKey
+pub fn bitcoin::taproot::TaprootSpendInfo::merkle_root(&self) -> core::option::Option<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::TaprootSpendInfo::new_key_spend<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::taproot::TaprootSpendInfo::output_key(&self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::taproot::TaprootSpendInfo::output_key_parity(&self) -> secp256k1::key::Parity
+pub fn bitcoin::taproot::TaprootSpendInfo::partial_cmp(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootSpendInfo::script_map(&self) -> &alloc::collections::btree::map::BTreeMap<(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion), alloc::collections::btree::set::BTreeSet<bitcoin::taproot::merkle_branch::TaprootMerkleBranch>>
+pub fn bitcoin::taproot::TaprootSpendInfo::tap_tweak(&self) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TaprootSpendInfo::with_huffman_tree<C, I>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, script_weights: I) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, bitcoin::blockdata::script::ScriptBuf)>, C: secp256k1::context::Verification
+pub fn bitcoin::taproot::merkle_branch::IntoIter::as_mut_slice(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::IntoIter::as_slice(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::IntoIter::clone(&self) -> bitcoin::taproot::merkle_branch::IntoIter
+pub fn bitcoin::taproot::merkle_branch::IntoIter::count(self) -> usize
+pub fn bitcoin::taproot::merkle_branch::IntoIter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::merkle_branch::IntoIter::last(self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::nth_back(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_inner(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_mut(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_ref(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_slice(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::borrow(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::borrow_mut(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::clone(&self) -> bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::cmp(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> core::cmp::Ordering
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::decode(sl: &[u8]) -> core::result::Result<Self, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::default() -> bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deref(&self) -> &Self::Target
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::encode<Write: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut Write) -> bitcoin_io::Result<usize>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::eq(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> bool
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 0]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 100]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 101]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 102]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 103]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 104]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 105]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 106]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 107]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 108]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 109]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 10]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 110]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 111]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 112]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 113]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 114]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 115]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 116]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 117]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 118]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 119]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 11]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 120]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 121]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 122]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 123]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 124]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 125]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 126]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 127]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 128]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 12]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 13]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 14]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 15]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 16]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 17]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 18]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 19]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 1]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 20]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 21]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 22]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 23]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 24]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 25]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 26]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 27]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 28]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 29]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 2]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 30]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 31]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 32]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 33]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 34]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 35]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 36]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 37]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 38]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 39]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 3]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 40]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 41]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 42]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 43]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 44]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 45]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 46]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 47]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 48]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 49]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 4]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 50]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 51]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 52]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 53]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 54]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 55]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 56]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 57]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 58]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 59]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 5]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 60]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 61]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 62]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 63]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 64]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 65]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 66]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 67]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 68]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 69]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 6]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 70]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 71]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 72]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 73]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 74]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 75]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 76]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 77]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 78]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 79]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 7]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 80]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 81]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 82]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 83]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 84]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 85]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 86]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 87]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 88]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 89]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 8]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 90]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 91]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 92]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 93]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 94]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 95]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 96]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 97]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 98]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 99]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 9]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_inner(self) -> alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_vec(self) -> alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::is_empty(&self) -> bool
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::len(&self) -> usize
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::partial_cmp(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: &[bitcoin::taproot::TapNodeHash]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: alloc::boxed::Box<[bitcoin::taproot::TapNodeHash]>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: alloc::vec::Vec<bitcoin::taproot::TapNodeHash>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::as_slice(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::IntoIter::clone(&self) -> bitcoin::taproot::serialized_signature::IntoIter
+pub fn bitcoin::taproot::serialized_signature::IntoIter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::serialized_signature::IntoIter::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::clone(&self) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::cmp::Ordering
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::deref(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::eq(&self, other: &[u8]) -> bool
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::eq(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> bool
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from(value: &'a bitcoin::taproot::Signature) -> Self
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from(value: bitcoin::taproot::Signature) -> Self
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from_signature(sig: &bitcoin::taproot::Signature) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::len(&self) -> usize
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::partial_cmp(&self, other: &[u8]) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::partial_cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::to_signature(&self) -> core::result::Result<bitcoin::taproot::Signature, bitcoin::taproot::SigFromSliceError>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::write_to<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::transaction::effective_value(fee_rate: bitcoin::blockdata::fee_rate::FeeRate, satisfaction_weight: bitcoin::blockdata::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin::transaction::predict_weight<I, O>(inputs: I, output_script_lens: O) -> bitcoin::blockdata::weight::Weight where I: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::transaction::InputWeightPrediction>, O: core::iter::traits::collect::IntoIterator<Item = usize>
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::PubkeyHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::WPubkeyHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::bip32::XKeyIdentifier) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::blockdata::script::ScriptHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::sha256::Hash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_hashes::sha256::Hash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256::Hash::from(hashtype: bitcoin::blockdata::script::WScriptHash) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256d::Hash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_hashes::sha256d::Hash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::LegacySighash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::SegwitV0Sighash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::bip158::FilterHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::bip158::FilterHeader) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::BlockHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::TxMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::WitnessCommitment) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::WitnessMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::transaction::Txid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::transaction::Wtxid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>::from(hashtype: bitcoin::TapSighash) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>::from(hashtype: bitcoin::taproot::TapNodeHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>::from(hashtype: bitcoin::taproot::TapLeafHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>::from(hashtype: bitcoin::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin_units::amount::Amount::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::amount::Amount::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::amount::Amount::div(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bool::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bool::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn core::convert::Infallible::input_len(&self) -> usize
+pub fn core::num::error::ParseIntError::from(value: bitcoin::error::ParseIntError) -> Self
+pub fn i16::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i16::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i32::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i32::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i64::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i64::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i8::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i8::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn secp256k1::key::Keypair::from(pair: bitcoin::key::TweakedKeypair) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pair: bitcoin::key::TweakedPublicKey) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pk: bitcoin::CompressedPublicKey) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pk: bitcoin::PublicKey) -> secp256k1::key::XOnlyPublicKey
+pub fn std::collections::hash::map::HashMap<bitcoin::PublicKey, bitcoin::PrivateKey>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn std::collections::hash::set::HashSet<bitcoin::bip32::Xpriv>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn u16::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u16::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u32::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u32::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u32::from(cnum: bitcoin::bip32::ChildNumber) -> Self
+pub fn u32::from(sequence: bitcoin::blockdata::transaction::Sequence) -> u32
+pub fn u64::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u64::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u64::from(flags: bitcoin::p2p::ServiceFlags) -> Self
+pub fn u64::from(value: bitcoin::blockdata::fee_rate::FeeRate) -> Self
+pub fn u64::from(value: bitcoin::blockdata::weight::Weight) -> Self
+pub fn u64::mul(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn u8::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u8::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub mod bitcoin
+pub mod bitcoin::absolute
+pub mod bitcoin::address
+pub mod bitcoin::address::error
+pub mod bitcoin::amount
+pub mod bitcoin::base58
+pub mod bitcoin::bip152
+pub mod bitcoin::bip158
+pub mod bitcoin::bip32
+pub mod bitcoin::block
+pub mod bitcoin::blockdata
+pub mod bitcoin::blockdata::block
+pub mod bitcoin::blockdata::constants
+pub mod bitcoin::blockdata::fee_rate
+pub mod bitcoin::blockdata::locktime
+pub mod bitcoin::blockdata::locktime::absolute
+pub mod bitcoin::blockdata::locktime::relative
+pub mod bitcoin::blockdata::opcodes
+pub mod bitcoin::blockdata::opcodes::all
+pub mod bitcoin::blockdata::script
+pub mod bitcoin::blockdata::script::witness_program
+pub mod bitcoin::blockdata::script::witness_version
+pub mod bitcoin::blockdata::transaction
+pub mod bitcoin::blockdata::weight
+pub mod bitcoin::blockdata::witness
+pub mod bitcoin::consensus
+pub mod bitcoin::consensus::encode
+pub mod bitcoin::consensus::params
+pub mod bitcoin::constants
+pub mod bitcoin::ecdsa
+pub mod bitcoin::error
+pub mod bitcoin::hash_types
+pub mod bitcoin::key
+pub mod bitcoin::locktime
+pub mod bitcoin::locktime::absolute
+pub mod bitcoin::locktime::relative
+pub mod bitcoin::merkle_tree
+pub mod bitcoin::network
+pub mod bitcoin::opcodes
+pub mod bitcoin::opcodes::all
+pub mod bitcoin::p2p
+pub mod bitcoin::p2p::address
+pub mod bitcoin::p2p::message
+pub mod bitcoin::p2p::message_blockdata
+pub mod bitcoin::p2p::message_bloom
+pub mod bitcoin::p2p::message_compact_blocks
+pub mod bitcoin::p2p::message_filter
+pub mod bitcoin::p2p::message_network
+pub mod bitcoin::policy
+pub mod bitcoin::pow
+pub mod bitcoin::psbt
+pub mod bitcoin::psbt::raw
+pub mod bitcoin::psbt::serialize
+pub mod bitcoin::relative
+pub mod bitcoin::script
+pub mod bitcoin::script::witness_program
+pub mod bitcoin::script::witness_version
+pub mod bitcoin::sighash
+pub mod bitcoin::sign_message
+pub mod bitcoin::string
+pub mod bitcoin::taproot
+pub mod bitcoin::taproot::merkle_branch
+pub mod bitcoin::taproot::serialized_signature
+pub mod bitcoin::transaction
+pub mod bitcoin::witness
+pub mod bitcoin::witness_program
+pub mod bitcoin::witness_version
+pub static bitcoin::blockdata::opcodes::OP_0: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_FALSE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_NOP2: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_NOP3: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_TRUE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_0: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_FALSE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_NOP2: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_NOP3: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_TRUE: bitcoin::blockdata::opcodes::Opcode
+pub struct bitcoin::Block
+pub struct bitcoin::BlockHash(_)
+pub struct bitcoin::CompactTarget(_)
+pub struct bitcoin::CompressedPublicKey(pub secp256k1::key::PublicKey)
+pub struct bitcoin::FeeRate(_)
+pub struct bitcoin::FilterHash(_)
+pub struct bitcoin::FilterHeader(_)
+pub struct bitcoin::LegacySighash(_)
+pub struct bitcoin::MerkleBlock
+pub struct bitcoin::Opcode
+pub struct bitcoin::OutPoint
+pub struct bitcoin::PrivateKey
+pub struct bitcoin::Psbt
+pub struct bitcoin::PubkeyHash(_)
+pub struct bitcoin::PublicKey
+pub struct bitcoin::ScriptBuf(_)
+pub struct bitcoin::ScriptHash(_)
+pub struct bitcoin::SegwitV0Sighash(_)
+pub struct bitcoin::Sequence(pub u32)
+pub struct bitcoin::TapBranchTag
+pub struct bitcoin::TapLeafHash(_)
+pub struct bitcoin::TapLeafTag
+pub struct bitcoin::TapNodeHash(_)
+pub struct bitcoin::TapSighash(_)
+pub struct bitcoin::TapSighashTag
+pub struct bitcoin::TapTweakHash(_)
+pub struct bitcoin::TapTweakTag
+pub struct bitcoin::Target(_)
+pub struct bitcoin::Transaction
+pub struct bitcoin::TxIn
+pub struct bitcoin::TxMerkleNode(_)
+pub struct bitcoin::TxOut
+pub struct bitcoin::Txid(_)
+pub struct bitcoin::VarInt(pub u64)
+pub struct bitcoin::WPubkeyHash(_)
+pub struct bitcoin::WScriptHash(_)
+pub struct bitcoin::Weight(_)
+pub struct bitcoin::Witness
+pub struct bitcoin::WitnessCommitment(_)
+pub struct bitcoin::WitnessMerkleNode(_)
+pub struct bitcoin::WitnessProgram
+pub struct bitcoin::Work(_)
+pub struct bitcoin::Wtxid(_)
+pub struct bitcoin::XKeyIdentifier(_)
+pub struct bitcoin::absolute::Height(_)
+pub struct bitcoin::absolute::ParseHeightError(_)
+pub struct bitcoin::absolute::ParseTimeError(_)
+pub struct bitcoin::absolute::Time(_)
+pub struct bitcoin::bip152::BlockTransactions
+pub struct bitcoin::bip152::BlockTransactionsRequest
+pub struct bitcoin::bip152::HeaderAndShortIds
+pub struct bitcoin::bip152::PrefilledTransaction
+pub struct bitcoin::bip152::ShortId(_)
+pub struct bitcoin::bip158::BitStreamReader<'a, R: core::marker::Sized>
+pub struct bitcoin::bip158::BitStreamWriter<'a, W>
+pub struct bitcoin::bip158::BlockFilter
+pub struct bitcoin::bip158::BlockFilterReader
+pub struct bitcoin::bip158::BlockFilterWriter<'a, W>
+pub struct bitcoin::bip158::FilterHash(_)
+pub struct bitcoin::bip158::FilterHeader(_)
+pub struct bitcoin::bip158::GcsFilterReader
+pub struct bitcoin::bip158::GcsFilterWriter<'a, W>
+pub struct bitcoin::bip32::ChainCode(_)
+pub struct bitcoin::bip32::DerivationPath(_)
+pub struct bitcoin::bip32::DerivationPathIterator<'a>
+pub struct bitcoin::bip32::Fingerprint(_)
+pub struct bitcoin::bip32::XKeyIdentifier(_)
+pub struct bitcoin::bip32::Xpriv
+pub struct bitcoin::bip32::Xpub
+pub struct bitcoin::block::Block
+pub struct bitcoin::block::BlockHash(_)
+pub struct bitcoin::block::Header
+pub struct bitcoin::block::TxMerkleNode(_)
+pub struct bitcoin::block::Version(_)
+pub struct bitcoin::block::WitnessCommitment(_)
+pub struct bitcoin::block::WitnessMerkleNode(_)
+pub struct bitcoin::blockdata::FeeRate(_)
+pub struct bitcoin::blockdata::Weight(_)
+pub struct bitcoin::blockdata::block::Block
+pub struct bitcoin::blockdata::block::BlockHash(_)
+pub struct bitcoin::blockdata::block::Header
+pub struct bitcoin::blockdata::block::TxMerkleNode(_)
+pub struct bitcoin::blockdata::block::Version(_)
+pub struct bitcoin::blockdata::block::WitnessCommitment(_)
+pub struct bitcoin::blockdata::block::WitnessMerkleNode(_)
+pub struct bitcoin::blockdata::constants::ChainHash(_)
+pub struct bitcoin::blockdata::fee_rate::FeeRate(_)
+pub struct bitcoin::blockdata::locktime::absolute::Height(_)
+pub struct bitcoin::blockdata::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin::blockdata::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin::blockdata::locktime::absolute::Time(_)
+pub struct bitcoin::blockdata::locktime::relative::Height(_)
+pub struct bitcoin::blockdata::locktime::relative::Time(_)
+pub struct bitcoin::blockdata::opcodes::Opcode
+pub struct bitcoin::blockdata::script::Builder(_, _)
+pub struct bitcoin::blockdata::script::Bytes<'a>(_)
+pub struct bitcoin::blockdata::script::InstructionIndices<'a>
+pub struct bitcoin::blockdata::script::Instructions<'a>
+pub struct bitcoin::blockdata::script::PushBytesBuf(_)
+pub struct bitcoin::blockdata::script::PushBytesError
+pub struct bitcoin::blockdata::script::ScriptBuf(_)
+pub struct bitcoin::blockdata::script::ScriptHash(_)
+pub struct bitcoin::blockdata::script::WScriptHash(_)
+pub struct bitcoin::blockdata::script::witness_program::WitnessProgram
+pub struct bitcoin::blockdata::transaction::InputWeightPrediction
+pub struct bitcoin::blockdata::transaction::OutPoint
+pub struct bitcoin::blockdata::transaction::Sequence(pub u32)
+pub struct bitcoin::blockdata::transaction::Transaction
+pub struct bitcoin::blockdata::transaction::TxIn
+pub struct bitcoin::blockdata::transaction::TxOut
+pub struct bitcoin::blockdata::transaction::Txid(_)
+pub struct bitcoin::blockdata::transaction::Version(pub i32)
+pub struct bitcoin::blockdata::transaction::Wtxid(_)
+pub struct bitcoin::blockdata::weight::Weight(_)
+pub struct bitcoin::blockdata::witness::Iter<'a>
+pub struct bitcoin::blockdata::witness::Witness
+pub struct bitcoin::consensus::encode::CheckedData
+pub struct bitcoin::consensus::encode::VarInt(pub u64)
+pub struct bitcoin::constants::ChainHash(_)
+pub struct bitcoin::ecdsa::SerializedSignature
+pub struct bitcoin::ecdsa::Signature
+pub struct bitcoin::hash_types::BlockHash(_)
+pub struct bitcoin::hash_types::FilterHash(_)
+pub struct bitcoin::hash_types::FilterHeader(_)
+pub struct bitcoin::hash_types::TxMerkleNode(_)
+pub struct bitcoin::hash_types::Txid(_)
+pub struct bitcoin::hash_types::WitnessCommitment(_)
+pub struct bitcoin::hash_types::WitnessMerkleNode(_)
+pub struct bitcoin::hash_types::Wtxid(_)
+pub struct bitcoin::key::CompressedPublicKey(pub secp256k1::key::PublicKey)
+pub struct bitcoin::key::PrivateKey
+pub struct bitcoin::key::PubkeyHash(_)
+pub struct bitcoin::key::PublicKey
+pub struct bitcoin::key::SortKey(_)
+pub struct bitcoin::key::TweakedKeypair(_)
+pub struct bitcoin::key::TweakedPublicKey(_)
+pub struct bitcoin::key::WPubkeyHash(_)
+pub struct bitcoin::locktime::absolute::Height(_)
+pub struct bitcoin::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin::locktime::absolute::Time(_)
+pub struct bitcoin::locktime::relative::Height(_)
+pub struct bitcoin::locktime::relative::Time(_)
+pub struct bitcoin::merkle_tree::MerkleBlock
+pub struct bitcoin::merkle_tree::PartialMerkleTree
+pub struct bitcoin::opcodes::Opcode
+pub struct bitcoin::p2p::Address
+pub struct bitcoin::p2p::Magic(_)
+pub struct bitcoin::p2p::ServiceFlags(_)
+pub struct bitcoin::p2p::address::AddrV2Message
+pub struct bitcoin::p2p::address::Address
+pub struct bitcoin::p2p::message::CommandString(_)
+pub struct bitcoin::p2p::message::RawNetworkMessage
+pub struct bitcoin::p2p::message_blockdata::GetBlocksMessage
+pub struct bitcoin::p2p::message_blockdata::GetHeadersMessage
+pub struct bitcoin::p2p::message_bloom::FilterAdd
+pub struct bitcoin::p2p::message_bloom::FilterLoad
+pub struct bitcoin::p2p::message_compact_blocks::BlockTxn
+pub struct bitcoin::p2p::message_compact_blocks::CmpctBlock
+pub struct bitcoin::p2p::message_compact_blocks::GetBlockTxn
+pub struct bitcoin::p2p::message_compact_blocks::SendCmpct
+pub struct bitcoin::p2p::message_filter::CFCheckpt
+pub struct bitcoin::p2p::message_filter::CFHeaders
+pub struct bitcoin::p2p::message_filter::CFilter
+pub struct bitcoin::p2p::message_filter::GetCFCheckpt
+pub struct bitcoin::p2p::message_filter::GetCFHeaders
+pub struct bitcoin::p2p::message_filter::GetCFilters
+pub struct bitcoin::p2p::message_network::Reject
+pub struct bitcoin::p2p::message_network::VersionMessage
+pub struct bitcoin::pow::CompactTarget(_)
+pub struct bitcoin::pow::Target(_)
+pub struct bitcoin::pow::Work(_)
+pub struct bitcoin::psbt::Input
+pub struct bitcoin::psbt::Output
+pub struct bitcoin::psbt::Psbt
+pub struct bitcoin::psbt::PsbtSighashType
+pub struct bitcoin::psbt::raw::Key
+pub struct bitcoin::psbt::raw::Pair
+pub struct bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+pub struct bitcoin::relative::Height(_)
+pub struct bitcoin::relative::Time(_)
+pub struct bitcoin::script::Builder(_, _)
+pub struct bitcoin::script::Bytes<'a>(_)
+pub struct bitcoin::script::InstructionIndices<'a>
+pub struct bitcoin::script::Instructions<'a>
+pub struct bitcoin::script::PushBytesBuf(_)
+pub struct bitcoin::script::PushBytesError
+pub struct bitcoin::script::ScriptBuf(_)
+pub struct bitcoin::script::ScriptHash(_)
+pub struct bitcoin::script::WScriptHash(_)
+pub struct bitcoin::script::witness_program::WitnessProgram
+pub struct bitcoin::sighash::Annex<'a>(_)
+pub struct bitcoin::sighash::LegacySighash(_)
+pub struct bitcoin::sighash::ScriptPath<'s>
+pub struct bitcoin::sighash::SegwitV0Sighash(_)
+pub struct bitcoin::sighash::SighashCache<T: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>>
+pub struct bitcoin::sighash::TapSighash(_)
+pub struct bitcoin::sighash::TapSighashTag
+pub struct bitcoin::sign_message::MessageSignature
+pub struct bitcoin::taproot::ControlBlock
+pub struct bitcoin::taproot::FutureLeafVersion(_)
+pub struct bitcoin::taproot::LeafNode
+pub struct bitcoin::taproot::LeafNodes<'a>
+pub struct bitcoin::taproot::NodeInfo
+pub struct bitcoin::taproot::ScriptLeaf<'leaf>
+pub struct bitcoin::taproot::ScriptLeaves<'tree>
+pub struct bitcoin::taproot::Signature
+pub struct bitcoin::taproot::TapBranchTag
+pub struct bitcoin::taproot::TapLeafHash(_)
+pub struct bitcoin::taproot::TapLeafTag
+pub struct bitcoin::taproot::TapNodeHash(_)
+pub struct bitcoin::taproot::TapTree(_)
+pub struct bitcoin::taproot::TapTweakHash(_)
+pub struct bitcoin::taproot::TapTweakTag
+pub struct bitcoin::taproot::TaprootBuilder
+pub struct bitcoin::taproot::TaprootMerkleBranch(_)
+pub struct bitcoin::taproot::TaprootSpendInfo
+pub struct bitcoin::taproot::merkle_branch::IntoIter(_)
+pub struct bitcoin::taproot::merkle_branch::TaprootMerkleBranch(_)
+pub struct bitcoin::taproot::serialized_signature::IntoIter
+pub struct bitcoin::taproot::serialized_signature::SerializedSignature
+pub struct bitcoin::transaction::InputWeightPrediction
+pub struct bitcoin::transaction::OutPoint
+pub struct bitcoin::transaction::Sequence(pub u32)
+pub struct bitcoin::transaction::Transaction
+pub struct bitcoin::transaction::TxIn
+pub struct bitcoin::transaction::TxOut
+pub struct bitcoin::transaction::Txid(_)
+pub struct bitcoin::transaction::Version(pub i32)
+pub struct bitcoin::transaction::Wtxid(_)
+pub struct bitcoin::witness::Iter<'a>
+pub struct bitcoin::witness::Witness
+pub struct bitcoin::witness_program::WitnessProgram
+pub trait bitcoin::address::NetworkValidation: sealed::NetworkValidation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub trait bitcoin::bip32::IntoDerivationPath
+pub trait bitcoin::blockdata::script::PushBytesErrorReport
+pub trait bitcoin::consensus::Decodable: core::marker::Sized
+pub trait bitcoin::consensus::Encodable
+pub trait bitcoin::consensus::ReadExt: bitcoin_io::Read
+pub trait bitcoin::consensus::WriteExt: bitcoin_io::Write
+pub trait bitcoin::consensus::encode::Decodable: core::marker::Sized
+pub trait bitcoin::consensus::encode::Encodable
+pub trait bitcoin::consensus::encode::ReadExt: bitcoin_io::Read
+pub trait bitcoin::consensus::encode::WriteExt: bitcoin_io::Write
+pub trait bitcoin::key::TapTweak
+pub trait bitcoin::psbt::GetKey
+pub trait bitcoin::script::PushBytesErrorReport
+pub trait bitcoin::string::FromHexStr: core::marker::Sized
+pub type &'a bitcoin::bip32::DerivationPath::IntoIter = core::slice::iter::Iter<'a, bitcoin::bip32::ChildNumber>
+pub type &'a bitcoin::bip32::DerivationPath::Item = &'a bitcoin::bip32::ChildNumber
+pub type &'a bitcoin::blockdata::script::PushBytes::Error = bitcoin::blockdata::script::PushBytesError
+pub type &'a bitcoin::blockdata::witness::Witness::IntoIter = bitcoin::blockdata::witness::Iter<'a>
+pub type &'a bitcoin::blockdata::witness::Witness::Item = &'a [u8]
+pub type &'a bitcoin::ecdsa::SerializedSignature::IntoIter = core::slice::iter::Iter<'a, u8>
+pub type &'a bitcoin::ecdsa::SerializedSignature::Item = &'a u8
+pub type &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = core::slice::iter::Iter<'a, bitcoin::taproot::TapNodeHash>
+pub type &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = &'a bitcoin::taproot::TapNodeHash
+pub type &'a bitcoin::taproot::serialized_signature::SerializedSignature::IntoIter = core::slice::iter::Iter<'a, u8>
+pub type &'a bitcoin::taproot::serialized_signature::SerializedSignature::Item = &'a u8
+pub type &'a mut bitcoin::blockdata::script::PushBytes::Error = bitcoin::blockdata::script::PushBytesError
+pub type &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = core::slice::iter::IterMut<'a, bitcoin::taproot::TapNodeHash>
+pub type &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = &'a mut bitcoin::taproot::TapNodeHash
+pub type alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>::Error = bitcoin::psbt::GetKeyError
+pub type alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>::Error = bitcoin::psbt::GetKeyError
+pub type bitcoin::CompressedPublicKey::Err = bitcoin::key::Error
+pub type bitcoin::CompressedPublicKey::Error = bitcoin::key::UncompressedPubkeyError
+pub type bitcoin::EcdsaSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::LegacySighash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::LegacySighash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::LegacySighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::LegacySighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::PrivateKey::Err = bitcoin::key::Error
+pub type bitcoin::PrivateKey::Output = [u8]
+pub type bitcoin::PubkeyHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::PubkeyHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::PubkeyHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::PubkeyHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::PublicKey::Err = bitcoin::key::Error
+pub type bitcoin::SegwitV0Sighash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::SegwitV0Sighash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::SegwitV0Sighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::SegwitV0Sighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::TapSighash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::TapSighash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::TapSighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::TapSighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::TapSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::WPubkeyHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::WPubkeyHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::WPubkeyHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::WPubkeyHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::Err = bitcoin::address::error::ParseError
+pub type bitcoin::address::AddressType::Err = bitcoin::address::error::UnknownAddressTypeError
+pub type bitcoin::bip152::ShortId::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip152::ShortId::Error = core::array::TryFromSliceError
+pub type bitcoin::bip152::ShortId::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip158::FilterHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip158::FilterHash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip158::FilterHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip158::FilterHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip158::FilterHeader::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip158::FilterHeader::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip158::FilterHeader::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip158::FilterHeader::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip32::ChainCode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::ChainCode::Error = core::array::TryFromSliceError
+pub type bitcoin::bip32::ChainCode::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::ChildNumber::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::DerivationPath::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::DerivationPath::Output = <alloc::vec::Vec<bitcoin::bip32::ChildNumber> as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::DerivationPathIterator<'a>::Item = bitcoin::bip32::DerivationPath
+pub type bitcoin::bip32::ExtendendPrivKey = bitcoin::bip32::Xpriv
+pub type bitcoin::bip32::ExtendendPubKey = bitcoin::bip32::Xpub
+pub type bitcoin::bip32::Fingerprint::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::Fingerprint::Error = core::array::TryFromSliceError
+pub type bitcoin::bip32::Fingerprint::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::KeySource = (bitcoin::bip32::Fingerprint, bitcoin::bip32::DerivationPath)
+pub type bitcoin::bip32::XKeyIdentifier::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip32::XKeyIdentifier::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip32::XKeyIdentifier::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::XKeyIdentifier::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip32::Xpriv::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::Xpriv::Error = bitcoin::psbt::GetKeyError
+pub type bitcoin::bip32::Xpub::Err = bitcoin::bip32::Error
+pub type bitcoin::blockdata::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::BlockHash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::BlockHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::BlockHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::TxMerkleNode::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::TxMerkleNode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::TxMerkleNode::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::WitnessCommitment::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::WitnessCommitment::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::WitnessCommitment::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::constants::ChainHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::constants::ChainHash::Error = core::array::TryFromSliceError
+pub type bitcoin::blockdata::constants::ChainHash::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::blockdata::fee_rate::FeeRate::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::fee_rate::FeeRate::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::fee_rate::FeeRate::Output = bitcoin_units::amount::Amount
+pub type bitcoin::blockdata::locktime::absolute::Height::Err = bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub type bitcoin::blockdata::locktime::absolute::Height::Error = bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub type bitcoin::blockdata::locktime::absolute::LockTime::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::absolute::LockTime::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::absolute::Time::Err = bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub type bitcoin::blockdata::locktime::absolute::Time::Error = bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub type bitcoin::blockdata::locktime::relative::Height::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Height::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Time::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Time::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::script::Bytes<'_>::Item = u8
+pub type bitcoin::blockdata::script::InstructionIndices<'a>::Item = core::result::Result<(usize, bitcoin::blockdata::script::Instruction<'a>), bitcoin::blockdata::script::Error>
+pub type bitcoin::blockdata::script::Instructions<'a>::Item = core::result::Result<bitcoin::blockdata::script::Instruction<'a>, bitcoin::blockdata::script::Error>
+pub type bitcoin::blockdata::script::PushBytes::Output = bitcoin::blockdata::script::PushBytes
+pub type bitcoin::blockdata::script::PushBytes::Output = u8
+pub type bitcoin::blockdata::script::PushBytes::Owned = bitcoin::blockdata::script::PushBytesBuf
+pub type bitcoin::blockdata::script::PushBytesBuf::Error = bitcoin::blockdata::script::PushBytesError
+pub type bitcoin::blockdata::script::PushBytesBuf::Target = bitcoin::blockdata::script::PushBytes
+pub type bitcoin::blockdata::script::Script::Output = bitcoin::blockdata::script::Script
+pub type bitcoin::blockdata::script::Script::Owned = bitcoin::blockdata::script::ScriptBuf
+pub type bitcoin::blockdata::script::ScriptBuf::Target = bitcoin::blockdata::script::Script
+pub type bitcoin::blockdata::script::ScriptHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::script::ScriptHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::script::ScriptHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::script::ScriptHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::script::WScriptHash::Bytes = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::script::WScriptHash::Engine = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::script::WScriptHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::script::WScriptHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Err = bitcoin::blockdata::script::witness_version::FromStrError
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Error = bitcoin::blockdata::script::witness_version::TryFromError
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Error = bitcoin::blockdata::script::witness_version::TryFromInstructionError
+pub type bitcoin::blockdata::transaction::OutPoint::Err = bitcoin::blockdata::transaction::ParseOutPointError
+pub type bitcoin::blockdata::transaction::Sequence::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::transaction::Sequence::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::transaction::Txid::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::transaction::Txid::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::transaction::Txid::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::transaction::Wtxid::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::transaction::Wtxid::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::transaction::Wtxid::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::weight::Weight::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::weight::Weight::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::weight::Weight::Output = bitcoin::blockdata::weight::Weight
+pub type bitcoin::blockdata::weight::Weight::Output = bitcoin_units::amount::Amount
+pub type bitcoin::blockdata::weight::Weight::Output = u64
+pub type bitcoin::blockdata::witness::Iter<'a>::Item = &'a [u8]
+pub type bitcoin::blockdata::witness::Witness::Output = [u8]
+pub type bitcoin::ecdsa::SerializedSignature::Target = [u8]
+pub type bitcoin::ecdsa::Signature::Err = bitcoin::ecdsa::Error
+pub type bitcoin::key::TapTweak::TweakedAux
+pub type bitcoin::key::TapTweak::TweakedKey
+pub type bitcoin::key::UntweakedKeypair = secp256k1::key::Keypair
+pub type bitcoin::key::UntweakedKeypair::TweakedAux = bitcoin::key::TweakedKeypair
+pub type bitcoin::key::UntweakedKeypair::TweakedKey = bitcoin::key::TweakedKeypair
+pub type bitcoin::key::UntweakedPublicKey = secp256k1::key::XOnlyPublicKey
+pub type bitcoin::key::UntweakedPublicKey::TweakedAux = (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub type bitcoin::key::UntweakedPublicKey::TweakedKey = bitcoin::key::TweakedPublicKey
+pub type bitcoin::network::Network::Err = bitcoin::network::ParseNetworkError
+pub type bitcoin::network::Network::Error = bitcoin::network::UnknownChainHashError
+pub type bitcoin::network::Network::Error = bitcoin::p2p::UnknownMagicError
+pub type bitcoin::p2p::Magic::Err = bitcoin::p2p::ParseMagicError
+pub type bitcoin::p2p::ServiceFlags::Output = bitcoin::p2p::ServiceFlags
+pub type bitcoin::p2p::address::AddrV2Message::Iter = core::iter::sources::once::Once<core::net::socket_addr::SocketAddr>
+pub type bitcoin::p2p::address::Address::Iter = core::iter::sources::once::Once<core::net::socket_addr::SocketAddr>
+pub type bitcoin::p2p::message::CommandString::Err = bitcoin::p2p::message::CommandStringError
+pub type bitcoin::p2p::message::CommandString::Error = bitcoin::p2p::message::CommandStringError
+pub type bitcoin::pow::CompactTarget::Error = bitcoin::error::ParseIntError
+pub type bitcoin::pow::Work::Output = bitcoin::pow::Work
+pub type bitcoin::psbt::GetKey::Error: core::fmt::Debug
+pub type bitcoin::psbt::PsbtSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::psbt::SigningErrors = alloc::collections::btree::map::BTreeMap<usize, bitcoin::psbt::SignError>
+pub type bitcoin::psbt::SigningKeys = alloc::collections::btree::map::BTreeMap<usize, alloc::vec::Vec<bitcoin::PublicKey>>
+pub type bitcoin::psbt::raw::ProprietaryKey<Subtype>::Error = bitcoin::psbt::Error
+pub type bitcoin::psbt::raw::ProprietaryType = u8
+pub type bitcoin::string::FromHexStr::Error
+pub type bitcoin::taproot::LeafNodes<'a>::Item = &'a bitcoin::taproot::LeafNode
+pub type bitcoin::taproot::NodeInfo::Error = bitcoin::taproot::IncompleteBuilderError
+pub type bitcoin::taproot::ScriptLeaves<'tree>::Item = bitcoin::taproot::ScriptLeaf<'tree>
+pub type bitcoin::taproot::Signature::Error = bitcoin::taproot::SigFromSliceError
+pub type bitcoin::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapLeafHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapLeafHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapLeafHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::TapNodeHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapNodeHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapNodeHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapNodeHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::TapTree::Error = bitcoin::taproot::HiddenNodesError
+pub type bitcoin::taproot::TapTree::Error = bitcoin::taproot::IncompleteBuilderError
+pub type bitcoin::taproot::TapTweakHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapTweakHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapTweakHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapTweakHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::merkle_branch::IntoIter::Item = bitcoin::taproot::TapNodeHash
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Error = bitcoin::taproot::TaprootError
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = bitcoin::taproot::merkle_branch::IntoIter
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = bitcoin::taproot::TapNodeHash
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Target = [bitcoin::taproot::TapNodeHash]
+pub type bitcoin::taproot::serialized_signature::IntoIter::Item = u8
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::IntoIter = bitcoin::taproot::serialized_signature::IntoIter
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::Item = u8
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::Target = [u8]
+pub type bitcoin_units::amount::Amount::Output = bitcoin::blockdata::fee_rate::FeeRate
+pub type std::collections::hash::map::HashMap<bitcoin::PublicKey, bitcoin::PrivateKey>::Error = bitcoin::psbt::GetKeyError
+pub type std::collections::hash::set::HashSet<bitcoin::bip32::Xpriv>::Error = bitcoin::psbt::GetKeyError
+pub type u64::Output = bitcoin::blockdata::weight::Weight
+pub use bitcoin::Amount
+pub use bitcoin::Denomination
+pub use bitcoin::SignedAmount
+pub use bitcoin::XOnlyPublicKey
+pub use bitcoin::amount::Amount
+pub use bitcoin::amount::CheckedSum
+pub use bitcoin::amount::Denomination
+pub use bitcoin::amount::Display
+pub use bitcoin::amount::ParseAmountError
+pub use bitcoin::amount::SignedAmount
+pub use bitcoin::key::Keypair
+pub use bitcoin::key::Parity
+pub use bitcoin::key::Secp256k1
+pub use bitcoin::key::Verification
+pub use bitcoin::key::XOnlyPublicKey
+pub use bitcoin::key::constants
+pub use bitcoin::key::secp256k1

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -1,0 +1,8848 @@
+#[non_exhaustive] pub enum bitcoin::AddressType
+#[non_exhaustive] pub enum bitcoin::KnownHrp
+#[non_exhaustive] pub enum bitcoin::Network
+#[non_exhaustive] pub enum bitcoin::absolute::Error
+#[non_exhaustive] pub enum bitcoin::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::address::AddressType
+#[non_exhaustive] pub enum bitcoin::address::Error
+#[non_exhaustive] pub enum bitcoin::address::KnownHrp
+#[non_exhaustive] pub enum bitcoin::address::ParseError
+#[non_exhaustive] pub enum bitcoin::address::error::Error
+#[non_exhaustive] pub enum bitcoin::address::error::ParseError
+#[non_exhaustive] pub enum bitcoin::base58::Error
+#[non_exhaustive] pub enum bitcoin::bip152::Error
+#[non_exhaustive] pub enum bitcoin::bip158::Error
+#[non_exhaustive] pub enum bitcoin::bip32::Error
+#[non_exhaustive] pub enum bitcoin::block::Bip34Error
+#[non_exhaustive] pub enum bitcoin::block::ValidationError
+#[non_exhaustive] pub enum bitcoin::blockdata::block::Bip34Error
+#[non_exhaustive] pub enum bitcoin::blockdata::block::ValidationError
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::absolute::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::blockdata::locktime::relative::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::blockdata::script::witness_version::TryFromInstructionError
+#[non_exhaustive] pub enum bitcoin::blockdata::transaction::ParseOutPointError
+#[non_exhaustive] pub enum bitcoin::consensus::encode::Error
+#[non_exhaustive] pub enum bitcoin::ecdsa::Error
+#[non_exhaustive] pub enum bitcoin::key::Error
+#[non_exhaustive] pub enum bitcoin::locktime::absolute::Error
+#[non_exhaustive] pub enum bitcoin::locktime::absolute::OperationError
+#[non_exhaustive] pub enum bitcoin::locktime::relative::Error
+#[non_exhaustive] pub enum bitcoin::merkle_tree::MerkleBlockError
+#[non_exhaustive] pub enum bitcoin::network::Network
+#[non_exhaustive] pub enum bitcoin::psbt::Error
+#[non_exhaustive] pub enum bitcoin::psbt::ExtractTxError
+#[non_exhaustive] pub enum bitcoin::psbt::GetKeyError
+#[non_exhaustive] pub enum bitcoin::psbt::IndexOutOfBoundsError
+#[non_exhaustive] pub enum bitcoin::psbt::KeyRequest
+#[non_exhaustive] pub enum bitcoin::psbt::OutputType
+#[non_exhaustive] pub enum bitcoin::psbt::SignError
+#[non_exhaustive] pub enum bitcoin::relative::Error
+#[non_exhaustive] pub enum bitcoin::script::Error
+#[non_exhaustive] pub enum bitcoin::script::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::script::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::script::witness_version::TryFromInstructionError
+#[non_exhaustive] pub enum bitcoin::sighash::AnnexError
+#[non_exhaustive] pub enum bitcoin::sighash::P2wpkhError
+#[non_exhaustive] pub enum bitcoin::sighash::PrevoutsIndexError
+#[non_exhaustive] pub enum bitcoin::sighash::TaprootError
+#[non_exhaustive] pub enum bitcoin::string::FromHexError<E>
+#[non_exhaustive] pub enum bitcoin::taproot::HiddenNodesError
+#[non_exhaustive] pub enum bitcoin::taproot::IncompleteBuilderError
+#[non_exhaustive] pub enum bitcoin::taproot::SigFromSliceError
+#[non_exhaustive] pub enum bitcoin::taproot::TaprootBuilderError
+#[non_exhaustive] pub enum bitcoin::taproot::TaprootError
+#[non_exhaustive] pub enum bitcoin::transaction::ParseOutPointError
+#[non_exhaustive] pub enum bitcoin::witness_program::Error
+#[non_exhaustive] pub enum bitcoin::witness_version::FromStrError
+#[non_exhaustive] pub enum bitcoin::witness_version::TryFromInstructionError
+#[non_exhaustive] pub struct bitcoin::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::address::UnknownAddressTypeError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::UnknownHrpError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::error::UnknownAddressTypeError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::address::error::UnknownHrpError(pub alloc::string::String)
+#[non_exhaustive] pub struct bitcoin::bip152::TxIndexOutOfRangeError(_)
+#[non_exhaustive] pub struct bitcoin::blockdata::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::blockdata::script::witness_version::TryFromError
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::IndexOutOfBoundsError
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::InputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::blockdata::transaction::OutputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::consensus::Params
+#[non_exhaustive] pub struct bitcoin::consensus::params::Params
+#[non_exhaustive] pub struct bitcoin::error::ParseIntError
+#[non_exhaustive] pub struct bitcoin::key::UncompressedPubkeyError
+#[non_exhaustive] pub struct bitcoin::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin::network::ParseNetworkError(_)
+#[non_exhaustive] pub struct bitcoin::network::UnknownChainHashError(_)
+#[non_exhaustive] pub struct bitcoin::p2p::ParseMagicError
+#[non_exhaustive] pub struct bitcoin::p2p::UnknownMagicError(_)
+#[non_exhaustive] pub struct bitcoin::pow::TryFromError(_)
+#[non_exhaustive] pub struct bitcoin::script::witness_version::TryFromError
+#[non_exhaustive] pub struct bitcoin::sighash::InvalidSighashTypeError(pub u32)
+#[non_exhaustive] pub struct bitcoin::sighash::NonStandardSighashTypeError(pub u32)
+#[non_exhaustive] pub struct bitcoin::sighash::PrevoutsKindError
+#[non_exhaustive] pub struct bitcoin::sighash::PrevoutsSizeError
+#[non_exhaustive] pub struct bitcoin::sighash::SighashTypeParseError
+#[non_exhaustive] pub struct bitcoin::sighash::SingleMissingOutputError
+#[non_exhaustive] pub struct bitcoin::transaction::IndexOutOfBoundsError
+#[non_exhaustive] pub struct bitcoin::transaction::InputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::transaction::OutputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
+#[non_exhaustive] pub struct bitcoin::witness_version::TryFromError
+#[repr(transparent)] pub struct bitcoin::Address<V> where V: bitcoin::address::NetworkValidation(_, _)
+#[repr(transparent)] pub struct bitcoin::Script(_)
+#[repr(transparent)] pub struct bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation(_, _)
+#[repr(transparent)] pub struct bitcoin::blockdata::script::PushBytes(_)
+#[repr(transparent)] pub struct bitcoin::blockdata::script::Script(_)
+#[repr(transparent)] pub struct bitcoin::script::PushBytes(_)
+#[repr(transparent)] pub struct bitcoin::script::Script(_)
+#[repr(u8)] pub enum bitcoin::WitnessVersion
+#[repr(u8)] pub enum bitcoin::blockdata::script::witness_version::WitnessVersion
+#[repr(u8)] pub enum bitcoin::script::witness_version::WitnessVersion
+#[repr(u8)] pub enum bitcoin::witness_version::WitnessVersion
+impl !core::marker::Sized for bitcoin::blockdata::script::PushBytes
+impl !core::marker::Sized for bitcoin::blockdata::script::Script
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Error
+impl alloc::borrow::ToOwned for bitcoin::blockdata::script::PushBytes
+impl alloc::borrow::ToOwned for bitcoin::blockdata::script::Script
+impl bitcoin::CompressedPublicKey
+impl bitcoin::EcdsaSighashType
+impl bitcoin::LegacySighash
+impl bitcoin::MerkleBlock
+impl bitcoin::PrivateKey
+impl bitcoin::PubkeyHash
+impl bitcoin::PublicKey
+impl bitcoin::SegwitV0Sighash
+impl bitcoin::TapSighash
+impl bitcoin::TapSighashType
+impl bitcoin::WPubkeyHash
+impl bitcoin::address::Address
+impl bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+impl bitcoin::address::NetworkValidation for bitcoin::address::NetworkChecked
+impl bitcoin::address::NetworkValidation for bitcoin::address::NetworkUnchecked
+impl bitcoin::bip152::BlockTransactions
+impl bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::bip152::ShortId
+impl bitcoin::bip158::BlockFilter
+impl bitcoin::bip158::BlockFilterReader
+impl bitcoin::bip158::FilterHash
+impl bitcoin::bip158::FilterHeader
+impl bitcoin::bip158::GcsFilterReader
+impl bitcoin::bip32::ChainCode
+impl bitcoin::bip32::ChildNumber
+impl bitcoin::bip32::DerivationPath
+impl bitcoin::bip32::Fingerprint
+impl bitcoin::bip32::IntoDerivationPath for alloc::string::String
+impl bitcoin::bip32::XKeyIdentifier
+impl bitcoin::bip32::Xpriv
+impl bitcoin::bip32::Xpub
+impl bitcoin::blockdata::block::Block
+impl bitcoin::blockdata::block::BlockHash
+impl bitcoin::blockdata::block::Header
+impl bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::blockdata::block::Version
+impl bitcoin::blockdata::block::WitnessCommitment
+impl bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::blockdata::constants::ChainHash
+impl bitcoin::blockdata::fee_rate::FeeRate
+impl bitcoin::blockdata::locktime::absolute::Height
+impl bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::blockdata::locktime::absolute::Time
+impl bitcoin::blockdata::locktime::relative::Height
+impl bitcoin::blockdata::locktime::relative::LockTime
+impl bitcoin::blockdata::locktime::relative::Time
+impl bitcoin::blockdata::opcodes::Opcode
+impl bitcoin::blockdata::script::Builder
+impl bitcoin::blockdata::script::PushBytes
+impl bitcoin::blockdata::script::PushBytesBuf
+impl bitcoin::blockdata::script::PushBytesErrorReport for bitcoin::blockdata::script::PushBytesError
+impl bitcoin::blockdata::script::PushBytesErrorReport for core::convert::Infallible
+impl bitcoin::blockdata::script::Script
+impl bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::blockdata::script::ScriptHash
+impl bitcoin::blockdata::script::WScriptHash
+impl bitcoin::blockdata::script::witness_program::WitnessProgram
+impl bitcoin::blockdata::script::witness_version::WitnessVersion
+impl bitcoin::blockdata::transaction::InputWeightPrediction
+impl bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::blockdata::transaction::Sequence
+impl bitcoin::blockdata::transaction::Transaction
+impl bitcoin::blockdata::transaction::TxIn
+impl bitcoin::blockdata::transaction::TxOut
+impl bitcoin::blockdata::transaction::Txid
+impl bitcoin::blockdata::transaction::Version
+impl bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::blockdata::weight::Weight
+impl bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Decodable for [u16; 8]
+impl bitcoin::consensus::encode::Decodable for [u8; 10]
+impl bitcoin::consensus::encode::Decodable for [u8; 12]
+impl bitcoin::consensus::encode::Decodable for [u8; 16]
+impl bitcoin::consensus::encode::Decodable for [u8; 2]
+impl bitcoin::consensus::encode::Decodable for [u8; 32]
+impl bitcoin::consensus::encode::Decodable for [u8; 33]
+impl bitcoin::consensus::encode::Decodable for [u8; 4]
+impl bitcoin::consensus::encode::Decodable for [u8; 6]
+impl bitcoin::consensus::encode::Decodable for [u8; 8]
+impl bitcoin::consensus::encode::Decodable for alloc::borrow::Cow<'static, str>
+impl bitcoin::consensus::encode::Decodable for alloc::boxed::Box<[u8]>
+impl bitcoin::consensus::encode::Decodable for alloc::string::String
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<alloc::vec::Vec<u8>>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip152::ShortId>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip158::FilterHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::bip158::FilterHeader>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::Header>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::consensus::encode::VarInt>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<bitcoin::taproot::TapLeafHash>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<u64>
+impl bitcoin::consensus::encode::Decodable for alloc::vec::Vec<u8>
+impl bitcoin::consensus::encode::Decodable for bitcoin::MerkleBlock
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::BlockTransactions
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::BlockTransactionsRequest
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::PrefilledTransaction
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip152::ShortId
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip158::FilterHash
+impl bitcoin::consensus::encode::Decodable for bitcoin::bip158::FilterHeader
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Block
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::BlockHash
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Header
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::Version
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Transaction
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::TxIn
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::TxOut
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Txid
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Version
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::Decodable for bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Decodable for bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::encode::Decodable for bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::Magic
+impl bitcoin::consensus::encode::Decodable for bitcoin::p2p::ServiceFlags
+impl bitcoin::consensus::encode::Decodable for bitcoin::pow::CompactTarget
+impl bitcoin::consensus::encode::Decodable for bitcoin::taproot::TapLeafHash
+impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256::Hash
+impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256d::Hash
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Decodable for bool
+impl bitcoin::consensus::encode::Decodable for i16
+impl bitcoin::consensus::encode::Decodable for i32
+impl bitcoin::consensus::encode::Decodable for i64
+impl bitcoin::consensus::encode::Decodable for i8
+impl bitcoin::consensus::encode::Decodable for u16
+impl bitcoin::consensus::encode::Decodable for u32
+impl bitcoin::consensus::encode::Decodable for u64
+impl bitcoin::consensus::encode::Decodable for u8
+impl bitcoin::consensus::encode::Encodable for [u16; 8]
+impl bitcoin::consensus::encode::Encodable for [u8; 10]
+impl bitcoin::consensus::encode::Encodable for [u8; 12]
+impl bitcoin::consensus::encode::Encodable for [u8; 16]
+impl bitcoin::consensus::encode::Encodable for [u8; 2]
+impl bitcoin::consensus::encode::Encodable for [u8; 32]
+impl bitcoin::consensus::encode::Encodable for [u8; 33]
+impl bitcoin::consensus::encode::Encodable for [u8; 4]
+impl bitcoin::consensus::encode::Encodable for [u8; 6]
+impl bitcoin::consensus::encode::Encodable for [u8; 8]
+impl bitcoin::consensus::encode::Encodable for alloc::borrow::Cow<'static, str>
+impl bitcoin::consensus::encode::Encodable for alloc::boxed::Box<[u8]>
+impl bitcoin::consensus::encode::Encodable for alloc::string::String
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<alloc::vec::Vec<u8>>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip152::ShortId>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip158::FilterHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::bip158::FilterHeader>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::Header>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::consensus::encode::VarInt>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<bitcoin::taproot::TapLeafHash>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<u64>
+impl bitcoin::consensus::encode::Encodable for alloc::vec::Vec<u8>
+impl bitcoin::consensus::encode::Encodable for bitcoin::MerkleBlock
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::BlockTransactions
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::BlockTransactionsRequest
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::HeaderAndShortIds
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::PrefilledTransaction
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip152::ShortId
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip158::FilterHash
+impl bitcoin::consensus::encode::Encodable for bitcoin::bip158::FilterHeader
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Block
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::BlockHash
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Header
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::Version
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::script::Script
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::script::ScriptBuf
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::OutPoint
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Transaction
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::TxIn
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::TxOut
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Txid
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Version
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::witness::Witness
+impl bitcoin::consensus::encode::Encodable for bitcoin::consensus::encode::CheckedData
+impl bitcoin::consensus::encode::Encodable for bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::encode::Encodable for bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::Magic
+impl bitcoin::consensus::encode::Encodable for bitcoin::p2p::ServiceFlags
+impl bitcoin::consensus::encode::Encodable for bitcoin::pow::CompactTarget
+impl bitcoin::consensus::encode::Encodable for bitcoin::taproot::TapLeafHash
+impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256::Hash
+impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256d::Hash
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Encodable for bool
+impl bitcoin::consensus::encode::Encodable for i16
+impl bitcoin::consensus::encode::Encodable for i32
+impl bitcoin::consensus::encode::Encodable for i64
+impl bitcoin::consensus::encode::Encodable for i8
+impl bitcoin::consensus::encode::Encodable for u16
+impl bitcoin::consensus::encode::Encodable for u32
+impl bitcoin::consensus::encode::Encodable for u64
+impl bitcoin::consensus::encode::Encodable for u8
+impl bitcoin::consensus::encode::VarInt
+impl bitcoin::consensus::params::Params
+impl bitcoin::ecdsa::SerializedSignature
+impl bitcoin::ecdsa::Signature
+impl bitcoin::error::ParseIntError
+impl bitcoin::key::TapTweak for bitcoin::key::UntweakedKeypair
+impl bitcoin::key::TapTweak for bitcoin::key::UntweakedPublicKey
+impl bitcoin::key::TweakedKeypair
+impl bitcoin::key::TweakedPublicKey
+impl bitcoin::merkle_tree::PartialMerkleTree
+impl bitcoin::network::Network
+impl bitcoin::network::NetworkKind
+impl bitcoin::p2p::Magic
+impl bitcoin::p2p::ServiceFlags
+impl bitcoin::pow::CompactTarget
+impl bitcoin::pow::Target
+impl bitcoin::pow::Work
+impl bitcoin::psbt::GetKey for alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>
+impl bitcoin::psbt::GetKey for alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>
+impl bitcoin::psbt::GetKey for bitcoin::bip32::Xpriv
+impl bitcoin::psbt::Input
+impl bitcoin::psbt::Output
+impl bitcoin::psbt::OutputType
+impl bitcoin::psbt::Psbt
+impl bitcoin::psbt::PsbtSighashType
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::Height
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::LockTime
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::locktime::absolute::Time
+impl bitcoin::string::FromHexStr for bitcoin::blockdata::transaction::Sequence
+impl bitcoin::string::FromHexStr for bitcoin::pow::CompactTarget
+impl bitcoin::taproot::ControlBlock
+impl bitcoin::taproot::FutureLeafVersion
+impl bitcoin::taproot::HiddenNodesError
+impl bitcoin::taproot::IncompleteBuilderError
+impl bitcoin::taproot::LeafNode
+impl bitcoin::taproot::LeafVersion
+impl bitcoin::taproot::NodeInfo
+impl bitcoin::taproot::Signature
+impl bitcoin::taproot::TapLeaf
+impl bitcoin::taproot::TapLeafHash
+impl bitcoin::taproot::TapNodeHash
+impl bitcoin::taproot::TapTree
+impl bitcoin::taproot::TapTweakHash
+impl bitcoin::taproot::TaprootBuilder
+impl bitcoin::taproot::TaprootSpendInfo
+impl bitcoin::taproot::merkle_branch::IntoIter
+impl bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl bitcoin::taproot::serialized_signature::IntoIter
+impl bitcoin::taproot::serialized_signature::SerializedSignature
+impl bitcoin_hashes::Hash for bitcoin::LegacySighash
+impl bitcoin_hashes::Hash for bitcoin::PubkeyHash
+impl bitcoin_hashes::Hash for bitcoin::SegwitV0Sighash
+impl bitcoin_hashes::Hash for bitcoin::TapSighash
+impl bitcoin_hashes::Hash for bitcoin::WPubkeyHash
+impl bitcoin_hashes::Hash for bitcoin::bip158::FilterHash
+impl bitcoin_hashes::Hash for bitcoin::bip158::FilterHeader
+impl bitcoin_hashes::Hash for bitcoin::bip32::XKeyIdentifier
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin::blockdata::block::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin::blockdata::script::ScriptHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::script::WScriptHash
+impl bitcoin_hashes::Hash for bitcoin::blockdata::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin::blockdata::transaction::Wtxid
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapLeafHash
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapNodeHash
+impl bitcoin_hashes::Hash for bitcoin::taproot::TapTweakHash
+impl bitcoin_hashes::sha256t::Tag for bitcoin::TapSighashTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapBranchTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapLeafTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin::taproot::TapTweakTag
+impl core::borrow::Borrow<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::borrow::Borrow<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::Borrow<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::borrow::Borrow<[u8; 4]> for bitcoin::p2p::Magic
+impl core::borrow::Borrow<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::borrow::Borrow<[u8]> for bitcoin::LegacySighash
+impl core::borrow::Borrow<[u8]> for bitcoin::PubkeyHash
+impl core::borrow::Borrow<[u8]> for bitcoin::SegwitV0Sighash
+impl core::borrow::Borrow<[u8]> for bitcoin::TapSighash
+impl core::borrow::Borrow<[u8]> for bitcoin::WPubkeyHash
+impl core::borrow::Borrow<[u8]> for bitcoin::bip152::ShortId
+impl core::borrow::Borrow<[u8]> for bitcoin::bip158::FilterHash
+impl core::borrow::Borrow<[u8]> for bitcoin::bip158::FilterHeader
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::ChainCode
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::Fingerprint
+impl core::borrow::Borrow<[u8]> for bitcoin::bip32::XKeyIdentifier
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::script::ScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::script::WScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin::blockdata::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::borrow::Borrow<[u8]> for bitcoin::p2p::Magic
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::borrow::Borrow<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::borrow::Borrow<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::borrow::BorrowMut<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::borrow::BorrowMut<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::borrow::BorrowMut<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::BorrowMut<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::borrow::BorrowMut<[u8; 4]> for bitcoin::p2p::Magic
+impl core::borrow::BorrowMut<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip152::ShortId
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip32::ChainCode
+impl core::borrow::BorrowMut<[u8]> for bitcoin::bip32::Fingerprint
+impl core::borrow::BorrowMut<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::borrow::BorrowMut<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::borrow::BorrowMut<[u8]> for bitcoin::p2p::Magic
+impl core::borrow::BorrowMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::borrow::BorrowMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::clone::Clone for bitcoin::CompressedPublicKey
+impl core::clone::Clone for bitcoin::EcdsaSighashType
+impl core::clone::Clone for bitcoin::LegacySighash
+impl core::clone::Clone for bitcoin::MerkleBlock
+impl core::clone::Clone for bitcoin::PrivateKey
+impl core::clone::Clone for bitcoin::PubkeyHash
+impl core::clone::Clone for bitcoin::PublicKey
+impl core::clone::Clone for bitcoin::SegwitV0Sighash
+impl core::clone::Clone for bitcoin::TapSighash
+impl core::clone::Clone for bitcoin::TapSighashTag
+impl core::clone::Clone for bitcoin::TapSighashType
+impl core::clone::Clone for bitcoin::WPubkeyHash
+impl core::clone::Clone for bitcoin::address::AddressType
+impl core::clone::Clone for bitcoin::address::KnownHrp
+impl core::clone::Clone for bitcoin::address::NetworkChecked
+impl core::clone::Clone for bitcoin::address::NetworkUnchecked
+impl core::clone::Clone for bitcoin::address::error::Error
+impl core::clone::Clone for bitcoin::address::error::ParseError
+impl core::clone::Clone for bitcoin::address::error::UnknownAddressTypeError
+impl core::clone::Clone for bitcoin::address::error::UnknownHrpError
+impl core::clone::Clone for bitcoin::base58::Error
+impl core::clone::Clone for bitcoin::bip152::BlockTransactions
+impl core::clone::Clone for bitcoin::bip152::BlockTransactionsRequest
+impl core::clone::Clone for bitcoin::bip152::Error
+impl core::clone::Clone for bitcoin::bip152::HeaderAndShortIds
+impl core::clone::Clone for bitcoin::bip152::PrefilledTransaction
+impl core::clone::Clone for bitcoin::bip152::ShortId
+impl core::clone::Clone for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::clone::Clone for bitcoin::bip158::BlockFilter
+impl core::clone::Clone for bitcoin::bip158::FilterHash
+impl core::clone::Clone for bitcoin::bip158::FilterHeader
+impl core::clone::Clone for bitcoin::bip32::ChainCode
+impl core::clone::Clone for bitcoin::bip32::ChildNumber
+impl core::clone::Clone for bitcoin::bip32::DerivationPath
+impl core::clone::Clone for bitcoin::bip32::Error
+impl core::clone::Clone for bitcoin::bip32::Fingerprint
+impl core::clone::Clone for bitcoin::bip32::XKeyIdentifier
+impl core::clone::Clone for bitcoin::bip32::Xpriv
+impl core::clone::Clone for bitcoin::bip32::Xpub
+impl core::clone::Clone for bitcoin::blockdata::block::Bip34Error
+impl core::clone::Clone for bitcoin::blockdata::block::Block
+impl core::clone::Clone for bitcoin::blockdata::block::BlockHash
+impl core::clone::Clone for bitcoin::blockdata::block::Header
+impl core::clone::Clone for bitcoin::blockdata::block::TxMerkleNode
+impl core::clone::Clone for bitcoin::blockdata::block::ValidationError
+impl core::clone::Clone for bitcoin::blockdata::block::Version
+impl core::clone::Clone for bitcoin::blockdata::block::WitnessCommitment
+impl core::clone::Clone for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::clone::Clone for bitcoin::blockdata::constants::ChainHash
+impl core::clone::Clone for bitcoin::blockdata::fee_rate::FeeRate
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Error
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Height
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::Time
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Error
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Height
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::LockTime
+impl core::clone::Clone for bitcoin::blockdata::locktime::relative::Time
+impl core::clone::Clone for bitcoin::blockdata::opcodes::Class
+impl core::clone::Clone for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::clone::Clone for bitcoin::blockdata::opcodes::Opcode
+impl core::clone::Clone for bitcoin::blockdata::script::Builder
+impl core::clone::Clone for bitcoin::blockdata::script::Error
+impl core::clone::Clone for bitcoin::blockdata::script::PushBytesBuf
+impl core::clone::Clone for bitcoin::blockdata::script::PushBytesError
+impl core::clone::Clone for bitcoin::blockdata::script::ScriptBuf
+impl core::clone::Clone for bitcoin::blockdata::script::ScriptHash
+impl core::clone::Clone for bitcoin::blockdata::script::WScriptHash
+impl core::clone::Clone for bitcoin::blockdata::script::witness_program::Error
+impl core::clone::Clone for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::clone::Clone for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::clone::Clone for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::clone::Clone for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::clone::Clone for bitcoin::blockdata::transaction::InputsIndexError
+impl core::clone::Clone for bitcoin::blockdata::transaction::OutPoint
+impl core::clone::Clone for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::clone::Clone for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::clone::Clone for bitcoin::blockdata::transaction::Sequence
+impl core::clone::Clone for bitcoin::blockdata::transaction::Transaction
+impl core::clone::Clone for bitcoin::blockdata::transaction::TxIn
+impl core::clone::Clone for bitcoin::blockdata::transaction::TxOut
+impl core::clone::Clone for bitcoin::blockdata::transaction::Txid
+impl core::clone::Clone for bitcoin::blockdata::transaction::Version
+impl core::clone::Clone for bitcoin::blockdata::transaction::Wtxid
+impl core::clone::Clone for bitcoin::blockdata::weight::Weight
+impl core::clone::Clone for bitcoin::blockdata::witness::Witness
+impl core::clone::Clone for bitcoin::consensus::encode::CheckedData
+impl core::clone::Clone for bitcoin::consensus::encode::VarInt
+impl core::clone::Clone for bitcoin::consensus::params::Params
+impl core::clone::Clone for bitcoin::ecdsa::Error
+impl core::clone::Clone for bitcoin::ecdsa::SerializedSignature
+impl core::clone::Clone for bitcoin::ecdsa::Signature
+impl core::clone::Clone for bitcoin::error::ParseIntError
+impl core::clone::Clone for bitcoin::key::Error
+impl core::clone::Clone for bitcoin::key::SortKey
+impl core::clone::Clone for bitcoin::key::TweakedKeypair
+impl core::clone::Clone for bitcoin::key::TweakedPublicKey
+impl core::clone::Clone for bitcoin::key::UncompressedPubkeyError
+impl core::clone::Clone for bitcoin::merkle_tree::MerkleBlockError
+impl core::clone::Clone for bitcoin::merkle_tree::PartialMerkleTree
+impl core::clone::Clone for bitcoin::network::Network
+impl core::clone::Clone for bitcoin::network::NetworkKind
+impl core::clone::Clone for bitcoin::network::ParseNetworkError
+impl core::clone::Clone for bitcoin::network::UnknownChainHashError
+impl core::clone::Clone for bitcoin::p2p::Magic
+impl core::clone::Clone for bitcoin::p2p::ParseMagicError
+impl core::clone::Clone for bitcoin::p2p::ServiceFlags
+impl core::clone::Clone for bitcoin::p2p::UnknownMagicError
+impl core::clone::Clone for bitcoin::pow::CompactTarget
+impl core::clone::Clone for bitcoin::pow::Target
+impl core::clone::Clone for bitcoin::pow::TryFromError
+impl core::clone::Clone for bitcoin::pow::Work
+impl core::clone::Clone for bitcoin::psbt::ExtractTxError
+impl core::clone::Clone for bitcoin::psbt::GetKeyError
+impl core::clone::Clone for bitcoin::psbt::IndexOutOfBoundsError
+impl core::clone::Clone for bitcoin::psbt::Input
+impl core::clone::Clone for bitcoin::psbt::KeyRequest
+impl core::clone::Clone for bitcoin::psbt::Output
+impl core::clone::Clone for bitcoin::psbt::OutputType
+impl core::clone::Clone for bitcoin::psbt::Psbt
+impl core::clone::Clone for bitcoin::psbt::PsbtSighashType
+impl core::clone::Clone for bitcoin::psbt::SignError
+impl core::clone::Clone for bitcoin::psbt::SigningAlgorithm
+impl core::clone::Clone for bitcoin::psbt::raw::Key
+impl core::clone::Clone for bitcoin::sighash::AnnexError
+impl core::clone::Clone for bitcoin::sighash::InvalidSighashTypeError
+impl core::clone::Clone for bitcoin::sighash::NonStandardSighashTypeError
+impl core::clone::Clone for bitcoin::sighash::P2wpkhError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsIndexError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsKindError
+impl core::clone::Clone for bitcoin::sighash::PrevoutsSizeError
+impl core::clone::Clone for bitcoin::sighash::SighashTypeParseError
+impl core::clone::Clone for bitcoin::sighash::SingleMissingOutputError
+impl core::clone::Clone for bitcoin::sighash::TaprootError
+impl core::clone::Clone for bitcoin::taproot::ControlBlock
+impl core::clone::Clone for bitcoin::taproot::FutureLeafVersion
+impl core::clone::Clone for bitcoin::taproot::HiddenNodesError
+impl core::clone::Clone for bitcoin::taproot::IncompleteBuilderError
+impl core::clone::Clone for bitcoin::taproot::LeafNode
+impl core::clone::Clone for bitcoin::taproot::LeafVersion
+impl core::clone::Clone for bitcoin::taproot::NodeInfo
+impl core::clone::Clone for bitcoin::taproot::SigFromSliceError
+impl core::clone::Clone for bitcoin::taproot::Signature
+impl core::clone::Clone for bitcoin::taproot::TapBranchTag
+impl core::clone::Clone for bitcoin::taproot::TapLeaf
+impl core::clone::Clone for bitcoin::taproot::TapLeafHash
+impl core::clone::Clone for bitcoin::taproot::TapLeafTag
+impl core::clone::Clone for bitcoin::taproot::TapNodeHash
+impl core::clone::Clone for bitcoin::taproot::TapTree
+impl core::clone::Clone for bitcoin::taproot::TapTweakHash
+impl core::clone::Clone for bitcoin::taproot::TapTweakTag
+impl core::clone::Clone for bitcoin::taproot::TaprootBuilder
+impl core::clone::Clone for bitcoin::taproot::TaprootBuilderError
+impl core::clone::Clone for bitcoin::taproot::TaprootError
+impl core::clone::Clone for bitcoin::taproot::TaprootSpendInfo
+impl core::clone::Clone for bitcoin::taproot::merkle_branch::IntoIter
+impl core::clone::Clone for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::clone::Clone for bitcoin::taproot::serialized_signature::IntoIter
+impl core::clone::Clone for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::Eq for bitcoin::CompressedPublicKey
+impl core::cmp::Eq for bitcoin::EcdsaSighashType
+impl core::cmp::Eq for bitcoin::LegacySighash
+impl core::cmp::Eq for bitcoin::MerkleBlock
+impl core::cmp::Eq for bitcoin::PrivateKey
+impl core::cmp::Eq for bitcoin::PubkeyHash
+impl core::cmp::Eq for bitcoin::PublicKey
+impl core::cmp::Eq for bitcoin::SegwitV0Sighash
+impl core::cmp::Eq for bitcoin::TapSighash
+impl core::cmp::Eq for bitcoin::TapSighashTag
+impl core::cmp::Eq for bitcoin::TapSighashType
+impl core::cmp::Eq for bitcoin::WPubkeyHash
+impl core::cmp::Eq for bitcoin::address::AddressType
+impl core::cmp::Eq for bitcoin::address::KnownHrp
+impl core::cmp::Eq for bitcoin::address::NetworkChecked
+impl core::cmp::Eq for bitcoin::address::NetworkUnchecked
+impl core::cmp::Eq for bitcoin::address::error::Error
+impl core::cmp::Eq for bitcoin::address::error::ParseError
+impl core::cmp::Eq for bitcoin::address::error::UnknownAddressTypeError
+impl core::cmp::Eq for bitcoin::address::error::UnknownHrpError
+impl core::cmp::Eq for bitcoin::base58::Error
+impl core::cmp::Eq for bitcoin::bip152::BlockTransactions
+impl core::cmp::Eq for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::Eq for bitcoin::bip152::Error
+impl core::cmp::Eq for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::Eq for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::Eq for bitcoin::bip152::ShortId
+impl core::cmp::Eq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::cmp::Eq for bitcoin::bip158::BlockFilter
+impl core::cmp::Eq for bitcoin::bip158::FilterHash
+impl core::cmp::Eq for bitcoin::bip158::FilterHeader
+impl core::cmp::Eq for bitcoin::bip32::ChainCode
+impl core::cmp::Eq for bitcoin::bip32::ChildNumber
+impl core::cmp::Eq for bitcoin::bip32::DerivationPath
+impl core::cmp::Eq for bitcoin::bip32::Error
+impl core::cmp::Eq for bitcoin::bip32::Fingerprint
+impl core::cmp::Eq for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::Eq for bitcoin::bip32::Xpriv
+impl core::cmp::Eq for bitcoin::bip32::Xpub
+impl core::cmp::Eq for bitcoin::blockdata::block::Bip34Error
+impl core::cmp::Eq for bitcoin::blockdata::block::Block
+impl core::cmp::Eq for bitcoin::blockdata::block::BlockHash
+impl core::cmp::Eq for bitcoin::blockdata::block::Header
+impl core::cmp::Eq for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::Eq for bitcoin::blockdata::block::ValidationError
+impl core::cmp::Eq for bitcoin::blockdata::block::Version
+impl core::cmp::Eq for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::Eq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Error
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Error
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::cmp::Eq for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::Class
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::Eq for bitcoin::blockdata::opcodes::Opcode
+impl core::cmp::Eq for bitcoin::blockdata::script::Builder
+impl core::cmp::Eq for bitcoin::blockdata::script::Error
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytes
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::Eq for bitcoin::blockdata::script::PushBytesError
+impl core::cmp::Eq for bitcoin::blockdata::script::Script
+impl core::cmp::Eq for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::Eq for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::Eq for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_program::Error
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::cmp::Eq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::Eq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::Eq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::Eq for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::Eq for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Txid
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Version
+impl core::cmp::Eq for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::Eq for bitcoin::blockdata::weight::Weight
+impl core::cmp::Eq for bitcoin::blockdata::witness::Witness
+impl core::cmp::Eq for bitcoin::consensus::encode::CheckedData
+impl core::cmp::Eq for bitcoin::consensus::encode::VarInt
+impl core::cmp::Eq for bitcoin::ecdsa::Error
+impl core::cmp::Eq for bitcoin::ecdsa::SerializedSignature
+impl core::cmp::Eq for bitcoin::ecdsa::Signature
+impl core::cmp::Eq for bitcoin::error::ParseIntError
+impl core::cmp::Eq for bitcoin::key::Error
+impl core::cmp::Eq for bitcoin::key::SortKey
+impl core::cmp::Eq for bitcoin::key::TweakedKeypair
+impl core::cmp::Eq for bitcoin::key::TweakedPublicKey
+impl core::cmp::Eq for bitcoin::key::UncompressedPubkeyError
+impl core::cmp::Eq for bitcoin::merkle_tree::MerkleBlockError
+impl core::cmp::Eq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::cmp::Eq for bitcoin::network::Network
+impl core::cmp::Eq for bitcoin::network::NetworkKind
+impl core::cmp::Eq for bitcoin::network::ParseNetworkError
+impl core::cmp::Eq for bitcoin::network::UnknownChainHashError
+impl core::cmp::Eq for bitcoin::p2p::Magic
+impl core::cmp::Eq for bitcoin::p2p::ParseMagicError
+impl core::cmp::Eq for bitcoin::p2p::ServiceFlags
+impl core::cmp::Eq for bitcoin::p2p::UnknownMagicError
+impl core::cmp::Eq for bitcoin::pow::CompactTarget
+impl core::cmp::Eq for bitcoin::pow::Target
+impl core::cmp::Eq for bitcoin::pow::TryFromError
+impl core::cmp::Eq for bitcoin::pow::Work
+impl core::cmp::Eq for bitcoin::psbt::ExtractTxError
+impl core::cmp::Eq for bitcoin::psbt::GetKeyError
+impl core::cmp::Eq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::cmp::Eq for bitcoin::psbt::Input
+impl core::cmp::Eq for bitcoin::psbt::KeyRequest
+impl core::cmp::Eq for bitcoin::psbt::Output
+impl core::cmp::Eq for bitcoin::psbt::OutputType
+impl core::cmp::Eq for bitcoin::psbt::Psbt
+impl core::cmp::Eq for bitcoin::psbt::PsbtSighashType
+impl core::cmp::Eq for bitcoin::psbt::SignError
+impl core::cmp::Eq for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::Eq for bitcoin::psbt::raw::Key
+impl core::cmp::Eq for bitcoin::psbt::raw::Pair
+impl core::cmp::Eq for bitcoin::sighash::AnnexError
+impl core::cmp::Eq for bitcoin::sighash::InvalidSighashTypeError
+impl core::cmp::Eq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::cmp::Eq for bitcoin::sighash::P2wpkhError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsIndexError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsKindError
+impl core::cmp::Eq for bitcoin::sighash::PrevoutsSizeError
+impl core::cmp::Eq for bitcoin::sighash::SighashTypeParseError
+impl core::cmp::Eq for bitcoin::sighash::SingleMissingOutputError
+impl core::cmp::Eq for bitcoin::sighash::TaprootError
+impl core::cmp::Eq for bitcoin::taproot::ControlBlock
+impl core::cmp::Eq for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::Eq for bitcoin::taproot::HiddenNodesError
+impl core::cmp::Eq for bitcoin::taproot::IncompleteBuilderError
+impl core::cmp::Eq for bitcoin::taproot::LeafNode
+impl core::cmp::Eq for bitcoin::taproot::LeafVersion
+impl core::cmp::Eq for bitcoin::taproot::NodeInfo
+impl core::cmp::Eq for bitcoin::taproot::SigFromSliceError
+impl core::cmp::Eq for bitcoin::taproot::Signature
+impl core::cmp::Eq for bitcoin::taproot::TapBranchTag
+impl core::cmp::Eq for bitcoin::taproot::TapLeaf
+impl core::cmp::Eq for bitcoin::taproot::TapLeafHash
+impl core::cmp::Eq for bitcoin::taproot::TapLeafTag
+impl core::cmp::Eq for bitcoin::taproot::TapNodeHash
+impl core::cmp::Eq for bitcoin::taproot::TapTree
+impl core::cmp::Eq for bitcoin::taproot::TapTweakHash
+impl core::cmp::Eq for bitcoin::taproot::TapTweakTag
+impl core::cmp::Eq for bitcoin::taproot::TaprootBuilder
+impl core::cmp::Eq for bitcoin::taproot::TaprootBuilderError
+impl core::cmp::Eq for bitcoin::taproot::TaprootError
+impl core::cmp::Eq for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::Eq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::Eq for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::Ord for bitcoin::CompressedPublicKey
+impl core::cmp::Ord for bitcoin::LegacySighash
+impl core::cmp::Ord for bitcoin::PubkeyHash
+impl core::cmp::Ord for bitcoin::PublicKey
+impl core::cmp::Ord for bitcoin::SegwitV0Sighash
+impl core::cmp::Ord for bitcoin::TapSighash
+impl core::cmp::Ord for bitcoin::TapSighashTag
+impl core::cmp::Ord for bitcoin::TapSighashType
+impl core::cmp::Ord for bitcoin::WPubkeyHash
+impl core::cmp::Ord for bitcoin::address::AddressType
+impl core::cmp::Ord for bitcoin::address::KnownHrp
+impl core::cmp::Ord for bitcoin::address::NetworkChecked
+impl core::cmp::Ord for bitcoin::address::NetworkUnchecked
+impl core::cmp::Ord for bitcoin::bip152::BlockTransactions
+impl core::cmp::Ord for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::Ord for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::Ord for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::Ord for bitcoin::bip152::ShortId
+impl core::cmp::Ord for bitcoin::bip158::FilterHash
+impl core::cmp::Ord for bitcoin::bip158::FilterHeader
+impl core::cmp::Ord for bitcoin::bip32::ChainCode
+impl core::cmp::Ord for bitcoin::bip32::ChildNumber
+impl core::cmp::Ord for bitcoin::bip32::DerivationPath
+impl core::cmp::Ord for bitcoin::bip32::Fingerprint
+impl core::cmp::Ord for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::Ord for bitcoin::bip32::Xpub
+impl core::cmp::Ord for bitcoin::blockdata::block::BlockHash
+impl core::cmp::Ord for bitcoin::blockdata::block::Header
+impl core::cmp::Ord for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::Ord for bitcoin::blockdata::block::Version
+impl core::cmp::Ord for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::Ord for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::Ord for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::Ord for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::Ord for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::Ord for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::Ord for bitcoin::blockdata::script::PushBytes
+impl core::cmp::Ord for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::Ord for bitcoin::blockdata::script::Script
+impl core::cmp::Ord for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::Ord for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::Ord for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::Ord for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::Ord for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::Ord for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::Ord for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::Ord for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Txid
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Version
+impl core::cmp::Ord for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::Ord for bitcoin::blockdata::weight::Weight
+impl core::cmp::Ord for bitcoin::blockdata::witness::Witness
+impl core::cmp::Ord for bitcoin::consensus::encode::VarInt
+impl core::cmp::Ord for bitcoin::key::SortKey
+impl core::cmp::Ord for bitcoin::key::TweakedKeypair
+impl core::cmp::Ord for bitcoin::key::TweakedPublicKey
+impl core::cmp::Ord for bitcoin::network::Network
+impl core::cmp::Ord for bitcoin::network::NetworkKind
+impl core::cmp::Ord for bitcoin::p2p::Magic
+impl core::cmp::Ord for bitcoin::p2p::ServiceFlags
+impl core::cmp::Ord for bitcoin::pow::CompactTarget
+impl core::cmp::Ord for bitcoin::pow::Target
+impl core::cmp::Ord for bitcoin::pow::Work
+impl core::cmp::Ord for bitcoin::psbt::OutputType
+impl core::cmp::Ord for bitcoin::psbt::PsbtSighashType
+impl core::cmp::Ord for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::Ord for bitcoin::psbt::raw::Key
+impl core::cmp::Ord for bitcoin::taproot::ControlBlock
+impl core::cmp::Ord for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::Ord for bitcoin::taproot::LeafNode
+impl core::cmp::Ord for bitcoin::taproot::LeafVersion
+impl core::cmp::Ord for bitcoin::taproot::NodeInfo
+impl core::cmp::Ord for bitcoin::taproot::Signature
+impl core::cmp::Ord for bitcoin::taproot::TapBranchTag
+impl core::cmp::Ord for bitcoin::taproot::TapLeaf
+impl core::cmp::Ord for bitcoin::taproot::TapLeafHash
+impl core::cmp::Ord for bitcoin::taproot::TapLeafTag
+impl core::cmp::Ord for bitcoin::taproot::TapNodeHash
+impl core::cmp::Ord for bitcoin::taproot::TapTweakHash
+impl core::cmp::Ord for bitcoin::taproot::TapTweakTag
+impl core::cmp::Ord for bitcoin::taproot::TaprootBuilder
+impl core::cmp::Ord for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::Ord for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::Ord for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq for bitcoin::CompressedPublicKey
+impl core::cmp::PartialEq for bitcoin::EcdsaSighashType
+impl core::cmp::PartialEq for bitcoin::LegacySighash
+impl core::cmp::PartialEq for bitcoin::MerkleBlock
+impl core::cmp::PartialEq for bitcoin::PrivateKey
+impl core::cmp::PartialEq for bitcoin::PubkeyHash
+impl core::cmp::PartialEq for bitcoin::PublicKey
+impl core::cmp::PartialEq for bitcoin::SegwitV0Sighash
+impl core::cmp::PartialEq for bitcoin::TapSighash
+impl core::cmp::PartialEq for bitcoin::TapSighashTag
+impl core::cmp::PartialEq for bitcoin::TapSighashType
+impl core::cmp::PartialEq for bitcoin::WPubkeyHash
+impl core::cmp::PartialEq for bitcoin::address::AddressType
+impl core::cmp::PartialEq for bitcoin::address::KnownHrp
+impl core::cmp::PartialEq for bitcoin::address::NetworkChecked
+impl core::cmp::PartialEq for bitcoin::address::NetworkUnchecked
+impl core::cmp::PartialEq for bitcoin::address::error::Error
+impl core::cmp::PartialEq for bitcoin::address::error::ParseError
+impl core::cmp::PartialEq for bitcoin::address::error::UnknownAddressTypeError
+impl core::cmp::PartialEq for bitcoin::address::error::UnknownHrpError
+impl core::cmp::PartialEq for bitcoin::base58::Error
+impl core::cmp::PartialEq for bitcoin::bip152::BlockTransactions
+impl core::cmp::PartialEq for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::PartialEq for bitcoin::bip152::Error
+impl core::cmp::PartialEq for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::PartialEq for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::PartialEq for bitcoin::bip152::ShortId
+impl core::cmp::PartialEq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::cmp::PartialEq for bitcoin::bip158::BlockFilter
+impl core::cmp::PartialEq for bitcoin::bip158::FilterHash
+impl core::cmp::PartialEq for bitcoin::bip158::FilterHeader
+impl core::cmp::PartialEq for bitcoin::bip32::ChainCode
+impl core::cmp::PartialEq for bitcoin::bip32::ChildNumber
+impl core::cmp::PartialEq for bitcoin::bip32::DerivationPath
+impl core::cmp::PartialEq for bitcoin::bip32::Error
+impl core::cmp::PartialEq for bitcoin::bip32::Fingerprint
+impl core::cmp::PartialEq for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::PartialEq for bitcoin::bip32::Xpriv
+impl core::cmp::PartialEq for bitcoin::bip32::Xpub
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Bip34Error
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Block
+impl core::cmp::PartialEq for bitcoin::blockdata::block::BlockHash
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Header
+impl core::cmp::PartialEq for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin::blockdata::block::ValidationError
+impl core::cmp::PartialEq for bitcoin::blockdata::block::Version
+impl core::cmp::PartialEq for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::PartialEq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::Class
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::PartialEq for bitcoin::blockdata::opcodes::Opcode
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Builder
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytes
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::PartialEq for bitcoin::blockdata::script::PushBytesError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::Script
+impl core::cmp::PartialEq for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialEq for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::PartialEq for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_program::Error
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::cmp::PartialEq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Txid
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Version
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin::blockdata::weight::Weight
+impl core::cmp::PartialEq for bitcoin::blockdata::witness::Witness
+impl core::cmp::PartialEq for bitcoin::consensus::encode::CheckedData
+impl core::cmp::PartialEq for bitcoin::consensus::encode::VarInt
+impl core::cmp::PartialEq for bitcoin::ecdsa::Error
+impl core::cmp::PartialEq for bitcoin::ecdsa::SerializedSignature
+impl core::cmp::PartialEq for bitcoin::ecdsa::Signature
+impl core::cmp::PartialEq for bitcoin::error::ParseIntError
+impl core::cmp::PartialEq for bitcoin::key::Error
+impl core::cmp::PartialEq for bitcoin::key::SortKey
+impl core::cmp::PartialEq for bitcoin::key::TweakedKeypair
+impl core::cmp::PartialEq for bitcoin::key::TweakedPublicKey
+impl core::cmp::PartialEq for bitcoin::key::UncompressedPubkeyError
+impl core::cmp::PartialEq for bitcoin::merkle_tree::MerkleBlockError
+impl core::cmp::PartialEq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::cmp::PartialEq for bitcoin::network::Network
+impl core::cmp::PartialEq for bitcoin::network::NetworkKind
+impl core::cmp::PartialEq for bitcoin::network::ParseNetworkError
+impl core::cmp::PartialEq for bitcoin::network::UnknownChainHashError
+impl core::cmp::PartialEq for bitcoin::p2p::Magic
+impl core::cmp::PartialEq for bitcoin::p2p::ParseMagicError
+impl core::cmp::PartialEq for bitcoin::p2p::ServiceFlags
+impl core::cmp::PartialEq for bitcoin::p2p::UnknownMagicError
+impl core::cmp::PartialEq for bitcoin::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin::pow::Target
+impl core::cmp::PartialEq for bitcoin::pow::TryFromError
+impl core::cmp::PartialEq for bitcoin::pow::Work
+impl core::cmp::PartialEq for bitcoin::psbt::ExtractTxError
+impl core::cmp::PartialEq for bitcoin::psbt::GetKeyError
+impl core::cmp::PartialEq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::cmp::PartialEq for bitcoin::psbt::Input
+impl core::cmp::PartialEq for bitcoin::psbt::KeyRequest
+impl core::cmp::PartialEq for bitcoin::psbt::Output
+impl core::cmp::PartialEq for bitcoin::psbt::OutputType
+impl core::cmp::PartialEq for bitcoin::psbt::Psbt
+impl core::cmp::PartialEq for bitcoin::psbt::PsbtSighashType
+impl core::cmp::PartialEq for bitcoin::psbt::SignError
+impl core::cmp::PartialEq for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::PartialEq for bitcoin::psbt::raw::Key
+impl core::cmp::PartialEq for bitcoin::psbt::raw::Pair
+impl core::cmp::PartialEq for bitcoin::sighash::AnnexError
+impl core::cmp::PartialEq for bitcoin::sighash::InvalidSighashTypeError
+impl core::cmp::PartialEq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::cmp::PartialEq for bitcoin::sighash::P2wpkhError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsIndexError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsKindError
+impl core::cmp::PartialEq for bitcoin::sighash::PrevoutsSizeError
+impl core::cmp::PartialEq for bitcoin::sighash::SighashTypeParseError
+impl core::cmp::PartialEq for bitcoin::sighash::SingleMissingOutputError
+impl core::cmp::PartialEq for bitcoin::sighash::TaprootError
+impl core::cmp::PartialEq for bitcoin::taproot::ControlBlock
+impl core::cmp::PartialEq for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::PartialEq for bitcoin::taproot::HiddenNodesError
+impl core::cmp::PartialEq for bitcoin::taproot::IncompleteBuilderError
+impl core::cmp::PartialEq for bitcoin::taproot::LeafNode
+impl core::cmp::PartialEq for bitcoin::taproot::LeafVersion
+impl core::cmp::PartialEq for bitcoin::taproot::NodeInfo
+impl core::cmp::PartialEq for bitcoin::taproot::SigFromSliceError
+impl core::cmp::PartialEq for bitcoin::taproot::Signature
+impl core::cmp::PartialEq for bitcoin::taproot::TapBranchTag
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeaf
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeafHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapLeafTag
+impl core::cmp::PartialEq for bitcoin::taproot::TapNodeHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapTree
+impl core::cmp::PartialEq for bitcoin::taproot::TapTweakHash
+impl core::cmp::PartialEq for bitcoin::taproot::TapTweakTag
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootBuilder
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootBuilderError
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootError
+impl core::cmp::PartialEq for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::PartialEq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::PartialEq for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialEq<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialEq<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::Script
+impl core::cmp::PartialEq<bitcoin::taproot::serialized_signature::SerializedSignature> for [u8]
+impl core::cmp::PartialOrd for bitcoin::CompressedPublicKey
+impl core::cmp::PartialOrd for bitcoin::LegacySighash
+impl core::cmp::PartialOrd for bitcoin::PubkeyHash
+impl core::cmp::PartialOrd for bitcoin::PublicKey
+impl core::cmp::PartialOrd for bitcoin::SegwitV0Sighash
+impl core::cmp::PartialOrd for bitcoin::TapSighash
+impl core::cmp::PartialOrd for bitcoin::TapSighashTag
+impl core::cmp::PartialOrd for bitcoin::TapSighashType
+impl core::cmp::PartialOrd for bitcoin::WPubkeyHash
+impl core::cmp::PartialOrd for bitcoin::address::AddressType
+impl core::cmp::PartialOrd for bitcoin::address::KnownHrp
+impl core::cmp::PartialOrd for bitcoin::address::NetworkChecked
+impl core::cmp::PartialOrd for bitcoin::address::NetworkUnchecked
+impl core::cmp::PartialOrd for bitcoin::bip152::BlockTransactions
+impl core::cmp::PartialOrd for bitcoin::bip152::BlockTransactionsRequest
+impl core::cmp::PartialOrd for bitcoin::bip152::HeaderAndShortIds
+impl core::cmp::PartialOrd for bitcoin::bip152::PrefilledTransaction
+impl core::cmp::PartialOrd for bitcoin::bip152::ShortId
+impl core::cmp::PartialOrd for bitcoin::bip158::FilterHash
+impl core::cmp::PartialOrd for bitcoin::bip158::FilterHeader
+impl core::cmp::PartialOrd for bitcoin::bip32::ChainCode
+impl core::cmp::PartialOrd for bitcoin::bip32::ChildNumber
+impl core::cmp::PartialOrd for bitcoin::bip32::DerivationPath
+impl core::cmp::PartialOrd for bitcoin::bip32::Fingerprint
+impl core::cmp::PartialOrd for bitcoin::bip32::XKeyIdentifier
+impl core::cmp::PartialOrd for bitcoin::bip32::Xpub
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::Header
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::Version
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin::blockdata::constants::ChainHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::fee_rate::FeeRate
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::absolute::Time
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::relative::Height
+impl core::cmp::PartialOrd for bitcoin::blockdata::locktime::relative::Time
+impl core::cmp::PartialOrd for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::PushBytes
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::PushBytesBuf
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::Script
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::ScriptHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::WScriptHash
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::cmp::PartialOrd for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Sequence
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Transaction
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::TxIn
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::TxOut
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Version
+impl core::cmp::PartialOrd for bitcoin::blockdata::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin::blockdata::weight::Weight
+impl core::cmp::PartialOrd for bitcoin::blockdata::witness::Witness
+impl core::cmp::PartialOrd for bitcoin::consensus::encode::VarInt
+impl core::cmp::PartialOrd for bitcoin::key::SortKey
+impl core::cmp::PartialOrd for bitcoin::key::TweakedKeypair
+impl core::cmp::PartialOrd for bitcoin::key::TweakedPublicKey
+impl core::cmp::PartialOrd for bitcoin::network::Network
+impl core::cmp::PartialOrd for bitcoin::network::NetworkKind
+impl core::cmp::PartialOrd for bitcoin::p2p::Magic
+impl core::cmp::PartialOrd for bitcoin::p2p::ServiceFlags
+impl core::cmp::PartialOrd for bitcoin::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin::pow::Target
+impl core::cmp::PartialOrd for bitcoin::pow::Work
+impl core::cmp::PartialOrd for bitcoin::psbt::OutputType
+impl core::cmp::PartialOrd for bitcoin::psbt::PsbtSighashType
+impl core::cmp::PartialOrd for bitcoin::psbt::SigningAlgorithm
+impl core::cmp::PartialOrd for bitcoin::psbt::raw::Key
+impl core::cmp::PartialOrd for bitcoin::taproot::ControlBlock
+impl core::cmp::PartialOrd for bitcoin::taproot::FutureLeafVersion
+impl core::cmp::PartialOrd for bitcoin::taproot::LeafNode
+impl core::cmp::PartialOrd for bitcoin::taproot::LeafVersion
+impl core::cmp::PartialOrd for bitcoin::taproot::NodeInfo
+impl core::cmp::PartialOrd for bitcoin::taproot::Signature
+impl core::cmp::PartialOrd for bitcoin::taproot::TapBranchTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeaf
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeafHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapLeafTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TapNodeHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapTweakHash
+impl core::cmp::PartialOrd for bitcoin::taproot::TapTweakTag
+impl core::cmp::PartialOrd for bitcoin::taproot::TaprootBuilder
+impl core::cmp::PartialOrd for bitcoin::taproot::TaprootSpendInfo
+impl core::cmp::PartialOrd for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::cmp::PartialOrd for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::cmp::PartialOrd<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::cmp::PartialOrd<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::Script
+impl core::cmp::PartialOrd<bitcoin::taproot::serialized_signature::SerializedSignature> for [u8]
+impl core::convert::AsMut<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::AsMut<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::convert::AsMut<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsMut<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsMut<[u8; 4]> for bitcoin::p2p::Magic
+impl core::convert::AsMut<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::convert::AsMut<[u8]> for bitcoin::bip152::ShortId
+impl core::convert::AsMut<[u8]> for bitcoin::bip32::ChainCode
+impl core::convert::AsMut<[u8]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::Script
+impl core::convert::AsMut<[u8]> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsMut<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsMut<[u8]> for bitcoin::p2p::Magic
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 0]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 10]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 11]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 12]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 13]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 14]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 15]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 16]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 17]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 18]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 19]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 1]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 20]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 21]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 22]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 23]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 24]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 25]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 26]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 27]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 28]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 29]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 2]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 30]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 31]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 32]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 33]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 34]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 35]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 36]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 37]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 38]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 39]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 3]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 40]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 41]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 42]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 43]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 44]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 45]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 46]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 47]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 48]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 49]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 4]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 50]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 51]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 52]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 53]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 54]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 55]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 56]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 57]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 58]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 59]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 5]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 60]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 61]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 62]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 63]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 64]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 65]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 66]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 67]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 68]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 69]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 6]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 70]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 71]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 72]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 73]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 7]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 8]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for [u8; 9]
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsMut<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::AsMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::Script
+impl core::convert::AsMut<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<[bitcoin::bip32::ChildNumber]> for bitcoin::bip32::ChildNumber
+impl core::convert::AsRef<[bitcoin::bip32::ChildNumber]> for bitcoin::bip32::DerivationPath
+impl core::convert::AsRef<[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::AsRef<[u8; 20]> for bitcoin::PubkeyHash
+impl core::convert::AsRef<[u8; 20]> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<[u8; 20]> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::AsRef<[u8; 20]> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::LegacySighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::SegwitV0Sighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::TapSighash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip158::FilterHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip158::FilterHeader
+impl core::convert::AsRef<[u8; 32]> for bitcoin::bip32::ChainCode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapLeafHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapNodeHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin::taproot::TapTweakHash
+impl core::convert::AsRef<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsRef<[u8; 4]> for bitcoin::p2p::Magic
+impl core::convert::AsRef<[u8; 6]> for bitcoin::bip152::ShortId
+impl core::convert::AsRef<[u8]> for bitcoin::LegacySighash
+impl core::convert::AsRef<[u8]> for bitcoin::PubkeyHash
+impl core::convert::AsRef<[u8]> for bitcoin::SegwitV0Sighash
+impl core::convert::AsRef<[u8]> for bitcoin::TapSighash
+impl core::convert::AsRef<[u8]> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<[u8]> for bitcoin::bip152::ShortId
+impl core::convert::AsRef<[u8]> for bitcoin::bip158::FilterHash
+impl core::convert::AsRef<[u8]> for bitcoin::bip158::FilterHeader
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::ChainCode
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::Fingerprint
+impl core::convert::AsRef<[u8]> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::constants::ChainHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::Script
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsRef<[u8]> for bitcoin::p2p::Magic
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapLeafHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapNodeHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::TapTweakHash
+impl core::convert::AsRef<[u8]> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 0]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 10]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 11]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 12]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 13]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 14]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 15]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 16]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 17]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 18]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 19]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 1]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 20]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 21]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 22]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 23]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 24]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 25]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 26]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 27]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 28]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 29]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 2]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 30]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 31]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 32]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 33]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 34]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 35]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 36]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 37]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 38]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 39]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 3]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 40]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 41]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 42]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 43]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 44]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 45]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 46]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 47]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 48]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 49]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 4]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 50]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 51]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 52]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 53]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 54]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 55]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 56]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 57]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 58]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 59]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 5]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 60]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 61]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 62]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 63]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 64]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 65]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 66]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 67]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 68]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 69]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 6]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 70]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 71]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 72]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 73]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 7]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 8]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for [u8; 9]
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::PubkeyHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::WPubkeyHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytes
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::AsRef<bitcoin::blockdata::script::PushBytes> for bitcoin::ecdsa::SerializedSignature
+impl core::convert::AsRef<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::Script
+impl core::convert::AsRef<bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::AsRef<bitcoin::blockdata::transaction::Transaction> for bitcoin::bip152::PrefilledTransaction
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin::error::ParseIntError
+impl core::convert::From<&[&[u8]]> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<&[alloc::vec::Vec<u8>]> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<&bitcoin::CompressedPublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<&bitcoin::CompressedPublicKey> for bitcoin::WPubkeyHash
+impl core::convert::From<&bitcoin::PublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<&bitcoin::bip32::Xpub> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<&bitcoin::blockdata::block::Block> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<&bitcoin::blockdata::block::Header> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<&bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<&bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<&bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<&bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<&bitcoin::network::Network> for &'static bitcoin::consensus::params::Params
+impl core::convert::From<&bitcoin::network::Network> for bitcoin::consensus::params::Params
+impl core::convert::From<&bitcoin::taproot::LeafNode> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<&bitcoin::taproot::TaprootSpendInfo> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 0]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 100]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 101]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 102]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 103]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 104]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 105]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 106]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 107]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 108]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 109]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 10]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 110]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 111]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 112]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 113]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 114]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 115]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 116]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 117]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 118]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 119]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 11]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 120]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 121]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 122]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 123]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 124]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 125]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 126]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 127]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 128]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 12]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 13]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 14]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 15]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 16]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 17]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 18]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 19]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 1]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 20]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 21]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 22]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 23]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 24]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 25]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 26]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 27]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 28]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 29]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 2]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 30]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 31]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 32]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 33]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 34]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 35]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 36]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 37]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 38]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 39]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 3]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 40]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 41]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 42]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 43]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 44]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 45]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 46]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 47]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 48]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 49]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 4]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 50]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 51]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 52]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 53]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 54]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 55]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 56]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 57]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 58]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 59]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 5]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 60]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 61]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 62]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 63]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 64]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 65]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 66]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 67]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 68]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 69]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 6]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 70]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 71]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 72]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 73]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 74]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 75]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 76]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 77]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 78]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 79]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 7]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 80]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 81]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 82]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 83]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 84]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 85]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 86]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 87]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 88]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 89]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 8]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 90]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 91]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 92]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 93]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 94]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 95]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 96]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 97]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 98]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 99]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[bitcoin::taproot::TapNodeHash; 9]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::From<[u8; 0]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 10]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 11]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 12]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 13]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 14]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 15]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 16]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 17]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 18]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 19]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 1]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 20]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 21]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 22]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 23]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 24]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 25]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 26]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 27]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 28]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 29]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 2]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 30]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 31]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 32]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 33]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 34]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 35]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 36]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 37]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 38]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 39]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 3]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 40]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 41]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 42]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 43]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 44]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 45]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 46]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 47]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 48]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 49]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 4]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 50]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 51]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 52]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 53]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 54]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 55]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 56]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 57]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 58]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 59]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 5]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 60]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 61]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 62]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 63]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 64]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 65]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 66]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 67]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 68]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 69]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 6]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 70]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 71]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 72]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 73]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 7]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 8]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<[u8; 9]> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin::blockdata::witness::Witness
+impl core::convert::From<alloc::vec::Vec<bitcoin::bip32::ChildNumber>> for bitcoin::bip32::DerivationPath
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::Builder
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::From<bech32::segwit::DecodeError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::PublicKey
+impl core::convert::From<bitcoin::CompressedPublicKey> for bitcoin::WPubkeyHash
+impl core::convert::From<bitcoin::CompressedPublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::EcdsaSighashType> for bitcoin::TapSighashType
+impl core::convert::From<bitcoin::EcdsaSighashType> for bitcoin::psbt::PsbtSighashType
+impl core::convert::From<bitcoin::LegacySighash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::PubkeyHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::PubkeyHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::PublicKey> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin::PublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::SegwitV0Sighash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::TapSighash> for bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+impl core::convert::From<bitcoin::TapSighashType> for bitcoin::psbt::PsbtSighashType
+impl core::convert::From<bitcoin::WPubkeyHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::WPubkeyHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::address::Address> for bitcoin::blockdata::script::ScriptBuf
+impl core::convert::From<bitcoin::address::error::UnknownHrpError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::bip32::Error
+impl core::convert::From<bitcoin::base58::Error> for bitcoin::key::Error
+impl core::convert::From<bitcoin::bip158::FilterHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::bip158::FilterHeader> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::bip32::ChildNumber> for u32
+impl core::convert::From<bitcoin::bip32::DerivationPath> for alloc::vec::Vec<bitcoin::bip32::ChildNumber>
+impl core::convert::From<bitcoin::bip32::Error> for bitcoin::psbt::GetKeyError
+impl core::convert::From<bitcoin::bip32::XKeyIdentifier> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::bip32::Xpub> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<bitcoin::blockdata::block::Block> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin::blockdata::block::BlockHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::Header> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin::blockdata::block::TxMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::WitnessCommitment> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::block::WitnessMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::fee_rate::FeeRate> for u64
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::ConversionError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::Height> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::OperationError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::blockdata::locktime::absolute::Time> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::relative::Height> for bitcoin::blockdata::locktime::relative::LockTime
+impl core::convert::From<bitcoin::blockdata::locktime::relative::Time> for bitcoin::blockdata::locktime::relative::LockTime
+impl core::convert::From<bitcoin::blockdata::script::PushBytesBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin::blockdata::script::Script>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<bitcoin::blockdata::script::ScriptBuf> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<bitcoin::blockdata::script::ScriptHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::blockdata::script::ScriptHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin::blockdata::script::WScriptHash> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::From<bitcoin::blockdata::script::WScriptHash> for bitcoin_hashes::sha256::Hash
+impl core::convert::From<bitcoin::blockdata::script::witness_program::Error> for bitcoin::address::error::Error
+impl core::convert::From<bitcoin::blockdata::script::witness_program::Error> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::Error
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::ParseError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bech32::primitives::gf32::Fe32
+impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bitcoin::blockdata::opcodes::Opcode
+impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::InputsIndexError
+impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::convert::From<bitcoin::blockdata::transaction::InputsIndexError> for bitcoin::sighash::P2wpkhError
+impl core::convert::From<bitcoin::blockdata::transaction::InputsIndexError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::blockdata::transaction::Sequence> for u32
+impl core::convert::From<bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<bitcoin::blockdata::transaction::Transaction> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<bitcoin::blockdata::transaction::Txid> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::From<bitcoin::blockdata::transaction::Txid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::transaction::Wtxid> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::From<bitcoin::blockdata::transaction::Wtxid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin::blockdata::weight::Weight> for u64
+impl core::convert::From<bitcoin::consensus::encode::Error> for bitcoin::psbt::Error
+impl core::convert::From<bitcoin::error::ParseIntError> for bitcoin::blockdata::locktime::absolute::Error
+impl core::convert::From<bitcoin::error::ParseIntError> for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::convert::From<bitcoin::error::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin::key::Error> for bitcoin::bip32::Error
+impl core::convert::From<bitcoin::key::TweakedKeypair> for bitcoin::key::TweakedPublicKey
+impl core::convert::From<bitcoin::key::TweakedKeypair> for secp256k1::key::Keypair
+impl core::convert::From<bitcoin::key::TweakedPublicKey> for secp256k1::key::XOnlyPublicKey
+impl core::convert::From<bitcoin::network::Network> for &'static bitcoin::consensus::params::Params
+impl core::convert::From<bitcoin::network::Network> for bitcoin::address::KnownHrp
+impl core::convert::From<bitcoin::network::Network> for bitcoin::consensus::params::Params
+impl core::convert::From<bitcoin::network::Network> for bitcoin::network::NetworkKind
+impl core::convert::From<bitcoin::network::Network> for bitcoin::p2p::Magic
+impl core::convert::From<bitcoin::p2p::ServiceFlags> for u64
+impl core::convert::From<bitcoin::pow::CompactTarget> for bitcoin::pow::Target
+impl core::convert::From<bitcoin::psbt::IndexOutOfBoundsError> for bitcoin::psbt::SignError
+impl core::convert::From<bitcoin::sighash::InvalidSighashTypeError> for bitcoin::taproot::SigFromSliceError
+impl core::convert::From<bitcoin::sighash::NonStandardSighashTypeError> for bitcoin::ecdsa::Error
+impl core::convert::From<bitcoin::sighash::P2wpkhError> for bitcoin::psbt::SignError
+impl core::convert::From<bitcoin::sighash::PrevoutsIndexError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::sighash::PrevoutsKindError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::sighash::PrevoutsSizeError> for bitcoin::sighash::TaprootError
+impl core::convert::From<bitcoin::taproot::LeafNode> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin::taproot::Signature> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::convert::From<bitcoin::taproot::TapLeafHash> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin::taproot::TapLeafHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+impl core::convert::From<bitcoin::taproot::TapNodeHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+impl core::convert::From<bitcoin::taproot::TapTree> for bitcoin::taproot::NodeInfo
+impl core::convert::From<bitcoin::taproot::TapTweakHash> for bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+impl core::convert::From<bitcoin::taproot::TaprootSpendInfo> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<bitcoin::taproot::merkle_branch::TaprootMerkleBranch> for alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+impl core::convert::From<bitcoin_hashes::FromSliceError> for bitcoin::psbt::Error
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::PubkeyHash
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::WPubkeyHash
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::bip32::XKeyIdentifier
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin::blockdata::script::ScriptHash
+impl core::convert::From<bitcoin_hashes::sha256::Hash> for bitcoin::blockdata::script::WScriptHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::LegacySighash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::SegwitV0Sighash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::bip158::FilterHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::bip158::FilterHeader
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::BlockHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::TxMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::WitnessCommitment
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::transaction::Txid
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin::blockdata::transaction::Wtxid
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>> for bitcoin::TapSighash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>> for bitcoin::taproot::TapNodeHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>> for bitcoin::taproot::TapLeafHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>> for bitcoin::taproot::TapTweakHash
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::bip158::Error
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::consensus::encode::Error
+impl core::convert::From<bitcoin_io::error::Error> for bitcoin::psbt::Error
+impl core::convert::From<hex_conservative::parse::HexToArrayError> for bitcoin::key::Error
+impl core::convert::From<hex_conservative::parse::HexToBytesError> for bitcoin::ecdsa::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::bip32::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::ecdsa::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::key::Error
+impl core::convert::From<secp256k1::Error> for bitcoin::taproot::SigFromSliceError
+impl core::convert::From<secp256k1::key::PublicKey> for bitcoin::PublicKey
+impl core::convert::From<u16> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::From<u16> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u32> for bitcoin::bip32::ChildNumber
+impl core::convert::From<u32> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u64> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<u64> for bitcoin::p2p::ServiceFlags
+impl core::convert::From<u8> for bitcoin::blockdata::opcodes::Opcode
+impl core::convert::From<u8> for bitcoin::consensus::encode::VarInt
+impl core::convert::From<usize> for bitcoin::consensus::encode::VarInt
+impl core::convert::TryFrom<&[bitcoin::taproot::TapNodeHash]> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<&str> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<[bitcoin::taproot::TapNodeHash]>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::relative::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::locktime::relative::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::transaction::Sequence
+impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::weight::Weight
+impl core::convert::TryFrom<alloc::vec::Vec<bitcoin::taproot::TapNodeHash>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::convert::TryFrom<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::PushBytesBuf
+impl core::convert::TryFrom<bech32::primitives::gf32::Fe32> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::convert::TryFrom<bitcoin::PublicKey> for bitcoin::CompressedPublicKey
+impl core::convert::TryFrom<bitcoin::blockdata::constants::ChainHash> for bitcoin::network::Network
+impl core::convert::TryFrom<bitcoin::blockdata::opcodes::Opcode> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::convert::TryFrom<bitcoin::p2p::Magic> for bitcoin::network::Network
+impl core::convert::TryFrom<bitcoin::taproot::NodeInfo> for bitcoin::taproot::TapTree
+impl core::convert::TryFrom<bitcoin::taproot::TaprootBuilder> for bitcoin::taproot::NodeInfo
+impl core::convert::TryFrom<bitcoin::taproot::TaprootBuilder> for bitcoin::taproot::TapTree
+impl core::convert::TryFrom<bitcoin::taproot::serialized_signature::SerializedSignature> for bitcoin::taproot::Signature
+impl core::convert::TryFrom<u8> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::default::Default for bitcoin::TapSighashTag
+impl core::default::Default for bitcoin::bip152::ShortId
+impl core::default::Default for bitcoin::bip32::DerivationPath
+impl core::default::Default for bitcoin::bip32::Fingerprint
+impl core::default::Default for bitcoin::blockdata::block::Version
+impl core::default::Default for bitcoin::blockdata::locktime::relative::Height
+impl core::default::Default for bitcoin::blockdata::locktime::relative::Time
+impl core::default::Default for bitcoin::blockdata::script::Builder
+impl core::default::Default for bitcoin::blockdata::script::PushBytesBuf
+impl core::default::Default for bitcoin::blockdata::script::ScriptBuf
+impl core::default::Default for bitcoin::blockdata::transaction::OutPoint
+impl core::default::Default for bitcoin::blockdata::transaction::Sequence
+impl core::default::Default for bitcoin::blockdata::transaction::TxIn
+impl core::default::Default for bitcoin::blockdata::witness::Witness
+impl core::default::Default for bitcoin::p2p::ServiceFlags
+impl core::default::Default for bitcoin::pow::CompactTarget
+impl core::default::Default for bitcoin::psbt::Input
+impl core::default::Default for bitcoin::psbt::Output
+impl core::default::Default for bitcoin::taproot::TapBranchTag
+impl core::default::Default for bitcoin::taproot::TapLeafTag
+impl core::default::Default for bitcoin::taproot::TapTweakTag
+impl core::default::Default for bitcoin::taproot::TaprootBuilder
+impl core::default::Default for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::fmt::Debug for bitcoin::CompressedPublicKey
+impl core::fmt::Debug for bitcoin::EcdsaSighashType
+impl core::fmt::Debug for bitcoin::LegacySighash
+impl core::fmt::Debug for bitcoin::MerkleBlock
+impl core::fmt::Debug for bitcoin::PrivateKey
+impl core::fmt::Debug for bitcoin::PubkeyHash
+impl core::fmt::Debug for bitcoin::PublicKey
+impl core::fmt::Debug for bitcoin::SegwitV0Sighash
+impl core::fmt::Debug for bitcoin::TapSighash
+impl core::fmt::Debug for bitcoin::TapSighashType
+impl core::fmt::Debug for bitcoin::WPubkeyHash
+impl core::fmt::Debug for bitcoin::address::AddressType
+impl core::fmt::Debug for bitcoin::address::KnownHrp
+impl core::fmt::Debug for bitcoin::address::NetworkChecked
+impl core::fmt::Debug for bitcoin::address::NetworkUnchecked
+impl core::fmt::Debug for bitcoin::address::error::Error
+impl core::fmt::Debug for bitcoin::address::error::ParseError
+impl core::fmt::Debug for bitcoin::address::error::UnknownAddressTypeError
+impl core::fmt::Debug for bitcoin::address::error::UnknownHrpError
+impl core::fmt::Debug for bitcoin::base58::Error
+impl core::fmt::Debug for bitcoin::bip152::BlockTransactions
+impl core::fmt::Debug for bitcoin::bip152::BlockTransactionsRequest
+impl core::fmt::Debug for bitcoin::bip152::Error
+impl core::fmt::Debug for bitcoin::bip152::HeaderAndShortIds
+impl core::fmt::Debug for bitcoin::bip152::PrefilledTransaction
+impl core::fmt::Debug for bitcoin::bip152::ShortId
+impl core::fmt::Debug for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::fmt::Debug for bitcoin::bip158::BlockFilter
+impl core::fmt::Debug for bitcoin::bip158::Error
+impl core::fmt::Debug for bitcoin::bip158::FilterHash
+impl core::fmt::Debug for bitcoin::bip158::FilterHeader
+impl core::fmt::Debug for bitcoin::bip32::ChainCode
+impl core::fmt::Debug for bitcoin::bip32::ChildNumber
+impl core::fmt::Debug for bitcoin::bip32::DerivationPath
+impl core::fmt::Debug for bitcoin::bip32::Error
+impl core::fmt::Debug for bitcoin::bip32::Fingerprint
+impl core::fmt::Debug for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::Debug for bitcoin::bip32::Xpriv
+impl core::fmt::Debug for bitcoin::bip32::Xpub
+impl core::fmt::Debug for bitcoin::blockdata::block::Bip34Error
+impl core::fmt::Debug for bitcoin::blockdata::block::Block
+impl core::fmt::Debug for bitcoin::blockdata::block::BlockHash
+impl core::fmt::Debug for bitcoin::blockdata::block::Header
+impl core::fmt::Debug for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::Debug for bitcoin::blockdata::block::ValidationError
+impl core::fmt::Debug for bitcoin::blockdata::block::Version
+impl core::fmt::Debug for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::Debug for bitcoin::blockdata::fee_rate::FeeRate
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Error
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::Time
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Error
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Height
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::LockTime
+impl core::fmt::Debug for bitcoin::blockdata::locktime::relative::Time
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::Class
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::fmt::Debug for bitcoin::blockdata::opcodes::Opcode
+impl core::fmt::Debug for bitcoin::blockdata::script::Builder
+impl core::fmt::Debug for bitcoin::blockdata::script::Error
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytes
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytesBuf
+impl core::fmt::Debug for bitcoin::blockdata::script::PushBytesError
+impl core::fmt::Debug for bitcoin::blockdata::script::Script
+impl core::fmt::Debug for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::Debug for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::Debug for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_program::Error
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::fmt::Debug for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::fmt::Debug for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::fmt::Debug for bitcoin::blockdata::transaction::InputsIndexError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::OutPoint
+impl core::fmt::Debug for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Transaction
+impl core::fmt::Debug for bitcoin::blockdata::transaction::TxIn
+impl core::fmt::Debug for bitcoin::blockdata::transaction::TxOut
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Txid
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Version
+impl core::fmt::Debug for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::Debug for bitcoin::blockdata::weight::Weight
+impl core::fmt::Debug for bitcoin::blockdata::witness::Witness
+impl core::fmt::Debug for bitcoin::consensus::encode::CheckedData
+impl core::fmt::Debug for bitcoin::consensus::encode::Error
+impl core::fmt::Debug for bitcoin::consensus::encode::VarInt
+impl core::fmt::Debug for bitcoin::consensus::params::Params
+impl core::fmt::Debug for bitcoin::ecdsa::Error
+impl core::fmt::Debug for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::Debug for bitcoin::ecdsa::Signature
+impl core::fmt::Debug for bitcoin::error::ParseIntError
+impl core::fmt::Debug for bitcoin::key::Error
+impl core::fmt::Debug for bitcoin::key::SortKey
+impl core::fmt::Debug for bitcoin::key::TweakedKeypair
+impl core::fmt::Debug for bitcoin::key::TweakedPublicKey
+impl core::fmt::Debug for bitcoin::key::UncompressedPubkeyError
+impl core::fmt::Debug for bitcoin::merkle_tree::MerkleBlockError
+impl core::fmt::Debug for bitcoin::merkle_tree::PartialMerkleTree
+impl core::fmt::Debug for bitcoin::network::Network
+impl core::fmt::Debug for bitcoin::network::NetworkKind
+impl core::fmt::Debug for bitcoin::network::ParseNetworkError
+impl core::fmt::Debug for bitcoin::network::UnknownChainHashError
+impl core::fmt::Debug for bitcoin::p2p::Magic
+impl core::fmt::Debug for bitcoin::p2p::ParseMagicError
+impl core::fmt::Debug for bitcoin::p2p::ServiceFlags
+impl core::fmt::Debug for bitcoin::p2p::UnknownMagicError
+impl core::fmt::Debug for bitcoin::pow::CompactTarget
+impl core::fmt::Debug for bitcoin::pow::Target
+impl core::fmt::Debug for bitcoin::pow::TryFromError
+impl core::fmt::Debug for bitcoin::pow::Work
+impl core::fmt::Debug for bitcoin::psbt::Error
+impl core::fmt::Debug for bitcoin::psbt::ExtractTxError
+impl core::fmt::Debug for bitcoin::psbt::GetKeyError
+impl core::fmt::Debug for bitcoin::psbt::IndexOutOfBoundsError
+impl core::fmt::Debug for bitcoin::psbt::Input
+impl core::fmt::Debug for bitcoin::psbt::KeyRequest
+impl core::fmt::Debug for bitcoin::psbt::Output
+impl core::fmt::Debug for bitcoin::psbt::OutputType
+impl core::fmt::Debug for bitcoin::psbt::Psbt
+impl core::fmt::Debug for bitcoin::psbt::PsbtSighashType
+impl core::fmt::Debug for bitcoin::psbt::SignError
+impl core::fmt::Debug for bitcoin::psbt::SigningAlgorithm
+impl core::fmt::Debug for bitcoin::psbt::raw::Key
+impl core::fmt::Debug for bitcoin::psbt::raw::Pair
+impl core::fmt::Debug for bitcoin::sighash::AnnexError
+impl core::fmt::Debug for bitcoin::sighash::InvalidSighashTypeError
+impl core::fmt::Debug for bitcoin::sighash::NonStandardSighashTypeError
+impl core::fmt::Debug for bitcoin::sighash::P2wpkhError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsIndexError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsKindError
+impl core::fmt::Debug for bitcoin::sighash::PrevoutsSizeError
+impl core::fmt::Debug for bitcoin::sighash::SighashTypeParseError
+impl core::fmt::Debug for bitcoin::sighash::SingleMissingOutputError
+impl core::fmt::Debug for bitcoin::sighash::TaprootError
+impl core::fmt::Debug for bitcoin::taproot::ControlBlock
+impl core::fmt::Debug for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::Debug for bitcoin::taproot::HiddenNodesError
+impl core::fmt::Debug for bitcoin::taproot::IncompleteBuilderError
+impl core::fmt::Debug for bitcoin::taproot::LeafNode
+impl core::fmt::Debug for bitcoin::taproot::LeafVersion
+impl core::fmt::Debug for bitcoin::taproot::NodeInfo
+impl core::fmt::Debug for bitcoin::taproot::SigFromSliceError
+impl core::fmt::Debug for bitcoin::taproot::Signature
+impl core::fmt::Debug for bitcoin::taproot::TapLeaf
+impl core::fmt::Debug for bitcoin::taproot::TapLeafHash
+impl core::fmt::Debug for bitcoin::taproot::TapNodeHash
+impl core::fmt::Debug for bitcoin::taproot::TapTree
+impl core::fmt::Debug for bitcoin::taproot::TapTweakHash
+impl core::fmt::Debug for bitcoin::taproot::TaprootBuilder
+impl core::fmt::Debug for bitcoin::taproot::TaprootBuilderError
+impl core::fmt::Debug for bitcoin::taproot::TaprootError
+impl core::fmt::Debug for bitcoin::taproot::TaprootSpendInfo
+impl core::fmt::Debug for bitcoin::taproot::merkle_branch::IntoIter
+impl core::fmt::Debug for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::fmt::Debug for bitcoin::taproot::serialized_signature::IntoIter
+impl core::fmt::Debug for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::fmt::Display for bitcoin::CompressedPublicKey
+impl core::fmt::Display for bitcoin::EcdsaSighashType
+impl core::fmt::Display for bitcoin::LegacySighash
+impl core::fmt::Display for bitcoin::PrivateKey
+impl core::fmt::Display for bitcoin::PubkeyHash
+impl core::fmt::Display for bitcoin::PublicKey
+impl core::fmt::Display for bitcoin::SegwitV0Sighash
+impl core::fmt::Display for bitcoin::TapSighash
+impl core::fmt::Display for bitcoin::TapSighashType
+impl core::fmt::Display for bitcoin::WPubkeyHash
+impl core::fmt::Display for bitcoin::address::Address
+impl core::fmt::Display for bitcoin::address::AddressType
+impl core::fmt::Display for bitcoin::address::error::Error
+impl core::fmt::Display for bitcoin::address::error::ParseError
+impl core::fmt::Display for bitcoin::address::error::UnknownAddressTypeError
+impl core::fmt::Display for bitcoin::address::error::UnknownHrpError
+impl core::fmt::Display for bitcoin::base58::Error
+impl core::fmt::Display for bitcoin::bip152::Error
+impl core::fmt::Display for bitcoin::bip152::ShortId
+impl core::fmt::Display for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::fmt::Display for bitcoin::bip158::Error
+impl core::fmt::Display for bitcoin::bip158::FilterHash
+impl core::fmt::Display for bitcoin::bip158::FilterHeader
+impl core::fmt::Display for bitcoin::bip32::ChainCode
+impl core::fmt::Display for bitcoin::bip32::ChildNumber
+impl core::fmt::Display for bitcoin::bip32::DerivationPath
+impl core::fmt::Display for bitcoin::bip32::Error
+impl core::fmt::Display for bitcoin::bip32::Fingerprint
+impl core::fmt::Display for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::Display for bitcoin::bip32::Xpriv
+impl core::fmt::Display for bitcoin::bip32::Xpub
+impl core::fmt::Display for bitcoin::blockdata::block::Bip34Error
+impl core::fmt::Display for bitcoin::blockdata::block::BlockHash
+impl core::fmt::Display for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::Display for bitcoin::blockdata::block::ValidationError
+impl core::fmt::Display for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::Display for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::Display for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::Display for bitcoin::blockdata::fee_rate::FeeRate
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Error
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Height
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::Time
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Error
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Height
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::LockTime
+impl core::fmt::Display for bitcoin::blockdata::locktime::relative::Time
+impl core::fmt::Display for bitcoin::blockdata::opcodes::Opcode
+impl core::fmt::Display for bitcoin::blockdata::script::Builder
+impl core::fmt::Display for bitcoin::blockdata::script::Error
+impl core::fmt::Display for bitcoin::blockdata::script::PushBytesError
+impl core::fmt::Display for bitcoin::blockdata::script::Script
+impl core::fmt::Display for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::Display for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::Display for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::Display for bitcoin::blockdata::script::witness_program::Error
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::fmt::Display for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::fmt::Display for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::fmt::Display for bitcoin::blockdata::transaction::InputsIndexError
+impl core::fmt::Display for bitcoin::blockdata::transaction::OutPoint
+impl core::fmt::Display for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::fmt::Display for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::fmt::Display for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::Display for bitcoin::blockdata::transaction::Txid
+impl core::fmt::Display for bitcoin::blockdata::transaction::Version
+impl core::fmt::Display for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::Display for bitcoin::blockdata::weight::Weight
+impl core::fmt::Display for bitcoin::consensus::encode::Error
+impl core::fmt::Display for bitcoin::ecdsa::Error
+impl core::fmt::Display for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::Display for bitcoin::ecdsa::Signature
+impl core::fmt::Display for bitcoin::error::ParseIntError
+impl core::fmt::Display for bitcoin::key::Error
+impl core::fmt::Display for bitcoin::key::TweakedPublicKey
+impl core::fmt::Display for bitcoin::key::UncompressedPubkeyError
+impl core::fmt::Display for bitcoin::merkle_tree::MerkleBlockError
+impl core::fmt::Display for bitcoin::network::Network
+impl core::fmt::Display for bitcoin::network::ParseNetworkError
+impl core::fmt::Display for bitcoin::network::UnknownChainHashError
+impl core::fmt::Display for bitcoin::p2p::Magic
+impl core::fmt::Display for bitcoin::p2p::ParseMagicError
+impl core::fmt::Display for bitcoin::p2p::ServiceFlags
+impl core::fmt::Display for bitcoin::p2p::UnknownMagicError
+impl core::fmt::Display for bitcoin::pow::Target
+impl core::fmt::Display for bitcoin::pow::TryFromError
+impl core::fmt::Display for bitcoin::pow::Work
+impl core::fmt::Display for bitcoin::psbt::Error
+impl core::fmt::Display for bitcoin::psbt::ExtractTxError
+impl core::fmt::Display for bitcoin::psbt::GetKeyError
+impl core::fmt::Display for bitcoin::psbt::IndexOutOfBoundsError
+impl core::fmt::Display for bitcoin::psbt::PsbtSighashType
+impl core::fmt::Display for bitcoin::psbt::SignError
+impl core::fmt::Display for bitcoin::psbt::raw::Key
+impl core::fmt::Display for bitcoin::sighash::AnnexError
+impl core::fmt::Display for bitcoin::sighash::InvalidSighashTypeError
+impl core::fmt::Display for bitcoin::sighash::NonStandardSighashTypeError
+impl core::fmt::Display for bitcoin::sighash::P2wpkhError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsIndexError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsKindError
+impl core::fmt::Display for bitcoin::sighash::PrevoutsSizeError
+impl core::fmt::Display for bitcoin::sighash::SighashTypeParseError
+impl core::fmt::Display for bitcoin::sighash::SingleMissingOutputError
+impl core::fmt::Display for bitcoin::sighash::TaprootError
+impl core::fmt::Display for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::Display for bitcoin::taproot::HiddenNodesError
+impl core::fmt::Display for bitcoin::taproot::IncompleteBuilderError
+impl core::fmt::Display for bitcoin::taproot::LeafVersion
+impl core::fmt::Display for bitcoin::taproot::SigFromSliceError
+impl core::fmt::Display for bitcoin::taproot::TapLeafHash
+impl core::fmt::Display for bitcoin::taproot::TapNodeHash
+impl core::fmt::Display for bitcoin::taproot::TapTweakHash
+impl core::fmt::Display for bitcoin::taproot::TaprootBuilderError
+impl core::fmt::Display for bitcoin::taproot::TaprootError
+impl core::fmt::Display for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::fmt::LowerHex for bitcoin::LegacySighash
+impl core::fmt::LowerHex for bitcoin::PubkeyHash
+impl core::fmt::LowerHex for bitcoin::SegwitV0Sighash
+impl core::fmt::LowerHex for bitcoin::TapSighash
+impl core::fmt::LowerHex for bitcoin::WPubkeyHash
+impl core::fmt::LowerHex for bitcoin::bip152::ShortId
+impl core::fmt::LowerHex for bitcoin::bip158::FilterHash
+impl core::fmt::LowerHex for bitcoin::bip158::FilterHeader
+impl core::fmt::LowerHex for bitcoin::bip32::ChainCode
+impl core::fmt::LowerHex for bitcoin::bip32::Fingerprint
+impl core::fmt::LowerHex for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::LowerHex for bitcoin::blockdata::block::BlockHash
+impl core::fmt::LowerHex for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::LowerHex for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::LowerHex for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::LowerHex for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::LowerHex for bitcoin::blockdata::script::Script
+impl core::fmt::LowerHex for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::LowerHex for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::LowerHex for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Txid
+impl core::fmt::LowerHex for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::LowerHex for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::LowerHex for bitcoin::key::TweakedPublicKey
+impl core::fmt::LowerHex for bitcoin::p2p::Magic
+impl core::fmt::LowerHex for bitcoin::p2p::ServiceFlags
+impl core::fmt::LowerHex for bitcoin::pow::CompactTarget
+impl core::fmt::LowerHex for bitcoin::pow::Target
+impl core::fmt::LowerHex for bitcoin::pow::Work
+impl core::fmt::LowerHex for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::LowerHex for bitcoin::taproot::LeafVersion
+impl core::fmt::LowerHex for bitcoin::taproot::TapLeafHash
+impl core::fmt::LowerHex for bitcoin::taproot::TapNodeHash
+impl core::fmt::LowerHex for bitcoin::taproot::TapTweakHash
+impl core::fmt::UpperHex for bitcoin::LegacySighash
+impl core::fmt::UpperHex for bitcoin::PubkeyHash
+impl core::fmt::UpperHex for bitcoin::SegwitV0Sighash
+impl core::fmt::UpperHex for bitcoin::TapSighash
+impl core::fmt::UpperHex for bitcoin::WPubkeyHash
+impl core::fmt::UpperHex for bitcoin::bip152::ShortId
+impl core::fmt::UpperHex for bitcoin::bip158::FilterHash
+impl core::fmt::UpperHex for bitcoin::bip158::FilterHeader
+impl core::fmt::UpperHex for bitcoin::bip32::ChainCode
+impl core::fmt::UpperHex for bitcoin::bip32::Fingerprint
+impl core::fmt::UpperHex for bitcoin::bip32::XKeyIdentifier
+impl core::fmt::UpperHex for bitcoin::blockdata::block::BlockHash
+impl core::fmt::UpperHex for bitcoin::blockdata::block::TxMerkleNode
+impl core::fmt::UpperHex for bitcoin::blockdata::block::WitnessCommitment
+impl core::fmt::UpperHex for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::fmt::UpperHex for bitcoin::blockdata::constants::ChainHash
+impl core::fmt::UpperHex for bitcoin::blockdata::script::Script
+impl core::fmt::UpperHex for bitcoin::blockdata::script::ScriptBuf
+impl core::fmt::UpperHex for bitcoin::blockdata::script::ScriptHash
+impl core::fmt::UpperHex for bitcoin::blockdata::script::WScriptHash
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Sequence
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Txid
+impl core::fmt::UpperHex for bitcoin::blockdata::transaction::Wtxid
+impl core::fmt::UpperHex for bitcoin::ecdsa::SerializedSignature
+impl core::fmt::UpperHex for bitcoin::p2p::Magic
+impl core::fmt::UpperHex for bitcoin::p2p::ServiceFlags
+impl core::fmt::UpperHex for bitcoin::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin::pow::Target
+impl core::fmt::UpperHex for bitcoin::pow::Work
+impl core::fmt::UpperHex for bitcoin::taproot::FutureLeafVersion
+impl core::fmt::UpperHex for bitcoin::taproot::LeafVersion
+impl core::fmt::UpperHex for bitcoin::taproot::TapLeafHash
+impl core::fmt::UpperHex for bitcoin::taproot::TapNodeHash
+impl core::fmt::UpperHex for bitcoin::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin::CompressedPublicKey
+impl core::hash::Hash for bitcoin::EcdsaSighashType
+impl core::hash::Hash for bitcoin::LegacySighash
+impl core::hash::Hash for bitcoin::PubkeyHash
+impl core::hash::Hash for bitcoin::PublicKey
+impl core::hash::Hash for bitcoin::SegwitV0Sighash
+impl core::hash::Hash for bitcoin::TapSighash
+impl core::hash::Hash for bitcoin::TapSighashTag
+impl core::hash::Hash for bitcoin::TapSighashType
+impl core::hash::Hash for bitcoin::WPubkeyHash
+impl core::hash::Hash for bitcoin::address::AddressType
+impl core::hash::Hash for bitcoin::address::KnownHrp
+impl core::hash::Hash for bitcoin::address::NetworkChecked
+impl core::hash::Hash for bitcoin::address::NetworkUnchecked
+impl core::hash::Hash for bitcoin::bip152::BlockTransactions
+impl core::hash::Hash for bitcoin::bip152::BlockTransactionsRequest
+impl core::hash::Hash for bitcoin::bip152::HeaderAndShortIds
+impl core::hash::Hash for bitcoin::bip152::PrefilledTransaction
+impl core::hash::Hash for bitcoin::bip152::ShortId
+impl core::hash::Hash for bitcoin::bip158::FilterHash
+impl core::hash::Hash for bitcoin::bip158::FilterHeader
+impl core::hash::Hash for bitcoin::bip32::ChainCode
+impl core::hash::Hash for bitcoin::bip32::ChildNumber
+impl core::hash::Hash for bitcoin::bip32::DerivationPath
+impl core::hash::Hash for bitcoin::bip32::Fingerprint
+impl core::hash::Hash for bitcoin::bip32::XKeyIdentifier
+impl core::hash::Hash for bitcoin::bip32::Xpub
+impl core::hash::Hash for bitcoin::blockdata::block::BlockHash
+impl core::hash::Hash for bitcoin::blockdata::block::Header
+impl core::hash::Hash for bitcoin::blockdata::block::TxMerkleNode
+impl core::hash::Hash for bitcoin::blockdata::block::Version
+impl core::hash::Hash for bitcoin::blockdata::block::WitnessCommitment
+impl core::hash::Hash for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::hash::Hash for bitcoin::blockdata::constants::ChainHash
+impl core::hash::Hash for bitcoin::blockdata::fee_rate::FeeRate
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::Height
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::hash::Hash for bitcoin::blockdata::locktime::absolute::Time
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::Height
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::LockTime
+impl core::hash::Hash for bitcoin::blockdata::locktime::relative::Time
+impl core::hash::Hash for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::hash::Hash for bitcoin::blockdata::script::PushBytes
+impl core::hash::Hash for bitcoin::blockdata::script::PushBytesBuf
+impl core::hash::Hash for bitcoin::blockdata::script::Script
+impl core::hash::Hash for bitcoin::blockdata::script::ScriptBuf
+impl core::hash::Hash for bitcoin::blockdata::script::ScriptHash
+impl core::hash::Hash for bitcoin::blockdata::script::WScriptHash
+impl core::hash::Hash for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::hash::Hash for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::hash::Hash for bitcoin::blockdata::transaction::OutPoint
+impl core::hash::Hash for bitcoin::blockdata::transaction::Sequence
+impl core::hash::Hash for bitcoin::blockdata::transaction::Transaction
+impl core::hash::Hash for bitcoin::blockdata::transaction::TxIn
+impl core::hash::Hash for bitcoin::blockdata::transaction::TxOut
+impl core::hash::Hash for bitcoin::blockdata::transaction::Txid
+impl core::hash::Hash for bitcoin::blockdata::transaction::Version
+impl core::hash::Hash for bitcoin::blockdata::transaction::Wtxid
+impl core::hash::Hash for bitcoin::blockdata::weight::Weight
+impl core::hash::Hash for bitcoin::blockdata::witness::Witness
+impl core::hash::Hash for bitcoin::ecdsa::SerializedSignature
+impl core::hash::Hash for bitcoin::ecdsa::Signature
+impl core::hash::Hash for bitcoin::key::SortKey
+impl core::hash::Hash for bitcoin::key::TweakedKeypair
+impl core::hash::Hash for bitcoin::key::TweakedPublicKey
+impl core::hash::Hash for bitcoin::network::Network
+impl core::hash::Hash for bitcoin::network::NetworkKind
+impl core::hash::Hash for bitcoin::p2p::Magic
+impl core::hash::Hash for bitcoin::p2p::ServiceFlags
+impl core::hash::Hash for bitcoin::pow::CompactTarget
+impl core::hash::Hash for bitcoin::pow::Target
+impl core::hash::Hash for bitcoin::pow::Work
+impl core::hash::Hash for bitcoin::psbt::Input
+impl core::hash::Hash for bitcoin::psbt::Output
+impl core::hash::Hash for bitcoin::psbt::OutputType
+impl core::hash::Hash for bitcoin::psbt::Psbt
+impl core::hash::Hash for bitcoin::psbt::PsbtSighashType
+impl core::hash::Hash for bitcoin::psbt::SigningAlgorithm
+impl core::hash::Hash for bitcoin::psbt::raw::Key
+impl core::hash::Hash for bitcoin::taproot::ControlBlock
+impl core::hash::Hash for bitcoin::taproot::FutureLeafVersion
+impl core::hash::Hash for bitcoin::taproot::LeafNode
+impl core::hash::Hash for bitcoin::taproot::LeafVersion
+impl core::hash::Hash for bitcoin::taproot::NodeInfo
+impl core::hash::Hash for bitcoin::taproot::Signature
+impl core::hash::Hash for bitcoin::taproot::TapBranchTag
+impl core::hash::Hash for bitcoin::taproot::TapLeaf
+impl core::hash::Hash for bitcoin::taproot::TapLeafHash
+impl core::hash::Hash for bitcoin::taproot::TapLeafTag
+impl core::hash::Hash for bitcoin::taproot::TapNodeHash
+impl core::hash::Hash for bitcoin::taproot::TapTree
+impl core::hash::Hash for bitcoin::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin::taproot::TapTweakTag
+impl core::hash::Hash for bitcoin::taproot::TaprootBuilder
+impl core::hash::Hash for bitcoin::taproot::TaprootSpendInfo
+impl core::hash::Hash for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::hash::Hash for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::iter::traits::accum::Sum for bitcoin::blockdata::weight::Weight
+impl core::iter::traits::collect::FromIterator<bitcoin::bip32::ChildNumber> for bitcoin::bip32::DerivationPath
+impl core::iter::traits::collect::IntoIterator for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::iter::traits::collect::IntoIterator for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::iterator::Iterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::iterator::Iterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::Bytes<'_>
+impl core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::InstructionIndices<'_>
+impl core::iter::traits::marker::FusedIterator for bitcoin::taproot::merkle_branch::IntoIter
+impl core::iter::traits::marker::FusedIterator for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Copy for bitcoin::CompressedPublicKey
+impl core::marker::Copy for bitcoin::EcdsaSighashType
+impl core::marker::Copy for bitcoin::LegacySighash
+impl core::marker::Copy for bitcoin::PrivateKey
+impl core::marker::Copy for bitcoin::PubkeyHash
+impl core::marker::Copy for bitcoin::PublicKey
+impl core::marker::Copy for bitcoin::SegwitV0Sighash
+impl core::marker::Copy for bitcoin::TapSighash
+impl core::marker::Copy for bitcoin::TapSighashTag
+impl core::marker::Copy for bitcoin::TapSighashType
+impl core::marker::Copy for bitcoin::WPubkeyHash
+impl core::marker::Copy for bitcoin::address::AddressType
+impl core::marker::Copy for bitcoin::address::KnownHrp
+impl core::marker::Copy for bitcoin::bip152::ShortId
+impl core::marker::Copy for bitcoin::bip158::FilterHash
+impl core::marker::Copy for bitcoin::bip158::FilterHeader
+impl core::marker::Copy for bitcoin::bip32::ChainCode
+impl core::marker::Copy for bitcoin::bip32::ChildNumber
+impl core::marker::Copy for bitcoin::bip32::Fingerprint
+impl core::marker::Copy for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Copy for bitcoin::bip32::Xpriv
+impl core::marker::Copy for bitcoin::bip32::Xpub
+impl core::marker::Copy for bitcoin::blockdata::block::BlockHash
+impl core::marker::Copy for bitcoin::blockdata::block::Header
+impl core::marker::Copy for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Copy for bitcoin::blockdata::block::Version
+impl core::marker::Copy for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Copy for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Copy for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Copy for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Copy for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Copy for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Copy for bitcoin::blockdata::opcodes::Class
+impl core::marker::Copy for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Copy for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Copy for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Copy for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Copy for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Copy for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Copy for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Copy for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Copy for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Copy for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Copy for bitcoin::blockdata::transaction::Txid
+impl core::marker::Copy for bitcoin::blockdata::transaction::Version
+impl core::marker::Copy for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Copy for bitcoin::blockdata::weight::Weight
+impl core::marker::Copy for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Copy for bitcoin::ecdsa::Signature
+impl core::marker::Copy for bitcoin::key::SortKey
+impl core::marker::Copy for bitcoin::key::TweakedKeypair
+impl core::marker::Copy for bitcoin::key::TweakedPublicKey
+impl core::marker::Copy for bitcoin::network::Network
+impl core::marker::Copy for bitcoin::network::NetworkKind
+impl core::marker::Copy for bitcoin::p2p::Magic
+impl core::marker::Copy for bitcoin::p2p::ServiceFlags
+impl core::marker::Copy for bitcoin::pow::CompactTarget
+impl core::marker::Copy for bitcoin::pow::Target
+impl core::marker::Copy for bitcoin::pow::Work
+impl core::marker::Copy for bitcoin::psbt::OutputType
+impl core::marker::Copy for bitcoin::psbt::PsbtSighashType
+impl core::marker::Copy for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Copy for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Copy for bitcoin::taproot::LeafVersion
+impl core::marker::Copy for bitcoin::taproot::Signature
+impl core::marker::Copy for bitcoin::taproot::TapBranchTag
+impl core::marker::Copy for bitcoin::taproot::TapLeafHash
+impl core::marker::Copy for bitcoin::taproot::TapLeafTag
+impl core::marker::Copy for bitcoin::taproot::TapNodeHash
+impl core::marker::Copy for bitcoin::taproot::TapTweakHash
+impl core::marker::Copy for bitcoin::taproot::TapTweakTag
+impl core::marker::Copy for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::Send for bitcoin::CompressedPublicKey
+impl core::marker::Send for bitcoin::EcdsaSighashType
+impl core::marker::Send for bitcoin::LegacySighash
+impl core::marker::Send for bitcoin::MerkleBlock
+impl core::marker::Send for bitcoin::PrivateKey
+impl core::marker::Send for bitcoin::PubkeyHash
+impl core::marker::Send for bitcoin::PublicKey
+impl core::marker::Send for bitcoin::SegwitV0Sighash
+impl core::marker::Send for bitcoin::TapSighash
+impl core::marker::Send for bitcoin::TapSighashTag
+impl core::marker::Send for bitcoin::TapSighashType
+impl core::marker::Send for bitcoin::WPubkeyHash
+impl core::marker::Send for bitcoin::address::AddressType
+impl core::marker::Send for bitcoin::address::KnownHrp
+impl core::marker::Send for bitcoin::address::NetworkChecked
+impl core::marker::Send for bitcoin::address::NetworkUnchecked
+impl core::marker::Send for bitcoin::address::error::Error
+impl core::marker::Send for bitcoin::address::error::ParseError
+impl core::marker::Send for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Send for bitcoin::address::error::UnknownHrpError
+impl core::marker::Send for bitcoin::base58::Error
+impl core::marker::Send for bitcoin::bip152::BlockTransactions
+impl core::marker::Send for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Send for bitcoin::bip152::Error
+impl core::marker::Send for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Send for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Send for bitcoin::bip152::ShortId
+impl core::marker::Send for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Send for bitcoin::bip158::BlockFilter
+impl core::marker::Send for bitcoin::bip158::BlockFilterReader
+impl core::marker::Send for bitcoin::bip158::Error
+impl core::marker::Send for bitcoin::bip158::FilterHash
+impl core::marker::Send for bitcoin::bip158::FilterHeader
+impl core::marker::Send for bitcoin::bip158::GcsFilterReader
+impl core::marker::Send for bitcoin::bip32::ChainCode
+impl core::marker::Send for bitcoin::bip32::ChildNumber
+impl core::marker::Send for bitcoin::bip32::DerivationPath
+impl core::marker::Send for bitcoin::bip32::Error
+impl core::marker::Send for bitcoin::bip32::Fingerprint
+impl core::marker::Send for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Send for bitcoin::bip32::Xpriv
+impl core::marker::Send for bitcoin::bip32::Xpub
+impl core::marker::Send for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Send for bitcoin::blockdata::block::Block
+impl core::marker::Send for bitcoin::blockdata::block::BlockHash
+impl core::marker::Send for bitcoin::blockdata::block::Header
+impl core::marker::Send for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Send for bitcoin::blockdata::block::ValidationError
+impl core::marker::Send for bitcoin::blockdata::block::Version
+impl core::marker::Send for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Send for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Send for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Send for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Send for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Send for bitcoin::blockdata::opcodes::Class
+impl core::marker::Send for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Send for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Send for bitcoin::blockdata::script::Builder
+impl core::marker::Send for bitcoin::blockdata::script::Error
+impl core::marker::Send for bitcoin::blockdata::script::PushBytes
+impl core::marker::Send for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Send for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Send for bitcoin::blockdata::script::Script
+impl core::marker::Send for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Send for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Send for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Send for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Send for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Send for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Send for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Send for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Send for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Send for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Send for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Send for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Send for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Send for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Send for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Send for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Send for bitcoin::blockdata::transaction::Txid
+impl core::marker::Send for bitcoin::blockdata::transaction::Version
+impl core::marker::Send for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Send for bitcoin::blockdata::weight::Weight
+impl core::marker::Send for bitcoin::blockdata::witness::Witness
+impl core::marker::Send for bitcoin::consensus::encode::CheckedData
+impl core::marker::Send for bitcoin::consensus::encode::Error
+impl core::marker::Send for bitcoin::consensus::encode::VarInt
+impl core::marker::Send for bitcoin::consensus::params::Params
+impl core::marker::Send for bitcoin::ecdsa::Error
+impl core::marker::Send for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Send for bitcoin::ecdsa::Signature
+impl core::marker::Send for bitcoin::error::ParseIntError
+impl core::marker::Send for bitcoin::key::Error
+impl core::marker::Send for bitcoin::key::SortKey
+impl core::marker::Send for bitcoin::key::TweakedKeypair
+impl core::marker::Send for bitcoin::key::TweakedPublicKey
+impl core::marker::Send for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Send for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Send for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Send for bitcoin::network::Network
+impl core::marker::Send for bitcoin::network::NetworkKind
+impl core::marker::Send for bitcoin::network::ParseNetworkError
+impl core::marker::Send for bitcoin::network::UnknownChainHashError
+impl core::marker::Send for bitcoin::p2p::Magic
+impl core::marker::Send for bitcoin::p2p::ParseMagicError
+impl core::marker::Send for bitcoin::p2p::ServiceFlags
+impl core::marker::Send for bitcoin::p2p::UnknownMagicError
+impl core::marker::Send for bitcoin::pow::CompactTarget
+impl core::marker::Send for bitcoin::pow::Target
+impl core::marker::Send for bitcoin::pow::TryFromError
+impl core::marker::Send for bitcoin::pow::Work
+impl core::marker::Send for bitcoin::psbt::Error
+impl core::marker::Send for bitcoin::psbt::ExtractTxError
+impl core::marker::Send for bitcoin::psbt::GetKeyError
+impl core::marker::Send for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Send for bitcoin::psbt::Input
+impl core::marker::Send for bitcoin::psbt::KeyRequest
+impl core::marker::Send for bitcoin::psbt::Output
+impl core::marker::Send for bitcoin::psbt::OutputType
+impl core::marker::Send for bitcoin::psbt::Psbt
+impl core::marker::Send for bitcoin::psbt::PsbtSighashType
+impl core::marker::Send for bitcoin::psbt::SignError
+impl core::marker::Send for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Send for bitcoin::psbt::raw::Key
+impl core::marker::Send for bitcoin::psbt::raw::Pair
+impl core::marker::Send for bitcoin::sighash::AnnexError
+impl core::marker::Send for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Send for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Send for bitcoin::sighash::P2wpkhError
+impl core::marker::Send for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Send for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Send for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Send for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Send for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Send for bitcoin::sighash::TaprootError
+impl core::marker::Send for bitcoin::taproot::ControlBlock
+impl core::marker::Send for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Send for bitcoin::taproot::HiddenNodesError
+impl core::marker::Send for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Send for bitcoin::taproot::LeafNode
+impl core::marker::Send for bitcoin::taproot::LeafVersion
+impl core::marker::Send for bitcoin::taproot::NodeInfo
+impl core::marker::Send for bitcoin::taproot::SigFromSliceError
+impl core::marker::Send for bitcoin::taproot::Signature
+impl core::marker::Send for bitcoin::taproot::TapBranchTag
+impl core::marker::Send for bitcoin::taproot::TapLeaf
+impl core::marker::Send for bitcoin::taproot::TapLeafHash
+impl core::marker::Send for bitcoin::taproot::TapLeafTag
+impl core::marker::Send for bitcoin::taproot::TapNodeHash
+impl core::marker::Send for bitcoin::taproot::TapTree
+impl core::marker::Send for bitcoin::taproot::TapTweakHash
+impl core::marker::Send for bitcoin::taproot::TapTweakTag
+impl core::marker::Send for bitcoin::taproot::TaprootBuilder
+impl core::marker::Send for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Send for bitcoin::taproot::TaprootError
+impl core::marker::Send for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Send for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Send for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Send for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Send for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::StructuralPartialEq for bitcoin::CompressedPublicKey
+impl core::marker::StructuralPartialEq for bitcoin::EcdsaSighashType
+impl core::marker::StructuralPartialEq for bitcoin::LegacySighash
+impl core::marker::StructuralPartialEq for bitcoin::MerkleBlock
+impl core::marker::StructuralPartialEq for bitcoin::PrivateKey
+impl core::marker::StructuralPartialEq for bitcoin::PubkeyHash
+impl core::marker::StructuralPartialEq for bitcoin::PublicKey
+impl core::marker::StructuralPartialEq for bitcoin::SegwitV0Sighash
+impl core::marker::StructuralPartialEq for bitcoin::TapSighash
+impl core::marker::StructuralPartialEq for bitcoin::TapSighashTag
+impl core::marker::StructuralPartialEq for bitcoin::TapSighashType
+impl core::marker::StructuralPartialEq for bitcoin::WPubkeyHash
+impl core::marker::StructuralPartialEq for bitcoin::address::AddressType
+impl core::marker::StructuralPartialEq for bitcoin::address::KnownHrp
+impl core::marker::StructuralPartialEq for bitcoin::address::NetworkChecked
+impl core::marker::StructuralPartialEq for bitcoin::address::NetworkUnchecked
+impl core::marker::StructuralPartialEq for bitcoin::address::error::Error
+impl core::marker::StructuralPartialEq for bitcoin::address::error::ParseError
+impl core::marker::StructuralPartialEq for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::StructuralPartialEq for bitcoin::address::error::UnknownHrpError
+impl core::marker::StructuralPartialEq for bitcoin::base58::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip152::BlockTransactions
+impl core::marker::StructuralPartialEq for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::StructuralPartialEq for bitcoin::bip152::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::StructuralPartialEq for bitcoin::bip152::PrefilledTransaction
+impl core::marker::StructuralPartialEq for bitcoin::bip152::ShortId
+impl core::marker::StructuralPartialEq for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin::bip158::BlockFilter
+impl core::marker::StructuralPartialEq for bitcoin::bip158::FilterHash
+impl core::marker::StructuralPartialEq for bitcoin::bip158::FilterHeader
+impl core::marker::StructuralPartialEq for bitcoin::bip32::ChainCode
+impl core::marker::StructuralPartialEq for bitcoin::bip32::ChildNumber
+impl core::marker::StructuralPartialEq for bitcoin::bip32::DerivationPath
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Error
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Fingerprint
+impl core::marker::StructuralPartialEq for bitcoin::bip32::XKeyIdentifier
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Xpriv
+impl core::marker::StructuralPartialEq for bitcoin::bip32::Xpub
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Bip34Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Block
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Header
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::ValidationError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Version
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::constants::ChainHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::Class
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Builder
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytes
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::PushBytesError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::Script
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::ScriptHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::WScriptHash
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Sequence
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Transaction
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::TxIn
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::TxOut
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::weight::Weight
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::witness::Witness
+impl core::marker::StructuralPartialEq for bitcoin::consensus::encode::CheckedData
+impl core::marker::StructuralPartialEq for bitcoin::consensus::encode::VarInt
+impl core::marker::StructuralPartialEq for bitcoin::ecdsa::Error
+impl core::marker::StructuralPartialEq for bitcoin::ecdsa::Signature
+impl core::marker::StructuralPartialEq for bitcoin::error::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin::key::Error
+impl core::marker::StructuralPartialEq for bitcoin::key::SortKey
+impl core::marker::StructuralPartialEq for bitcoin::key::TweakedKeypair
+impl core::marker::StructuralPartialEq for bitcoin::key::TweakedPublicKey
+impl core::marker::StructuralPartialEq for bitcoin::key::UncompressedPubkeyError
+impl core::marker::StructuralPartialEq for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::StructuralPartialEq for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::StructuralPartialEq for bitcoin::network::Network
+impl core::marker::StructuralPartialEq for bitcoin::network::NetworkKind
+impl core::marker::StructuralPartialEq for bitcoin::network::ParseNetworkError
+impl core::marker::StructuralPartialEq for bitcoin::network::UnknownChainHashError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::Magic
+impl core::marker::StructuralPartialEq for bitcoin::p2p::ParseMagicError
+impl core::marker::StructuralPartialEq for bitcoin::p2p::ServiceFlags
+impl core::marker::StructuralPartialEq for bitcoin::p2p::UnknownMagicError
+impl core::marker::StructuralPartialEq for bitcoin::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin::pow::Target
+impl core::marker::StructuralPartialEq for bitcoin::pow::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin::pow::Work
+impl core::marker::StructuralPartialEq for bitcoin::psbt::ExtractTxError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::GetKeyError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Input
+impl core::marker::StructuralPartialEq for bitcoin::psbt::KeyRequest
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Output
+impl core::marker::StructuralPartialEq for bitcoin::psbt::OutputType
+impl core::marker::StructuralPartialEq for bitcoin::psbt::Psbt
+impl core::marker::StructuralPartialEq for bitcoin::psbt::PsbtSighashType
+impl core::marker::StructuralPartialEq for bitcoin::psbt::SignError
+impl core::marker::StructuralPartialEq for bitcoin::psbt::SigningAlgorithm
+impl core::marker::StructuralPartialEq for bitcoin::psbt::raw::Key
+impl core::marker::StructuralPartialEq for bitcoin::psbt::raw::Pair
+impl core::marker::StructuralPartialEq for bitcoin::sighash::AnnexError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::P2wpkhError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsKindError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::SighashTypeParseError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::StructuralPartialEq for bitcoin::sighash::TaprootError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::ControlBlock
+impl core::marker::StructuralPartialEq for bitcoin::taproot::FutureLeafVersion
+impl core::marker::StructuralPartialEq for bitcoin::taproot::HiddenNodesError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::LeafNode
+impl core::marker::StructuralPartialEq for bitcoin::taproot::LeafVersion
+impl core::marker::StructuralPartialEq for bitcoin::taproot::SigFromSliceError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::Signature
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapBranchTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeaf
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeafHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeafTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapNodeHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTree
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTweakHash
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTweakTag
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootBuilder
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootBuilderError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootError
+impl core::marker::StructuralPartialEq for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::StructuralPartialEq for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Sync for bitcoin::CompressedPublicKey
+impl core::marker::Sync for bitcoin::EcdsaSighashType
+impl core::marker::Sync for bitcoin::LegacySighash
+impl core::marker::Sync for bitcoin::MerkleBlock
+impl core::marker::Sync for bitcoin::PrivateKey
+impl core::marker::Sync for bitcoin::PubkeyHash
+impl core::marker::Sync for bitcoin::PublicKey
+impl core::marker::Sync for bitcoin::SegwitV0Sighash
+impl core::marker::Sync for bitcoin::TapSighash
+impl core::marker::Sync for bitcoin::TapSighashTag
+impl core::marker::Sync for bitcoin::TapSighashType
+impl core::marker::Sync for bitcoin::WPubkeyHash
+impl core::marker::Sync for bitcoin::address::AddressType
+impl core::marker::Sync for bitcoin::address::KnownHrp
+impl core::marker::Sync for bitcoin::address::NetworkChecked
+impl core::marker::Sync for bitcoin::address::NetworkUnchecked
+impl core::marker::Sync for bitcoin::address::error::Error
+impl core::marker::Sync for bitcoin::address::error::ParseError
+impl core::marker::Sync for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Sync for bitcoin::address::error::UnknownHrpError
+impl core::marker::Sync for bitcoin::base58::Error
+impl core::marker::Sync for bitcoin::bip152::BlockTransactions
+impl core::marker::Sync for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Sync for bitcoin::bip152::Error
+impl core::marker::Sync for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Sync for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Sync for bitcoin::bip152::ShortId
+impl core::marker::Sync for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Sync for bitcoin::bip158::BlockFilter
+impl core::marker::Sync for bitcoin::bip158::BlockFilterReader
+impl core::marker::Sync for bitcoin::bip158::Error
+impl core::marker::Sync for bitcoin::bip158::FilterHash
+impl core::marker::Sync for bitcoin::bip158::FilterHeader
+impl core::marker::Sync for bitcoin::bip158::GcsFilterReader
+impl core::marker::Sync for bitcoin::bip32::ChainCode
+impl core::marker::Sync for bitcoin::bip32::ChildNumber
+impl core::marker::Sync for bitcoin::bip32::DerivationPath
+impl core::marker::Sync for bitcoin::bip32::Error
+impl core::marker::Sync for bitcoin::bip32::Fingerprint
+impl core::marker::Sync for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Sync for bitcoin::bip32::Xpriv
+impl core::marker::Sync for bitcoin::bip32::Xpub
+impl core::marker::Sync for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Sync for bitcoin::blockdata::block::Block
+impl core::marker::Sync for bitcoin::blockdata::block::BlockHash
+impl core::marker::Sync for bitcoin::blockdata::block::Header
+impl core::marker::Sync for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Sync for bitcoin::blockdata::block::ValidationError
+impl core::marker::Sync for bitcoin::blockdata::block::Version
+impl core::marker::Sync for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Sync for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Sync for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Sync for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Sync for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Sync for bitcoin::blockdata::opcodes::Class
+impl core::marker::Sync for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Sync for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Sync for bitcoin::blockdata::script::Builder
+impl core::marker::Sync for bitcoin::blockdata::script::Error
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytes
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Sync for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Sync for bitcoin::blockdata::script::Script
+impl core::marker::Sync for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Sync for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Sync for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Sync for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Sync for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Sync for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Sync for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Sync for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Sync for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Sync for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Sync for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Sync for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Sync for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Sync for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Sync for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Sync for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Sync for bitcoin::blockdata::transaction::Txid
+impl core::marker::Sync for bitcoin::blockdata::transaction::Version
+impl core::marker::Sync for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Sync for bitcoin::blockdata::weight::Weight
+impl core::marker::Sync for bitcoin::blockdata::witness::Witness
+impl core::marker::Sync for bitcoin::consensus::encode::CheckedData
+impl core::marker::Sync for bitcoin::consensus::encode::Error
+impl core::marker::Sync for bitcoin::consensus::encode::VarInt
+impl core::marker::Sync for bitcoin::consensus::params::Params
+impl core::marker::Sync for bitcoin::ecdsa::Error
+impl core::marker::Sync for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Sync for bitcoin::ecdsa::Signature
+impl core::marker::Sync for bitcoin::error::ParseIntError
+impl core::marker::Sync for bitcoin::key::Error
+impl core::marker::Sync for bitcoin::key::SortKey
+impl core::marker::Sync for bitcoin::key::TweakedKeypair
+impl core::marker::Sync for bitcoin::key::TweakedPublicKey
+impl core::marker::Sync for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Sync for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Sync for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Sync for bitcoin::network::Network
+impl core::marker::Sync for bitcoin::network::NetworkKind
+impl core::marker::Sync for bitcoin::network::ParseNetworkError
+impl core::marker::Sync for bitcoin::network::UnknownChainHashError
+impl core::marker::Sync for bitcoin::p2p::Magic
+impl core::marker::Sync for bitcoin::p2p::ParseMagicError
+impl core::marker::Sync for bitcoin::p2p::ServiceFlags
+impl core::marker::Sync for bitcoin::p2p::UnknownMagicError
+impl core::marker::Sync for bitcoin::pow::CompactTarget
+impl core::marker::Sync for bitcoin::pow::Target
+impl core::marker::Sync for bitcoin::pow::TryFromError
+impl core::marker::Sync for bitcoin::pow::Work
+impl core::marker::Sync for bitcoin::psbt::Error
+impl core::marker::Sync for bitcoin::psbt::ExtractTxError
+impl core::marker::Sync for bitcoin::psbt::GetKeyError
+impl core::marker::Sync for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Sync for bitcoin::psbt::Input
+impl core::marker::Sync for bitcoin::psbt::KeyRequest
+impl core::marker::Sync for bitcoin::psbt::Output
+impl core::marker::Sync for bitcoin::psbt::OutputType
+impl core::marker::Sync for bitcoin::psbt::Psbt
+impl core::marker::Sync for bitcoin::psbt::PsbtSighashType
+impl core::marker::Sync for bitcoin::psbt::SignError
+impl core::marker::Sync for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Sync for bitcoin::psbt::raw::Key
+impl core::marker::Sync for bitcoin::psbt::raw::Pair
+impl core::marker::Sync for bitcoin::sighash::AnnexError
+impl core::marker::Sync for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Sync for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Sync for bitcoin::sighash::P2wpkhError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Sync for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Sync for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Sync for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Sync for bitcoin::sighash::TaprootError
+impl core::marker::Sync for bitcoin::taproot::ControlBlock
+impl core::marker::Sync for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Sync for bitcoin::taproot::HiddenNodesError
+impl core::marker::Sync for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Sync for bitcoin::taproot::LeafNode
+impl core::marker::Sync for bitcoin::taproot::LeafVersion
+impl core::marker::Sync for bitcoin::taproot::NodeInfo
+impl core::marker::Sync for bitcoin::taproot::SigFromSliceError
+impl core::marker::Sync for bitcoin::taproot::Signature
+impl core::marker::Sync for bitcoin::taproot::TapBranchTag
+impl core::marker::Sync for bitcoin::taproot::TapLeaf
+impl core::marker::Sync for bitcoin::taproot::TapLeafHash
+impl core::marker::Sync for bitcoin::taproot::TapLeafTag
+impl core::marker::Sync for bitcoin::taproot::TapNodeHash
+impl core::marker::Sync for bitcoin::taproot::TapTree
+impl core::marker::Sync for bitcoin::taproot::TapTweakHash
+impl core::marker::Sync for bitcoin::taproot::TapTweakTag
+impl core::marker::Sync for bitcoin::taproot::TaprootBuilder
+impl core::marker::Sync for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Sync for bitcoin::taproot::TaprootError
+impl core::marker::Sync for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Sync for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Sync for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Sync for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Sync for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::marker::Unpin for bitcoin::CompressedPublicKey
+impl core::marker::Unpin for bitcoin::EcdsaSighashType
+impl core::marker::Unpin for bitcoin::LegacySighash
+impl core::marker::Unpin for bitcoin::MerkleBlock
+impl core::marker::Unpin for bitcoin::PrivateKey
+impl core::marker::Unpin for bitcoin::PubkeyHash
+impl core::marker::Unpin for bitcoin::PublicKey
+impl core::marker::Unpin for bitcoin::SegwitV0Sighash
+impl core::marker::Unpin for bitcoin::TapSighash
+impl core::marker::Unpin for bitcoin::TapSighashTag
+impl core::marker::Unpin for bitcoin::TapSighashType
+impl core::marker::Unpin for bitcoin::WPubkeyHash
+impl core::marker::Unpin for bitcoin::address::AddressType
+impl core::marker::Unpin for bitcoin::address::KnownHrp
+impl core::marker::Unpin for bitcoin::address::NetworkChecked
+impl core::marker::Unpin for bitcoin::address::NetworkUnchecked
+impl core::marker::Unpin for bitcoin::address::error::Error
+impl core::marker::Unpin for bitcoin::address::error::ParseError
+impl core::marker::Unpin for bitcoin::address::error::UnknownAddressTypeError
+impl core::marker::Unpin for bitcoin::address::error::UnknownHrpError
+impl core::marker::Unpin for bitcoin::base58::Error
+impl core::marker::Unpin for bitcoin::bip152::BlockTransactions
+impl core::marker::Unpin for bitcoin::bip152::BlockTransactionsRequest
+impl core::marker::Unpin for bitcoin::bip152::Error
+impl core::marker::Unpin for bitcoin::bip152::HeaderAndShortIds
+impl core::marker::Unpin for bitcoin::bip152::PrefilledTransaction
+impl core::marker::Unpin for bitcoin::bip152::ShortId
+impl core::marker::Unpin for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::marker::Unpin for bitcoin::bip158::BlockFilter
+impl core::marker::Unpin for bitcoin::bip158::BlockFilterReader
+impl core::marker::Unpin for bitcoin::bip158::Error
+impl core::marker::Unpin for bitcoin::bip158::FilterHash
+impl core::marker::Unpin for bitcoin::bip158::FilterHeader
+impl core::marker::Unpin for bitcoin::bip158::GcsFilterReader
+impl core::marker::Unpin for bitcoin::bip32::ChainCode
+impl core::marker::Unpin for bitcoin::bip32::ChildNumber
+impl core::marker::Unpin for bitcoin::bip32::DerivationPath
+impl core::marker::Unpin for bitcoin::bip32::Error
+impl core::marker::Unpin for bitcoin::bip32::Fingerprint
+impl core::marker::Unpin for bitcoin::bip32::XKeyIdentifier
+impl core::marker::Unpin for bitcoin::bip32::Xpriv
+impl core::marker::Unpin for bitcoin::bip32::Xpub
+impl core::marker::Unpin for bitcoin::blockdata::block::Bip34Error
+impl core::marker::Unpin for bitcoin::blockdata::block::Block
+impl core::marker::Unpin for bitcoin::blockdata::block::BlockHash
+impl core::marker::Unpin for bitcoin::blockdata::block::Header
+impl core::marker::Unpin for bitcoin::blockdata::block::TxMerkleNode
+impl core::marker::Unpin for bitcoin::blockdata::block::ValidationError
+impl core::marker::Unpin for bitcoin::blockdata::block::Version
+impl core::marker::Unpin for bitcoin::blockdata::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin::blockdata::constants::ChainHash
+impl core::marker::Unpin for bitcoin::blockdata::fee_rate::FeeRate
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Error
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::Time
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Error
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Height
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::LockTime
+impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Time
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::Class
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::marker::Unpin for bitcoin::blockdata::opcodes::Opcode
+impl core::marker::Unpin for bitcoin::blockdata::script::Builder
+impl core::marker::Unpin for bitcoin::blockdata::script::Error
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytes
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytesBuf
+impl core::marker::Unpin for bitcoin::blockdata::script::PushBytesError
+impl core::marker::Unpin for bitcoin::blockdata::script::Script
+impl core::marker::Unpin for bitcoin::blockdata::script::ScriptBuf
+impl core::marker::Unpin for bitcoin::blockdata::script::ScriptHash
+impl core::marker::Unpin for bitcoin::blockdata::script::WScriptHash
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_program::Error
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::marker::Unpin for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::marker::Unpin for bitcoin::blockdata::transaction::InputsIndexError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::OutPoint
+impl core::marker::Unpin for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Sequence
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Transaction
+impl core::marker::Unpin for bitcoin::blockdata::transaction::TxIn
+impl core::marker::Unpin for bitcoin::blockdata::transaction::TxOut
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Txid
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Version
+impl core::marker::Unpin for bitcoin::blockdata::transaction::Wtxid
+impl core::marker::Unpin for bitcoin::blockdata::weight::Weight
+impl core::marker::Unpin for bitcoin::blockdata::witness::Witness
+impl core::marker::Unpin for bitcoin::consensus::encode::CheckedData
+impl core::marker::Unpin for bitcoin::consensus::encode::Error
+impl core::marker::Unpin for bitcoin::consensus::encode::VarInt
+impl core::marker::Unpin for bitcoin::consensus::params::Params
+impl core::marker::Unpin for bitcoin::ecdsa::Error
+impl core::marker::Unpin for bitcoin::ecdsa::SerializedSignature
+impl core::marker::Unpin for bitcoin::ecdsa::Signature
+impl core::marker::Unpin for bitcoin::error::ParseIntError
+impl core::marker::Unpin for bitcoin::key::Error
+impl core::marker::Unpin for bitcoin::key::SortKey
+impl core::marker::Unpin for bitcoin::key::TweakedKeypair
+impl core::marker::Unpin for bitcoin::key::TweakedPublicKey
+impl core::marker::Unpin for bitcoin::key::UncompressedPubkeyError
+impl core::marker::Unpin for bitcoin::merkle_tree::MerkleBlockError
+impl core::marker::Unpin for bitcoin::merkle_tree::PartialMerkleTree
+impl core::marker::Unpin for bitcoin::network::Network
+impl core::marker::Unpin for bitcoin::network::NetworkKind
+impl core::marker::Unpin for bitcoin::network::ParseNetworkError
+impl core::marker::Unpin for bitcoin::network::UnknownChainHashError
+impl core::marker::Unpin for bitcoin::p2p::Magic
+impl core::marker::Unpin for bitcoin::p2p::ParseMagicError
+impl core::marker::Unpin for bitcoin::p2p::ServiceFlags
+impl core::marker::Unpin for bitcoin::p2p::UnknownMagicError
+impl core::marker::Unpin for bitcoin::pow::CompactTarget
+impl core::marker::Unpin for bitcoin::pow::Target
+impl core::marker::Unpin for bitcoin::pow::TryFromError
+impl core::marker::Unpin for bitcoin::pow::Work
+impl core::marker::Unpin for bitcoin::psbt::Error
+impl core::marker::Unpin for bitcoin::psbt::ExtractTxError
+impl core::marker::Unpin for bitcoin::psbt::GetKeyError
+impl core::marker::Unpin for bitcoin::psbt::IndexOutOfBoundsError
+impl core::marker::Unpin for bitcoin::psbt::Input
+impl core::marker::Unpin for bitcoin::psbt::KeyRequest
+impl core::marker::Unpin for bitcoin::psbt::Output
+impl core::marker::Unpin for bitcoin::psbt::OutputType
+impl core::marker::Unpin for bitcoin::psbt::Psbt
+impl core::marker::Unpin for bitcoin::psbt::PsbtSighashType
+impl core::marker::Unpin for bitcoin::psbt::SignError
+impl core::marker::Unpin for bitcoin::psbt::SigningAlgorithm
+impl core::marker::Unpin for bitcoin::psbt::raw::Key
+impl core::marker::Unpin for bitcoin::psbt::raw::Pair
+impl core::marker::Unpin for bitcoin::sighash::AnnexError
+impl core::marker::Unpin for bitcoin::sighash::InvalidSighashTypeError
+impl core::marker::Unpin for bitcoin::sighash::NonStandardSighashTypeError
+impl core::marker::Unpin for bitcoin::sighash::P2wpkhError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsIndexError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsKindError
+impl core::marker::Unpin for bitcoin::sighash::PrevoutsSizeError
+impl core::marker::Unpin for bitcoin::sighash::SighashTypeParseError
+impl core::marker::Unpin for bitcoin::sighash::SingleMissingOutputError
+impl core::marker::Unpin for bitcoin::sighash::TaprootError
+impl core::marker::Unpin for bitcoin::taproot::ControlBlock
+impl core::marker::Unpin for bitcoin::taproot::FutureLeafVersion
+impl core::marker::Unpin for bitcoin::taproot::HiddenNodesError
+impl core::marker::Unpin for bitcoin::taproot::IncompleteBuilderError
+impl core::marker::Unpin for bitcoin::taproot::LeafNode
+impl core::marker::Unpin for bitcoin::taproot::LeafVersion
+impl core::marker::Unpin for bitcoin::taproot::NodeInfo
+impl core::marker::Unpin for bitcoin::taproot::SigFromSliceError
+impl core::marker::Unpin for bitcoin::taproot::Signature
+impl core::marker::Unpin for bitcoin::taproot::TapBranchTag
+impl core::marker::Unpin for bitcoin::taproot::TapLeaf
+impl core::marker::Unpin for bitcoin::taproot::TapLeafHash
+impl core::marker::Unpin for bitcoin::taproot::TapLeafTag
+impl core::marker::Unpin for bitcoin::taproot::TapNodeHash
+impl core::marker::Unpin for bitcoin::taproot::TapTree
+impl core::marker::Unpin for bitcoin::taproot::TapTweakHash
+impl core::marker::Unpin for bitcoin::taproot::TapTweakTag
+impl core::marker::Unpin for bitcoin::taproot::TaprootBuilder
+impl core::marker::Unpin for bitcoin::taproot::TaprootBuilderError
+impl core::marker::Unpin for bitcoin::taproot::TaprootError
+impl core::marker::Unpin for bitcoin::taproot::TaprootSpendInfo
+impl core::marker::Unpin for bitcoin::taproot::merkle_branch::IntoIter
+impl core::marker::Unpin for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::marker::Unpin for bitcoin::taproot::serialized_signature::IntoIter
+impl core::marker::Unpin for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::ops::arith::Add for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Add for bitcoin::pow::Work
+impl core::ops::arith::AddAssign for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Div for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Div<bitcoin::blockdata::weight::Weight> for bitcoin_units::amount::Amount
+impl core::ops::arith::Div<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::DivAssign<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Mul<bitcoin::blockdata::fee_rate::FeeRate> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Mul<bitcoin::blockdata::weight::Weight> for bitcoin::blockdata::fee_rate::FeeRate
+impl core::ops::arith::Mul<bitcoin::blockdata::weight::Weight> for u64
+impl core::ops::arith::Mul<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::MulAssign<u64> for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Sub for bitcoin::blockdata::weight::Weight
+impl core::ops::arith::Sub for bitcoin::pow::Work
+impl core::ops::arith::SubAssign for bitcoin::blockdata::weight::Weight
+impl core::ops::bit::BitOr for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitOrAssign for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitXor for bitcoin::p2p::ServiceFlags
+impl core::ops::bit::BitXorAssign for bitcoin::p2p::ServiceFlags
+impl core::ops::deref::Deref for bitcoin::blockdata::script::PushBytesBuf
+impl core::ops::deref::Deref for bitcoin::blockdata::script::ScriptBuf
+impl core::ops::deref::Deref for bitcoin::ecdsa::SerializedSignature
+impl core::ops::deref::Deref for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::ops::deref::Deref for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::ops::deref::DerefMut for bitcoin::blockdata::script::PushBytesBuf
+impl core::ops::deref::DerefMut for bitcoin::blockdata::script::ScriptBuf
+impl core::ops::deref::DerefMut for bitcoin::ecdsa::SerializedSignature
+impl core::ops::deref::DerefMut for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::PrivateKey
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin::blockdata::script::Script
+impl core::ops::index::Index<usize> for bitcoin::blockdata::script::PushBytes
+impl core::ops::index::Index<usize> for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::CompressedPublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::EcdsaSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::LegacySighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::MerkleBlock
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PrivateKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PubkeyHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::SegwitV0Sighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighashTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::WPubkeyHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::AddressType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::KnownHrp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::NetworkChecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::NetworkUnchecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::UnknownAddressTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::UnknownHrpError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::base58::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::BlockTransactions
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::BlockTransactionsRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::HeaderAndShortIds
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::PrefilledTransaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::ShortId
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilterReader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::FilterHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::FilterHeader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::GcsFilterReader
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::ChainCode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::ChildNumber
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::DerivationPath
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Fingerprint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::XKeyIdentifier
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Xpriv
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Xpub
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Bip34Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Block
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::ValidationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::constants::ChainHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::Class
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::Opcode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Builder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytes
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytesBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Script
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::ScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::WScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_program::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::InputsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Sequence
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Transaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::TxIn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::TxOut
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::weight::Weight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::CheckedData
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::VarInt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::params::Params
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::SerializedSignature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::Signature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::error::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::SortKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::TweakedKeypair
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::TweakedPublicKey
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::UncompressedPubkeyError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::merkle_tree::MerkleBlockError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::merkle_tree::PartialMerkleTree
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::Network
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::NetworkKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::ParseNetworkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::UnknownChainHashError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::Magic
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::ParseMagicError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::ServiceFlags
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::UnknownMagicError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::Target
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::Work
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::ExtractTxError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::GetKeyError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::IndexOutOfBoundsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Input
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::KeyRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Output
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::OutputType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Psbt
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::PsbtSighashType
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SignError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SigningAlgorithm
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::Key
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::Pair
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::AnnexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::InvalidSighashTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::NonStandardSighashTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::P2wpkhError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsIndexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsKindError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsSizeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SighashTypeParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SingleMissingOutputError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::TaprootError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ControlBlock
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::FutureLeafVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::HiddenNodesError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::IncompleteBuilderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::NodeInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::SigFromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::Signature
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapBranchTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeaf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeafHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeafTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapNodeHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTree
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTweakHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTweakTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootBuilder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootBuilderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootSpendInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::merkle_branch::IntoIter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::serialized_signature::IntoIter
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::CompressedPublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::EcdsaSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::LegacySighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::MerkleBlock
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PrivateKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PubkeyHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::PublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::SegwitV0Sighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighashTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::WPubkeyHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::AddressType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::KnownHrp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::NetworkChecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::NetworkUnchecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::UnknownAddressTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::UnknownHrpError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::base58::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::BlockTransactions
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::BlockTransactionsRequest
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::HeaderAndShortIds
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::PrefilledTransaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::ShortId
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::TxIndexOutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilterReader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::FilterHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::FilterHeader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::GcsFilterReader
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::ChainCode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::ChildNumber
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::DerivationPath
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Fingerprint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::XKeyIdentifier
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Xpriv
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Xpub
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Bip34Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Block
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::ValidationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::constants::ChainHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::fee_rate::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::OperationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::Class
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::ClassifyContext
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::Opcode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Builder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytes
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytesBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytesError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Script
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::ScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::WScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_program::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::FromStrError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::InputWeightPrediction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::InputsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::OutputsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::ParseOutPointError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Sequence
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Transaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::TxIn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::TxOut
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::weight::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::witness::Witness
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::CheckedData
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::VarInt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::params::Params
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::SerializedSignature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::Signature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::error::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::SortKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::TweakedKeypair
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::TweakedPublicKey
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::UncompressedPubkeyError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::merkle_tree::MerkleBlockError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::merkle_tree::PartialMerkleTree
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::Network
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::NetworkKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::ParseNetworkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::UnknownChainHashError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::Magic
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::ParseMagicError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::ServiceFlags
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::UnknownMagicError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::Target
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::Work
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::ExtractTxError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::GetKeyError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::IndexOutOfBoundsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Input
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::KeyRequest
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Output
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::OutputType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Psbt
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::PsbtSighashType
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SignError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SigningAlgorithm
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::Key
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::Pair
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::AnnexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::InvalidSighashTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::NonStandardSighashTypeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::P2wpkhError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsIndexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsKindError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsSizeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SighashTypeParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SingleMissingOutputError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::TaprootError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ControlBlock
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::FutureLeafVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::HiddenNodesError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::IncompleteBuilderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::NodeInfo
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::SigFromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::Signature
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapBranchTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeaf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeafHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeafTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapNodeHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTree
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTweakHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTweakTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootBuilder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootBuilderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootSpendInfo
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::merkle_branch::IntoIter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::serialized_signature::IntoIter
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::serialized_signature::SerializedSignature
+impl core::str::traits::FromStr for bitcoin::CompressedPublicKey
+impl core::str::traits::FromStr for bitcoin::EcdsaSighashType
+impl core::str::traits::FromStr for bitcoin::LegacySighash
+impl core::str::traits::FromStr for bitcoin::PrivateKey
+impl core::str::traits::FromStr for bitcoin::PubkeyHash
+impl core::str::traits::FromStr for bitcoin::PublicKey
+impl core::str::traits::FromStr for bitcoin::SegwitV0Sighash
+impl core::str::traits::FromStr for bitcoin::TapSighash
+impl core::str::traits::FromStr for bitcoin::TapSighashType
+impl core::str::traits::FromStr for bitcoin::WPubkeyHash
+impl core::str::traits::FromStr for bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+impl core::str::traits::FromStr for bitcoin::address::AddressType
+impl core::str::traits::FromStr for bitcoin::bip152::ShortId
+impl core::str::traits::FromStr for bitcoin::bip158::FilterHash
+impl core::str::traits::FromStr for bitcoin::bip158::FilterHeader
+impl core::str::traits::FromStr for bitcoin::bip32::ChainCode
+impl core::str::traits::FromStr for bitcoin::bip32::ChildNumber
+impl core::str::traits::FromStr for bitcoin::bip32::DerivationPath
+impl core::str::traits::FromStr for bitcoin::bip32::Fingerprint
+impl core::str::traits::FromStr for bitcoin::bip32::XKeyIdentifier
+impl core::str::traits::FromStr for bitcoin::bip32::Xpriv
+impl core::str::traits::FromStr for bitcoin::bip32::Xpub
+impl core::str::traits::FromStr for bitcoin::blockdata::block::BlockHash
+impl core::str::traits::FromStr for bitcoin::blockdata::block::TxMerkleNode
+impl core::str::traits::FromStr for bitcoin::blockdata::block::WitnessCommitment
+impl core::str::traits::FromStr for bitcoin::blockdata::block::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin::blockdata::constants::ChainHash
+impl core::str::traits::FromStr for bitcoin::blockdata::fee_rate::FeeRate
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::LockTime
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::absolute::Time
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::relative::Height
+impl core::str::traits::FromStr for bitcoin::blockdata::locktime::relative::Time
+impl core::str::traits::FromStr for bitcoin::blockdata::script::ScriptHash
+impl core::str::traits::FromStr for bitcoin::blockdata::script::WScriptHash
+impl core::str::traits::FromStr for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::OutPoint
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Sequence
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Txid
+impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Wtxid
+impl core::str::traits::FromStr for bitcoin::blockdata::weight::Weight
+impl core::str::traits::FromStr for bitcoin::ecdsa::Signature
+impl core::str::traits::FromStr for bitcoin::network::Network
+impl core::str::traits::FromStr for bitcoin::p2p::Magic
+impl core::str::traits::FromStr for bitcoin::psbt::PsbtSighashType
+impl core::str::traits::FromStr for bitcoin::taproot::TapLeafHash
+impl core::str::traits::FromStr for bitcoin::taproot::TapNodeHash
+impl core::str::traits::FromStr for bitcoin::taproot::TapTweakHash
+impl hex_conservative::parse::FromHex for bitcoin::bip152::ShortId
+impl hex_conservative::parse::FromHex for bitcoin::bip32::ChainCode
+impl hex_conservative::parse::FromHex for bitcoin::bip32::Fingerprint
+impl hex_conservative::parse::FromHex for bitcoin::blockdata::constants::ChainHash
+impl secp256k1::ThirtyTwoByteHash for bitcoin::LegacySighash
+impl secp256k1::ThirtyTwoByteHash for bitcoin::SegwitV0Sighash
+impl secp256k1::ThirtyTwoByteHash for bitcoin::TapSighash
+impl<'a, R: bitcoin_io::BufRead + core::marker::Sized> bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, R: core::marker::Sized> core::marker::Send for bitcoin::bip158::BitStreamReader<'a, R> where R: core::marker::Send
+impl<'a, R: core::marker::Sized> core::marker::Sync for bitcoin::bip158::BitStreamReader<'a, R> where R: core::marker::Sync
+impl<'a, R: core::marker::Sized> core::marker::Unpin for bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, R: core::marker::Sized> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BitStreamReader<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BitStreamReader<'a, R>
+impl<'a, T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for &'a T
+impl<'a, T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for &'a mut T
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W: bitcoin_io::Write> bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> core::marker::Send for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Send for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Send for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::marker::Send
+impl<'a, W> core::marker::Sync for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Sync for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Sync for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::marker::Sync
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::BitStreamWriter<'a, W>
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<'a, W> core::marker::Unpin for bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
+impl<'a> bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> bitcoin::bip32::IntoDerivationPath for &'a str
+impl<'a> bitcoin::blockdata::script::Instruction<'a>
+impl<'a> bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> bitcoin::blockdata::script::Instructions<'a>
+impl<'a> bitcoin::consensus::encode::Encodable for bitcoin::sighash::Annex<'a>
+impl<'a> bitcoin::sighash::Annex<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::clone::Clone for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::clone::Clone for bitcoin::sighash::Annex<'a>
+impl<'a> core::cmp::Eq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::cmp::Eq for bitcoin::sighash::Annex<'a>
+impl<'a> core::cmp::PartialEq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::cmp::PartialEq for bitcoin::sighash::Annex<'a>
+impl<'a> core::convert::From<&'a [bitcoin::bip32::ChildNumber]> for bitcoin::bip32::DerivationPath
+impl<'a> core::convert::From<&'a [u8; 0]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 0]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 10]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 10]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 11]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 11]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 12]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 12]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 13]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 13]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 14]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 14]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 15]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 15]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 16]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 16]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 17]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 17]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 18]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 18]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 19]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 19]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 1]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 1]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 20]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 20]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 21]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 21]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 22]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 22]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 23]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 23]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 24]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 24]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 25]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 25]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 26]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 26]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 27]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 27]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 28]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 28]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 29]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 29]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 2]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 2]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 30]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 30]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 31]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 31]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 32]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 33]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 33]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 34]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 34]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 35]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 35]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 36]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 36]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 37]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 37]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 38]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 38]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 39]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 39]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 3]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 3]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 40]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 40]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 41]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 41]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 42]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 42]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 43]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 43]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 44]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 44]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 45]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 45]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 46]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 46]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 47]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 47]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 48]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 48]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 49]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 49]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 4]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 4]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::From<&'a [u8; 4]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 50]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 50]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 51]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 51]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 52]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 52]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 53]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 53]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 54]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 54]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 55]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 55]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 56]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 56]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 57]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 57]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 58]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 58]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 59]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 59]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 5]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 5]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 60]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 60]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 61]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 61]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 62]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 62]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 63]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 63]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 64]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 64]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 65]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 65]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 66]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 66]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 67]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 67]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 68]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 68]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 69]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 69]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 6]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 6]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::From<&'a [u8; 6]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 70]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 70]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 71]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 71]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 72]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 72]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 73]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 73]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 7]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 7]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 8]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 8]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a [u8; 9]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a [u8; 9]> for bitcoin::blockdata::script::PushBytesBuf
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::rc::Rc<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::sync::Arc<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::convert::From<&'a bitcoin::taproot::Signature> for bitcoin::taproot::serialized_signature::SerializedSignature
+impl<'a> core::convert::From<&'a mut [u8; 0]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 10]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 11]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 12]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 13]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 14]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 15]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 16]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 17]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 18]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 19]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 1]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 20]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 21]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 22]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 23]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 24]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 25]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 26]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 27]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 28]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 29]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 2]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 30]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 31]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 32]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 33]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 34]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 35]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 36]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 37]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 38]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 39]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 3]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 40]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 41]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 42]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 43]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 44]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 45]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 46]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 47]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 48]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 49]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 4]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 50]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 51]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 52]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 53]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 54]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 55]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 56]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 57]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 58]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 59]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 5]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 60]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 61]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 62]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 63]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 64]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 65]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 66]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 67]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 68]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 69]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 6]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 70]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 71]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 72]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 73]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 7]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 8]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<&'a mut [u8; 9]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::From<[u8; 32]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::From<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::From<[u8; 4]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::From<[u8; 6]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::convert::TryFrom<&'a [u8]> for &'a bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip152::ShortId
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip32::ChainCode
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip32::Fingerprint
+impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::blockdata::constants::ChainHash
+impl<'a> core::convert::TryFrom<&'a bitcoin::taproot::serialized_signature::SerializedSignature> for bitcoin::taproot::Signature
+impl<'a> core::convert::TryFrom<&'a mut [u8]> for &'a mut bitcoin::blockdata::script::PushBytes
+impl<'a> core::convert::TryFrom<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::fmt::Debug for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::fmt::Debug for bitcoin::sighash::Annex<'a>
+impl<'a> core::hash::Hash for bitcoin::sighash::Annex<'a>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin::blockdata::weight::Weight> for bitcoin::blockdata::weight::Weight
+impl<'a> core::iter::traits::collect::Extend<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::iter::traits::collect::FromIterator<bitcoin::blockdata::script::Instruction<'a>> for bitcoin::blockdata::script::ScriptBuf
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::bip32::DerivationPath
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::blockdata::witness::Witness
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::ecdsa::SerializedSignature
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::taproot::serialized_signature::SerializedSignature
+impl<'a> core::iter::traits::collect::IntoIterator for &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+impl<'a> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::iter::traits::marker::FusedIterator for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Copy for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Send for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Send for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Send for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Send for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::marker::StructuralPartialEq for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::StructuralPartialEq for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Sync for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Sync for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Sync for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Sync for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::marker::Unpin for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::marker::Unpin for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::marker::Unpin for bitcoin::sighash::Annex<'a>
+impl<'a> core::marker::Unpin for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::Annex<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafNodes<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::DerivationPathIterator<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Bytes<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Instruction<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::InstructionIndices<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Instructions<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::Annex<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafNodes<'a>
+impl<'leaf> bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::clone::Clone for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::Eq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::Ord for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::PartialEq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::cmp::PartialOrd for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::fmt::Debug for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::hash::Hash for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Send for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::StructuralPartialEq for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Sync for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::marker::Unpin for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'leaf> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<'s> bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::clone::Clone for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::Eq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::Ord for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::PartialEq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::cmp::PartialOrd for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::convert::From<bitcoin::sighash::ScriptPath<'s>> for bitcoin::taproot::TapLeafHash
+impl<'s> core::fmt::Debug for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::hash::Hash for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Send for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::StructuralPartialEq for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Sync for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::marker::Unpin for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::ScriptPath<'s>
+impl<'s> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::ScriptPath<'s>
+impl<'tree> core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::double_ended::DoubleEndedIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::exact_size::ExactSizeIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::iterator::Iterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::iter::traits::marker::FusedIterator for bitcoin::taproot::LeafNodes<'tree>
+impl<'tree> core::iter::traits::marker::FusedIterator for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Send for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Sync for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::marker::Unpin for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'tree> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ScriptLeaves<'tree>
+impl<'u, T> core::clone::Clone for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::clone::Clone
+impl<'u, T> core::cmp::Eq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::Eq
+impl<'u, T> core::cmp::Ord for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::Ord
+impl<'u, T> core::cmp::PartialEq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::PartialEq
+impl<'u, T> core::cmp::PartialOrd for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::PartialOrd
+impl<'u, T> core::fmt::Debug for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::fmt::Debug
+impl<'u, T> core::hash::Hash for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::hash::Hash
+impl<'u, T> core::marker::Send for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Sync + core::marker::Send
+impl<'u, T> core::marker::StructuralPartialEq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>
+impl<'u, T> core::marker::Sync for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Sync
+impl<'u, T> core::marker::Unpin for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Unpin
+impl<'u, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::Prevouts<'u, T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<'u, T> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::Prevouts<'u, T> where T: core::panic::unwind_safe::UnwindSafe + core::panic::unwind_safe::RefUnwindSafe
+impl<E: core::clone::Clone> core::clone::Clone for bitcoin::string::FromHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for bitcoin::string::FromHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin::string::FromHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for bitcoin::sighash::SigningDataError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for bitcoin::string::FromHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for bitcoin::sighash::SigningDataError<E>
+impl<E: core::fmt::Display> core::fmt::Display for bitcoin::string::FromHexError<E>
+impl<E> !core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SigningDataError<E>
+impl<E> !core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SigningDataError<E>
+impl<E> bitcoin::sighash::EncodeSigningDataResult<E>
+impl<E> core::convert::From<E> for bitcoin::string::FromHexError<E>
+impl<E> core::convert::From<bitcoin_io::error::Error> for bitcoin::sighash::SigningDataError<E>
+impl<E> core::marker::Send for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Send
+impl<E> core::marker::Send for bitcoin::sighash::SigningDataError<E> where E: core::marker::Send
+impl<E> core::marker::Send for bitcoin::string::FromHexError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for bitcoin::string::FromHexError<E>
+impl<E> core::marker::Sync for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for bitcoin::sighash::SigningDataError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for bitcoin::string::FromHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for bitcoin::sighash::SigningDataError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for bitcoin::string::FromHexError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::string::FromHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::string::FromHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::LegacySighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::PubkeyHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::SegwitV0Sighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::TapSighash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::WPubkeyHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip158::FilterHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip158::FilterHeader
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip32::XKeyIdentifier
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::BlockHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::TxMerkleNode
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::WitnessCommitment
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::WitnessMerkleNode
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::script::ScriptHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::script::WScriptHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::transaction::Txid
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::transaction::Wtxid
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapLeafHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapNodeHash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapTweakHash
+impl<I> core::ops::index::Index<I> for bitcoin::bip152::ShortId where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::ChainCode where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::DerivationPath where alloc::vec::Vec<bitcoin::bip32::ChildNumber>: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::bip32::Fingerprint where [u8]: core::ops::index::Index<I>
+impl<I> core::ops::index::Index<I> for bitcoin::blockdata::constants::ChainHash where [u8]: core::ops::index::Index<I>
+impl<R: bitcoin_io::Read + core::marker::Sized> bitcoin::consensus::encode::ReadExt for R
+impl<R: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>> bitcoin::sighash::SighashCache<R>
+impl<R: core::borrow::BorrowMut<bitcoin::blockdata::transaction::Transaction>> bitcoin::sighash::SighashCache<R>
+impl<Subtype> bitcoin::consensus::encode::Decodable for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> bitcoin::consensus::encode::Encodable for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::clone::Clone for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::clone::Clone
+impl<Subtype> core::cmp::Eq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::Eq
+impl<Subtype> core::cmp::Ord for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::Ord
+impl<Subtype> core::cmp::PartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::PartialEq
+impl<Subtype> core::cmp::PartialOrd for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::PartialOrd
+impl<Subtype> core::convert::TryFrom<bitcoin::psbt::raw::Key> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::fmt::Debug for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::fmt::Debug
+impl<Subtype> core::hash::Hash for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::hash::Hash
+impl<Subtype> core::marker::Send for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Send
+impl<Subtype> core::marker::StructuralPartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::marker::Sync for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Sync
+impl<Subtype> core::marker::Unpin for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Unpin
+impl<Subtype> core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::panic::unwind_safe::RefUnwindSafe
+impl<Subtype> core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::panic::unwind_safe::UnwindSafe
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable, T6: bitcoin::consensus::encode::Decodable, T7: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5, T6, T7)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable, T6: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5, T6)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable, T5: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4, T5)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable, T4: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3, T4)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable, T3: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2, T3)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable, T2: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1, T2)
+impl<T0: bitcoin::consensus::encode::Decodable, T1: bitcoin::consensus::encode::Decodable> bitcoin::consensus::encode::Decodable for (T0, T1)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable, T6: bitcoin::consensus::encode::Encodable, T7: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5, T6, T7)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable, T6: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5, T6)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable, T5: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4, T5)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable, T4: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3, T4)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable, T3: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2, T3)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable, T2: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1, T2)
+impl<T0: bitcoin::consensus::encode::Encodable, T1: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for (T0, T1)
+impl<T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for alloc::rc::Rc<T>
+impl<T: bitcoin::consensus::encode::Encodable> bitcoin::consensus::encode::Encodable for alloc::sync::Arc<T>
+impl<T: core::fmt::Debug + core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>> core::fmt::Debug for bitcoin::sighash::SighashCache<T>
+impl<T> bitcoin::bip32::IntoDerivationPath for T where T: core::convert::Into<bitcoin::bip32::DerivationPath>
+impl<T> core::marker::Send for bitcoin::sighash::SighashCache<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin::sighash::SighashCache<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin::sighash::SighashCache<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SighashCache<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SighashCache<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<V: bitcoin::address::NetworkValidation> bitcoin::address::Address<V>
+impl<V: bitcoin::address::NetworkValidation> core::fmt::Debug for bitcoin::address::Address<V>
+impl<V> core::clone::Clone for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::clone::Clone
+impl<V> core::cmp::Eq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::Eq
+impl<V> core::cmp::Ord for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::Ord
+impl<V> core::cmp::PartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialEq
+impl<V> core::cmp::PartialOrd for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialOrd
+impl<V> core::hash::Hash for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::hash::Hash
+impl<V> core::marker::Send for bitcoin::address::Address<V>
+impl<V> core::marker::StructuralPartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation
+impl<V> core::marker::Sync for bitcoin::address::Address<V>
+impl<V> core::marker::Unpin for bitcoin::address::Address<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::Address<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for bitcoin::address::Address<V> where V: core::panic::unwind_safe::UnwindSafe
+impl<W: bitcoin_io::Write + core::marker::Sized> bitcoin::consensus::encode::WriteExt for W
+pub bitcoin::AddressType::P2pkh
+pub bitcoin::AddressType::P2sh
+pub bitcoin::AddressType::P2tr
+pub bitcoin::AddressType::P2wpkh
+pub bitcoin::AddressType::P2wsh
+pub bitcoin::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::EcdsaSighashType::All = 1
+pub bitcoin::EcdsaSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::EcdsaSighashType::None = 2
+pub bitcoin::EcdsaSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::EcdsaSighashType::Single = 3
+pub bitcoin::EcdsaSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::KnownHrp::Mainnet
+pub bitcoin::KnownHrp::Regtest
+pub bitcoin::KnownHrp::Testnets
+pub bitcoin::MerkleBlock::header: bitcoin::blockdata::block::Header
+pub bitcoin::MerkleBlock::txn: bitcoin::merkle_tree::PartialMerkleTree
+pub bitcoin::Network::Bitcoin
+pub bitcoin::Network::Regtest
+pub bitcoin::Network::Signet
+pub bitcoin::Network::Testnet
+pub bitcoin::NetworkKind::Main
+pub bitcoin::NetworkKind::Test
+pub bitcoin::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::OutPoint::vout: u32
+pub bitcoin::PrivateKey::compressed: bool
+pub bitcoin::PrivateKey::inner: secp256k1::key::SecretKey
+pub bitcoin::PrivateKey::network: bitcoin::network::NetworkKind
+pub bitcoin::Psbt::inputs: alloc::vec::Vec<bitcoin::psbt::Input>
+pub bitcoin::Psbt::outputs: alloc::vec::Vec<bitcoin::psbt::Output>
+pub bitcoin::Psbt::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::Psbt::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::Psbt::unsigned_tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::Psbt::version: u32
+pub bitcoin::Psbt::xpub: alloc::collections::btree::map::BTreeMap<bitcoin::bip32::Xpub, bitcoin::bip32::KeySource>
+pub bitcoin::PublicKey::compressed: bool
+pub bitcoin::PublicKey::inner: secp256k1::key::PublicKey
+pub bitcoin::TapSighashType::All = 1
+pub bitcoin::TapSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::TapSighashType::Default = 0
+pub bitcoin::TapSighashType::None = 2
+pub bitcoin::TapSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::TapSighashType::Single = 3
+pub bitcoin::TapSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::WitnessVersion::V0 = 0
+pub bitcoin::WitnessVersion::V1 = 1
+pub bitcoin::WitnessVersion::V10 = 10
+pub bitcoin::WitnessVersion::V11 = 11
+pub bitcoin::WitnessVersion::V12 = 12
+pub bitcoin::WitnessVersion::V13 = 13
+pub bitcoin::WitnessVersion::V14 = 14
+pub bitcoin::WitnessVersion::V15 = 15
+pub bitcoin::WitnessVersion::V16 = 16
+pub bitcoin::WitnessVersion::V2 = 2
+pub bitcoin::WitnessVersion::V3 = 3
+pub bitcoin::WitnessVersion::V4 = 4
+pub bitcoin::WitnessVersion::V5 = 5
+pub bitcoin::WitnessVersion::V6 = 6
+pub bitcoin::WitnessVersion::V7 = 7
+pub bitcoin::WitnessVersion::V8 = 8
+pub bitcoin::WitnessVersion::V9 = 9
+pub bitcoin::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::absolute::OperationError::InvalidComparison
+pub bitcoin::address::AddressType::P2pkh
+pub bitcoin::address::AddressType::P2sh
+pub bitcoin::address::AddressType::P2tr
+pub bitcoin::address::AddressType::P2wpkh
+pub bitcoin::address::AddressType::P2wsh
+pub bitcoin::address::Error::ExcessiveScriptSize
+pub bitcoin::address::Error::NetworkValidation
+pub bitcoin::address::Error::NetworkValidation::address: bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub bitcoin::address::Error::NetworkValidation::required: bitcoin::network::Network
+pub bitcoin::address::Error::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::Error::UnrecognizedScript
+pub bitcoin::address::Error::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::Error::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::KnownHrp::Mainnet
+pub bitcoin::address::KnownHrp::Regtest
+pub bitcoin::address::KnownHrp::Testnets
+pub bitcoin::address::ParseError::Base58(bitcoin::base58::Error)
+pub bitcoin::address::ParseError::Bech32(bech32::segwit::DecodeError)
+pub bitcoin::address::ParseError::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::ParseError::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::ParseError::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::error::Error::ExcessiveScriptSize
+pub bitcoin::address::error::Error::NetworkValidation
+pub bitcoin::address::error::Error::NetworkValidation::address: bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub bitcoin::address::error::Error::NetworkValidation::required: bitcoin::network::Network
+pub bitcoin::address::error::Error::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::error::Error::UnrecognizedScript
+pub bitcoin::address::error::Error::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::error::Error::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::address::error::ParseError::Base58(bitcoin::base58::Error)
+pub bitcoin::address::error::ParseError::Bech32(bech32::segwit::DecodeError)
+pub bitcoin::address::error::ParseError::UnknownHrp(bitcoin::address::error::UnknownHrpError)
+pub bitcoin::address::error::ParseError::WitnessProgram(bitcoin::blockdata::script::witness_program::Error)
+pub bitcoin::address::error::ParseError::WitnessVersion(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::base58::Error::BadByte(u8)
+pub bitcoin::base58::Error::BadChecksum(u32, u32)
+pub bitcoin::base58::Error::InvalidAddressVersion(u8)
+pub bitcoin::base58::Error::InvalidExtendedKeyVersion([u8; 4])
+pub bitcoin::base58::Error::InvalidLength(usize)
+pub bitcoin::base58::Error::TooShort(usize)
+pub bitcoin::bip152::BlockTransactions::block_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::bip152::BlockTransactions::transactions: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::bip152::BlockTransactionsRequest::block_hash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::bip152::BlockTransactionsRequest::indexes: alloc::vec::Vec<u64>
+pub bitcoin::bip152::Error::InvalidPrefill
+pub bitcoin::bip152::Error::UnknownVersion
+pub bitcoin::bip152::HeaderAndShortIds::header: bitcoin::blockdata::block::Header
+pub bitcoin::bip152::HeaderAndShortIds::nonce: u64
+pub bitcoin::bip152::HeaderAndShortIds::prefilled_txs: alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>
+pub bitcoin::bip152::HeaderAndShortIds::short_ids: alloc::vec::Vec<bitcoin::bip152::ShortId>
+pub bitcoin::bip152::PrefilledTransaction::idx: u16
+pub bitcoin::bip152::PrefilledTransaction::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::bip158::BlockFilter::content: alloc::vec::Vec<u8>
+pub bitcoin::bip158::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::bip158::Error::UtxoMissing(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::bip32::ChildNumber::Hardened
+pub bitcoin::bip32::ChildNumber::Hardened::index: u32
+pub bitcoin::bip32::ChildNumber::Normal
+pub bitcoin::bip32::ChildNumber::Normal::index: u32
+pub bitcoin::bip32::Error::Base58(bitcoin::base58::Error)
+pub bitcoin::bip32::Error::CannotDeriveFromHardenedKey
+pub bitcoin::bip32::Error::Hex(hex_conservative::parse::HexToArrayError)
+pub bitcoin::bip32::Error::InvalidChildNumber(u32)
+pub bitcoin::bip32::Error::InvalidChildNumberFormat
+pub bitcoin::bip32::Error::InvalidDerivationPathFormat
+pub bitcoin::bip32::Error::InvalidPublicKeyHexLength(usize)
+pub bitcoin::bip32::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::bip32::Error::UnknownVersion([u8; 4])
+pub bitcoin::bip32::Error::WrongExtendedKeyLength(usize)
+pub bitcoin::bip32::Xpriv::chain_code: bitcoin::bip32::ChainCode
+pub bitcoin::bip32::Xpriv::child_number: bitcoin::bip32::ChildNumber
+pub bitcoin::bip32::Xpriv::depth: u8
+pub bitcoin::bip32::Xpriv::network: bitcoin::network::NetworkKind
+pub bitcoin::bip32::Xpriv::parent_fingerprint: bitcoin::bip32::Fingerprint
+pub bitcoin::bip32::Xpriv::private_key: secp256k1::key::SecretKey
+pub bitcoin::bip32::Xpub::chain_code: bitcoin::bip32::ChainCode
+pub bitcoin::bip32::Xpub::child_number: bitcoin::bip32::ChildNumber
+pub bitcoin::bip32::Xpub::depth: u8
+pub bitcoin::bip32::Xpub::network: bitcoin::network::NetworkKind
+pub bitcoin::bip32::Xpub::parent_fingerprint: bitcoin::bip32::Fingerprint
+pub bitcoin::bip32::Xpub::public_key: secp256k1::key::PublicKey
+pub bitcoin::block::Bip34Error::NegativeHeight
+pub bitcoin::block::Bip34Error::NotPresent
+pub bitcoin::block::Bip34Error::UnexpectedPush(alloc::vec::Vec<u8>)
+pub bitcoin::block::Bip34Error::Unsupported
+pub bitcoin::block::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::block::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::block::Header::bits: bitcoin::pow::CompactTarget
+pub bitcoin::block::Header::merkle_root: bitcoin::blockdata::block::TxMerkleNode
+pub bitcoin::block::Header::nonce: u32
+pub bitcoin::block::Header::prev_blockhash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::block::Header::time: u32
+pub bitcoin::block::Header::version: bitcoin::blockdata::block::Version
+pub bitcoin::block::ValidationError::BadProofOfWork
+pub bitcoin::block::ValidationError::BadTarget
+pub bitcoin::blockdata::block::Bip34Error::NegativeHeight
+pub bitcoin::blockdata::block::Bip34Error::NotPresent
+pub bitcoin::blockdata::block::Bip34Error::UnexpectedPush(alloc::vec::Vec<u8>)
+pub bitcoin::blockdata::block::Bip34Error::Unsupported
+pub bitcoin::blockdata::block::Block::header: bitcoin::blockdata::block::Header
+pub bitcoin::blockdata::block::Block::txdata: alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::blockdata::block::Header::bits: bitcoin::pow::CompactTarget
+pub bitcoin::blockdata::block::Header::merkle_root: bitcoin::blockdata::block::TxMerkleNode
+pub bitcoin::blockdata::block::Header::nonce: u32
+pub bitcoin::blockdata::block::Header::prev_blockhash: bitcoin::blockdata::block::BlockHash
+pub bitcoin::blockdata::block::Header::time: u32
+pub bitcoin::blockdata::block::Header::version: bitcoin::blockdata::block::Version
+pub bitcoin::blockdata::block::ValidationError::BadProofOfWork
+pub bitcoin::blockdata::block::ValidationError::BadTarget
+pub bitcoin::blockdata::locktime::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::blockdata::locktime::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::blockdata::locktime::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::locktime::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::blockdata::locktime::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::blockdata::locktime::absolute::OperationError::InvalidComparison
+pub bitcoin::blockdata::locktime::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::blockdata::locktime::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::blockdata::locktime::relative::Error::IntegerOverflow(u32)
+pub bitcoin::blockdata::locktime::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::blockdata::locktime::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::blockdata::opcodes::Class::IllegalOp
+pub bitcoin::blockdata::opcodes::Class::NoOp
+pub bitcoin::blockdata::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin::blockdata::opcodes::Class::PushBytes(u32)
+pub bitcoin::blockdata::opcodes::Class::PushNum(i32)
+pub bitcoin::blockdata::opcodes::Class::ReturnOp
+pub bitcoin::blockdata::opcodes::Class::SuccessOp
+pub bitcoin::blockdata::opcodes::ClassifyContext::Legacy
+pub bitcoin::blockdata::opcodes::ClassifyContext::TapScript
+pub bitcoin::blockdata::script::Error::EarlyEndOfScript
+pub bitcoin::blockdata::script::Error::NonMinimalPush
+pub bitcoin::blockdata::script::Error::NumericOverflow
+pub bitcoin::blockdata::script::Error::Serialization
+pub bitcoin::blockdata::script::Error::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::blockdata::script::Instruction::Op(bitcoin::blockdata::opcodes::Opcode)
+pub bitcoin::blockdata::script::Instruction::PushBytes(&'a bitcoin::blockdata::script::PushBytes)
+pub bitcoin::blockdata::script::witness_program::Error::InvalidLength(usize)
+pub bitcoin::blockdata::script::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::blockdata::script::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::blockdata::script::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::script::witness_version::TryFromError::invalid: u8
+pub bitcoin::blockdata::script::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::blockdata::script::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::blockdata::script::witness_version::WitnessVersion::V9 = 9
+pub bitcoin::blockdata::transaction::IndexOutOfBoundsError::index: usize
+pub bitcoin::blockdata::transaction::IndexOutOfBoundsError::length: usize
+pub bitcoin::blockdata::transaction::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::blockdata::transaction::OutPoint::vout: u32
+pub bitcoin::blockdata::transaction::ParseOutPointError::Format
+pub bitcoin::blockdata::transaction::ParseOutPointError::TooLong
+pub bitcoin::blockdata::transaction::ParseOutPointError::Txid(hex_conservative::parse::HexToArrayError)
+pub bitcoin::blockdata::transaction::ParseOutPointError::Vout(bitcoin::error::ParseIntError)
+pub bitcoin::blockdata::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin::blockdata::transaction::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::blockdata::transaction::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::blockdata::transaction::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::blockdata::transaction::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::blockdata::transaction::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::blockdata::transaction::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::blockdata::transaction::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::blockdata::transaction::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::blockdata::transaction::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::blockdata::transaction::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::consensus::Params::allow_min_difficulty_blocks: bool
+pub bitcoin::consensus::Params::bip16_time: u32
+pub bitcoin::consensus::Params::bip34_height: u32
+pub bitcoin::consensus::Params::bip65_height: u32
+pub bitcoin::consensus::Params::bip66_height: u32
+pub bitcoin::consensus::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::Params::network: bitcoin::network::Network
+pub bitcoin::consensus::Params::no_pow_retargeting: bool
+pub bitcoin::consensus::Params::pow_limit: bitcoin::pow::Target
+pub bitcoin::consensus::Params::pow_target_spacing: u64
+pub bitcoin::consensus::Params::pow_target_timespan: u64
+pub bitcoin::consensus::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::encode::Error::InvalidChecksum
+pub bitcoin::consensus::encode::Error::InvalidChecksum::actual: [u8; 4]
+pub bitcoin::consensus::encode::Error::InvalidChecksum::expected: [u8; 4]
+pub bitcoin::consensus::encode::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::consensus::encode::Error::NonMinimalVarInt
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation::max: usize
+pub bitcoin::consensus::encode::Error::OversizedVectorAllocation::requested: usize
+pub bitcoin::consensus::encode::Error::ParseFailed(&'static str)
+pub bitcoin::consensus::encode::Error::UnsupportedSegwitFlag(u8)
+pub bitcoin::consensus::params::Params::allow_min_difficulty_blocks: bool
+pub bitcoin::consensus::params::Params::bip16_time: u32
+pub bitcoin::consensus::params::Params::bip34_height: u32
+pub bitcoin::consensus::params::Params::bip65_height: u32
+pub bitcoin::consensus::params::Params::bip66_height: u32
+pub bitcoin::consensus::params::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::params::Params::network: bitcoin::network::Network
+pub bitcoin::consensus::params::Params::no_pow_retargeting: bool
+pub bitcoin::consensus::params::Params::pow_limit: bitcoin::pow::Target
+pub bitcoin::consensus::params::Params::pow_target_spacing: u64
+pub bitcoin::consensus::params::Params::pow_target_timespan: u64
+pub bitcoin::consensus::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::ecdsa::Error::EmptySignature
+pub bitcoin::ecdsa::Error::Hex(hex_conservative::parse::HexToBytesError)
+pub bitcoin::ecdsa::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::ecdsa::Error::SighashType(bitcoin::sighash::NonStandardSighashTypeError)
+pub bitcoin::ecdsa::Signature::sighash_type: bitcoin::EcdsaSighashType
+pub bitcoin::ecdsa::Signature::signature: secp256k1::ecdsa::Signature
+pub bitcoin::key::Error::Base58(bitcoin::base58::Error)
+pub bitcoin::key::Error::Hex(hex_conservative::parse::HexToArrayError)
+pub bitcoin::key::Error::InvalidHexLength(usize)
+pub bitcoin::key::Error::InvalidKeyPrefix(u8)
+pub bitcoin::key::Error::Secp256k1(secp256k1::Error)
+pub bitcoin::key::PrivateKey::compressed: bool
+pub bitcoin::key::PrivateKey::inner: secp256k1::key::SecretKey
+pub bitcoin::key::PrivateKey::network: bitcoin::network::NetworkKind
+pub bitcoin::key::PublicKey::compressed: bool
+pub bitcoin::key::PublicKey::inner: secp256k1::key::PublicKey
+pub bitcoin::locktime::absolute::Error::Conversion(bitcoin::blockdata::locktime::absolute::ConversionError)
+pub bitcoin::locktime::absolute::Error::Operation(bitcoin::blockdata::locktime::absolute::OperationError)
+pub bitcoin::locktime::absolute::Error::Parse(bitcoin::error::ParseIntError)
+pub bitcoin::locktime::absolute::LockTime::Blocks(bitcoin::blockdata::locktime::absolute::Height)
+pub bitcoin::locktime::absolute::LockTime::Seconds(bitcoin::blockdata::locktime::absolute::Time)
+pub bitcoin::locktime::absolute::OperationError::InvalidComparison
+pub bitcoin::locktime::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::locktime::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::locktime::relative::Error::IntegerOverflow(u32)
+pub bitcoin::locktime::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::locktime::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::merkle_tree::MerkleBlock::header: bitcoin::blockdata::block::Header
+pub bitcoin::merkle_tree::MerkleBlock::txn: bitcoin::merkle_tree::PartialMerkleTree
+pub bitcoin::merkle_tree::MerkleBlockError::BitsArrayOverflow
+pub bitcoin::merkle_tree::MerkleBlockError::HashesArrayOverflow
+pub bitcoin::merkle_tree::MerkleBlockError::IdenticalHashesFound
+pub bitcoin::merkle_tree::MerkleBlockError::MerkleRootMismatch
+pub bitcoin::merkle_tree::MerkleBlockError::NoTransactions
+pub bitcoin::merkle_tree::MerkleBlockError::NotAllBitsConsumed
+pub bitcoin::merkle_tree::MerkleBlockError::NotAllHashesConsumed
+pub bitcoin::merkle_tree::MerkleBlockError::NotEnoughBits
+pub bitcoin::merkle_tree::MerkleBlockError::TooManyHashes
+pub bitcoin::merkle_tree::MerkleBlockError::TooManyTransactions
+pub bitcoin::network::Network::Bitcoin
+pub bitcoin::network::Network::Regtest
+pub bitcoin::network::Network::Signet
+pub bitcoin::network::Network::Testnet
+pub bitcoin::network::NetworkKind::Main
+pub bitcoin::network::NetworkKind::Test
+pub bitcoin::opcodes::Class::IllegalOp
+pub bitcoin::opcodes::Class::NoOp
+pub bitcoin::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin::opcodes::Class::PushBytes(u32)
+pub bitcoin::opcodes::Class::PushNum(i32)
+pub bitcoin::opcodes::Class::ReturnOp
+pub bitcoin::opcodes::Class::SuccessOp
+pub bitcoin::opcodes::ClassifyContext::Legacy
+pub bitcoin::opcodes::ClassifyContext::TapScript
+pub bitcoin::psbt::Error::CombineInconsistentKeySources(alloc::boxed::Box<bitcoin::bip32::Xpub>)
+pub bitcoin::psbt::Error::ConsensusEncoding(bitcoin::consensus::encode::Error)
+pub bitcoin::psbt::Error::DuplicateKey(bitcoin::psbt::raw::Key)
+pub bitcoin::psbt::Error::FeeOverflow
+pub bitcoin::psbt::Error::InvalidControlBlock
+pub bitcoin::psbt::Error::InvalidEcdsaSignature(bitcoin::ecdsa::Error)
+pub bitcoin::psbt::Error::InvalidHash(bitcoin_hashes::FromSliceError)
+pub bitcoin::psbt::Error::InvalidKey(bitcoin::psbt::raw::Key)
+pub bitcoin::psbt::Error::InvalidLeafVersion
+pub bitcoin::psbt::Error::InvalidMagic
+pub bitcoin::psbt::Error::InvalidPreimageHashPair
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::hash: alloc::boxed::Box<[u8]>
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::hash_type: PsbtHash
+pub bitcoin::psbt::Error::InvalidPreimageHashPair::preimage: alloc::boxed::Box<[u8]>
+pub bitcoin::psbt::Error::InvalidProprietaryKey
+pub bitcoin::psbt::Error::InvalidPublicKey(bitcoin::key::Error)
+pub bitcoin::psbt::Error::InvalidSecp256k1PublicKey(secp256k1::Error)
+pub bitcoin::psbt::Error::InvalidSeparator
+pub bitcoin::psbt::Error::InvalidTaprootSignature(bitcoin::taproot::SigFromSliceError)
+pub bitcoin::psbt::Error::InvalidXOnlyPublicKey
+pub bitcoin::psbt::Error::Io(bitcoin_io::error::Error)
+pub bitcoin::psbt::Error::MissingUtxo
+pub bitcoin::psbt::Error::MustHaveUnsignedTx
+pub bitcoin::psbt::Error::NegativeFee
+pub bitcoin::psbt::Error::NoMorePairs
+pub bitcoin::psbt::Error::NonStandardSighashType(u32)
+pub bitcoin::psbt::Error::PartialDataConsumption
+pub bitcoin::psbt::Error::PsbtUtxoOutOfbounds
+pub bitcoin::psbt::Error::TapTree(bitcoin::taproot::IncompleteBuilderError)
+pub bitcoin::psbt::Error::Taproot(&'static str)
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx::actual: alloc::boxed::Box<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Error::UnexpectedUnsignedTx::expected: alloc::boxed::Box<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Error::UnsignedTxHasScriptSigs
+pub bitcoin::psbt::Error::UnsignedTxHasScriptWitnesses
+pub bitcoin::psbt::Error::Version(&'static str)
+pub bitcoin::psbt::Error::XPubKey(&'static str)
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate::fee_rate: bitcoin::blockdata::fee_rate::FeeRate
+pub bitcoin::psbt::ExtractTxError::AbsurdFeeRate::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::ExtractTxError::MissingInputValue
+pub bitcoin::psbt::ExtractTxError::MissingInputValue::tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::ExtractTxError::SendingTooMuch
+pub bitcoin::psbt::ExtractTxError::SendingTooMuch::psbt: bitcoin::psbt::Psbt
+pub bitcoin::psbt::GetKeyError::Bip32(bitcoin::bip32::Error)
+pub bitcoin::psbt::GetKeyError::NotSupported
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs::index: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::Inputs::length: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput::index: usize
+pub bitcoin::psbt::IndexOutOfBoundsError::TxInput::length: usize
+pub bitcoin::psbt::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
+pub bitcoin::psbt::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::hash256_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::sha256d::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::non_witness_utxo: core::option::Option<bitcoin::blockdata::transaction::Transaction>
+pub bitcoin::psbt::Input::partial_sigs: alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::ecdsa::Signature>
+pub bitcoin::psbt::Input::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::redeem_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::ripemd160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::ripemd160::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::sha256_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::sha256::Hash, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::sighash_type: core::option::Option<bitcoin::psbt::PsbtSighashType>
+pub bitcoin::psbt::Input::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
+pub bitcoin::psbt::Input::tap_key_origins: alloc::collections::btree::map::BTreeMap<secp256k1::key::XOnlyPublicKey, (alloc::vec::Vec<bitcoin::taproot::TapLeafHash>, bitcoin::bip32::KeySource)>
+pub bitcoin::psbt::Input::tap_key_sig: core::option::Option<bitcoin::taproot::Signature>
+pub bitcoin::psbt::Input::tap_merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>
+pub bitcoin::psbt::Input::tap_script_sigs: alloc::collections::btree::map::BTreeMap<(secp256k1::key::XOnlyPublicKey, bitcoin::taproot::TapLeafHash), bitcoin::taproot::Signature>
+pub bitcoin::psbt::Input::tap_scripts: alloc::collections::btree::map::BTreeMap<bitcoin::taproot::ControlBlock, (bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)>
+pub bitcoin::psbt::Input::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Input::witness_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Input::witness_utxo: core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::psbt::KeyRequest::Bip32(bitcoin::bip32::KeySource)
+pub bitcoin::psbt::KeyRequest::Pubkey(bitcoin::PublicKey)
+pub bitcoin::psbt::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::Output::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::Output::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
+pub bitcoin::psbt::Output::tap_key_origins: alloc::collections::btree::map::BTreeMap<secp256k1::key::XOnlyPublicKey, (alloc::vec::Vec<bitcoin::taproot::TapLeafHash>, bitcoin::bip32::KeySource)>
+pub bitcoin::psbt::Output::tap_tree: core::option::Option<bitcoin::taproot::TapTree>
+pub bitcoin::psbt::Output::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Output::witness_script: core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub bitcoin::psbt::OutputType::Bare
+pub bitcoin::psbt::OutputType::Sh
+pub bitcoin::psbt::OutputType::ShWpkh
+pub bitcoin::psbt::OutputType::ShWsh
+pub bitcoin::psbt::OutputType::Tr
+pub bitcoin::psbt::OutputType::Wpkh
+pub bitcoin::psbt::OutputType::Wsh
+pub bitcoin::psbt::Psbt::inputs: alloc::vec::Vec<bitcoin::psbt::Input>
+pub bitcoin::psbt::Psbt::outputs: alloc::vec::Vec<bitcoin::psbt::Output>
+pub bitcoin::psbt::Psbt::proprietary: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::ProprietaryKey, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Psbt::unknown: alloc::collections::btree::map::BTreeMap<bitcoin::psbt::raw::Key, alloc::vec::Vec<u8>>
+pub bitcoin::psbt::Psbt::unsigned_tx: bitcoin::blockdata::transaction::Transaction
+pub bitcoin::psbt::Psbt::version: u32
+pub bitcoin::psbt::Psbt::xpub: alloc::collections::btree::map::BTreeMap<bitcoin::bip32::Xpub, bitcoin::bip32::KeySource>
+pub bitcoin::psbt::SignError::IndexOutOfBounds(bitcoin::psbt::IndexOutOfBoundsError)
+pub bitcoin::psbt::SignError::InvalidSighashType
+pub bitcoin::psbt::SignError::KeyNotFound
+pub bitcoin::psbt::SignError::MismatchedAlgoKey
+pub bitcoin::psbt::SignError::MissingInputUtxo
+pub bitcoin::psbt::SignError::MissingRedeemScript
+pub bitcoin::psbt::SignError::MissingSpendUtxo
+pub bitcoin::psbt::SignError::MissingWitnessScript
+pub bitcoin::psbt::SignError::NotEcdsa
+pub bitcoin::psbt::SignError::NotWpkh
+pub bitcoin::psbt::SignError::P2wpkhSighash(bitcoin::sighash::P2wpkhError)
+pub bitcoin::psbt::SignError::SegwitV0Sighash(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::psbt::SignError::UnknownOutputType
+pub bitcoin::psbt::SignError::Unsupported
+pub bitcoin::psbt::SignError::WrongSigningAlgorithm
+pub bitcoin::psbt::SigningAlgorithm::Ecdsa
+pub bitcoin::psbt::SigningAlgorithm::Schnorr
+pub bitcoin::psbt::raw::Key::key: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::Key::type_value: u8
+pub bitcoin::psbt::raw::Pair::key: bitcoin::psbt::raw::Key
+pub bitcoin::psbt::raw::Pair::value: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::key: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::prefix: alloc::vec::Vec<u8>
+pub bitcoin::psbt::raw::ProprietaryKey::subtype: Subtype
+pub bitcoin::relative::Error::IncompatibleHeight(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::relative::Error::IncompatibleTime(bitcoin::blockdata::locktime::relative::LockTime, bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::relative::Error::IntegerOverflow(u32)
+pub bitcoin::relative::LockTime::Blocks(bitcoin::blockdata::locktime::relative::Height)
+pub bitcoin::relative::LockTime::Time(bitcoin::blockdata::locktime::relative::Time)
+pub bitcoin::script::Error::EarlyEndOfScript
+pub bitcoin::script::Error::NonMinimalPush
+pub bitcoin::script::Error::NumericOverflow
+pub bitcoin::script::Error::Serialization
+pub bitcoin::script::Error::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
+pub bitcoin::script::Instruction::Op(bitcoin::blockdata::opcodes::Opcode)
+pub bitcoin::script::Instruction::PushBytes(&'a bitcoin::blockdata::script::PushBytes)
+pub bitcoin::script::witness_program::Error::InvalidLength(usize)
+pub bitcoin::script::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::script::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::script::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::script::witness_version::TryFromError::invalid: u8
+pub bitcoin::script::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::script::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::script::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::script::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::script::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::script::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::script::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::script::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::script::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::script::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::script::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::script::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::script::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::script::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::script::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::script::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::script::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::script::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::script::witness_version::WitnessVersion::V9 = 9
+pub bitcoin::sighash::AnnexError::Empty
+pub bitcoin::sighash::AnnexError::IncorrectPrefix(u8)
+pub bitcoin::sighash::EcdsaSighashType::All = 1
+pub bitcoin::sighash::EcdsaSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::sighash::EcdsaSighashType::None = 2
+pub bitcoin::sighash::EcdsaSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::sighash::EcdsaSighashType::Single = 3
+pub bitcoin::sighash::EcdsaSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::sighash::EncodeSigningDataResult::SighashSingleBug
+pub bitcoin::sighash::EncodeSigningDataResult::WriteResult(core::result::Result<(), E>)
+pub bitcoin::sighash::P2wpkhError::NotP2wpkhScript
+pub bitcoin::sighash::P2wpkhError::Sighash(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::sighash::Prevouts::All(&'u [T])
+pub bitcoin::sighash::Prevouts::One(usize, T)
+pub bitcoin::sighash::PrevoutsIndexError::InvalidAllIndex
+pub bitcoin::sighash::PrevoutsIndexError::InvalidOneIndex
+pub bitcoin::sighash::SighashTypeParseError::unrecognized: alloc::string::String
+pub bitcoin::sighash::SigningDataError::Io(bitcoin_io::error::Error)
+pub bitcoin::sighash::SigningDataError::Sighash(E)
+pub bitcoin::sighash::SingleMissingOutputError::input_index: usize
+pub bitcoin::sighash::SingleMissingOutputError::outputs_length: usize
+pub bitcoin::sighash::TapSighashType::All = 1
+pub bitcoin::sighash::TapSighashType::AllPlusAnyoneCanPay = 129
+pub bitcoin::sighash::TapSighashType::Default = 0
+pub bitcoin::sighash::TapSighashType::None = 2
+pub bitcoin::sighash::TapSighashType::NonePlusAnyoneCanPay = 130
+pub bitcoin::sighash::TapSighashType::Single = 3
+pub bitcoin::sighash::TapSighashType::SinglePlusAnyoneCanPay = 131
+pub bitcoin::sighash::TaprootError::InputsIndex(bitcoin::blockdata::transaction::InputsIndexError)
+pub bitcoin::sighash::TaprootError::InvalidSighashType(u32)
+pub bitcoin::sighash::TaprootError::PrevoutsIndex(bitcoin::sighash::PrevoutsIndexError)
+pub bitcoin::sighash::TaprootError::PrevoutsKind(bitcoin::sighash::PrevoutsKindError)
+pub bitcoin::sighash::TaprootError::PrevoutsSize(bitcoin::sighash::PrevoutsSizeError)
+pub bitcoin::sighash::TaprootError::SingleMissingOutput(bitcoin::sighash::SingleMissingOutputError)
+pub bitcoin::string::FromHexError::MissingPrefix(alloc::string::String)
+pub bitcoin::string::FromHexError::ParseHex(E)
+pub bitcoin::taproot::ControlBlock::internal_key: bitcoin::key::UntweakedPublicKey
+pub bitcoin::taproot::ControlBlock::leaf_version: bitcoin::taproot::LeafVersion
+pub bitcoin::taproot::ControlBlock::merkle_branch: bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub bitcoin::taproot::ControlBlock::output_key_parity: secp256k1::key::Parity
+pub bitcoin::taproot::HiddenNodesError::HiddenParts(bitcoin::taproot::NodeInfo)
+pub bitcoin::taproot::IncompleteBuilderError::HiddenParts(bitcoin::taproot::TaprootBuilder)
+pub bitcoin::taproot::IncompleteBuilderError::NotFinalized(bitcoin::taproot::TaprootBuilder)
+pub bitcoin::taproot::LeafVersion::Future(bitcoin::taproot::FutureLeafVersion)
+pub bitcoin::taproot::LeafVersion::TapScript
+pub bitcoin::taproot::SigFromSliceError::InvalidSignatureSize(usize)
+pub bitcoin::taproot::SigFromSliceError::Secp256k1(secp256k1::Error)
+pub bitcoin::taproot::SigFromSliceError::SighashType(bitcoin::sighash::InvalidSighashTypeError)
+pub bitcoin::taproot::Signature::sighash_type: bitcoin::TapSighashType
+pub bitcoin::taproot::Signature::signature: secp256k1::schnorr::Signature
+pub bitcoin::taproot::TapLeaf::Hidden(bitcoin::taproot::TapNodeHash)
+pub bitcoin::taproot::TapLeaf::Script(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)
+pub bitcoin::taproot::TaprootBuilderError::EmptyTree
+pub bitcoin::taproot::TaprootBuilderError::InvalidInternalKey(secp256k1::Error)
+pub bitcoin::taproot::TaprootBuilderError::InvalidMerkleTreeDepth(usize)
+pub bitcoin::taproot::TaprootBuilderError::NodeNotInDfsOrder
+pub bitcoin::taproot::TaprootBuilderError::OverCompleteTree
+pub bitcoin::taproot::TaprootError::EmptyTree
+pub bitcoin::taproot::TaprootError::InvalidControlBlockSize(usize)
+pub bitcoin::taproot::TaprootError::InvalidInternalKey(secp256k1::Error)
+pub bitcoin::taproot::TaprootError::InvalidMerkleBranchSize(usize)
+pub bitcoin::taproot::TaprootError::InvalidMerkleTreeDepth(usize)
+pub bitcoin::taproot::TaprootError::InvalidTaprootLeafVersion(u8)
+pub bitcoin::transaction::IndexOutOfBoundsError::index: usize
+pub bitcoin::transaction::IndexOutOfBoundsError::length: usize
+pub bitcoin::transaction::OutPoint::txid: bitcoin::blockdata::transaction::Txid
+pub bitcoin::transaction::OutPoint::vout: u32
+pub bitcoin::transaction::ParseOutPointError::Format
+pub bitcoin::transaction::ParseOutPointError::TooLong
+pub bitcoin::transaction::ParseOutPointError::Txid(hex_conservative::parse::HexToArrayError)
+pub bitcoin::transaction::ParseOutPointError::Vout(bitcoin::error::ParseIntError)
+pub bitcoin::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin::transaction::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
+pub bitcoin::transaction::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
+pub bitcoin::transaction::Transaction::output: alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>
+pub bitcoin::transaction::Transaction::version: bitcoin::blockdata::transaction::Version
+pub bitcoin::transaction::TxIn::previous_output: bitcoin::blockdata::transaction::OutPoint
+pub bitcoin::transaction::TxIn::script_sig: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::transaction::TxIn::sequence: bitcoin::blockdata::transaction::Sequence
+pub bitcoin::transaction::TxIn::witness: bitcoin::blockdata::witness::Witness
+pub bitcoin::transaction::TxOut::script_pubkey: bitcoin::blockdata::script::ScriptBuf
+pub bitcoin::transaction::TxOut::value: bitcoin_units::amount::Amount
+pub bitcoin::witness_program::Error::InvalidLength(usize)
+pub bitcoin::witness_program::Error::InvalidSegwitV0Length(usize)
+pub bitcoin::witness_version::FromStrError::Invalid(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::witness_version::FromStrError::Unparsable(bitcoin::error::ParseIntError)
+pub bitcoin::witness_version::TryFromError::invalid: u8
+pub bitcoin::witness_version::TryFromInstructionError::DataPush
+pub bitcoin::witness_version::TryFromInstructionError::TryFrom(bitcoin::blockdata::script::witness_version::TryFromError)
+pub bitcoin::witness_version::WitnessVersion::V0 = 0
+pub bitcoin::witness_version::WitnessVersion::V1 = 1
+pub bitcoin::witness_version::WitnessVersion::V10 = 10
+pub bitcoin::witness_version::WitnessVersion::V11 = 11
+pub bitcoin::witness_version::WitnessVersion::V12 = 12
+pub bitcoin::witness_version::WitnessVersion::V13 = 13
+pub bitcoin::witness_version::WitnessVersion::V14 = 14
+pub bitcoin::witness_version::WitnessVersion::V15 = 15
+pub bitcoin::witness_version::WitnessVersion::V16 = 16
+pub bitcoin::witness_version::WitnessVersion::V2 = 2
+pub bitcoin::witness_version::WitnessVersion::V3 = 3
+pub bitcoin::witness_version::WitnessVersion::V4 = 4
+pub bitcoin::witness_version::WitnessVersion::V5 = 5
+pub bitcoin::witness_version::WitnessVersion::V6 = 6
+pub bitcoin::witness_version::WitnessVersion::V7 = 7
+pub bitcoin::witness_version::WitnessVersion::V8 = 8
+pub bitcoin::witness_version::WitnessVersion::V9 = 9
+pub const bitcoin::LegacySighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::LegacySighash::LEN: usize
+pub const bitcoin::PubkeyHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::PubkeyHash::LEN: usize
+pub const bitcoin::SegwitV0Sighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::SegwitV0Sighash::LEN: usize
+pub const bitcoin::TapSighash::DISPLAY_BACKWARD: bool
+pub const bitcoin::TapSighash::LEN: usize
+pub const bitcoin::WPubkeyHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::WPubkeyHash::LEN: usize
+pub const bitcoin::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::address::NetworkChecked::IS_CHECKED: bool
+pub const bitcoin::address::NetworkUnchecked::IS_CHECKED: bool
+pub const bitcoin::address::NetworkValidation::IS_CHECKED: bool
+pub const bitcoin::bip158::FilterHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip158::FilterHash::LEN: usize
+pub const bitcoin::bip158::FilterHeader::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip158::FilterHeader::LEN: usize
+pub const bitcoin::bip32::XKeyIdentifier::DISPLAY_BACKWARD: bool
+pub const bitcoin::bip32::XKeyIdentifier::LEN: usize
+pub const bitcoin::blockdata::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::BlockHash::LEN: usize
+pub const bitcoin::blockdata::block::Header::SIZE: usize
+pub const bitcoin::blockdata::block::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::TxMerkleNode::LEN: usize
+pub const bitcoin::blockdata::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin::blockdata::block::Version::ONE: Self
+pub const bitcoin::blockdata::block::Version::TWO: Self
+pub const bitcoin::blockdata::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::WitnessCommitment::LEN: usize
+pub const bitcoin::blockdata::block::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::block::WitnessMerkleNode::LEN: usize
+pub const bitcoin::blockdata::constants::COINBASE_MATURITY: u32 = 100u32
+pub const bitcoin::blockdata::constants::ChainHash::BITCOIN: Self
+pub const bitcoin::blockdata::constants::ChainHash::REGTEST: Self
+pub const bitcoin::blockdata::constants::ChainHash::SIGNET: Self
+pub const bitcoin::blockdata::constants::ChainHash::TESTNET: Self
+pub const bitcoin::blockdata::constants::DIFFCHANGE_INTERVAL: u32 = 2_016u32
+pub const bitcoin::blockdata::constants::DIFFCHANGE_TIMESPAN: _
+pub const bitcoin::blockdata::constants::MAX_BLOCK_SIGOPS_COST: i64 = 80_000i64
+pub const bitcoin::blockdata::constants::MAX_SCRIPTNUM_VALUE: u32 = 2_147_483_648u32
+pub const bitcoin::blockdata::constants::MAX_SCRIPT_ELEMENT_SIZE: usize = 520usize
+pub const bitcoin::blockdata::constants::PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0u8
+pub const bitcoin::blockdata::constants::PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111u8
+pub const bitcoin::blockdata::constants::SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5u8
+pub const bitcoin::blockdata::constants::SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196u8
+pub const bitcoin::blockdata::constants::SUBSIDY_HALVING_INTERVAL: u32 = 210_000u32
+pub const bitcoin::blockdata::constants::TARGET_BLOCK_SPACING: u32 = 600u32
+pub const bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR: usize = 4usize
+pub const bitcoin::blockdata::fee_rate::FeeRate::BROADCAST_MIN: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::DUST: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::MAX: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::MIN: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::fee_rate::FeeRate::ZERO: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::blockdata::locktime::absolute::Height::MAX: Self
+pub const bitcoin::blockdata::locktime::absolute::Height::MIN: Self
+pub const bitcoin::blockdata::locktime::absolute::Height::ZERO: Self
+pub const bitcoin::blockdata::locktime::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::blockdata::locktime::absolute::LockTime::SIZE: usize
+pub const bitcoin::blockdata::locktime::absolute::LockTime::ZERO: bitcoin::blockdata::locktime::absolute::LockTime
+pub const bitcoin::blockdata::locktime::absolute::Time::MAX: Self
+pub const bitcoin::blockdata::locktime::absolute::Time::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Height::MAX: Self
+pub const bitcoin::blockdata::locktime::relative::Height::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Height::ZERO: Self
+pub const bitcoin::blockdata::locktime::relative::Time::MAX: Self
+pub const bitcoin::blockdata::locktime::relative::Time::MIN: Self
+pub const bitcoin::blockdata::locktime::relative::Time::ZERO: Self
+pub const bitcoin::blockdata::opcodes::all::OP_0NOTEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_1ADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_1SUB: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DIV: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DROP: _
+pub const bitcoin::blockdata::opcodes::all::OP_2DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_2MUL: _
+pub const bitcoin::blockdata::opcodes::all::OP_2OVER: _
+pub const bitcoin::blockdata::opcodes::all::OP_2ROT: _
+pub const bitcoin::blockdata::opcodes::all::OP_2SWAP: _
+pub const bitcoin::blockdata::opcodes::all::OP_3DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_ABS: _
+pub const bitcoin::blockdata::opcodes::all::OP_ADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_AND: _
+pub const bitcoin::blockdata::opcodes::all::OP_BOOLAND: _
+pub const bitcoin::blockdata::opcodes::all::OP_BOOLOR: _
+pub const bitcoin::blockdata::opcodes::all::OP_CAT: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKMULTISIG: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKMULTISIGVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIG: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIGADD: _
+pub const bitcoin::blockdata::opcodes::all::OP_CHECKSIGVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_CLTV: _
+pub const bitcoin::blockdata::opcodes::all::OP_CODESEPARATOR: _
+pub const bitcoin::blockdata::opcodes::all::OP_CSV: _
+pub const bitcoin::blockdata::opcodes::all::OP_DEPTH: _
+pub const bitcoin::blockdata::opcodes::all::OP_DIV: _
+pub const bitcoin::blockdata::opcodes::all::OP_DROP: _
+pub const bitcoin::blockdata::opcodes::all::OP_DUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_ELSE: _
+pub const bitcoin::blockdata::opcodes::all::OP_ENDIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_EQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_EQUALVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_FROMALTSTACK: _
+pub const bitcoin::blockdata::opcodes::all::OP_GREATERTHAN: _
+pub const bitcoin::blockdata::opcodes::all::OP_GREATERTHANOREQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_HASH160: _
+pub const bitcoin::blockdata::opcodes::all::OP_HASH256: _
+pub const bitcoin::blockdata::opcodes::all::OP_IF: _
+pub const bitcoin::blockdata::opcodes::all::OP_IFDUP: _
+pub const bitcoin::blockdata::opcodes::all::OP_INVALIDOPCODE: _
+pub const bitcoin::blockdata::opcodes::all::OP_INVERT: _
+pub const bitcoin::blockdata::opcodes::all::OP_LEFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_LESSTHAN: _
+pub const bitcoin::blockdata::opcodes::all::OP_LESSTHANOREQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_LSHIFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_MAX: _
+pub const bitcoin::blockdata::opcodes::all::OP_MIN: _
+pub const bitcoin::blockdata::opcodes::all::OP_MOD: _
+pub const bitcoin::blockdata::opcodes::all::OP_MUL: _
+pub const bitcoin::blockdata::opcodes::all::OP_NEGATE: _
+pub const bitcoin::blockdata::opcodes::all::OP_NIP: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP10: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP1: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP4: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP5: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP6: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP7: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP8: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP9: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOP: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOT: _
+pub const bitcoin::blockdata::opcodes::all::OP_NOTIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMEQUALVERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_NUMNOTEQUAL: _
+pub const bitcoin::blockdata::opcodes::all::OP_OR: _
+pub const bitcoin::blockdata::opcodes::all::OP_OVER: _
+pub const bitcoin::blockdata::opcodes::all::OP_PICK: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_0: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_10: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_11: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_12: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_13: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_14: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_15: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_16: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_17: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_18: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_19: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_20: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_21: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_22: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_23: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_24: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_25: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_26: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_27: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_28: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_29: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_30: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_31: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_32: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_33: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_34: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_35: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_36: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_37: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_38: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_39: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_3: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_40: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_41: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_42: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_43: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_44: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_45: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_46: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_47: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_48: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_49: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_50: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_51: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_52: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_53: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_54: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_55: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_56: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_57: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_58: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_59: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_5: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_60: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_61: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_62: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_63: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_64: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_65: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_66: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_67: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_68: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_69: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_6: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_70: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_71: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_72: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_73: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_74: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_75: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_7: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_8: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_9: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHDATA4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_10: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_11: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_12: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_13: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_14: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_15: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_16: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_1: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_2: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_3: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_4: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_5: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_6: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_7: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_8: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_9: _
+pub const bitcoin::blockdata::opcodes::all::OP_PUSHNUM_NEG1: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED1: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED2: _
+pub const bitcoin::blockdata::opcodes::all::OP_RESERVED: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_187: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_188: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_189: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_190: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_191: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_192: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_193: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_194: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_195: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_196: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_197: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_198: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_199: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_200: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_201: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_202: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_203: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_204: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_205: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_206: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_207: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_208: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_209: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_210: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_211: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_212: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_213: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_214: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_215: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_216: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_217: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_218: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_219: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_220: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_221: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_222: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_223: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_224: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_225: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_226: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_227: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_228: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_229: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_230: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_231: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_232: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_233: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_234: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_235: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_236: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_237: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_238: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_239: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_240: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_241: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_242: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_243: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_244: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_245: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_246: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_247: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_248: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_249: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_250: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_251: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_252: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_253: _
+pub const bitcoin::blockdata::opcodes::all::OP_RETURN_254: _
+pub const bitcoin::blockdata::opcodes::all::OP_RIGHT: _
+pub const bitcoin::blockdata::opcodes::all::OP_RIPEMD160: _
+pub const bitcoin::blockdata::opcodes::all::OP_ROLL: _
+pub const bitcoin::blockdata::opcodes::all::OP_ROT: _
+pub const bitcoin::blockdata::opcodes::all::OP_RSHIFT: _
+pub const bitcoin::blockdata::opcodes::all::OP_SHA1: _
+pub const bitcoin::blockdata::opcodes::all::OP_SHA256: _
+pub const bitcoin::blockdata::opcodes::all::OP_SIZE: _
+pub const bitcoin::blockdata::opcodes::all::OP_SUB: _
+pub const bitcoin::blockdata::opcodes::all::OP_SUBSTR: _
+pub const bitcoin::blockdata::opcodes::all::OP_SWAP: _
+pub const bitcoin::blockdata::opcodes::all::OP_TOALTSTACK: _
+pub const bitcoin::blockdata::opcodes::all::OP_TUCK: _
+pub const bitcoin::blockdata::opcodes::all::OP_VER: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERIFY: _
+pub const bitcoin::blockdata::opcodes::all::OP_VERNOTIF: _
+pub const bitcoin::blockdata::opcodes::all::OP_WITHIN: _
+pub const bitcoin::blockdata::opcodes::all::OP_XOR: _
+pub const bitcoin::blockdata::script::ScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::script::ScriptHash::LEN: usize
+pub const bitcoin::blockdata::script::WScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::script::WScriptHash::LEN: usize
+pub const bitcoin::blockdata::script::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::blockdata::script::witness_program::MIN_SIZE: usize = 2usize
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2PKH_COMPRESSED_MAX: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2PKH_UNCOMPRESSED_MAX: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2TR_KEY_DEFAULT_SIGHASH: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2TR_KEY_NON_DEFAULT_SIGHASH: Self
+pub const bitcoin::blockdata::transaction::InputWeightPrediction::P2WPKH_MAX: Self
+pub const bitcoin::blockdata::transaction::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
+pub const bitcoin::blockdata::transaction::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
+pub const bitcoin::blockdata::transaction::Sequence::MAX: Self
+pub const bitcoin::blockdata::transaction::Sequence::ZERO: Self
+pub const bitcoin::blockdata::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::transaction::TxOut::NULL: Self
+pub const bitcoin::blockdata::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::transaction::Txid::LEN: usize
+pub const bitcoin::blockdata::transaction::Version::ONE: Self
+pub const bitcoin::blockdata::transaction::Version::TWO: Self
+pub const bitcoin::blockdata::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const bitcoin::blockdata::transaction::Wtxid::LEN: usize
+pub const bitcoin::blockdata::weight::Weight::MAX: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MAX_BLOCK: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MIN: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::MIN_TRANSACTION: bitcoin::blockdata::weight::Weight
+pub const bitcoin::blockdata::weight::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin::blockdata::weight::Weight::ZERO: bitcoin::blockdata::weight::Weight
+pub const bitcoin::consensus::encode::MAX_VEC_SIZE: usize = 4_000_000usize
+pub const bitcoin::constants::COINBASE_MATURITY: u32 = 100u32
+pub const bitcoin::constants::DIFFCHANGE_INTERVAL: u32 = 2_016u32
+pub const bitcoin::constants::DIFFCHANGE_TIMESPAN: _
+pub const bitcoin::constants::MAX_BLOCK_SIGOPS_COST: i64 = 80_000i64
+pub const bitcoin::constants::MAX_SCRIPTNUM_VALUE: u32 = 2_147_483_648u32
+pub const bitcoin::constants::MAX_SCRIPT_ELEMENT_SIZE: usize = 520usize
+pub const bitcoin::constants::PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0u8
+pub const bitcoin::constants::PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111u8
+pub const bitcoin::constants::SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5u8
+pub const bitcoin::constants::SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196u8
+pub const bitcoin::constants::SUBSIDY_HALVING_INTERVAL: u32 = 210_000u32
+pub const bitcoin::constants::TARGET_BLOCK_SPACING: u32 = 600u32
+pub const bitcoin::constants::WITNESS_SCALE_FACTOR: usize = 4usize
+pub const bitcoin::locktime::absolute::LOCK_TIME_THRESHOLD: u32 = 500_000_000u32
+pub const bitcoin::opcodes::all::OP_0NOTEQUAL: _
+pub const bitcoin::opcodes::all::OP_1ADD: _
+pub const bitcoin::opcodes::all::OP_1SUB: _
+pub const bitcoin::opcodes::all::OP_2DIV: _
+pub const bitcoin::opcodes::all::OP_2DROP: _
+pub const bitcoin::opcodes::all::OP_2DUP: _
+pub const bitcoin::opcodes::all::OP_2MUL: _
+pub const bitcoin::opcodes::all::OP_2OVER: _
+pub const bitcoin::opcodes::all::OP_2ROT: _
+pub const bitcoin::opcodes::all::OP_2SWAP: _
+pub const bitcoin::opcodes::all::OP_3DUP: _
+pub const bitcoin::opcodes::all::OP_ABS: _
+pub const bitcoin::opcodes::all::OP_ADD: _
+pub const bitcoin::opcodes::all::OP_AND: _
+pub const bitcoin::opcodes::all::OP_BOOLAND: _
+pub const bitcoin::opcodes::all::OP_BOOLOR: _
+pub const bitcoin::opcodes::all::OP_CAT: _
+pub const bitcoin::opcodes::all::OP_CHECKMULTISIG: _
+pub const bitcoin::opcodes::all::OP_CHECKMULTISIGVERIFY: _
+pub const bitcoin::opcodes::all::OP_CHECKSIG: _
+pub const bitcoin::opcodes::all::OP_CHECKSIGADD: _
+pub const bitcoin::opcodes::all::OP_CHECKSIGVERIFY: _
+pub const bitcoin::opcodes::all::OP_CLTV: _
+pub const bitcoin::opcodes::all::OP_CODESEPARATOR: _
+pub const bitcoin::opcodes::all::OP_CSV: _
+pub const bitcoin::opcodes::all::OP_DEPTH: _
+pub const bitcoin::opcodes::all::OP_DIV: _
+pub const bitcoin::opcodes::all::OP_DROP: _
+pub const bitcoin::opcodes::all::OP_DUP: _
+pub const bitcoin::opcodes::all::OP_ELSE: _
+pub const bitcoin::opcodes::all::OP_ENDIF: _
+pub const bitcoin::opcodes::all::OP_EQUAL: _
+pub const bitcoin::opcodes::all::OP_EQUALVERIFY: _
+pub const bitcoin::opcodes::all::OP_FROMALTSTACK: _
+pub const bitcoin::opcodes::all::OP_GREATERTHAN: _
+pub const bitcoin::opcodes::all::OP_GREATERTHANOREQUAL: _
+pub const bitcoin::opcodes::all::OP_HASH160: _
+pub const bitcoin::opcodes::all::OP_HASH256: _
+pub const bitcoin::opcodes::all::OP_IF: _
+pub const bitcoin::opcodes::all::OP_IFDUP: _
+pub const bitcoin::opcodes::all::OP_INVALIDOPCODE: _
+pub const bitcoin::opcodes::all::OP_INVERT: _
+pub const bitcoin::opcodes::all::OP_LEFT: _
+pub const bitcoin::opcodes::all::OP_LESSTHAN: _
+pub const bitcoin::opcodes::all::OP_LESSTHANOREQUAL: _
+pub const bitcoin::opcodes::all::OP_LSHIFT: _
+pub const bitcoin::opcodes::all::OP_MAX: _
+pub const bitcoin::opcodes::all::OP_MIN: _
+pub const bitcoin::opcodes::all::OP_MOD: _
+pub const bitcoin::opcodes::all::OP_MUL: _
+pub const bitcoin::opcodes::all::OP_NEGATE: _
+pub const bitcoin::opcodes::all::OP_NIP: _
+pub const bitcoin::opcodes::all::OP_NOP10: _
+pub const bitcoin::opcodes::all::OP_NOP1: _
+pub const bitcoin::opcodes::all::OP_NOP4: _
+pub const bitcoin::opcodes::all::OP_NOP5: _
+pub const bitcoin::opcodes::all::OP_NOP6: _
+pub const bitcoin::opcodes::all::OP_NOP7: _
+pub const bitcoin::opcodes::all::OP_NOP8: _
+pub const bitcoin::opcodes::all::OP_NOP9: _
+pub const bitcoin::opcodes::all::OP_NOP: _
+pub const bitcoin::opcodes::all::OP_NOT: _
+pub const bitcoin::opcodes::all::OP_NOTIF: _
+pub const bitcoin::opcodes::all::OP_NUMEQUAL: _
+pub const bitcoin::opcodes::all::OP_NUMEQUALVERIFY: _
+pub const bitcoin::opcodes::all::OP_NUMNOTEQUAL: _
+pub const bitcoin::opcodes::all::OP_OR: _
+pub const bitcoin::opcodes::all::OP_OVER: _
+pub const bitcoin::opcodes::all::OP_PICK: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_0: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_10: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_11: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_12: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_13: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_14: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_15: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_16: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_17: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_18: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_19: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_1: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_20: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_21: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_22: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_23: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_24: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_25: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_26: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_27: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_28: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_29: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_2: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_30: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_31: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_32: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_33: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_34: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_35: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_36: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_37: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_38: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_39: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_3: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_40: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_41: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_42: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_43: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_44: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_45: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_46: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_47: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_48: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_49: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_4: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_50: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_51: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_52: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_53: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_54: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_55: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_56: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_57: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_58: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_59: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_5: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_60: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_61: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_62: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_63: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_64: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_65: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_66: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_67: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_68: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_69: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_6: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_70: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_71: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_72: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_73: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_74: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_75: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_7: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_8: _
+pub const bitcoin::opcodes::all::OP_PUSHBYTES_9: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA1: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA2: _
+pub const bitcoin::opcodes::all::OP_PUSHDATA4: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_10: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_11: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_12: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_13: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_14: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_15: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_16: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_1: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_2: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_3: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_4: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_5: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_6: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_7: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_8: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_9: _
+pub const bitcoin::opcodes::all::OP_PUSHNUM_NEG1: _
+pub const bitcoin::opcodes::all::OP_RESERVED1: _
+pub const bitcoin::opcodes::all::OP_RESERVED2: _
+pub const bitcoin::opcodes::all::OP_RESERVED: _
+pub const bitcoin::opcodes::all::OP_RETURN: _
+pub const bitcoin::opcodes::all::OP_RETURN_187: _
+pub const bitcoin::opcodes::all::OP_RETURN_188: _
+pub const bitcoin::opcodes::all::OP_RETURN_189: _
+pub const bitcoin::opcodes::all::OP_RETURN_190: _
+pub const bitcoin::opcodes::all::OP_RETURN_191: _
+pub const bitcoin::opcodes::all::OP_RETURN_192: _
+pub const bitcoin::opcodes::all::OP_RETURN_193: _
+pub const bitcoin::opcodes::all::OP_RETURN_194: _
+pub const bitcoin::opcodes::all::OP_RETURN_195: _
+pub const bitcoin::opcodes::all::OP_RETURN_196: _
+pub const bitcoin::opcodes::all::OP_RETURN_197: _
+pub const bitcoin::opcodes::all::OP_RETURN_198: _
+pub const bitcoin::opcodes::all::OP_RETURN_199: _
+pub const bitcoin::opcodes::all::OP_RETURN_200: _
+pub const bitcoin::opcodes::all::OP_RETURN_201: _
+pub const bitcoin::opcodes::all::OP_RETURN_202: _
+pub const bitcoin::opcodes::all::OP_RETURN_203: _
+pub const bitcoin::opcodes::all::OP_RETURN_204: _
+pub const bitcoin::opcodes::all::OP_RETURN_205: _
+pub const bitcoin::opcodes::all::OP_RETURN_206: _
+pub const bitcoin::opcodes::all::OP_RETURN_207: _
+pub const bitcoin::opcodes::all::OP_RETURN_208: _
+pub const bitcoin::opcodes::all::OP_RETURN_209: _
+pub const bitcoin::opcodes::all::OP_RETURN_210: _
+pub const bitcoin::opcodes::all::OP_RETURN_211: _
+pub const bitcoin::opcodes::all::OP_RETURN_212: _
+pub const bitcoin::opcodes::all::OP_RETURN_213: _
+pub const bitcoin::opcodes::all::OP_RETURN_214: _
+pub const bitcoin::opcodes::all::OP_RETURN_215: _
+pub const bitcoin::opcodes::all::OP_RETURN_216: _
+pub const bitcoin::opcodes::all::OP_RETURN_217: _
+pub const bitcoin::opcodes::all::OP_RETURN_218: _
+pub const bitcoin::opcodes::all::OP_RETURN_219: _
+pub const bitcoin::opcodes::all::OP_RETURN_220: _
+pub const bitcoin::opcodes::all::OP_RETURN_221: _
+pub const bitcoin::opcodes::all::OP_RETURN_222: _
+pub const bitcoin::opcodes::all::OP_RETURN_223: _
+pub const bitcoin::opcodes::all::OP_RETURN_224: _
+pub const bitcoin::opcodes::all::OP_RETURN_225: _
+pub const bitcoin::opcodes::all::OP_RETURN_226: _
+pub const bitcoin::opcodes::all::OP_RETURN_227: _
+pub const bitcoin::opcodes::all::OP_RETURN_228: _
+pub const bitcoin::opcodes::all::OP_RETURN_229: _
+pub const bitcoin::opcodes::all::OP_RETURN_230: _
+pub const bitcoin::opcodes::all::OP_RETURN_231: _
+pub const bitcoin::opcodes::all::OP_RETURN_232: _
+pub const bitcoin::opcodes::all::OP_RETURN_233: _
+pub const bitcoin::opcodes::all::OP_RETURN_234: _
+pub const bitcoin::opcodes::all::OP_RETURN_235: _
+pub const bitcoin::opcodes::all::OP_RETURN_236: _
+pub const bitcoin::opcodes::all::OP_RETURN_237: _
+pub const bitcoin::opcodes::all::OP_RETURN_238: _
+pub const bitcoin::opcodes::all::OP_RETURN_239: _
+pub const bitcoin::opcodes::all::OP_RETURN_240: _
+pub const bitcoin::opcodes::all::OP_RETURN_241: _
+pub const bitcoin::opcodes::all::OP_RETURN_242: _
+pub const bitcoin::opcodes::all::OP_RETURN_243: _
+pub const bitcoin::opcodes::all::OP_RETURN_244: _
+pub const bitcoin::opcodes::all::OP_RETURN_245: _
+pub const bitcoin::opcodes::all::OP_RETURN_246: _
+pub const bitcoin::opcodes::all::OP_RETURN_247: _
+pub const bitcoin::opcodes::all::OP_RETURN_248: _
+pub const bitcoin::opcodes::all::OP_RETURN_249: _
+pub const bitcoin::opcodes::all::OP_RETURN_250: _
+pub const bitcoin::opcodes::all::OP_RETURN_251: _
+pub const bitcoin::opcodes::all::OP_RETURN_252: _
+pub const bitcoin::opcodes::all::OP_RETURN_253: _
+pub const bitcoin::opcodes::all::OP_RETURN_254: _
+pub const bitcoin::opcodes::all::OP_RIGHT: _
+pub const bitcoin::opcodes::all::OP_RIPEMD160: _
+pub const bitcoin::opcodes::all::OP_ROLL: _
+pub const bitcoin::opcodes::all::OP_ROT: _
+pub const bitcoin::opcodes::all::OP_RSHIFT: _
+pub const bitcoin::opcodes::all::OP_SHA1: _
+pub const bitcoin::opcodes::all::OP_SHA256: _
+pub const bitcoin::opcodes::all::OP_SIZE: _
+pub const bitcoin::opcodes::all::OP_SUB: _
+pub const bitcoin::opcodes::all::OP_SUBSTR: _
+pub const bitcoin::opcodes::all::OP_SWAP: _
+pub const bitcoin::opcodes::all::OP_TOALTSTACK: _
+pub const bitcoin::opcodes::all::OP_TUCK: _
+pub const bitcoin::opcodes::all::OP_VER: _
+pub const bitcoin::opcodes::all::OP_VERIF: _
+pub const bitcoin::opcodes::all::OP_VERIFY: _
+pub const bitcoin::opcodes::all::OP_VERNOTIF: _
+pub const bitcoin::opcodes::all::OP_WITHIN: _
+pub const bitcoin::opcodes::all::OP_XOR: _
+pub const bitcoin::p2p::Magic::BITCOIN: Self
+pub const bitcoin::p2p::Magic::REGTEST: Self
+pub const bitcoin::p2p::Magic::SIGNET: Self
+pub const bitcoin::p2p::Magic::TESTNET: Self
+pub const bitcoin::p2p::PROTOCOL_VERSION: u32 = 70_001u32
+pub const bitcoin::p2p::ServiceFlags::BLOOM: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::COMPACT_FILTERS: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::GETUTXO: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NETWORK: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NETWORK_LIMITED: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::NONE: bitcoin::p2p::ServiceFlags
+pub const bitcoin::p2p::ServiceFlags::WITNESS: bitcoin::p2p::ServiceFlags
+pub const bitcoin::policy::DEFAULT_BYTES_PER_SIGOP: u32 = 20u32
+pub const bitcoin::policy::DEFAULT_INCREMENTAL_RELAY_FEE: u32 = 1_000u32
+pub const bitcoin::policy::DEFAULT_MEMPOOL_EXPIRY: u32 = 336u32
+pub const bitcoin::policy::DEFAULT_MIN_RELAY_TX_FEE: u32 = 1_000u32
+pub const bitcoin::policy::DUST_RELAY_TX_FEE: u32 = 3_000u32
+pub const bitcoin::policy::MAX_STANDARD_TX_SIGOPS_COST: _
+pub const bitcoin::policy::MAX_STANDARD_TX_WEIGHT: u32 = 400_000u32
+pub const bitcoin::policy::MIN_STANDARD_TX_NONWITNESS_SIZE: u32 = 82u32
+pub const bitcoin::pow::Target::MAX: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_MAINNET: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_REGTEST: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_SIGNET: Self
+pub const bitcoin::pow::Target::MAX_ATTAINABLE_TESTNET: Self
+pub const bitcoin::pow::Target::ZERO: bitcoin::pow::Target
+pub const bitcoin::psbt::Psbt::DEFAULT_MAX_FEE_RATE: bitcoin::blockdata::fee_rate::FeeRate
+pub const bitcoin::script::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::script::witness_program::MIN_SIZE: usize = 2usize
+pub const bitcoin::sign_message::BITCOIN_SIGNED_MSG_PREFIX: &[u8]
+pub const bitcoin::taproot::TAPROOT_ANNEX_PREFIX: u8 = 80u8
+pub const bitcoin::taproot::TAPROOT_CONTROL_BASE_SIZE: usize = 33usize
+pub const bitcoin::taproot::TAPROOT_CONTROL_MAX_NODE_COUNT: usize = 128usize
+pub const bitcoin::taproot::TAPROOT_CONTROL_MAX_SIZE: _
+pub const bitcoin::taproot::TAPROOT_CONTROL_NODE_SIZE: usize = 32usize
+pub const bitcoin::taproot::TAPROOT_LEAF_MASK: u8 = 254u8
+pub const bitcoin::taproot::TAPROOT_LEAF_TAPSCRIPT: u8 = 192u8
+pub const bitcoin::taproot::TapLeafHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapLeafHash::LEN: usize
+pub const bitcoin::taproot::TapNodeHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapNodeHash::LEN: usize
+pub const bitcoin::taproot::TapTweakHash::DISPLAY_BACKWARD: bool
+pub const bitcoin::taproot::TapTweakHash::LEN: usize
+pub const bitcoin::witness_program::MAX_SIZE: usize = 40usize
+pub const bitcoin::witness_program::MIN_SIZE: usize = 2usize
+pub const fn bitcoin::blockdata::constants::ChainHash::using_genesis_block(network: bitcoin::network::Network) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_vb_unchecked(sat_vb: u64) -> Self
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_kwu(self) -> u64
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin::blockdata::fee_rate::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin::blockdata::opcodes::Opcode::to_u8(self) -> u8
+pub const fn bitcoin::blockdata::script::ScriptBuf::new() -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::from_slice(input_script_len: usize, witness_element_lengths: &[usize]) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::ground_p2pkh_compressed(bytes_to_grind: usize) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::ground_p2wpkh(bytes_to_grind: usize) -> Self
+pub const fn bitcoin::blockdata::transaction::InputWeightPrediction::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::transaction::predict_weight_from_slices(inputs: &[bitcoin::blockdata::transaction::InputWeightPrediction], output_script_lens: &[usize]) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::weight::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin::blockdata::weight::Weight
+pub const fn bitcoin::blockdata::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::from_wu_usize(wu: usize) -> Self
+pub const fn bitcoin::blockdata::weight::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin::blockdata::weight::Weight::to_wu(self) -> u64
+pub const fn bitcoin::consensus::encode::VarInt::size(&self) -> usize
+pub const fn bitcoin::consensus::params::Params::new(network: bitcoin::network::Network) -> Self
+pub const fn bitcoin::network::Network::params(self) -> &'static bitcoin::consensus::params::Params
+pub const fn bitcoin::transaction::predict_weight_from_slices(inputs: &[bitcoin::blockdata::transaction::InputWeightPrediction], output_script_lens: &[usize]) -> bitcoin::blockdata::weight::Weight
+pub enum bitcoin::EcdsaSighashType
+pub enum bitcoin::NetworkKind
+pub enum bitcoin::TapSighashType
+pub enum bitcoin::absolute::LockTime
+pub enum bitcoin::address::NetworkChecked
+pub enum bitcoin::address::NetworkUnchecked
+pub enum bitcoin::bip32::ChildNumber
+pub enum bitcoin::blockdata::locktime::absolute::LockTime
+pub enum bitcoin::blockdata::locktime::relative::LockTime
+pub enum bitcoin::blockdata::opcodes::Class
+pub enum bitcoin::blockdata::opcodes::ClassifyContext
+pub enum bitcoin::blockdata::script::Instruction<'a>
+pub enum bitcoin::locktime::absolute::LockTime
+pub enum bitcoin::locktime::relative::LockTime
+pub enum bitcoin::network::NetworkKind
+pub enum bitcoin::opcodes::Class
+pub enum bitcoin::opcodes::ClassifyContext
+pub enum bitcoin::psbt::SigningAlgorithm
+pub enum bitcoin::relative::LockTime
+pub enum bitcoin::script::Instruction<'a>
+pub enum bitcoin::sighash::EcdsaSighashType
+pub enum bitcoin::sighash::EncodeSigningDataResult<E>
+pub enum bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>
+pub enum bitcoin::sighash::SigningDataError<E>
+pub enum bitcoin::sighash::TapSighashType
+pub enum bitcoin::taproot::LeafVersion
+pub enum bitcoin::taproot::TapLeaf
+pub extern crate bitcoin::hashes
+pub extern crate bitcoin::hex
+pub extern crate bitcoin::io
+pub extern crate bitcoin::secp256k1
+pub fn &'a T::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn &'a bitcoin::bip32::DerivationPath::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 0]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 10]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 11]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 12]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 13]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 14]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 15]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 16]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 17]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 18]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 19]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 1]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 20]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 21]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 22]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 23]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 24]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 25]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 26]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 27]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 28]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 29]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 2]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 30]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 31]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 32]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 33]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 34]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 35]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 36]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 37]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 38]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 39]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 3]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 40]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 41]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 42]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 43]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 44]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 45]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 46]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 47]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 48]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 49]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 4]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 50]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 51]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 52]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 53]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 54]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 55]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 56]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 57]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 58]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 59]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 5]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 60]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 61]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 62]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 63]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 64]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 65]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 66]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 67]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 68]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 69]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 6]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 70]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 71]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 72]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 73]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 7]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 8]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::from(bytes: &'a [u8; 9]) -> Self
+pub fn &'a bitcoin::blockdata::script::PushBytes::try_from(bytes: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn &'a bitcoin::blockdata::witness::Witness::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::ecdsa::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn &'a bitcoin::taproot::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn &'a mut T::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 0]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 10]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 11]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 12]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 13]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 14]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 15]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 16]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 17]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 18]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 19]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 1]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 20]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 21]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 22]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 23]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 24]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 25]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 26]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 27]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 28]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 29]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 2]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 30]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 31]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 32]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 33]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 34]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 35]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 36]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 37]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 38]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 39]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 3]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 40]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 41]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 42]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 43]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 44]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 45]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 46]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 47]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 48]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 49]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 4]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 50]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 51]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 52]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 53]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 54]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 55]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 56]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 57]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 58]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 59]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 5]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 60]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 61]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 62]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 63]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 64]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 65]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 66]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 67]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 68]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 69]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 6]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 70]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 71]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 72]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 73]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 7]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 8]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::from(bytes: &'a mut [u8; 9]) -> Self
+pub fn &'a mut bitcoin::blockdata::script::PushBytes::try_from(bytes: &'a mut [u8]) -> core::result::Result<Self, Self::Error>
+pub fn &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn &'a str::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn &'static bitcoin::consensus::params::Params::from(value: &bitcoin::network::Network) -> Self
+pub fn &'static bitcoin::consensus::params::Params::from(value: bitcoin::network::Network) -> Self
+pub fn (T0, T1)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6, T7)::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn (T0, T1, T2, T3, T4, T5, T6, T7)::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn R::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn R::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn R::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn R::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn R::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn R::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn R::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn R::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn R::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn R::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn T::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn W::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn W::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn [u16; 8]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u16; 8]::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 0]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 0]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 10]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 10]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 11]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 11]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 12]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 12]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 13]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 13]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 14]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 14]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 15]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 15]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 16]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 16]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 17]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 17]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 18]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 18]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 19]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 19]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 1]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 1]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 20]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 20]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 21]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 21]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 22]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 22]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 23]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 23]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 24]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 24]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 25]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 25]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 26]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 26]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 27]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 27]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 28]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 28]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 29]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 29]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 2]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 2]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 30]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 30]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 31]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 31]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 32]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 32]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 33]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 33]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 33]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 33]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 34]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 34]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 35]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 35]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 36]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 36]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 37]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 37]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 38]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 38]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 39]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 39]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 3]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 3]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 40]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 40]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 41]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 41]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 42]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 42]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 43]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 43]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 44]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 44]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 45]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 45]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 46]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 46]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 47]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 47]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 48]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 48]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 49]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 49]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 4]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 4]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 50]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 50]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 51]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 51]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 52]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 52]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 53]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 53]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 54]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 54]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 55]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 55]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 56]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 56]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 57]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 57]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 58]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 58]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 59]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 59]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 5]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 5]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 60]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 60]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 61]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 61]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 62]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 62]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 63]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 63]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 64]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 64]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 65]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 65]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 66]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 66]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 67]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 67]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 68]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 68]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 69]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 69]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 6]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 6]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 70]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 70]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 71]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 71]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 72]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 72]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 73]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 73]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 7]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 7]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8; 8]::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn [u8; 8]::consensus_encode<W: bitcoin::consensus::encode::WriteExt + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn [u8; 9]::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn [u8; 9]::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn [u8]::eq(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> bool
+pub fn [u8]::partial_cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn alloc::borrow::Cow<'_, bitcoin::blockdata::script::Script>::from(value: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::borrow::Cow<'static, str>::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<alloc::borrow::Cow<'static, str>, bitcoin::consensus::encode::Error>
+pub fn alloc::borrow::Cow<'static, str>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::boxed::Box<[u8]>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::boxed::Box<[u8]>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(value: alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>) -> Self
+pub fn alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn alloc::rc::Rc<T>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::rc::Rc<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::string::String::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<alloc::string::String, bitcoin::consensus::encode::Error>
+pub fn alloc::string::String::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::string::String::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn alloc::sync::Arc<T>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::sync::Arc<bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn alloc::vec::Vec<alloc::vec::Vec<u8>>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<alloc::vec::Vec<u8>>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::PrefilledTransaction>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::ShortId>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip152::ShortId>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHeader>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::bip158::FilterHeader>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::bip32::ChildNumber>::from(path: bitcoin::bip32::DerivationPath) -> Self
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::BlockHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::Header>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::Header>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::Transaction>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::blockdata::transaction::TxOut>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::consensus::encode::VarInt>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::consensus::encode::VarInt>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapLeafHash>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapLeafHash>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<bitcoin::taproot::TapNodeHash>::from(branch: bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> Self
+pub fn alloc::vec::Vec<u64>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<u64>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<u8>::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn alloc::vec::Vec<u8>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn alloc::vec::Vec<u8>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn alloc::vec::Vec<u8>::from(value: bitcoin::blockdata::script::PushBytesBuf) -> Self
+pub fn bech32::primitives::gf32::Fe32::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> Self
+pub fn bitcoin::CompressedPublicKey::clone(&self) -> bitcoin::CompressedPublicKey
+pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::cmp::Ordering
+pub fn bitcoin::CompressedPublicKey::eq(&self, other: &bitcoin::CompressedPublicKey) -> bool
+pub fn bitcoin::CompressedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPubkeyError>
+pub fn bitcoin::CompressedPublicKey::from_slice(data: &[u8]) -> core::result::Result<Self, secp256k1::Error>
+pub fn bitcoin::CompressedPublicKey::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::CompressedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::CompressedPublicKey::partial_cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::CompressedPublicKey::pubkey_hash(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::CompressedPublicKey::read_from<R: bitcoin_io::Read + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin::CompressedPublicKey::to_bytes(&self) -> [u8; 33]
+pub fn bitcoin::CompressedPublicKey::try_from(value: bitcoin::PublicKey) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::CompressedPublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), bitcoin::key::Error>
+pub fn bitcoin::CompressedPublicKey::wpubkey_hash(&self) -> bitcoin::WPubkeyHash
+pub fn bitcoin::CompressedPublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::EcdsaSighashType::clone(&self) -> bitcoin::EcdsaSighashType
+pub fn bitcoin::EcdsaSighashType::eq(&self, other: &bitcoin::EcdsaSighashType) -> bool
+pub fn bitcoin::EcdsaSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::EcdsaSighashType::from_consensus(n: u32) -> bitcoin::EcdsaSighashType
+pub fn bitcoin::EcdsaSighashType::from_standard(n: u32) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
+pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::LegacySighash::borrow(&self) -> &[u8]
+pub fn bitcoin::LegacySighash::clone(&self) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::cmp(&self, other: &bitcoin::LegacySighash) -> core::cmp::Ordering
+pub fn bitcoin::LegacySighash::engine() -> Self::Engine
+pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
+pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::LegacySighash::from_str(s: &str) -> core::result::Result<bitcoin::LegacySighash, Self::Err>
+pub fn bitcoin::LegacySighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::LegacySighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::LegacySighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::LegacySighash::partial_cmp(&self, other: &bitcoin::LegacySighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::LegacySighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::LegacySighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::MerkleBlock::clone(&self) -> bitcoin::MerkleBlock
+pub fn bitcoin::MerkleBlock::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::MerkleBlock::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::MerkleBlock::eq(&self, other: &bitcoin::MerkleBlock) -> bool
+pub fn bitcoin::MerkleBlock::extract_matches(&self, matches: &mut alloc::vec::Vec<bitcoin::blockdata::transaction::Txid>, indexes: &mut alloc::vec::Vec<u32>) -> core::result::Result<(), bitcoin::merkle_tree::MerkleBlockError>
+pub fn bitcoin::MerkleBlock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::MerkleBlock::from_block_with_predicate<F>(block: &bitcoin::blockdata::block::Block, match_txids: F) -> Self where F: core::ops::function::Fn(&bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::MerkleBlock::from_header_txids_with_predicate<F>(header: &bitcoin::blockdata::block::Header, block_txids: &[bitcoin::blockdata::transaction::Txid], match_txids: F) -> Self where F: core::ops::function::Fn(&bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::PrivateKey::clone(&self) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::eq(&self, other: &bitcoin::PrivateKey) -> bool
+pub fn bitcoin::PrivateKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PrivateKey::fmt_wif(&self, fmt: &mut dyn core::fmt::Write) -> core::fmt::Result
+pub fn bitcoin::PrivateKey::from_slice(data: &[u8], network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::from_str(s: &str) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::from_wif(wif: &str) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::Error>
+pub fn bitcoin::PrivateKey::index(&self, core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin::PrivateKey::new(key: secp256k1::key::SecretKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::new_uncompressed(key: secp256k1::key::SecretKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::public_key<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::PublicKey
+pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
+pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::PubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::PubkeyHash::borrow(&self) -> &[u8]
+pub fn bitcoin::PubkeyHash::clone(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::cmp(&self, other: &bitcoin::PubkeyHash) -> core::cmp::Ordering
+pub fn bitcoin::PubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::PubkeyHash::eq(&self, other: &bitcoin::PubkeyHash) -> bool
+pub fn bitcoin::PubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::PubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::PubkeyHash, Self::Err>
+pub fn bitcoin::PubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PubkeyHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::PubkeyHash::partial_cmp(&self, other: &bitcoin::PubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::PubkeyHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::PubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::PublicKey::clone(&self) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::cmp(&self, other: &bitcoin::PublicKey) -> core::cmp::Ordering
+pub fn bitcoin::PublicKey::eq(&self, other: &bitcoin::PublicKey) -> bool
+pub fn bitcoin::PublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::PublicKey::from(pk: secp256k1::key::PublicKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from(value: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from_slice(data: &[u8]) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::Error>
+pub fn bitcoin::PublicKey::from_str(s: &str) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::Error>
+pub fn bitcoin::PublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PublicKey::new(key: impl core::convert::Into<secp256k1::key::PublicKey>) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::new_uncompressed(key: impl core::convert::Into<secp256k1::key::PublicKey>) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::partial_cmp(&self, other: &bitcoin::PublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::PublicKey::pubkey_hash(&self) -> bitcoin::PubkeyHash
+pub fn bitcoin::PublicKey::read_from<R: bitcoin_io::Read + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin::PublicKey::to_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::PublicKey::to_sort_key(self) -> bitcoin::key::SortKey
+pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), bitcoin::key::Error>
+pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPubkeyError>
+pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::SegwitV0Sighash::borrow(&self) -> &[u8]
+pub fn bitcoin::SegwitV0Sighash::clone(&self) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::cmp::Ordering
+pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
+pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
+pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::SegwitV0Sighash::from_str(s: &str) -> core::result::Result<bitcoin::SegwitV0Sighash, Self::Err>
+pub fn bitcoin::SegwitV0Sighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::SegwitV0Sighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8]
+pub fn bitcoin::TapSighash::borrow(&self) -> &[u8]
+pub fn bitcoin::TapSighash::clone(&self) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::cmp(&self, other: &bitcoin::TapSighash) -> core::cmp::Ordering
+pub fn bitcoin::TapSighash::engine() -> Self::Engine
+pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
+pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::TapSighash::from_str(s: &str) -> core::result::Result<bitcoin::TapSighash, Self::Err>
+pub fn bitcoin::TapSighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::TapSighash::into_32(self) -> [u8; 32]
+pub fn bitcoin::TapSighash::partial_cmp(&self, other: &bitcoin::TapSighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::TapSighash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin::TapSighashTag::clone(&self) -> bitcoin::TapSighashTag
+pub fn bitcoin::TapSighashTag::cmp(&self, other: &bitcoin::TapSighashTag) -> core::cmp::Ordering
+pub fn bitcoin::TapSighashTag::default() -> bitcoin::TapSighashTag
+pub fn bitcoin::TapSighashTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::TapSighashTag::eq(&self, other: &bitcoin::TapSighashTag) -> bool
+pub fn bitcoin::TapSighashTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighashTag::partial_cmp(&self, other: &bitcoin::TapSighashTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighashType::clone(&self) -> bitcoin::TapSighashType
+pub fn bitcoin::TapSighashType::cmp(&self, other: &bitcoin::TapSighashType) -> core::cmp::Ordering
+pub fn bitcoin::TapSighashType::eq(&self, other: &bitcoin::TapSighashType) -> bool
+pub fn bitcoin::TapSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::TapSighashType::from(s: bitcoin::EcdsaSighashType) -> Self
+pub fn bitcoin::TapSighashType::from_consensus_u8(sighash_type: u8) -> core::result::Result<Self, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::WPubkeyHash::borrow(&self) -> &[u8]
+pub fn bitcoin::WPubkeyHash::clone(&self) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::cmp(&self, other: &bitcoin::WPubkeyHash) -> core::cmp::Ordering
+pub fn bitcoin::WPubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::WPubkeyHash::eq(&self, other: &bitcoin::WPubkeyHash) -> bool
+pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::WPubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::WPubkeyHash, Self::Err>
+pub fn bitcoin::WPubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::WPubkeyHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::WPubkeyHash::partial_cmp(&self, other: &bitcoin::WPubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::WPubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bitcoin::address::AddressType>
+pub fn bitcoin::address::Address::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::Address::from_script(script: &bitcoin::blockdata::script::Script, network: bitcoin::network::Network) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::Address::from_witness_program(program: bitcoin::blockdata::script::witness_program::WitnessProgram, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: &bitcoin::PublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: &secp256k1::key::XOnlyPublicKey) -> bool
+pub fn bitcoin::address::Address::is_spend_standard(&self) -> bool
+pub fn bitcoin::address::Address::matches_script_pubkey(&self, script: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::address::Address::p2pkh(pk: impl core::convert::Into<bitcoin::PubkeyHash>, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2sh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::Address::p2shwpkh(pk: &bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2shwsh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2wpkh(pk: &bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
+pub fn bitcoin::address::Address::p2wsh(script: &bitcoin::blockdata::script::Script, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bitcoin::PubkeyHash>
+pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
+pub fn bitcoin::address::Address::script_pubkey(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::address::Address::to_qr_uri(&self) -> alloc::string::String
+pub fn bitcoin::address::Address<V>::as_unchecked(&self) -> &bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub fn bitcoin::address::Address<V>::clone(&self) -> bitcoin::address::Address<V>
+pub fn bitcoin::address::Address<V>::cmp(&self, other: &bitcoin::address::Address<V>) -> core::cmp::Ordering
+pub fn bitcoin::address::Address<V>::eq(&self, other: &bitcoin::address::Address<V>) -> bool
+pub fn bitcoin::address::Address<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::Address<V>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::Address<V>::partial_cmp(&self, other: &bitcoin::address::Address<V>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::assume_checked(self) -> bitcoin::address::Address
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::assume_checked_ref(&self) -> &bitcoin::address::Address
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::from_str(s: &str) -> core::result::Result<bitcoin::address::Address<bitcoin::address::NetworkUnchecked>, bitcoin::address::error::ParseError>
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::is_valid_for_network(&self, n: bitcoin::network::Network) -> bool
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::require_network(self, required: bitcoin::network::Network) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::Error>
+pub fn bitcoin::address::AddressType::clone(&self) -> bitcoin::address::AddressType
+pub fn bitcoin::address::AddressType::cmp(&self, other: &bitcoin::address::AddressType) -> core::cmp::Ordering
+pub fn bitcoin::address::AddressType::eq(&self, other: &bitcoin::address::AddressType) -> bool
+pub fn bitcoin::address::AddressType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::AddressType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::address::AddressType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::AddressType::partial_cmp(&self, other: &bitcoin::address::AddressType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::KnownHrp::clone(&self) -> bitcoin::address::KnownHrp
+pub fn bitcoin::address::KnownHrp::cmp(&self, other: &bitcoin::address::KnownHrp) -> core::cmp::Ordering
+pub fn bitcoin::address::KnownHrp::eq(&self, other: &bitcoin::address::KnownHrp) -> bool
+pub fn bitcoin::address::KnownHrp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::KnownHrp::from(n: bitcoin::network::Network) -> Self
+pub fn bitcoin::address::KnownHrp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::KnownHrp::partial_cmp(&self, other: &bitcoin::address::KnownHrp) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::NetworkChecked::clone(&self) -> bitcoin::address::NetworkChecked
+pub fn bitcoin::address::NetworkChecked::cmp(&self, other: &bitcoin::address::NetworkChecked) -> core::cmp::Ordering
+pub fn bitcoin::address::NetworkChecked::eq(&self, other: &bitcoin::address::NetworkChecked) -> bool
+pub fn bitcoin::address::NetworkChecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::NetworkChecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::NetworkChecked::partial_cmp(&self, other: &bitcoin::address::NetworkChecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::NetworkUnchecked::clone(&self) -> bitcoin::address::NetworkUnchecked
+pub fn bitcoin::address::NetworkUnchecked::cmp(&self, other: &bitcoin::address::NetworkUnchecked) -> core::cmp::Ordering
+pub fn bitcoin::address::NetworkUnchecked::eq(&self, other: &bitcoin::address::NetworkUnchecked) -> bool
+pub fn bitcoin::address::NetworkUnchecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::NetworkUnchecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::address::NetworkUnchecked::partial_cmp(&self, other: &bitcoin::address::NetworkUnchecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::address::error::Error::clone(&self) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::Error::eq(&self, other: &bitcoin::address::error::Error) -> bool
+pub fn bitcoin::address::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::Error::from(e: bitcoin::blockdata::script::witness_program::Error) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::Error::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> bitcoin::address::error::Error
+pub fn bitcoin::address::error::ParseError::clone(&self) -> bitcoin::address::error::ParseError
+pub fn bitcoin::address::error::ParseError::eq(&self, other: &bitcoin::address::error::ParseError) -> bool
+pub fn bitcoin::address::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::ParseError::from(e: bech32::segwit::DecodeError) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::address::error::UnknownHrpError) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::base58::Error) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::blockdata::script::witness_program::Error) -> Self
+pub fn bitcoin::address::error::ParseError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::address::error::UnknownAddressTypeError::clone(&self) -> bitcoin::address::error::UnknownAddressTypeError
+pub fn bitcoin::address::error::UnknownAddressTypeError::eq(&self, other: &bitcoin::address::error::UnknownAddressTypeError) -> bool
+pub fn bitcoin::address::error::UnknownAddressTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::address::error::UnknownHrpError::clone(&self) -> bitcoin::address::error::UnknownHrpError
+pub fn bitcoin::address::error::UnknownHrpError::eq(&self, other: &bitcoin::address::error::UnknownHrpError) -> bool
+pub fn bitcoin::address::error::UnknownHrpError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::base58::Error::clone(&self) -> bitcoin::base58::Error
+pub fn bitcoin::base58::Error::eq(&self, other: &bitcoin::base58::Error) -> bool
+pub fn bitcoin::base58::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::base58::decode(data: &str) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin::base58::Error>
+pub fn bitcoin::base58::decode_check(data: &str) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin::base58::Error>
+pub fn bitcoin::base58::encode(data: &[u8]) -> alloc::string::String
+pub fn bitcoin::base58::encode_check(data: &[u8]) -> alloc::string::String
+pub fn bitcoin::base58::encode_check_to_fmt(fmt: &mut core::fmt::Formatter<'_>, data: &[u8]) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactions::clone(&self) -> bitcoin::bip152::BlockTransactions
+pub fn bitcoin::bip152::BlockTransactions::cmp(&self, other: &bitcoin::bip152::BlockTransactions) -> core::cmp::Ordering
+pub fn bitcoin::bip152::BlockTransactions::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactions::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactions::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::BlockTransactions::eq(&self, other: &bitcoin::bip152::BlockTransactions) -> bool
+pub fn bitcoin::bip152::BlockTransactions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactions::from_request(request: &bitcoin::bip152::BlockTransactionsRequest, block: &bitcoin::blockdata::block::Block) -> core::result::Result<bitcoin::bip152::BlockTransactions, bitcoin::bip152::TxIndexOutOfRangeError>
+pub fn bitcoin::bip152::BlockTransactions::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::BlockTransactions::partial_cmp(&self, other: &bitcoin::bip152::BlockTransactions) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::BlockTransactionsRequest::clone(&self) -> bitcoin::bip152::BlockTransactionsRequest
+pub fn bitcoin::bip152::BlockTransactionsRequest::cmp(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> core::cmp::Ordering
+pub fn bitcoin::bip152::BlockTransactionsRequest::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::BlockTransactionsRequest::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::BlockTransactionsRequest::eq(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> bool
+pub fn bitcoin::bip152::BlockTransactionsRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::BlockTransactionsRequest::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::BlockTransactionsRequest::partial_cmp(&self, other: &bitcoin::bip152::BlockTransactionsRequest) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::Error::clone(&self) -> bitcoin::bip152::Error
+pub fn bitcoin::bip152::Error::eq(&self, other: &bitcoin::bip152::Error) -> bool
+pub fn bitcoin::bip152::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::HeaderAndShortIds::clone(&self) -> bitcoin::bip152::HeaderAndShortIds
+pub fn bitcoin::bip152::HeaderAndShortIds::cmp(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> core::cmp::Ordering
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::eq(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> bool
+pub fn bitcoin::bip152::HeaderAndShortIds::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::HeaderAndShortIds::from_block(block: &bitcoin::blockdata::block::Block, nonce: u64, version: u32, prefill: &[usize]) -> core::result::Result<bitcoin::bip152::HeaderAndShortIds, bitcoin::bip152::Error>
+pub fn bitcoin::bip152::HeaderAndShortIds::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::HeaderAndShortIds::partial_cmp(&self, other: &bitcoin::bip152::HeaderAndShortIds) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::PrefilledTransaction::as_ref(&self) -> &bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::bip152::PrefilledTransaction::clone(&self) -> bitcoin::bip152::PrefilledTransaction
+pub fn bitcoin::bip152::PrefilledTransaction::cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::cmp::Ordering
+pub fn bitcoin::bip152::PrefilledTransaction::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::PrefilledTransaction::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::PrefilledTransaction::eq(&self, other: &bitcoin::bip152::PrefilledTransaction) -> bool
+pub fn bitcoin::bip152::PrefilledTransaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::PrefilledTransaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::PrefilledTransaction::partial_cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8; 6]
+pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip152::ShortId::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip152::ShortId::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip152::ShortId::as_ref(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip152::ShortId::borrow(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::borrow(&self) -> &[u8]
+pub fn bitcoin::bip152::ShortId::borrow_mut(&mut self) -> &mut [u8; 6]
+pub fn bitcoin::bip152::ShortId::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip152::ShortId::calculate_siphash_keys(header: &bitcoin::blockdata::block::Header, nonce: u64) -> (u64, u64)
+pub fn bitcoin::bip152::ShortId::clone(&self) -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::ShortId::cmp(&self, other: &bitcoin::bip152::ShortId) -> core::cmp::Ordering
+pub fn bitcoin::bip152::ShortId::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::bip152::ShortId, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip152::ShortId::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip152::ShortId::default() -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::ShortId::eq(&self, other: &bitcoin::bip152::ShortId) -> bool
+pub fn bitcoin::bip152::ShortId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip152::ShortId::from(data: &'a [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from(data: [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip152::ShortId::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip152::ShortId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip152::ShortId::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip152::ShortId::is_empty(&self) -> bool
+pub fn bitcoin::bip152::ShortId::len(&self) -> usize
+pub fn bitcoin::bip152::ShortId::partial_cmp(&self, other: &bitcoin::bip152::ShortId) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip152::ShortId::to_bytes(self) -> [u8; 6]
+pub fn bitcoin::bip152::ShortId::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip152::ShortId::with_siphash_keys<T: core::convert::AsRef<[u8]>>(txid: &T, siphash_keys: (u64, u64)) -> bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::clone(&self) -> bitcoin::bip152::TxIndexOutOfRangeError
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::eq(&self, other: &bitcoin::bip152::TxIndexOutOfRangeError) -> bool
+pub fn bitcoin::bip152::TxIndexOutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::BitStreamReader<'a, R>::new(reader: &'a mut R) -> bitcoin::bip158::BitStreamReader<'a, R>
+pub fn bitcoin::bip158::BitStreamReader<'a, R>::read(&mut self, nbits: u8) -> core::result::Result<u64, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::flush(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::new(writer: &'a mut W) -> bitcoin::bip158::BitStreamWriter<'a, W>
+pub fn bitcoin::bip158::BitStreamWriter<'a, W>::write(&mut self, data: u64, nbits: u8) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BlockFilter::clone(&self) -> bitcoin::bip158::BlockFilter
+pub fn bitcoin::bip158::BlockFilter::eq(&self, other: &bitcoin::bip158::BlockFilter) -> bool
+pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::BlockFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::new(content: &[u8]) -> bitcoin::bip158::BlockFilter
+pub fn bitcoin::bip158::BlockFilter::new_script_filter<M, S>(block: &bitcoin::blockdata::block::Block, script_for_coin: M) -> core::result::Result<bitcoin::bip158::BlockFilter, bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
+pub fn bitcoin::bip158::BlockFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::BlockFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: &bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_element(&mut self, data: &[u8])
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_input_scripts<M, S>(&mut self, script_for_coin: M) -> core::result::Result<(), bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_output_scripts(&mut self)
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::new(writer: &'a mut W, block: &'a bitcoin::blockdata::block::Block) -> bitcoin::bip158::BlockFilterWriter<'a, W>
+pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHash::borrow(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHash::clone(&self) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::cmp::Ordering
+pub fn bitcoin::bip158::FilterHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::FilterHash::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
+pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip158::FilterHash::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHash, Self::Err>
+pub fn bitcoin::bip158::FilterHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHeader::borrow(&self) -> &[u8]
+pub fn bitcoin::bip158::FilterHeader::clone(&self) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::cmp::Ordering
+pub fn bitcoin::bip158::FilterHeader::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::bip158::FilterHeader::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
+pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip158::FilterHeader::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHeader, Self::Err>
+pub fn bitcoin::bip158::FilterHeader::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHeader::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip158::FilterHeader::partial_cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip158::FilterHeader::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::bip158::GcsFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::GcsFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
+pub fn bitcoin::bip158::GcsFilterReader::new(k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterReader
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::add_element(&mut self, element: &[u8])
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::new(writer: &'a mut W, k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterWriter<'a, W>
+pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::ChainCode::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip32::ChainCode::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip32::ChainCode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::ChainCode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::ChainCode::borrow_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::bip32::ChainCode::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::ChainCode::clone(&self) -> bitcoin::bip32::ChainCode
+pub fn bitcoin::bip32::ChainCode::cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::cmp::Ordering
+pub fn bitcoin::bip32::ChainCode::eq(&self, other: &bitcoin::bip32::ChainCode) -> bool
+pub fn bitcoin::bip32::ChainCode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::ChainCode::from(data: &'a [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from(data: [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip32::ChainCode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip32::ChainCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::ChainCode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::ChainCode::is_empty(&self) -> bool
+pub fn bitcoin::bip32::ChainCode::len(&self) -> usize
+pub fn bitcoin::bip32::ChainCode::partial_cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::ChainCode::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::bip32::ChainCode::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip32::ChildNumber::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
+pub fn bitcoin::bip32::ChildNumber::clone(&self) -> bitcoin::bip32::ChildNumber
+pub fn bitcoin::bip32::ChildNumber::cmp(&self, other: &bitcoin::bip32::ChildNumber) -> core::cmp::Ordering
+pub fn bitcoin::bip32::ChildNumber::eq(&self, other: &bitcoin::bip32::ChildNumber) -> bool
+pub fn bitcoin::bip32::ChildNumber::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::ChildNumber::from(number: u32) -> Self
+pub fn bitcoin::bip32::ChildNumber::from_hardened_idx(index: u32) -> core::result::Result<Self, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::from_normal_idx(index: u32) -> core::result::Result<Self, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::ChildNumber, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::ChildNumber::increment(self) -> core::result::Result<bitcoin::bip32::ChildNumber, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::ChildNumber::is_hardened(&self) -> bool
+pub fn bitcoin::bip32::ChildNumber::is_normal(&self) -> bool
+pub fn bitcoin::bip32::ChildNumber::partial_cmp(&self, other: &bitcoin::bip32::ChildNumber) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::DerivationPath::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
+pub fn bitcoin::bip32::DerivationPath::child(&self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::children_from(&self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::clone(&self) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::cmp(&self, other: &bitcoin::bip32::DerivationPath) -> core::cmp::Ordering
+pub fn bitcoin::bip32::DerivationPath::default() -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::eq(&self, other: &bitcoin::bip32::DerivationPath) -> bool
+pub fn bitcoin::bip32::DerivationPath::extend<T: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, path: T) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::DerivationPath::from(numbers: &'a [bitcoin::bip32::ChildNumber]) -> Self
+pub fn bitcoin::bip32::DerivationPath::from(numbers: alloc::vec::Vec<bitcoin::bip32::ChildNumber>) -> Self
+pub fn bitcoin::bip32::DerivationPath::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::bip32::ChildNumber>
+pub fn bitcoin::bip32::DerivationPath::from_str(path: &str) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::DerivationPath::hardened_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::DerivationPath::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::DerivationPath::into_child(self, cn: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::is_empty(&self) -> bool
+pub fn bitcoin::bip32::DerivationPath::is_master(&self) -> bool
+pub fn bitcoin::bip32::DerivationPath::len(&self) -> usize
+pub fn bitcoin::bip32::DerivationPath::master() -> bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::normal_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
+pub fn bitcoin::bip32::DerivationPath::partial_cmp(&self, other: &bitcoin::bip32::DerivationPath) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::DerivationPath::to_u32_vec(&self) -> alloc::vec::Vec<u32>
+pub fn bitcoin::bip32::DerivationPathIterator<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::bip32::DerivationPathIterator<'a>::start_from(path: &'a bitcoin::bip32::DerivationPath, start: bitcoin::bip32::ChildNumber) -> bitcoin::bip32::DerivationPathIterator<'a>
+pub fn bitcoin::bip32::Error::clone(&self) -> bitcoin::bip32::Error
+pub fn bitcoin::bip32::Error::eq(&self, other: &bitcoin::bip32::Error) -> bool
+pub fn bitcoin::bip32::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Error::from(e: secp256k1::Error) -> bitcoin::bip32::Error
+pub fn bitcoin::bip32::Error::from(err: bitcoin::base58::Error) -> Self
+pub fn bitcoin::bip32::Error::from(err: bitcoin::key::Error) -> Self
+pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::Fingerprint::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::bip32::Fingerprint::as_ptr(&self) -> *const u8
+pub fn bitcoin::bip32::Fingerprint::as_ref(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::Fingerprint::borrow(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::Fingerprint::borrow_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::bip32::Fingerprint::clone(&self) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Fingerprint::cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::cmp::Ordering
+pub fn bitcoin::bip32::Fingerprint::default() -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Fingerprint::eq(&self, other: &bitcoin::bip32::Fingerprint) -> bool
+pub fn bitcoin::bip32::Fingerprint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Fingerprint::from(data: &'a [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from(data: [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::bip32::Fingerprint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::bip32::Fingerprint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::Fingerprint::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::Fingerprint::is_empty(&self) -> bool
+pub fn bitcoin::bip32::Fingerprint::len(&self) -> usize
+pub fn bitcoin::bip32::Fingerprint::partial_cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::Fingerprint::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::bip32::IntoDerivationPath::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8]
+pub fn bitcoin::bip32::XKeyIdentifier::borrow(&self) -> &[u8]
+pub fn bitcoin::bip32::XKeyIdentifier::clone(&self) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::cmp::Ordering
+pub fn bitcoin::bip32::XKeyIdentifier::engine() -> Self::Engine
+pub fn bitcoin::bip32::XKeyIdentifier::eq(&self, other: &bitcoin::bip32::XKeyIdentifier) -> bool
+pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::bip32::XKeyIdentifier::from_str(s: &str) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, Self::Err>
+pub fn bitcoin::bip32::XKeyIdentifier::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::XKeyIdentifier::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::bip32::XKeyIdentifier::partial_cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::bip32::XKeyIdentifier::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::bip32::Xpriv::clone(&self) -> bitcoin::bip32::Xpriv
+pub fn bitcoin::bip32::Xpriv::decode(data: &[u8]) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::derive_priv<C: secp256k1::context::Signing, P: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, secp: &secp256k1::Secp256k1<C>, path: &P) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::encode(&self) -> [u8; 78]
+pub fn bitcoin::bip32::Xpriv::eq(&self, other: &bitcoin::bip32::Xpriv) -> bool
+pub fn bitcoin::bip32::Xpriv::fingerprint<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Xpriv::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpriv::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpriv::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn bitcoin::bip32::Xpriv::identifier<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::Xpriv::new_master(network: impl core::convert::Into<bitcoin::network::NetworkKind>, seed: &[u8]) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpriv::to_keypair<C: secp256k1::context::Signing>(self, secp: &secp256k1::Secp256k1<C>) -> secp256k1::key::Keypair
+pub fn bitcoin::bip32::Xpriv::to_priv(self) -> bitcoin::PrivateKey
+pub fn bitcoin::bip32::Xpub::ckd_pub<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, i: bitcoin::bip32::ChildNumber) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::ckd_pub_tweak(&self, i: bitcoin::bip32::ChildNumber) -> core::result::Result<(secp256k1::key::SecretKey, bitcoin::bip32::ChainCode), bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::clone(&self) -> bitcoin::bip32::Xpub
+pub fn bitcoin::bip32::Xpub::cmp(&self, other: &bitcoin::bip32::Xpub) -> core::cmp::Ordering
+pub fn bitcoin::bip32::Xpub::decode(data: &[u8]) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::derive_pub<C: secp256k1::context::Verification, P: core::convert::AsRef<[bitcoin::bip32::ChildNumber]>>(&self, secp: &secp256k1::Secp256k1<C>, path: &P) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::encode(&self) -> [u8; 78]
+pub fn bitcoin::bip32::Xpub::eq(&self, other: &bitcoin::bip32::Xpub) -> bool
+pub fn bitcoin::bip32::Xpub::fingerprint(&self) -> bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Xpub::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpub::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::bip32::Xpub::from_priv<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::bip32::Xpriv) -> bitcoin::bip32::Xpub
+pub fn bitcoin::bip32::Xpub::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::Xpub::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::Xpub::identifier(&self) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::Xpub::partial_cmp(&self, other: &bitcoin::bip32::Xpub) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::Xpub::to_pub(self) -> bitcoin::CompressedPublicKey
+pub fn bitcoin::bip32::Xpub::to_x_only_pub(self) -> secp256k1::key::XOnlyPublicKey
+pub fn bitcoin::blockdata::block::Bip34Error::clone(&self) -> bitcoin::blockdata::block::Bip34Error
+pub fn bitcoin::blockdata::block::Bip34Error::eq(&self, other: &bitcoin::blockdata::block::Bip34Error) -> bool
+pub fn bitcoin::blockdata::block::Bip34Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Block::bip34_block_height(&self) -> core::result::Result<u64, bitcoin::blockdata::block::Bip34Error>
+pub fn bitcoin::blockdata::block::Block::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::Block::check_merkle_root(&self) -> bool
+pub fn bitcoin::blockdata::block::Block::check_witness_commitment(&self) -> bool
+pub fn bitcoin::blockdata::block::Block::clone(&self) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::blockdata::block::Block::coinbase(&self) -> core::option::Option<&bitcoin::blockdata::transaction::Transaction>
+pub fn bitcoin::blockdata::block::Block::compute_merkle_root(&self) -> core::option::Option<bitcoin::blockdata::block::TxMerkleNode>
+pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: &bitcoin::blockdata::block::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::Block::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Block::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Block::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Block::eq(&self, other: &bitcoin::blockdata::block::Block) -> bool
+pub fn bitcoin::blockdata::block::Block::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
+pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
+pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::BlockHash::clone(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::BlockHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::BlockHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::BlockHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::BlockHash::eq(&self, other: &bitcoin::blockdata::block::BlockHash) -> bool
+pub fn bitcoin::blockdata::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::BlockHash::from(block: &bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::BlockHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::BlockHash, Self::Err>
+pub fn bitcoin::blockdata::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::BlockHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::BlockHash::partial_cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::BlockHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::Header::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::Header::clone(&self) -> bitcoin::blockdata::block::Header
+pub fn bitcoin::blockdata::block::Header::cmp(&self, other: &bitcoin::blockdata::block::Header) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::Header::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Header, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Header::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Header, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Header::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Header::difficulty(&self, network: bitcoin::network::Network) -> u128
+pub fn bitcoin::blockdata::block::Header::difficulty_float(&self) -> f64
+pub fn bitcoin::blockdata::block::Header::eq(&self, other: &bitcoin::blockdata::block::Header) -> bool
+pub fn bitcoin::blockdata::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::Header::partial_cmp(&self, other: &bitcoin::blockdata::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
+pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
+pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
+pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::TxMerkleNode::clone(&self) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> bool
+pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::TxMerkleNode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::TxMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::ValidationError::clone(&self) -> bitcoin::blockdata::block::ValidationError
+pub fn bitcoin::blockdata::block::ValidationError::eq(&self, other: &bitcoin::blockdata::block::ValidationError) -> bool
+pub fn bitcoin::blockdata::block::ValidationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Version::clone(&self) -> bitcoin::blockdata::block::Version
+pub fn bitcoin::blockdata::block::Version::cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::Version::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::Version::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::Version::default() -> bitcoin::blockdata::block::Version
+pub fn bitcoin::blockdata::block::Version::eq(&self, other: &bitcoin::blockdata::block::Version) -> bool
+pub fn bitcoin::blockdata::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::Version::from_consensus(v: i32) -> Self
+pub fn bitcoin::blockdata::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::Version::is_signalling_soft_fork(&self, bit: u8) -> bool
+pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
+pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessCommitment::clone(&self) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
+pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::clone(&self) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> bool
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::constants::ChainHash::as_mut_ptr(&mut self) -> *mut u8
+pub fn bitcoin::blockdata::constants::ChainHash::as_ptr(&self) -> *const u8
+pub fn bitcoin::blockdata::constants::ChainHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow_mut(&mut self) -> &mut [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::constants::ChainHash::clone(&self) -> bitcoin::blockdata::constants::ChainHash
+pub fn bitcoin::blockdata::constants::ChainHash::cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::constants::ChainHash::eq(&self, other: &bitcoin::blockdata::constants::ChainHash) -> bool
+pub fn bitcoin::blockdata::constants::ChainHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::constants::ChainHash::from(data: &'a [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from(data: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_byte_iter<I>(iter: I) -> core::result::Result<Self, hex_conservative::parse::HexToArrayError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin::blockdata::constants::ChainHash::from_genesis_block_hash(block_hash: bitcoin::blockdata::block::BlockHash) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::constants::ChainHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::constants::ChainHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::constants::ChainHash::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::constants::ChainHash::len(&self) -> usize
+pub fn bitcoin::blockdata::constants::ChainHash::partial_cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::constants::ChainHash::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::constants::genesis_block(network: bitcoin::network::Network) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin::blockdata::weight::Weight) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::clone(&self) -> bitcoin::blockdata::fee_rate::FeeRate
+pub fn bitcoin::blockdata::fee_rate::FeeRate::cmp(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::fee_rate::FeeRate::eq(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> bool
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fee_wu(self, weight: bitcoin::blockdata::weight::Weight) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::fee_rate::FeeRate::from_sat_per_vb(sat_vb: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::fee_rate::FeeRate::mul(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::fee_rate::FeeRate::partial_cmp(&self, other: &bitcoin::blockdata::fee_rate::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::fee_rate::FeeRate::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ConversionError
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Error::clone(&self) -> bitcoin::blockdata::locktime::absolute::Error
+pub fn bitcoin::blockdata::locktime::absolute::Error::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Error) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::blockdata::locktime::absolute::ConversionError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::blockdata::locktime::absolute::OperationError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Error::from(e: bitcoin::error::ParseIntError) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::Height::clone(&self) -> bitcoin::blockdata::locktime::absolute::Height
+pub fn bitcoin::blockdata::locktime::absolute::Height::cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::absolute::Height::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_consensus(n: u32) -> core::result::Result<bitcoin::blockdata::locktime::absolute::Height, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::Height::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::clone(&self) -> bitcoin::blockdata::locktime::absolute::LockTime
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::eq(&self, other: &bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from(h: bitcoin::blockdata::locktime::absolute::Height) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from(t: bitcoin::blockdata::locktime::absolute::Time) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_consensus(n: u32) -> Self
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_height(n: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_time(n: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_block_height(&self) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_block_time(&self) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_implied_by(&self, other: bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_same_unit(&self, other: bitcoin::blockdata::locktime::absolute::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::is_satisfied_by(&self, height: bitcoin::blockdata::locktime::absolute::Height, time: bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::LockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::clone(&self) -> bitcoin::blockdata::locktime::absolute::OperationError
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::OperationError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::OperationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Time::clone(&self) -> bitcoin::blockdata::locktime::absolute::Time
+pub fn bitcoin::blockdata::locktime::absolute::Time::cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::absolute::Time::eq(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::locktime::absolute::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_consensus(n: u32) -> core::result::Result<bitcoin::blockdata::locktime::absolute::Time, bitcoin::blockdata::locktime::absolute::ConversionError>
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::absolute::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::absolute::Time::partial_cmp(&self, other: &bitcoin::blockdata::locktime::absolute::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::absolute::Time::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Error::clone(&self) -> bitcoin::blockdata::locktime::relative::Error
+pub fn bitcoin::blockdata::locktime::relative::Error::eq(&self, other: &bitcoin::blockdata::locktime::relative::Error) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Height::clone(&self) -> bitcoin::blockdata::locktime::relative::Height
+pub fn bitcoin::blockdata::locktime::relative::Height::cmp(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::relative::Height::default() -> bitcoin::blockdata::locktime::relative::Height
+pub fn bitcoin::blockdata::locktime::relative::Height::eq(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Height::from(value: u16) -> Self
+pub fn bitcoin::blockdata::locktime::relative::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::relative::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::Height::partial_cmp(&self, other: &bitcoin::blockdata::locktime::relative::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Height::value(self) -> u16
+pub fn bitcoin::blockdata::locktime::relative::LockTime::clone(&self) -> bitcoin::blockdata::locktime::relative::LockTime
+pub fn bitcoin::blockdata::locktime::relative::LockTime::eq(&self, other: &bitcoin::blockdata::locktime::relative::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::LockTime::from(h: bitcoin::blockdata::locktime::relative::Height) -> Self
+pub fn bitcoin::blockdata::locktime::relative::LockTime::from(t: bitcoin::blockdata::locktime::relative::Time) -> Self
+pub fn bitcoin::blockdata::locktime::relative::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_implied_by(&self, other: bitcoin::blockdata::locktime::relative::LockTime) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by(&self, h: bitcoin::blockdata::locktime::relative::Height, t: bitcoin::blockdata::locktime::relative::Time) -> bool
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by_height(&self, h: bitcoin::blockdata::locktime::relative::Height) -> core::result::Result<bool, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::LockTime::is_satisfied_by_time(&self, t: bitcoin::blockdata::locktime::relative::Time) -> core::result::Result<bool, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::clone(&self) -> bitcoin::blockdata::locktime::relative::Time
+pub fn bitcoin::blockdata::locktime::relative::Time::cmp(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::locktime::relative::Time::default() -> bitcoin::blockdata::locktime::relative::Time
+pub fn bitcoin::blockdata::locktime::relative::Time::eq(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> bool
+pub fn bitcoin::blockdata::locktime::relative::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin::blockdata::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::locktime::relative::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::locktime::relative::Time::partial_cmp(&self, other: &bitcoin::blockdata::locktime::relative::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::locktime::relative::Time::value(self) -> u16
+pub fn bitcoin::blockdata::opcodes::Class::clone(&self) -> bitcoin::blockdata::opcodes::Class
+pub fn bitcoin::blockdata::opcodes::Class::eq(&self, other: &bitcoin::blockdata::opcodes::Class) -> bool
+pub fn bitcoin::blockdata::opcodes::Class::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::clone(&self) -> bitcoin::blockdata::opcodes::ClassifyContext
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::cmp(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::eq(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> bool
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::opcodes::ClassifyContext::partial_cmp(&self, other: &bitcoin::blockdata::opcodes::ClassifyContext) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::opcodes::Opcode::classify(self, ctx: bitcoin::blockdata::opcodes::ClassifyContext) -> bitcoin::blockdata::opcodes::Class
+pub fn bitcoin::blockdata::opcodes::Opcode::clone(&self) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::opcodes::Opcode::eq(&self, other: &bitcoin::blockdata::opcodes::Opcode) -> bool
+pub fn bitcoin::blockdata::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::opcodes::Opcode::from(b: u8) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::opcodes::Opcode::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::script::Builder::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Builder::as_script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Builder::clone(&self) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::default() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::eq(&self, other: &bitcoin::blockdata::script::Builder) -> bool
+pub fn bitcoin::blockdata::script::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Builder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::script::Builder::from(v: alloc::vec::Vec<u8>) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::Builder::into_script(self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Builder::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::Builder::len(&self) -> usize
+pub fn bitcoin::blockdata::script::Builder::new() -> Self
+pub fn bitcoin::blockdata::script::Builder::push_int(self, data: i64) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_key(self, key: &bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_lock_time(self, lock_time: bitcoin::blockdata::locktime::absolute::LockTime) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_opcode(self, data: bitcoin::blockdata::opcodes::Opcode) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_sequence(self, sequence: bitcoin::blockdata::transaction::Sequence) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(self, data: T) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_verify(self) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: &secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Bytes<'_>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::nth_back(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::Bytes<'_>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::Error::clone(&self) -> bitcoin::blockdata::script::Error
+pub fn bitcoin::blockdata::script::Error::eq(&self, other: &bitcoin::blockdata::script::Error) -> bool
+pub fn bitcoin::blockdata::script::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Instruction<'a>::clone(&self) -> bitcoin::blockdata::script::Instruction<'a>
+pub fn bitcoin::blockdata::script::Instruction<'a>::eq(&self, other: &bitcoin::blockdata::script::Instruction<'a>) -> bool
+pub fn bitcoin::blockdata::script::Instruction<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Instruction<'a>::opcode(&self) -> core::option::Option<bitcoin::blockdata::opcodes::Opcode>
+pub fn bitcoin::blockdata::script::Instruction<'a>::push_bytes(&self) -> core::option::Option<&bitcoin::blockdata::script::PushBytes>
+pub fn bitcoin::blockdata::script::Instruction<'a>::script_num(&self) -> core::option::Option<i64>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::as_script(&self) -> &'a bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::clone(&self) -> bitcoin::blockdata::script::InstructionIndices<'a>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::script::InstructionIndices<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::Instructions<'a>::as_script(&self) -> &'a bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Instructions<'a>::clone(&self) -> bitcoin::blockdata::script::Instructions<'a>
+pub fn bitcoin::blockdata::script::Instructions<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Instructions<'a>::next(&mut self) -> core::option::Option<core::result::Result<bitcoin::blockdata::script::Instruction<'a>, bitcoin::blockdata::script::Error>>
+pub fn bitcoin::blockdata::script::Instructions<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::script::PushBytes::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytes::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::PushBytes::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytes::cmp(&self, other: &bitcoin::blockdata::script::PushBytes) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::PushBytes::empty() -> &'static Self
+pub fn bitcoin::blockdata::script::PushBytes::eq(&self, other: &bitcoin::blockdata::script::PushBytes) -> bool
+pub fn bitcoin::blockdata::script::PushBytes::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytes::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin::blockdata::script::PushBytes::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::PushBytes::len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytes::partial_cmp(&self, other: &bitcoin::blockdata::script::PushBytes) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::PushBytes::to_owned(&self) -> Self::Owned
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_mut_push_bytes(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_push_bytes(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::borrow(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::borrow_mut(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::PushBytesBuf::capacity(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesBuf::clear(&mut self)
+pub fn bitcoin::blockdata::script::PushBytesBuf::clone(&self) -> bitcoin::blockdata::script::PushBytesBuf
+pub fn bitcoin::blockdata::script::PushBytesBuf::cmp(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::PushBytesBuf::default() -> bitcoin::blockdata::script::PushBytesBuf
+pub fn bitcoin::blockdata::script::PushBytesBuf::deref(&self) -> &Self::Target
+pub fn bitcoin::blockdata::script::PushBytesBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::blockdata::script::PushBytesBuf::eq(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> bool
+pub fn bitcoin::blockdata::script::PushBytesBuf::extend_from_slice(&mut self, bytes: &[u8]) -> core::result::Result<(), bitcoin::blockdata::script::PushBytesError>
+pub fn bitcoin::blockdata::script::PushBytesBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 0]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 10]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 11]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 12]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 13]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 14]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 15]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 16]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 17]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 18]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 19]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 1]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 20]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 21]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 22]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 23]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 24]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 25]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 26]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 27]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 28]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 29]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 2]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 30]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 31]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 32]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 33]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 34]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 35]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 36]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 37]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 38]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 39]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 3]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 40]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 41]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 42]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 43]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 44]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 45]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 46]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 47]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 48]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 49]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 4]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 50]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 51]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 52]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 53]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 54]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 55]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 56]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 57]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 58]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 59]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 5]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 60]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 61]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 62]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 63]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 64]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 65]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 66]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 67]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 68]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 69]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 6]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 70]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 71]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 72]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 73]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 7]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 8]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: &'a [u8; 9]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 0]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 10]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 11]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 12]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 13]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 14]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 15]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 16]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 17]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 18]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 19]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 1]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 20]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 21]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 22]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 23]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 24]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 25]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 26]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 27]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 28]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 29]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 2]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 30]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 31]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 33]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 34]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 35]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 36]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 37]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 38]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 39]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 3]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 40]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 41]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 42]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 43]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 44]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 45]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 46]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 47]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 48]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 49]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 4]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 50]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 51]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 52]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 53]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 54]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 55]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 56]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 57]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 58]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 59]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 5]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 60]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 61]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 62]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 63]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 64]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 65]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 66]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 67]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 68]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 69]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 6]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 70]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 71]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 72]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 73]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 7]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 8]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(bytes: [u8; 9]) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::from(hash: bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::PushBytesBuf::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::PushBytesBuf::len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesBuf::new() -> Self
+pub fn bitcoin::blockdata::script::PushBytesBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::PushBytesBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::PushBytesBuf::pop(&mut self) -> core::option::Option<u8>
+pub fn bitcoin::blockdata::script::PushBytesBuf::push(&mut self, byte: u8) -> core::result::Result<(), bitcoin::blockdata::script::PushBytesError>
+pub fn bitcoin::blockdata::script::PushBytesBuf::remove(&mut self, index: usize) -> u8
+pub fn bitcoin::blockdata::script::PushBytesBuf::reserve(&mut self, additional_capacity: usize)
+pub fn bitcoin::blockdata::script::PushBytesBuf::truncate(&mut self, len: usize)
+pub fn bitcoin::blockdata::script::PushBytesBuf::try_from(vec: alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::PushBytesBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin::blockdata::script::PushBytesError::clone(&self) -> bitcoin::blockdata::script::PushBytesError
+pub fn bitcoin::blockdata::script::PushBytesError::eq(&self, other: &bitcoin::blockdata::script::PushBytesError) -> bool
+pub fn bitcoin::blockdata::script::PushBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::PushBytesError::input_len(&self) -> usize
+pub fn bitcoin::blockdata::script::PushBytesErrorReport::input_len(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::as_bytes(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Script::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::Script::as_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::Script::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::Script::as_ref(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::builder() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Script::bytes(&self) -> bitcoin::blockdata::script::Bytes<'_>
+pub fn bitcoin::blockdata::script::Script::cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::Script::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::script::Script::count_sigops(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::count_sigops_legacy(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::eq(&self, other: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::blockdata::script::Script::eq(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> bool
+pub fn bitcoin::blockdata::script::Script::first_opcode(&self) -> core::option::Option<bitcoin::blockdata::opcodes::Opcode>
+pub fn bitcoin::blockdata::script::Script::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Script::fmt_asm(&self, f: &mut dyn core::fmt::Write) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::Script::from_bytes(bytes: &[u8]) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::from_bytes_mut(bytes: &mut [u8]) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::Script::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin::blockdata::script::Script::instruction_indices(&self) -> bitcoin::blockdata::script::InstructionIndices<'_>
+pub fn bitcoin::blockdata::script::Script::instruction_indices_minimal(&self) -> bitcoin::blockdata::script::InstructionIndices<'_>
+pub fn bitcoin::blockdata::script::Script::instructions(&self) -> bitcoin::blockdata::script::Instructions<'_>
+pub fn bitcoin::blockdata::script::Script::instructions_minimal(&self) -> bitcoin::blockdata::script::Instructions<'_>
+pub fn bitcoin::blockdata::script::Script::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_multisig(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_op_return(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2pk(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2pkh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2sh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2tr(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2wpkh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_p2wsh(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_provably_unspendable(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_push_only(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::is_witness_program(&self) -> bool
+pub fn bitcoin::blockdata::script::Script::len(&self) -> usize
+pub fn bitcoin::blockdata::script::Script::minimal_non_dust(&self) -> bitcoin_units::amount::Amount
+pub fn bitcoin::blockdata::script::Script::minimal_non_dust_custom(&self, dust_relay_fee: bitcoin::blockdata::fee_rate::FeeRate) -> bitcoin_units::amount::Amount
+pub fn bitcoin::blockdata::script::Script::new() -> &'static bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::p2pk_public_key(&self) -> core::option::Option<bitcoin::PublicKey>
+pub fn bitcoin::blockdata::script::Script::p2wpkh_script_code(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptBuf>
+pub fn bitcoin::blockdata::script::Script::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::Script::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::Script::script_hash(&self) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::Script::tapscript_leaf_hash(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::blockdata::script::Script::to_asm_string(&self) -> alloc::string::String
+pub fn bitcoin::blockdata::script::Script::to_bytes(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::Script::to_hex_string(&self) -> alloc::string::String
+pub fn bitcoin::blockdata::script::Script::to_owned(&self) -> Self::Owned
+pub fn bitcoin::blockdata::script::Script::to_p2sh(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::to_p2tr<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::to_p2wsh(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::Script::witness_version(&self) -> core::option::Option<bitcoin::blockdata::script::witness_version::WitnessVersion>
+pub fn bitcoin::blockdata::script::Script::wscript_hash(&self) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_mut_script(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptBuf::as_ref(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::as_script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::borrow(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::borrow_mut(&mut self) -> &mut bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::ScriptBuf::builder() -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::ScriptBuf::clone(&self) -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::ScriptBuf::cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::ScriptBuf::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::script::ScriptBuf::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::script::ScriptBuf::default() -> bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::ScriptBuf::deref(&self) -> &Self::Target
+pub fn bitcoin::blockdata::script::ScriptBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::blockdata::script::ScriptBuf::eq(&self, other: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::blockdata::script::ScriptBuf::eq(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> bool
+pub fn bitcoin::blockdata::script::ScriptBuf::extend<T>(&mut self, iter: T) where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::script::Instruction<'a>>
+pub fn bitcoin::blockdata::script::ScriptBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::ScriptBuf::from(a: bitcoin::address::Address) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(v: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(value: &'a bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from(value: alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::parse::HexToBytesError>
+pub fn bitcoin::blockdata::script::ScriptBuf::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::script::Instruction<'a>>
+pub fn bitcoin::blockdata::script::ScriptBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: &bitcoin::PublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: &bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: &bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_witness_program(witness_program: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptBuf::push_instruction(&mut self, instruction: bitcoin::blockdata::script::Instruction<'_>)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_instruction_no_opt(&mut self, instruction: bitcoin::blockdata::script::Instruction<'_>)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_opcode(&mut self, data: bitcoin::blockdata::opcodes::Opcode)
+pub fn bitcoin::blockdata::script::ScriptBuf::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(&mut self, data: T)
+pub fn bitcoin::blockdata::script::ScriptBuf::reserve(&mut self, additional_len: usize)
+pub fn bitcoin::blockdata::script::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
+pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
+pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::ScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::ScriptHash::clone(&self) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::ScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::ScriptHash::eq(&self, other: &bitcoin::blockdata::script::ScriptHash) -> bool
+pub fn bitcoin::blockdata::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::script::ScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::WScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::script::WScriptHash::clone(&self) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::WScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::WScriptHash::eq(&self, other: &bitcoin::blockdata::script::WScriptHash) -> bool
+pub fn bitcoin::blockdata::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::script::WScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::WScriptHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::script::WScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::script::WScriptHash::to_raw_hash(self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin::blockdata::script::read_scriptbool(v: &[u8]) -> bool
+pub fn bitcoin::blockdata::script::read_scriptint(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::blockdata::script::read_scriptint_non_minimal(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::blockdata::script::witness_program::Error::clone(&self) -> bitcoin::blockdata::script::witness_program::Error
+pub fn bitcoin::blockdata::script::witness_program::Error::eq(&self, other: &bitcoin::blockdata::script::witness_program::Error) -> bool
+pub fn bitcoin::blockdata::script::witness_program::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::clone(&self) -> bitcoin::blockdata::script::witness_program::WitnessProgram
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::eq(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2tr(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wpkh(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wsh(&self) -> bool
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::new(version: bitcoin::blockdata::script::witness_version::WitnessVersion, bytes: &[u8]) -> core::result::Result<Self, bitcoin::blockdata::script::witness_program::Error>
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wsh(script: &bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::program(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::version(&self) -> bitcoin::blockdata::script::witness_version::WitnessVersion
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::clone(&self) -> bitcoin::blockdata::script::witness_version::FromStrError
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::eq(&self, other: &bitcoin::blockdata::script::witness_version::FromStrError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::FromStrError::from(e: bitcoin::error::ParseIntError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::clone(&self) -> bitcoin::blockdata::script::witness_version::TryFromError
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::eq(&self, other: &bitcoin::blockdata::script::witness_version::TryFromError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::clone(&self) -> bitcoin::blockdata::script::witness_version::TryFromInstructionError
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::eq(&self, other: &bitcoin::blockdata::script::witness_version::TryFromInstructionError) -> bool
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::from(e: bitcoin::blockdata::script::witness_version::TryFromError) -> Self
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::clone(&self) -> bitcoin::blockdata::script::witness_version::WitnessVersion
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::eq(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> bool
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_fe(self) -> bech32::primitives::gf32::Fe32
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_num(self) -> u8
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(instruction: bitcoin::blockdata::script::Instruction<'_>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(opcode: bitcoin::blockdata::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(value: bech32::primitives::gf32::Fe32) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::clone(&self) -> bitcoin::blockdata::transaction::IndexOutOfBoundsError
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::eq(&self, other: &bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> bool
+pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::clone(&self) -> bitcoin::blockdata::transaction::InputWeightPrediction
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::InputWeightPrediction::new<T>(input_script_len: usize, witness_element_lengths: T) -> Self where T: core::iter::traits::collect::IntoIterator, <T as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<usize>
+pub fn bitcoin::blockdata::transaction::InputsIndexError::clone(&self) -> bitcoin::blockdata::transaction::InputsIndexError
+pub fn bitcoin::blockdata::transaction::InputsIndexError::eq(&self, other: &bitcoin::blockdata::transaction::InputsIndexError) -> bool
+pub fn bitcoin::blockdata::transaction::InputsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::InputsIndexError::from(e: bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::blockdata::transaction::OutPoint::clone(&self) -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::cmp(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::OutPoint::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::OutPoint::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::OutPoint::default() -> Self
+pub fn bitcoin::blockdata::transaction::OutPoint::eq(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> bool
+pub fn bitcoin::blockdata::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::OutPoint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::OutPoint::is_null(&self) -> bool
+pub fn bitcoin::blockdata::transaction::OutPoint::new(txid: bitcoin::blockdata::transaction::Txid, vout: u32) -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::null() -> bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::partial_cmp(&self, other: &bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::clone(&self) -> bitcoin::blockdata::transaction::OutputsIndexError
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::eq(&self, other: &bitcoin::blockdata::transaction::OutputsIndexError) -> bool
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::OutputsIndexError::from(e: bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::clone(&self) -> bitcoin::blockdata::transaction::ParseOutPointError
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::eq(&self, other: &bitcoin::blockdata::transaction::ParseOutPointError) -> bool
+pub fn bitcoin::blockdata::transaction::ParseOutPointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Sequence::clone(&self) -> bitcoin::blockdata::transaction::Sequence
+pub fn bitcoin::blockdata::transaction::Sequence::cmp(&self, other: &bitcoin::blockdata::transaction::Sequence) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Sequence::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::default() -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::enables_absolute_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::eq(&self, other: &bitcoin::blockdata::transaction::Sequence) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Sequence::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_consensus(n: u32) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_height(height: u16) -> Self
+pub fn bitcoin::blockdata::transaction::Sequence::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin::blockdata::locktime::relative::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::transaction::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Sequence::is_final(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_height_locked(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_rbf(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_relative_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::is_time_locked(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Sequence::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Sequence) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Sequence::to_consensus_u32(self) -> u32
+pub fn bitcoin::blockdata::transaction::Sequence::to_relative_lock_time(&self) -> core::option::Option<bitcoin::blockdata::locktime::relative::LockTime>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::base_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::clone(&self) -> bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::blockdata::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Transaction::compute_txid(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Transaction::compute_wtxid(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Transaction::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Transaction::eq(&self, other: &bitcoin::blockdata::transaction::Transaction) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Transaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Transaction::is_absolute_timelock_satisfied(&self, height: bitcoin::blockdata::locktime::absolute::Height, time: bitcoin::blockdata::locktime::absolute::Time) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_coinbase(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_explicitly_rbf(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::is_lock_time_enabled(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Transaction::ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Transaction::script_pubkey_lens(&self) -> impl core::iter::traits::iterator::Iterator<Item = usize> + '_
+pub fn bitcoin::blockdata::transaction::Transaction::total_sigop_cost<S>(&self, spent: S) -> usize where S: core::ops::function::FnMut(&bitcoin::blockdata::transaction::OutPoint) -> core::option::Option<bitcoin::blockdata::transaction::TxOut>
+pub fn bitcoin::blockdata::transaction::Transaction::total_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::tx_in(&self, input_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxIn, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::blockdata::transaction::Transaction::tx_out(&self, output_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::blockdata::transaction::OutputsIndexError>
+pub fn bitcoin::blockdata::transaction::Transaction::txid(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Transaction::vsize(&self) -> usize
+pub fn bitcoin::blockdata::transaction::Transaction::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::Transaction::wtxid(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::TxIn::base_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxIn::clone(&self) -> bitcoin::blockdata::transaction::TxIn
+pub fn bitcoin::blockdata::transaction::TxIn::cmp(&self, other: &bitcoin::blockdata::transaction::TxIn) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::TxIn::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxIn::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::TxIn::default() -> bitcoin::blockdata::transaction::TxIn
+pub fn bitcoin::blockdata::transaction::TxIn::enables_lock_time(&self) -> bool
+pub fn bitcoin::blockdata::transaction::TxIn::eq(&self, other: &bitcoin::blockdata::transaction::TxIn) -> bool
+pub fn bitcoin::blockdata::transaction::TxIn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::TxIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::TxIn::legacy_weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::TxIn::partial_cmp(&self, other: &bitcoin::blockdata::transaction::TxIn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::TxIn::segwit_weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::TxIn::total_size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxOut::clone(&self) -> bitcoin::blockdata::transaction::TxOut
+pub fn bitcoin::blockdata::transaction::TxOut::cmp(&self, other: &bitcoin::blockdata::transaction::TxOut) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::transaction::TxOut, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::transaction::TxOut, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::TxOut::eq(&self, other: &bitcoin::blockdata::transaction::TxOut) -> bool
+pub fn bitcoin::blockdata::transaction::TxOut::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::TxOut::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::TxOut::minimal_non_dust(script_pubkey: bitcoin::blockdata::script::ScriptBuf) -> Self
+pub fn bitcoin::blockdata::transaction::TxOut::minimal_non_dust_custom(script_pubkey: bitcoin::blockdata::script::ScriptBuf, dust_relay_fee: bitcoin::blockdata::fee_rate::FeeRate) -> Self
+pub fn bitcoin::blockdata::transaction::TxOut::partial_cmp(&self, other: &bitcoin::blockdata::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
+pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Txid::clone(&self) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Txid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Txid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Txid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Txid::eq(&self, other: &bitcoin::blockdata::transaction::Txid) -> bool
+pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::transaction::Txid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Txid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Txid::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::transaction::Txid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::transaction::Txid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Version::clone(&self) -> bitcoin::blockdata::transaction::Version
+pub fn bitcoin::blockdata::transaction::Version::cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Version::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Version::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Version::eq(&self, other: &bitcoin::blockdata::transaction::Version) -> bool
+pub fn bitcoin::blockdata::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Version::is_standard(&self) -> bool
+pub fn bitcoin::blockdata::transaction::Version::non_standard(version: i32) -> bitcoin::blockdata::transaction::Version
+pub fn bitcoin::blockdata::transaction::Version::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::blockdata::transaction::Wtxid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin::blockdata::transaction::Wtxid::clone(&self) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::transaction::Wtxid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Wtxid::eq(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> bool
+pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::blockdata::transaction::Wtxid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Wtxid::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::blockdata::transaction::Wtxid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::blockdata::transaction::Wtxid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::blockdata::transaction::effective_value(fee_rate: bitcoin::blockdata::fee_rate::FeeRate, satisfaction_weight: bitcoin::blockdata::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin::blockdata::transaction::predict_weight<I, O>(inputs: I, output_script_lens: O) -> bitcoin::blockdata::weight::Weight where I: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::transaction::InputWeightPrediction>, O: core::iter::traits::collect::IntoIterator<Item = usize>
+pub fn bitcoin::blockdata::weight::Weight::add(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::add_assign(&mut self, rhs: Self)
+pub fn bitcoin::blockdata::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::clone(&self) -> bitcoin::blockdata::weight::Weight
+pub fn bitcoin::blockdata::weight::Weight::cmp(&self, other: &bitcoin::blockdata::weight::Weight) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::weight::Weight::div(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin::blockdata::weight::Weight::eq(&self, other: &bitcoin::blockdata::weight::Weight) -> bool
+pub fn bitcoin::blockdata::weight::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::blockdata::weight::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::blockdata::weight::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::weight::Weight::mul(self, rhs: bitcoin::blockdata::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin::blockdata::weight::Weight::partial_cmp(&self, other: &bitcoin::blockdata::weight::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::weight::Weight::scale_by_witness_factor(self) -> core::option::Option<Self>
+pub fn bitcoin::blockdata::weight::Weight::sub(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bitcoin::blockdata::weight::Weight::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin::blockdata::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin::blockdata::weight::Weight>
+pub fn bitcoin::blockdata::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::weight::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::blockdata::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::blockdata::witness::Iter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::blockdata::witness::Witness::clear(&mut self)
+pub fn bitcoin::blockdata::witness::Witness::clone(&self) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::cmp::Ordering
+pub fn bitcoin::blockdata::witness::Witness::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::blockdata::witness::Witness::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::blockdata::witness::Witness::default() -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::eq(&self, other: &bitcoin::blockdata::witness::Witness) -> bool
+pub fn bitcoin::blockdata::witness::Witness::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::blockdata::witness::Witness::from(slice: &[&[u8]]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(slice: &[alloc::vec::Vec<u8>]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(vec: alloc::vec::Vec<&[u8]>) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from(vec: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
+pub fn bitcoin::blockdata::witness::Witness::from_slice<T: core::convert::AsRef<[u8]>>(slice: &[T]) -> Self
+pub fn bitcoin::blockdata::witness::Witness::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::witness::Witness::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin::blockdata::witness::Witness::is_empty(&self) -> bool
+pub fn bitcoin::blockdata::witness::Witness::iter(&self) -> bitcoin::blockdata::witness::Iter<'_>
+pub fn bitcoin::blockdata::witness::Witness::last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::len(&self) -> usize
+pub fn bitcoin::blockdata::witness::Witness::new() -> Self
+pub fn bitcoin::blockdata::witness::Witness::nth(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::p2tr_key_spend(signature: &bitcoin::taproot::Signature) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: &secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::partial_cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
+pub fn bitcoin::blockdata::witness::Witness::push_ecdsa_signature(&mut self, signature: &bitcoin::ecdsa::Signature)
+pub fn bitcoin::blockdata::witness::Witness::second_to_last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin::blockdata::witness::Witness::size(&self) -> usize
+pub fn bitcoin::blockdata::witness::Witness::tapscript(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
+pub fn bitcoin::consensus::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::Encodable::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::ReadExt::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::ReadExt::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::WriteExt::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::WriteExt::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::deserialize<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<T, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::deserialize_partial<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<(T, usize), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::CheckedData::checksum(&self) -> [u8; 4]
+pub fn bitcoin::consensus::encode::CheckedData::clone(&self) -> bitcoin::consensus::encode::CheckedData
+pub fn bitcoin::consensus::encode::CheckedData::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::CheckedData::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::CheckedData::data(&self) -> &[u8]
+pub fn bitcoin::consensus::encode::CheckedData::eq(&self, other: &bitcoin::consensus::encode::CheckedData) -> bool
+pub fn bitcoin::consensus::encode::CheckedData::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::CheckedData::into_data(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::consensus::encode::CheckedData::new(data: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin::consensus::encode::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::Encodable::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::Error::from(error: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::consensus::encode::ReadExt::read_bool(&mut self) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i16(&mut self) -> core::result::Result<i16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i32(&mut self) -> core::result::Result<i32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i64(&mut self) -> core::result::Result<i64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_i8(&mut self) -> core::result::Result<i8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_slice(&mut self, slice: &mut [u8]) -> core::result::Result<(), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u16(&mut self) -> core::result::Result<u16, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u32(&mut self) -> core::result::Result<u32, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u64(&mut self) -> core::result::Result<u64, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::ReadExt::read_u8(&mut self) -> core::result::Result<u8, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::VarInt::clone(&self) -> bitcoin::consensus::encode::VarInt
+pub fn bitcoin::consensus::encode::VarInt::cmp(&self, other: &bitcoin::consensus::encode::VarInt) -> core::cmp::Ordering
+pub fn bitcoin::consensus::encode::VarInt::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::VarInt::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::VarInt::eq(&self, other: &bitcoin::consensus::encode::VarInt) -> bool
+pub fn bitcoin::consensus::encode::VarInt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::encode::VarInt::from(x: u16) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u32) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u64) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: u8) -> Self
+pub fn bitcoin::consensus::encode::VarInt::from(x: usize) -> Self
+pub fn bitcoin::consensus::encode::VarInt::partial_cmp(&self, other: &bitcoin::consensus::encode::VarInt) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::consensus::encode::WriteExt::emit_bool(&mut self, v: bool) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i16(&mut self, v: i16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i32(&mut self, v: i32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i64(&mut self, v: i64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_i8(&mut self, v: i8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_slice(&mut self, v: &[u8]) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u16(&mut self, v: u16) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u32(&mut self, v: u32) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u64(&mut self, v: u64) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::WriteExt::emit_u8(&mut self, v: u8) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::consensus::encode::deserialize<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<T, bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::deserialize_partial<T: bitcoin::consensus::encode::Decodable>(data: &[u8]) -> core::result::Result<(T, usize), bitcoin::consensus::encode::Error>
+pub fn bitcoin::consensus::encode::serialize<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::vec::Vec<u8>
+pub fn bitcoin::consensus::encode::serialize_hex<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::string::String
+pub fn bitcoin::consensus::params::Params::clone(&self) -> bitcoin::consensus::params::Params
+pub fn bitcoin::consensus::params::Params::difficulty_adjustment_interval(&self) -> u64
+pub fn bitcoin::consensus::params::Params::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::consensus::params::Params::from(value: &bitcoin::network::Network) -> Self
+pub fn bitcoin::consensus::params::Params::from(value: bitcoin::network::Network) -> Self
+pub fn bitcoin::consensus::serialize<T: bitcoin::consensus::encode::Encodable + core::marker::Sized>(data: &T) -> alloc::vec::Vec<u8>
+pub fn bitcoin::constants::genesis_block(network: bitcoin::network::Network) -> bitcoin::blockdata::block::Block
+pub fn bitcoin::ecdsa::Error::clone(&self) -> bitcoin::ecdsa::Error
+pub fn bitcoin::ecdsa::Error::eq(&self, other: &bitcoin::ecdsa::Error) -> bool
+pub fn bitcoin::ecdsa::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::Error::from(e: secp256k1::Error) -> bitcoin::ecdsa::Error
+pub fn bitcoin::ecdsa::Error::from(err: bitcoin::sighash::NonStandardSighashTypeError) -> Self
+pub fn bitcoin::ecdsa::Error::from(err: hex_conservative::parse::HexToBytesError) -> Self
+pub fn bitcoin::ecdsa::SerializedSignature::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::ecdsa::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn bitcoin::ecdsa::SerializedSignature::as_ref(&self) -> &bitcoin::blockdata::script::PushBytes
+pub fn bitcoin::ecdsa::SerializedSignature::borrow(&self) -> &[u8]
+pub fn bitcoin::ecdsa::SerializedSignature::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::ecdsa::SerializedSignature::clone(&self) -> bitcoin::ecdsa::SerializedSignature
+pub fn bitcoin::ecdsa::SerializedSignature::deref(&self) -> &Self::Target
+pub fn bitcoin::ecdsa::SerializedSignature::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::ecdsa::SerializedSignature::eq(&self, other: &bitcoin::ecdsa::SerializedSignature) -> bool
+pub fn bitcoin::ecdsa::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::ecdsa::SerializedSignature::iter(&self) -> core::slice::iter::Iter<'_, u8>
+pub fn bitcoin::ecdsa::SerializedSignature::write_to<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::ecdsa::Signature::clone(&self) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::eq(&self, other: &bitcoin::ecdsa::Signature) -> bool
+pub fn bitcoin::ecdsa::Signature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::ecdsa::Signature::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin::ecdsa::Error>
+pub fn bitcoin::ecdsa::Signature::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::ecdsa::Signature::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::ecdsa::Signature::serialize(&self) -> bitcoin::ecdsa::SerializedSignature
+pub fn bitcoin::ecdsa::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::ecdsa::Signature::sighash_all(signature: secp256k1::ecdsa::Signature) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::to_vec(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::error::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin::error::ParseIntError::clone(&self) -> bitcoin::error::ParseIntError
+pub fn bitcoin::error::ParseIntError::eq(&self, other: &bitcoin::error::ParseIntError) -> bool
+pub fn bitcoin::error::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::error::ParseIntError::input(&self) -> &str
+pub fn bitcoin::key::Error::clone(&self) -> bitcoin::key::Error
+pub fn bitcoin::key::Error::eq(&self, other: &bitcoin::key::Error) -> bool
+pub fn bitcoin::key::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::Error::from(e: bitcoin::base58::Error) -> bitcoin::key::Error
+pub fn bitcoin::key::Error::from(e: hex_conservative::parse::HexToArrayError) -> Self
+pub fn bitcoin::key::Error::from(e: secp256k1::Error) -> bitcoin::key::Error
+pub fn bitcoin::key::SortKey::clone(&self) -> bitcoin::key::SortKey
+pub fn bitcoin::key::SortKey::cmp(&self, other: &bitcoin::key::SortKey) -> core::cmp::Ordering
+pub fn bitcoin::key::SortKey::eq(&self, other: &bitcoin::key::SortKey) -> bool
+pub fn bitcoin::key::SortKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::SortKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::SortKey::partial_cmp(&self, other: &bitcoin::key::SortKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TapTweak::dangerous_assume_tweaked(self) -> Self::TweakedKey
+pub fn bitcoin::key::TapTweak::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self::TweakedAux
+pub fn bitcoin::key::TweakedKeypair::clone(&self) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::TweakedKeypair::cmp(&self, other: &bitcoin::key::TweakedKeypair) -> core::cmp::Ordering
+pub fn bitcoin::key::TweakedKeypair::dangerous_assume_tweaked(pair: secp256k1::key::Keypair) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::TweakedKeypair::eq(&self, other: &bitcoin::key::TweakedKeypair) -> bool
+pub fn bitcoin::key::TweakedKeypair::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::TweakedKeypair::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::TweakedKeypair::partial_cmp(&self, other: &bitcoin::key::TweakedKeypair) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TweakedKeypair::public_parts(&self) -> (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub fn bitcoin::key::TweakedKeypair::to_inner(self) -> secp256k1::key::Keypair
+pub fn bitcoin::key::TweakedPublicKey::clone(&self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::TweakedPublicKey::cmp(&self, other: &bitcoin::key::TweakedPublicKey) -> core::cmp::Ordering
+pub fn bitcoin::key::TweakedPublicKey::dangerous_assume_tweaked(key: secp256k1::key::XOnlyPublicKey) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::TweakedPublicKey::eq(&self, other: &bitcoin::key::TweakedPublicKey) -> bool
+pub fn bitcoin::key::TweakedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::TweakedPublicKey::from(pair: bitcoin::key::TweakedKeypair) -> Self
+pub fn bitcoin::key::TweakedPublicKey::from_keypair(keypair: bitcoin::key::TweakedKeypair) -> Self
+pub fn bitcoin::key::TweakedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::key::TweakedPublicKey::partial_cmp(&self, other: &bitcoin::key::TweakedPublicKey) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::key::TweakedPublicKey::serialize(&self) -> [u8; 32]
+pub fn bitcoin::key::TweakedPublicKey::to_inner(self) -> secp256k1::key::XOnlyPublicKey
+pub fn bitcoin::key::UncompressedPubkeyError::clone(&self) -> bitcoin::key::UncompressedPubkeyError
+pub fn bitcoin::key::UncompressedPubkeyError::eq(&self, other: &bitcoin::key::UncompressedPubkeyError) -> bool
+pub fn bitcoin::key::UncompressedPubkeyError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::key::UntweakedKeypair::dangerous_assume_tweaked(self) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::UntweakedKeypair::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::UntweakedPublicKey::dangerous_assume_tweaked(self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::UntweakedPublicKey::tap_tweak<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub fn bitcoin::merkle_tree::MerkleBlockError::clone(&self) -> bitcoin::merkle_tree::MerkleBlockError
+pub fn bitcoin::merkle_tree::MerkleBlockError::eq(&self, other: &bitcoin::merkle_tree::MerkleBlockError) -> bool
+pub fn bitcoin::merkle_tree::MerkleBlockError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::merkle_tree::PartialMerkleTree::bits(&self) -> &alloc::vec::Vec<bool>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::clone(&self) -> bitcoin::merkle_tree::PartialMerkleTree
+pub fn bitcoin::merkle_tree::PartialMerkleTree::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::eq(&self, other: &bitcoin::merkle_tree::PartialMerkleTree) -> bool
+pub fn bitcoin::merkle_tree::PartialMerkleTree::extract_matches(&self, matches: &mut alloc::vec::Vec<bitcoin::blockdata::transaction::Txid>, indexes: &mut alloc::vec::Vec<u32>) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin::merkle_tree::MerkleBlockError>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::merkle_tree::PartialMerkleTree::from_txids(txids: &[bitcoin::blockdata::transaction::Txid], matches: &[bool]) -> Self
+pub fn bitcoin::merkle_tree::PartialMerkleTree::hashes(&self) -> &alloc::vec::Vec<bitcoin::blockdata::block::TxMerkleNode>
+pub fn bitcoin::merkle_tree::PartialMerkleTree::num_transactions(&self) -> u32
+pub fn bitcoin::merkle_tree::calculate_root<T, I>(hashes: I) -> core::option::Option<T> where T: bitcoin_hashes::Hash + bitcoin::consensus::encode::Encodable, <T as bitcoin_hashes::Hash>::Engine: bitcoin_io::Write, I: core::iter::traits::iterator::Iterator<Item = T>
+pub fn bitcoin::merkle_tree::calculate_root_inline<T>(hashes: &mut [T]) -> core::option::Option<T> where T: bitcoin_hashes::Hash + bitcoin::consensus::encode::Encodable, <T as bitcoin_hashes::Hash>::Engine: bitcoin_io::Write
+pub fn bitcoin::network::Network::chain_hash(self) -> bitcoin::blockdata::constants::ChainHash
+pub fn bitcoin::network::Network::clone(&self) -> bitcoin::network::Network
+pub fn bitcoin::network::Network::cmp(&self, other: &bitcoin::network::Network) -> core::cmp::Ordering
+pub fn bitcoin::network::Network::eq(&self, other: &bitcoin::network::Network) -> bool
+pub fn bitcoin::network::Network::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::Network::from_chain_hash(chain_hash: bitcoin::blockdata::constants::ChainHash) -> core::option::Option<bitcoin::network::Network>
+pub fn bitcoin::network::Network::from_core_arg(core_arg: &str) -> core::result::Result<Self, bitcoin::network::ParseNetworkError>
+pub fn bitcoin::network::Network::from_magic(magic: bitcoin::p2p::Magic) -> core::option::Option<bitcoin::network::Network>
+pub fn bitcoin::network::Network::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::network::Network::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::network::Network::magic(self) -> bitcoin::p2p::Magic
+pub fn bitcoin::network::Network::partial_cmp(&self, other: &bitcoin::network::Network) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::network::Network::to_core_arg(self) -> &'static str
+pub fn bitcoin::network::Network::try_from(chain_hash: bitcoin::blockdata::constants::ChainHash) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::network::Network::try_from(magic: bitcoin::p2p::Magic) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::network::NetworkKind::clone(&self) -> bitcoin::network::NetworkKind
+pub fn bitcoin::network::NetworkKind::cmp(&self, other: &bitcoin::network::NetworkKind) -> core::cmp::Ordering
+pub fn bitcoin::network::NetworkKind::eq(&self, other: &bitcoin::network::NetworkKind) -> bool
+pub fn bitcoin::network::NetworkKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::NetworkKind::from(n: bitcoin::network::Network) -> Self
+pub fn bitcoin::network::NetworkKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::network::NetworkKind::is_mainnet(&self) -> bool
+pub fn bitcoin::network::NetworkKind::partial_cmp(&self, other: &bitcoin::network::NetworkKind) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::network::ParseNetworkError::clone(&self) -> bitcoin::network::ParseNetworkError
+pub fn bitcoin::network::ParseNetworkError::eq(&self, other: &bitcoin::network::ParseNetworkError) -> bool
+pub fn bitcoin::network::ParseNetworkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::network::ParseNetworkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::network::UnknownChainHashError::clone(&self) -> bitcoin::network::UnknownChainHashError
+pub fn bitcoin::network::UnknownChainHashError::eq(&self, other: &bitcoin::network::UnknownChainHashError) -> bool
+pub fn bitcoin::network::UnknownChainHashError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::Magic::as_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::p2p::Magic::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::p2p::Magic::as_ref(&self) -> &[u8; 4]
+pub fn bitcoin::p2p::Magic::as_ref(&self) -> &[u8]
+pub fn bitcoin::p2p::Magic::borrow(&self) -> &[u8; 4]
+pub fn bitcoin::p2p::Magic::borrow(&self) -> &[u8]
+pub fn bitcoin::p2p::Magic::borrow_mut(&mut self) -> &mut [u8; 4]
+pub fn bitcoin::p2p::Magic::borrow_mut(&mut self) -> &mut [u8]
+pub fn bitcoin::p2p::Magic::clone(&self) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::cmp(&self, other: &bitcoin::p2p::Magic) -> core::cmp::Ordering
+pub fn bitcoin::p2p::Magic::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::Magic::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::Magic::eq(&self, other: &bitcoin::p2p::Magic) -> bool
+pub fn bitcoin::p2p::Magic::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::p2p::Magic::from(network: bitcoin::network::Network) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::from_bytes(bytes: [u8; 4]) -> bitcoin::p2p::Magic
+pub fn bitcoin::p2p::Magic::from_str(s: &str) -> core::result::Result<bitcoin::p2p::Magic, Self::Err>
+pub fn bitcoin::p2p::Magic::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::Magic::partial_cmp(&self, other: &bitcoin::p2p::Magic) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::Magic::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::p2p::ParseMagicError::clone(&self) -> bitcoin::p2p::ParseMagicError
+pub fn bitcoin::p2p::ParseMagicError::eq(&self, other: &bitcoin::p2p::ParseMagicError) -> bool
+pub fn bitcoin::p2p::ParseMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::ParseMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::p2p::ServiceFlags::add(&mut self, other: bitcoin::p2p::ServiceFlags) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::bitor(self, rhs: Self) -> Self
+pub fn bitcoin::p2p::ServiceFlags::bitor_assign(&mut self, rhs: Self)
+pub fn bitcoin::p2p::ServiceFlags::bitxor(self, rhs: Self) -> Self
+pub fn bitcoin::p2p::ServiceFlags::bitxor_assign(&mut self, rhs: Self)
+pub fn bitcoin::p2p::ServiceFlags::clone(&self) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::cmp(&self, other: &bitcoin::p2p::ServiceFlags) -> core::cmp::Ordering
+pub fn bitcoin::p2p::ServiceFlags::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::p2p::ServiceFlags::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::p2p::ServiceFlags::default() -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::eq(&self, other: &bitcoin::p2p::ServiceFlags) -> bool
+pub fn bitcoin::p2p::ServiceFlags::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::ServiceFlags::from(f: u64) -> Self
+pub fn bitcoin::p2p::ServiceFlags::has(self, flags: bitcoin::p2p::ServiceFlags) -> bool
+pub fn bitcoin::p2p::ServiceFlags::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::p2p::ServiceFlags::partial_cmp(&self, other: &bitcoin::p2p::ServiceFlags) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::p2p::ServiceFlags::remove(&mut self, other: bitcoin::p2p::ServiceFlags) -> bitcoin::p2p::ServiceFlags
+pub fn bitcoin::p2p::ServiceFlags::to_u64(self) -> u64
+pub fn bitcoin::p2p::UnknownMagicError::clone(&self) -> bitcoin::p2p::UnknownMagicError
+pub fn bitcoin::p2p::UnknownMagicError::eq(&self, other: &bitcoin::p2p::UnknownMagicError) -> bool
+pub fn bitcoin::p2p::UnknownMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::UnknownMagicError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin::policy::get_virtual_tx_size(weight: i64, n_sigops: i64) -> i64
+pub fn bitcoin::pow::CompactTarget::clone(&self) -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTarget::cmp(&self, other: &bitcoin::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin::pow::CompactTarget::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::pow::CompactTarget::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::pow::CompactTarget::default() -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTarget::eq(&self, other: &bitcoin::pow::CompactTarget) -> bool
+pub fn bitcoin::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin::pow::CompactTarget::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::CompactTarget::partial_cmp(&self, other: &bitcoin::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin::pow::Target::clone(&self) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::cmp(&self, other: &bitcoin::pow::Target) -> core::cmp::Ordering
+pub fn bitcoin::pow::Target::difficulty(&self, network: bitcoin::network::Network) -> u128
+pub fn bitcoin::pow::Target::difficulty_float(&self) -> f64
+pub fn bitcoin::pow::Target::eq(&self, other: &bitcoin::pow::Target) -> bool
+pub fn bitcoin::pow::Target::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::Target::from(c: bitcoin::pow::CompactTarget) -> Self
+pub fn bitcoin::pow::Target::from_be_bytes(bytes: [u8; 32]) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::from_compact(c: bitcoin::pow::CompactTarget) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::from_le_bytes(bytes: [u8; 32]) -> bitcoin::pow::Target
+pub fn bitcoin::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::Target::is_met_by(&self, hash: bitcoin::blockdata::block::BlockHash) -> bool
+pub fn bitcoin::pow::Target::max_difficulty_transition_threshold(&self) -> Self
+pub fn bitcoin::pow::Target::min_difficulty_transition_threshold(&self) -> Self
+pub fn bitcoin::pow::Target::partial_cmp(&self, other: &bitcoin::pow::Target) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::Target::to_be_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Target::to_compact_lossy(self) -> bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::Target::to_le_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Target::to_work(self) -> bitcoin::pow::Work
+pub fn bitcoin::pow::TryFromError::clone(&self) -> bitcoin::pow::TryFromError
+pub fn bitcoin::pow::TryFromError::eq(&self, other: &bitcoin::pow::TryFromError) -> bool
+pub fn bitcoin::pow::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::Work::add(self, rhs: Self) -> Self
+pub fn bitcoin::pow::Work::clone(&self) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::cmp(&self, other: &bitcoin::pow::Work) -> core::cmp::Ordering
+pub fn bitcoin::pow::Work::eq(&self, other: &bitcoin::pow::Work) -> bool
+pub fn bitcoin::pow::Work::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::pow::Work::from_be_bytes(bytes: [u8; 32]) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::from_le_bytes(bytes: [u8; 32]) -> bitcoin::pow::Work
+pub fn bitcoin::pow::Work::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::pow::Work::partial_cmp(&self, other: &bitcoin::pow::Work) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::pow::Work::sub(self, rhs: Self) -> Self
+pub fn bitcoin::pow::Work::to_be_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Work::to_le_bytes(self) -> [u8; 32]
+pub fn bitcoin::pow::Work::to_target(self) -> bitcoin::pow::Target
+pub fn bitcoin::psbt::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Error::from(e: bitcoin::consensus::encode::Error) -> Self
+pub fn bitcoin::psbt::Error::from(e: bitcoin_hashes::FromSliceError) -> bitcoin::psbt::Error
+pub fn bitcoin::psbt::Error::from(e: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::psbt::ExtractTxError::clone(&self) -> bitcoin::psbt::ExtractTxError
+pub fn bitcoin::psbt::ExtractTxError::eq(&self, other: &bitcoin::psbt::ExtractTxError) -> bool
+pub fn bitcoin::psbt::ExtractTxError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::GetKey::get_key<C: secp256k1::context::Signing>(&self, key_request: bitcoin::psbt::KeyRequest, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<core::option::Option<bitcoin::PrivateKey>, Self::Error>
+pub fn bitcoin::psbt::GetKeyError::clone(&self) -> bitcoin::psbt::GetKeyError
+pub fn bitcoin::psbt::GetKeyError::eq(&self, other: &bitcoin::psbt::GetKeyError) -> bool
+pub fn bitcoin::psbt::GetKeyError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::GetKeyError::from(e: bitcoin::bip32::Error) -> Self
+pub fn bitcoin::psbt::IndexOutOfBoundsError::clone(&self) -> bitcoin::psbt::IndexOutOfBoundsError
+pub fn bitcoin::psbt::IndexOutOfBoundsError::eq(&self, other: &bitcoin::psbt::IndexOutOfBoundsError) -> bool
+pub fn bitcoin::psbt::IndexOutOfBoundsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Input::clone(&self) -> bitcoin::psbt::Input
+pub fn bitcoin::psbt::Input::combine(&mut self, other: Self)
+pub fn bitcoin::psbt::Input::default() -> bitcoin::psbt::Input
+pub fn bitcoin::psbt::Input::ecdsa_hash_ty(&self) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::psbt::Input::eq(&self, other: &bitcoin::psbt::Input) -> bool
+pub fn bitcoin::psbt::Input::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Input::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::Input::taproot_hash_ty(&self) -> core::result::Result<bitcoin::TapSighashType, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::psbt::KeyRequest::clone(&self) -> bitcoin::psbt::KeyRequest
+pub fn bitcoin::psbt::KeyRequest::eq(&self, other: &bitcoin::psbt::KeyRequest) -> bool
+pub fn bitcoin::psbt::KeyRequest::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Output::clone(&self) -> bitcoin::psbt::Output
+pub fn bitcoin::psbt::Output::combine(&mut self, other: Self)
+pub fn bitcoin::psbt::Output::default() -> bitcoin::psbt::Output
+pub fn bitcoin::psbt::Output::eq(&self, other: &bitcoin::psbt::Output) -> bool
+pub fn bitcoin::psbt::Output::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Output::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::OutputType::clone(&self) -> bitcoin::psbt::OutputType
+pub fn bitcoin::psbt::OutputType::cmp(&self, other: &bitcoin::psbt::OutputType) -> core::cmp::Ordering
+pub fn bitcoin::psbt::OutputType::eq(&self, other: &bitcoin::psbt::OutputType) -> bool
+pub fn bitcoin::psbt::OutputType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::OutputType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::OutputType::partial_cmp(&self, other: &bitcoin::psbt::OutputType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::OutputType::signing_algorithm(&self) -> bitcoin::psbt::SigningAlgorithm
+pub fn bitcoin::psbt::Psbt::clone(&self) -> bitcoin::psbt::Psbt
+pub fn bitcoin::psbt::Psbt::combine(&mut self, other: Self) -> core::result::Result<(), bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::deserialize(bytes: &[u8]) -> core::result::Result<Self, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::eq(&self, other: &bitcoin::psbt::Psbt) -> bool
+pub fn bitcoin::psbt::Psbt::extract_tx(self) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::extract_tx_fee_rate_limit(self) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::extract_tx_unchecked_fee_rate(self) -> bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::psbt::Psbt::extract_tx_with_fee_rate_limit(self, max_fee_rate: bitcoin::blockdata::fee_rate::FeeRate) -> core::result::Result<bitcoin::blockdata::transaction::Transaction, bitcoin::psbt::ExtractTxError>
+pub fn bitcoin::psbt::Psbt::fee(&self) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::Psbt::from_unsigned_tx(tx: bitcoin::blockdata::transaction::Transaction) -> core::result::Result<Self, bitcoin::psbt::Error>
+pub fn bitcoin::psbt::Psbt::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::Psbt::iter_funding_utxos(&self) -> impl core::iter::traits::iterator::Iterator<Item = core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::psbt::Error>>
+pub fn bitcoin::psbt::Psbt::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::psbt::Psbt::serialize_hex(&self) -> alloc::string::String
+pub fn bitcoin::psbt::Psbt::sighash_ecdsa<T: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>>(&self, input_index: usize, cache: &mut bitcoin::sighash::SighashCache<T>) -> core::result::Result<(secp256k1::Message, bitcoin::EcdsaSighashType), bitcoin::psbt::SignError>
+pub fn bitcoin::psbt::Psbt::sign<C, K>(&mut self, k: &K, secp: &secp256k1::Secp256k1<C>) -> core::result::Result<bitcoin::psbt::SigningKeys, (bitcoin::psbt::SigningKeys, bitcoin::psbt::SigningErrors)> where C: secp256k1::context::Signing, K: bitcoin::psbt::GetKey
+pub fn bitcoin::psbt::Psbt::spend_utxo(&self, input_index: usize) -> core::result::Result<&bitcoin::blockdata::transaction::TxOut, bitcoin::psbt::SignError>
+pub fn bitcoin::psbt::PsbtSighashType::clone(&self) -> bitcoin::psbt::PsbtSighashType
+pub fn bitcoin::psbt::PsbtSighashType::cmp(&self, other: &bitcoin::psbt::PsbtSighashType) -> core::cmp::Ordering
+pub fn bitcoin::psbt::PsbtSighashType::ecdsa_hash_ty(self) -> core::result::Result<bitcoin::EcdsaSighashType, bitcoin::sighash::NonStandardSighashTypeError>
+pub fn bitcoin::psbt::PsbtSighashType::eq(&self, other: &bitcoin::psbt::PsbtSighashType) -> bool
+pub fn bitcoin::psbt::PsbtSighashType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::PsbtSighashType::from(ecdsa_hash_ty: bitcoin::EcdsaSighashType) -> Self
+pub fn bitcoin::psbt::PsbtSighashType::from(taproot_hash_ty: bitcoin::TapSighashType) -> Self
+pub fn bitcoin::psbt::PsbtSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin::psbt::PsbtSighashType::from_u32(n: u32) -> bitcoin::psbt::PsbtSighashType
+pub fn bitcoin::psbt::PsbtSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::PsbtSighashType::partial_cmp(&self, other: &bitcoin::psbt::PsbtSighashType) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::PsbtSighashType::taproot_hash_ty(self) -> core::result::Result<bitcoin::TapSighashType, bitcoin::sighash::InvalidSighashTypeError>
+pub fn bitcoin::psbt::PsbtSighashType::to_u32(self) -> u32
+pub fn bitcoin::psbt::SignError::clone(&self) -> bitcoin::psbt::SignError
+pub fn bitcoin::psbt::SignError::eq(&self, other: &bitcoin::psbt::SignError) -> bool
+pub fn bitcoin::psbt::SignError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::SignError::from(e: bitcoin::psbt::IndexOutOfBoundsError) -> Self
+pub fn bitcoin::psbt::SignError::from(e: bitcoin::sighash::P2wpkhError) -> Self
+pub fn bitcoin::psbt::SigningAlgorithm::clone(&self) -> bitcoin::psbt::SigningAlgorithm
+pub fn bitcoin::psbt::SigningAlgorithm::cmp(&self, other: &bitcoin::psbt::SigningAlgorithm) -> core::cmp::Ordering
+pub fn bitcoin::psbt::SigningAlgorithm::eq(&self, other: &bitcoin::psbt::SigningAlgorithm) -> bool
+pub fn bitcoin::psbt::SigningAlgorithm::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::SigningAlgorithm::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::SigningAlgorithm::partial_cmp(&self, other: &bitcoin::psbt::SigningAlgorithm) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::Key::clone(&self) -> bitcoin::psbt::raw::Key
+pub fn bitcoin::psbt::raw::Key::cmp(&self, other: &bitcoin::psbt::raw::Key) -> core::cmp::Ordering
+pub fn bitcoin::psbt::raw::Key::eq(&self, other: &bitcoin::psbt::raw::Key) -> bool
+pub fn bitcoin::psbt::raw::Key::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::Key::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::raw::Key::partial_cmp(&self, other: &bitcoin::psbt::raw::Key) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::Pair::eq(&self, other: &bitcoin::psbt::raw::Pair) -> bool
+pub fn bitcoin::psbt::raw::Pair::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::clone(&self) -> bitcoin::psbt::raw::ProprietaryKey<Subtype>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::cmp(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> core::cmp::Ordering
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::eq(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> bool
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::partial_cmp(&self, other: &bitcoin::psbt::raw::ProprietaryKey<Subtype>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::to_key(&self) -> bitcoin::psbt::raw::Key
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::try_from(key: bitcoin::psbt::raw::Key) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::script::PushBytesErrorReport::input_len(&self) -> usize
+pub fn bitcoin::script::read_scriptbool(v: &[u8]) -> bool
+pub fn bitcoin::script::read_scriptint(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::script::read_scriptint_non_minimal(v: &[u8]) -> core::result::Result<i64, bitcoin::blockdata::script::Error>
+pub fn bitcoin::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
+pub fn bitcoin::sighash::Annex<'a>::as_bytes(&self) -> &[u8]
+pub fn bitcoin::sighash::Annex<'a>::clone(&self) -> bitcoin::sighash::Annex<'a>
+pub fn bitcoin::sighash::Annex<'a>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::sighash::Annex<'a>::eq(&self, other: &bitcoin::sighash::Annex<'a>) -> bool
+pub fn bitcoin::sighash::Annex<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::Annex<'a>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::Annex<'a>::new(annex_bytes: &'a [u8]) -> core::result::Result<Self, bitcoin::sighash::AnnexError>
+pub fn bitcoin::sighash::AnnexError::clone(&self) -> bitcoin::sighash::AnnexError
+pub fn bitcoin::sighash::AnnexError::eq(&self, other: &bitcoin::sighash::AnnexError) -> bool
+pub fn bitcoin::sighash::AnnexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::EncodeSigningDataResult<E>::is_sighash_single_bug(self) -> core::result::Result<bool, E>
+pub fn bitcoin::sighash::EncodeSigningDataResult<E>::map_err<E2, F>(self, f: F) -> bitcoin::sighash::EncodeSigningDataResult<E2> where F: core::ops::function::FnOnce(E) -> E2
+pub fn bitcoin::sighash::InvalidSighashTypeError::clone(&self) -> bitcoin::sighash::InvalidSighashTypeError
+pub fn bitcoin::sighash::InvalidSighashTypeError::eq(&self, other: &bitcoin::sighash::InvalidSighashTypeError) -> bool
+pub fn bitcoin::sighash::InvalidSighashTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::NonStandardSighashTypeError::clone(&self) -> bitcoin::sighash::NonStandardSighashTypeError
+pub fn bitcoin::sighash::NonStandardSighashTypeError::eq(&self, other: &bitcoin::sighash::NonStandardSighashTypeError) -> bool
+pub fn bitcoin::sighash::NonStandardSighashTypeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::P2wpkhError::clone(&self) -> bitcoin::sighash::P2wpkhError
+pub fn bitcoin::sighash::P2wpkhError::eq(&self, other: &bitcoin::sighash::P2wpkhError) -> bool
+pub fn bitcoin::sighash::P2wpkhError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::P2wpkhError::from(value: bitcoin::blockdata::transaction::InputsIndexError) -> Self
+pub fn bitcoin::sighash::Prevouts<'u, T>::clone(&self) -> bitcoin::sighash::Prevouts<'u, T>
+pub fn bitcoin::sighash::Prevouts<'u, T>::cmp(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> core::cmp::Ordering
+pub fn bitcoin::sighash::Prevouts<'u, T>::eq(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> bool
+pub fn bitcoin::sighash::Prevouts<'u, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::Prevouts<'u, T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::Prevouts<'u, T>::partial_cmp(&self, other: &bitcoin::sighash::Prevouts<'u, T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::sighash::PrevoutsIndexError::clone(&self) -> bitcoin::sighash::PrevoutsIndexError
+pub fn bitcoin::sighash::PrevoutsIndexError::eq(&self, other: &bitcoin::sighash::PrevoutsIndexError) -> bool
+pub fn bitcoin::sighash::PrevoutsIndexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::PrevoutsKindError::clone(&self) -> bitcoin::sighash::PrevoutsKindError
+pub fn bitcoin::sighash::PrevoutsKindError::eq(&self, other: &bitcoin::sighash::PrevoutsKindError) -> bool
+pub fn bitcoin::sighash::PrevoutsKindError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::PrevoutsSizeError::clone(&self) -> bitcoin::sighash::PrevoutsSizeError
+pub fn bitcoin::sighash::PrevoutsSizeError::eq(&self, other: &bitcoin::sighash::PrevoutsSizeError) -> bool
+pub fn bitcoin::sighash::PrevoutsSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::ScriptPath<'s>::clone(&self) -> bitcoin::sighash::ScriptPath<'s>
+pub fn bitcoin::sighash::ScriptPath<'s>::cmp(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> core::cmp::Ordering
+pub fn bitcoin::sighash::ScriptPath<'s>::eq(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> bool
+pub fn bitcoin::sighash::ScriptPath<'s>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::ScriptPath<'s>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::sighash::ScriptPath<'s>::leaf_hash(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::sighash::ScriptPath<'s>::new(script: &'s bitcoin::blockdata::script::Script, leaf_version: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::sighash::ScriptPath<'s>::partial_cmp(&self, other: &bitcoin::sighash::ScriptPath<'s>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::sighash::ScriptPath<'s>::with_defaults(script: &'s bitcoin::blockdata::script::Script) -> Self
+pub fn bitcoin::sighash::SighashCache<R>::into_transaction(self) -> R
+pub fn bitcoin::sighash::SighashCache<R>::legacy_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized, U: core::convert::Into<u32>>(&self, writer: &mut W, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, sighash_type: U) -> bitcoin::sighash::EncodeSigningDataResult<bitcoin::sighash::SigningDataError<bitcoin::blockdata::transaction::InputsIndexError>>
+pub fn bitcoin::sighash::SighashCache<R>::legacy_signature_hash(&self, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, sighash_type: u32) -> core::result::Result<bitcoin::LegacySighash, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::sighash::SighashCache<R>::new(tx: R) -> Self
+pub fn bitcoin::sighash::SighashCache<R>::p2wpkh_signature_hash(&mut self, input_index: usize, script_pubkey: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin::sighash::P2wpkhError>
+pub fn bitcoin::sighash::SighashCache<R>::p2wsh_signature_hash(&mut self, input_index: usize, witness_script: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin::blockdata::transaction::InputsIndexError>
+pub fn bitcoin::sighash::SighashCache<R>::segwit_v0_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized>(&mut self, writer: &mut W, input_index: usize, script_code: &bitcoin::blockdata::script::Script, value: bitcoin_units::amount::Amount, sighash_type: bitcoin::EcdsaSighashType) -> core::result::Result<(), bitcoin::sighash::SigningDataError<bitcoin::blockdata::transaction::InputsIndexError>>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_encode_signing_data_to<W: bitcoin_io::Write + core::marker::Sized, T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, writer: &mut W, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, annex: core::option::Option<bitcoin::sighash::Annex<'_>>, leaf_hash_code_separator: core::option::Option<(bitcoin::taproot::TapLeafHash, u32)>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<(), bitcoin::sighash::SigningDataError<bitcoin::sighash::TaprootError>>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_key_spend_signature_hash<T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_script_spend_signature_hash<S: core::convert::Into<bitcoin::taproot::TapLeafHash>, T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, leaf_hash: S, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::taproot_signature_hash<T: core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>>(&mut self, input_index: usize, prevouts: &bitcoin::sighash::Prevouts<'_, T>, annex: core::option::Option<bitcoin::sighash::Annex<'_>>, leaf_hash_code_separator: core::option::Option<(bitcoin::taproot::TapLeafHash, u32)>, sighash_type: bitcoin::TapSighashType) -> core::result::Result<bitcoin::TapSighash, bitcoin::sighash::TaprootError>
+pub fn bitcoin::sighash::SighashCache<R>::transaction(&self) -> &bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::sighash::SighashCache<R>::witness_mut(&mut self, input_index: usize) -> core::option::Option<&mut bitcoin::blockdata::witness::Witness>
+pub fn bitcoin::sighash::SighashCache<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SighashTypeParseError::clone(&self) -> bitcoin::sighash::SighashTypeParseError
+pub fn bitcoin::sighash::SighashTypeParseError::eq(&self, other: &bitcoin::sighash::SighashTypeParseError) -> bool
+pub fn bitcoin::sighash::SighashTypeParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SigningDataError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::SigningDataError<E>::from(value: bitcoin_io::error::Error) -> Self
+pub fn bitcoin::sighash::SingleMissingOutputError::clone(&self) -> bitcoin::sighash::SingleMissingOutputError
+pub fn bitcoin::sighash::SingleMissingOutputError::eq(&self, other: &bitcoin::sighash::SingleMissingOutputError) -> bool
+pub fn bitcoin::sighash::SingleMissingOutputError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::TaprootError::clone(&self) -> bitcoin::sighash::TaprootError
+pub fn bitcoin::sighash::TaprootError::eq(&self, other: &bitcoin::sighash::TaprootError) -> bool
+pub fn bitcoin::sighash::TaprootError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::blockdata::transaction::InputsIndexError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsIndexError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsKindError) -> Self
+pub fn bitcoin::sighash::TaprootError::from(e: bitcoin::sighash::PrevoutsSizeError) -> Self
+pub fn bitcoin::sign_message::signed_msg_hash(msg: &str) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin::string::FromHexError<E>::clone(&self) -> bitcoin::string::FromHexError<E>
+pub fn bitcoin::string::FromHexError<E>::eq(&self, other: &bitcoin::string::FromHexError<E>) -> bool
+pub fn bitcoin::string::FromHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::string::FromHexError<E>::from(e: E) -> Self
+pub fn bitcoin::string::FromHexStr::from_hex_str<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, bitcoin::string::FromHexError<Self::Error>>
+pub fn bitcoin::string::FromHexStr::from_hex_str_no_prefix<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::ControlBlock::clone(&self) -> bitcoin::taproot::ControlBlock
+pub fn bitcoin::taproot::ControlBlock::cmp(&self, other: &bitcoin::taproot::ControlBlock) -> core::cmp::Ordering
+pub fn bitcoin::taproot::ControlBlock::decode(sl: &[u8]) -> core::result::Result<bitcoin::taproot::ControlBlock, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::ControlBlock::encode<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> bitcoin_io::Result<usize>
+pub fn bitcoin::taproot::ControlBlock::eq(&self, other: &bitcoin::taproot::ControlBlock) -> bool
+pub fn bitcoin::taproot::ControlBlock::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::ControlBlock::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::ControlBlock::partial_cmp(&self, other: &bitcoin::taproot::ControlBlock) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::ControlBlock::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::ControlBlock::size(&self) -> usize
+pub fn bitcoin::taproot::ControlBlock::verify_taproot_commitment<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, output_key: secp256k1::key::XOnlyPublicKey, script: &bitcoin::blockdata::script::Script) -> bool
+pub fn bitcoin::taproot::FutureLeafVersion::clone(&self) -> bitcoin::taproot::FutureLeafVersion
+pub fn bitcoin::taproot::FutureLeafVersion::cmp(&self, other: &bitcoin::taproot::FutureLeafVersion) -> core::cmp::Ordering
+pub fn bitcoin::taproot::FutureLeafVersion::eq(&self, other: &bitcoin::taproot::FutureLeafVersion) -> bool
+pub fn bitcoin::taproot::FutureLeafVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::FutureLeafVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::FutureLeafVersion::partial_cmp(&self, other: &bitcoin::taproot::FutureLeafVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::FutureLeafVersion::to_consensus(self) -> u8
+pub fn bitcoin::taproot::HiddenNodesError::clone(&self) -> bitcoin::taproot::HiddenNodesError
+pub fn bitcoin::taproot::HiddenNodesError::eq(&self, other: &bitcoin::taproot::HiddenNodesError) -> bool
+pub fn bitcoin::taproot::HiddenNodesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::HiddenNodesError::into_node_info(self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::IncompleteBuilderError::clone(&self) -> bitcoin::taproot::IncompleteBuilderError
+pub fn bitcoin::taproot::IncompleteBuilderError::eq(&self, other: &bitcoin::taproot::IncompleteBuilderError) -> bool
+pub fn bitcoin::taproot::IncompleteBuilderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::IncompleteBuilderError::into_builder(self) -> bitcoin::taproot::TaprootBuilder
+pub fn bitcoin::taproot::LeafNode::clone(&self) -> bitcoin::taproot::LeafNode
+pub fn bitcoin::taproot::LeafNode::cmp(&self, other: &bitcoin::taproot::LeafNode) -> core::cmp::Ordering
+pub fn bitcoin::taproot::LeafNode::depth(&self) -> u8
+pub fn bitcoin::taproot::LeafNode::eq(&self, other: &bitcoin::taproot::LeafNode) -> bool
+pub fn bitcoin::taproot::LeafNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::LeafNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::LeafNode::leaf(&self) -> &bitcoin::taproot::TapLeaf
+pub fn bitcoin::taproot::LeafNode::leaf_hash(&self) -> core::option::Option<bitcoin::taproot::TapLeafHash>
+pub fn bitcoin::taproot::LeafNode::leaf_version(&self) -> core::option::Option<bitcoin::taproot::LeafVersion>
+pub fn bitcoin::taproot::LeafNode::merkle_branch(&self) -> &bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::LeafNode::new_hidden(hash: bitcoin::taproot::TapNodeHash) -> Self
+pub fn bitcoin::taproot::LeafNode::new_script(script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::taproot::LeafNode::node_hash(&self) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::LeafNode::partial_cmp(&self, other: &bitcoin::taproot::LeafNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::LeafNode::script(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::taproot::LeafNodes<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::LeafNodes<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::LeafNodes<'tree>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::LeafVersion::clone(&self) -> bitcoin::taproot::LeafVersion
+pub fn bitcoin::taproot::LeafVersion::cmp(&self, other: &bitcoin::taproot::LeafVersion) -> core::cmp::Ordering
+pub fn bitcoin::taproot::LeafVersion::eq(&self, other: &bitcoin::taproot::LeafVersion) -> bool
+pub fn bitcoin::taproot::LeafVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::LeafVersion::from_consensus(version: u8) -> core::result::Result<Self, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::LeafVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::LeafVersion::partial_cmp(&self, other: &bitcoin::taproot::LeafVersion) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::LeafVersion::to_consensus(self) -> u8
+pub fn bitcoin::taproot::NodeInfo::clone(&self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::NodeInfo::cmp(&self, other: &bitcoin::taproot::NodeInfo) -> core::cmp::Ordering
+pub fn bitcoin::taproot::NodeInfo::combine(a: Self, b: Self) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::NodeInfo::eq(&self, other: &Self) -> bool
+pub fn bitcoin::taproot::NodeInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::NodeInfo::from(tree: bitcoin::taproot::TapTree) -> Self
+pub fn bitcoin::taproot::NodeInfo::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::taproot::NodeInfo::leaf_nodes(&self) -> bitcoin::taproot::LeafNodes<'_>
+pub fn bitcoin::taproot::NodeInfo::new_hidden_node(hash: bitcoin::taproot::TapNodeHash) -> Self
+pub fn bitcoin::taproot::NodeInfo::new_leaf_with_ver(script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> Self
+pub fn bitcoin::taproot::NodeInfo::partial_cmp(&self, other: &bitcoin::taproot::NodeInfo) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::NodeInfo::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::clone(&self) -> bitcoin::taproot::ScriptLeaf<'leaf>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::cmp(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> core::cmp::Ordering
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::eq(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> bool
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::from_leaf_node(leaf_node: &'leaf bitcoin::taproot::LeafNode) -> core::option::Option<Self>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::merkle_branch(&self) -> &bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::partial_cmp(&self, other: &bitcoin::taproot::ScriptLeaf<'leaf>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::script(&self) -> &bitcoin::blockdata::script::Script
+pub fn bitcoin::taproot::ScriptLeaf<'leaf>::version(&self) -> bitcoin::taproot::LeafVersion
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::ScriptLeaves<'tree>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::SigFromSliceError::clone(&self) -> bitcoin::taproot::SigFromSliceError
+pub fn bitcoin::taproot::SigFromSliceError::eq(&self, other: &bitcoin::taproot::SigFromSliceError) -> bool
+pub fn bitcoin::taproot::SigFromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::SigFromSliceError::from(e: secp256k1::Error) -> Self
+pub fn bitcoin::taproot::SigFromSliceError::from(err: bitcoin::sighash::InvalidSighashTypeError) -> Self
+pub fn bitcoin::taproot::Signature::clone(&self) -> bitcoin::taproot::Signature
+pub fn bitcoin::taproot::Signature::cmp(&self, other: &bitcoin::taproot::Signature) -> core::cmp::Ordering
+pub fn bitcoin::taproot::Signature::eq(&self, other: &bitcoin::taproot::Signature) -> bool
+pub fn bitcoin::taproot::Signature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::Signature::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin::taproot::SigFromSliceError>
+pub fn bitcoin::taproot::Signature::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::Signature::partial_cmp(&self, other: &bitcoin::taproot::Signature) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::Signature::serialize(self) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::taproot::Signature::to_vec(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::Signature::try_from(value: &'a bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::Signature::try_from(value: bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapBranchTag::clone(&self) -> bitcoin::taproot::TapBranchTag
+pub fn bitcoin::taproot::TapBranchTag::cmp(&self, other: &bitcoin::taproot::TapBranchTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapBranchTag::default() -> bitcoin::taproot::TapBranchTag
+pub fn bitcoin::taproot::TapBranchTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapBranchTag::eq(&self, other: &bitcoin::taproot::TapBranchTag) -> bool
+pub fn bitcoin::taproot::TapBranchTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapBranchTag::partial_cmp(&self, other: &bitcoin::taproot::TapBranchTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeaf::as_hidden(&self) -> core::option::Option<&bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::TapLeaf::as_script(&self) -> core::option::Option<(&bitcoin::blockdata::script::Script, bitcoin::taproot::LeafVersion)>
+pub fn bitcoin::taproot::TapLeaf::clone(&self) -> bitcoin::taproot::TapLeaf
+pub fn bitcoin::taproot::TapLeaf::cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeaf::eq(&self, other: &bitcoin::taproot::TapLeaf) -> bool
+pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapLeafHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapLeafHash::clone(&self) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeafHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin::taproot::TapLeafHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin::taproot::TapLeafHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLeafHash) -> bool
+pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapLeafHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapLeafHash, Self::Err>
+pub fn bitcoin::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapLeafHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin::taproot::TapLeafTag::clone(&self) -> bitcoin::taproot::TapLeafTag
+pub fn bitcoin::taproot::TapLeafTag::cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapLeafTag::default() -> bitcoin::taproot::TapLeafTag
+pub fn bitcoin::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeafTag) -> bool
+pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapNodeHash::assume_hidden(hash: [u8; 32]) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapNodeHash::clone(&self) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapNodeHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapNodeHash::eq(&self, other: &bitcoin::taproot::TapNodeHash) -> bool
+pub fn bitcoin::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapNodeHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapNodeHash, Self::Err>
+pub fn bitcoin::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapNodeHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapNodeHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin::taproot::TapTree::clone(&self) -> bitcoin::taproot::TapTree
+pub fn bitcoin::taproot::TapTree::eq(&self, other: &bitcoin::taproot::TapTree) -> bool
+pub fn bitcoin::taproot::TapTree::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapTree::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTree::into_node_info(self) -> bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::TapTree::node_info(&self) -> &bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::TapTree::script_leaves(&self) -> bitcoin::taproot::ScriptLeaves<'_>
+pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::TapTweakHash::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::TapTweakHash::clone(&self) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapTweakHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapTweakHash::eq(&self, other: &bitcoin::taproot::TapTweakHash) -> bool
+pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapTweakHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapTweakHash, Self::Err>
+pub fn bitcoin::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakHash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin::taproot::TapTweakHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin::taproot::TapTweakHash::to_scalar(self) -> secp256k1::scalar::Scalar
+pub fn bitcoin::taproot::TapTweakTag::clone(&self) -> bitcoin::taproot::TapTweakTag
+pub fn bitcoin::taproot::TapTweakTag::cmp(&self, other: &bitcoin::taproot::TapTweakTag) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TapTweakTag::default() -> bitcoin::taproot::TapTweakTag
+pub fn bitcoin::taproot::TapTweakTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin::taproot::TapTweakTag::eq(&self, other: &bitcoin::taproot::TapTweakTag) -> bool
+pub fn bitcoin::taproot::TapTweakTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakTag::partial_cmp(&self, other: &bitcoin::taproot::TapTweakTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootBuilder::add_hidden_node(self, depth: u8, hash: bitcoin::taproot::TapNodeHash) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::add_leaf(self, depth: u8, script: bitcoin::blockdata::script::ScriptBuf) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::add_leaf_with_ver(self, depth: u8, script: bitcoin::blockdata::script::ScriptBuf, ver: bitcoin::taproot::LeafVersion) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::clone(&self) -> bitcoin::taproot::TaprootBuilder
+pub fn bitcoin::taproot::TaprootBuilder::cmp(&self, other: &bitcoin::taproot::TaprootBuilder) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TaprootBuilder::default() -> Self
+pub fn bitcoin::taproot::TaprootBuilder::eq(&self, other: &bitcoin::taproot::TaprootBuilder) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::finalize<C: secp256k1::context::Verification>(self, secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey) -> core::result::Result<bitcoin::taproot::TaprootSpendInfo, bitcoin::taproot::TaprootBuilder>
+pub fn bitcoin::taproot::TaprootBuilder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootBuilder::has_hidden_nodes(&self) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TaprootBuilder::is_finalizable(&self) -> bool
+pub fn bitcoin::taproot::TaprootBuilder::new() -> Self
+pub fn bitcoin::taproot::TaprootBuilder::partial_cmp(&self, other: &bitcoin::taproot::TaprootBuilder) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootBuilder::try_into_node_info(self) -> core::result::Result<bitcoin::taproot::NodeInfo, bitcoin::taproot::IncompleteBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::try_into_taptree(self) -> core::result::Result<bitcoin::taproot::TapTree, bitcoin::taproot::IncompleteBuilderError>
+pub fn bitcoin::taproot::TaprootBuilder::with_capacity(size: usize) -> Self
+pub fn bitcoin::taproot::TaprootBuilder::with_huffman_tree<I>(script_weights: I) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, bitcoin::blockdata::script::ScriptBuf)>
+pub fn bitcoin::taproot::TaprootBuilderError::clone(&self) -> bitcoin::taproot::TaprootBuilderError
+pub fn bitcoin::taproot::TaprootBuilderError::eq(&self, other: &bitcoin::taproot::TaprootBuilderError) -> bool
+pub fn bitcoin::taproot::TaprootBuilderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootError::clone(&self) -> bitcoin::taproot::TaprootError
+pub fn bitcoin::taproot::TaprootError::eq(&self, other: &bitcoin::taproot::TaprootError) -> bool
+pub fn bitcoin::taproot::TaprootError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootSpendInfo::clone(&self) -> bitcoin::taproot::TaprootSpendInfo
+pub fn bitcoin::taproot::TaprootSpendInfo::cmp(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> core::cmp::Ordering
+pub fn bitcoin::taproot::TaprootSpendInfo::control_block(&self, script_ver: &(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)) -> core::option::Option<bitcoin::taproot::ControlBlock>
+pub fn bitcoin::taproot::TaprootSpendInfo::eq(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> bool
+pub fn bitcoin::taproot::TaprootSpendInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::TaprootSpendInfo::from_node_info<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, node: bitcoin::taproot::NodeInfo) -> bitcoin::taproot::TaprootSpendInfo
+pub fn bitcoin::taproot::TaprootSpendInfo::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TaprootSpendInfo::internal_key(&self) -> bitcoin::key::UntweakedPublicKey
+pub fn bitcoin::taproot::TaprootSpendInfo::merkle_root(&self) -> core::option::Option<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::TaprootSpendInfo::new_key_spend<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
+pub fn bitcoin::taproot::TaprootSpendInfo::output_key(&self) -> bitcoin::key::TweakedPublicKey
+pub fn bitcoin::taproot::TaprootSpendInfo::output_key_parity(&self) -> secp256k1::key::Parity
+pub fn bitcoin::taproot::TaprootSpendInfo::partial_cmp(&self, other: &bitcoin::taproot::TaprootSpendInfo) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TaprootSpendInfo::script_map(&self) -> &alloc::collections::btree::map::BTreeMap<(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion), alloc::collections::btree::set::BTreeSet<bitcoin::taproot::merkle_branch::TaprootMerkleBranch>>
+pub fn bitcoin::taproot::TaprootSpendInfo::tap_tweak(&self) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TaprootSpendInfo::with_huffman_tree<C, I>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, script_weights: I) -> core::result::Result<Self, bitcoin::taproot::TaprootBuilderError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, bitcoin::blockdata::script::ScriptBuf)>, C: secp256k1::context::Verification
+pub fn bitcoin::taproot::merkle_branch::IntoIter::as_mut_slice(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::IntoIter::as_slice(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::IntoIter::clone(&self) -> bitcoin::taproot::merkle_branch::IntoIter
+pub fn bitcoin::taproot::merkle_branch::IntoIter::count(self) -> usize
+pub fn bitcoin::taproot::merkle_branch::IntoIter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::merkle_branch::IntoIter::last(self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::nth_back(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::merkle_branch::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_inner(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_mut(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_ref(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::as_slice(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::borrow(&self) -> &[bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::borrow_mut(&mut self) -> &mut [bitcoin::taproot::TapNodeHash]
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::clone(&self) -> bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::cmp(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> core::cmp::Ordering
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::decode(sl: &[u8]) -> core::result::Result<Self, bitcoin::taproot::TaprootError>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::default() -> bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deref(&self) -> &Self::Target
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::encode<Write: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut Write) -> bitcoin_io::Result<usize>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::eq(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> bool
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 0]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 100]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 101]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 102]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 103]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 104]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 105]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 106]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 107]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 108]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 109]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 10]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 110]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 111]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 112]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 113]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 114]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 115]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 116]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 117]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 118]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 119]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 11]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 120]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 121]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 122]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 123]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 124]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 125]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 126]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 127]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 128]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 12]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 13]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 14]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 15]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 16]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 17]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 18]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 19]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 1]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 20]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 21]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 22]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 23]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 24]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 25]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 26]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 27]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 28]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 29]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 2]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 30]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 31]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 32]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 33]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 34]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 35]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 36]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 37]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 38]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 39]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 3]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 40]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 41]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 42]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 43]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 44]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 45]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 46]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 47]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 48]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 49]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 4]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 50]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 51]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 52]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 53]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 54]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 55]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 56]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 57]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 58]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 59]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 5]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 60]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 61]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 62]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 63]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 64]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 65]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 66]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 67]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 68]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 69]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 6]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 70]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 71]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 72]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 73]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 74]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 75]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 76]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 77]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 78]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 79]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 7]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 80]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 81]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 82]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 83]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 84]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 85]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 86]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 87]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 88]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 89]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 8]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 90]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 91]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 92]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 93]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 94]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 95]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 96]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 97]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 98]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 99]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(a: [bitcoin::taproot::TapNodeHash; 9]) -> Self
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_inner(self) -> alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_vec(self) -> alloc::vec::Vec<bitcoin::taproot::TapNodeHash>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::is_empty(&self) -> bool
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::len(&self) -> usize
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::partial_cmp(&self, other: &bitcoin::taproot::merkle_branch::TaprootMerkleBranch) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::serialize(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: &[bitcoin::taproot::TapNodeHash]) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: alloc::boxed::Box<[bitcoin::taproot::TapNodeHash]>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::try_from(v: alloc::vec::Vec<bitcoin::taproot::TapNodeHash>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::as_slice(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::IntoIter::clone(&self) -> bitcoin::taproot::serialized_signature::IntoIter
+pub fn bitcoin::taproot::serialized_signature::IntoIter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::serialized_signature::IntoIter::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::next_back(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+pub fn bitcoin::taproot::serialized_signature::IntoIter::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::as_ref(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::borrow(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::clone(&self) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::cmp::Ordering
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::deref(&self) -> &[u8]
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::eq(&self, other: &[u8]) -> bool
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::eq(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> bool
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from(value: &'a bitcoin::taproot::Signature) -> Self
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from(value: bitcoin::taproot::Signature) -> Self
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from_signature(sig: &bitcoin::taproot::Signature) -> bitcoin::taproot::serialized_signature::SerializedSignature
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::into_iter(self) -> Self::IntoIter
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::len(&self) -> usize
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::partial_cmp(&self, other: &[u8]) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::partial_cmp(&self, other: &bitcoin::taproot::serialized_signature::SerializedSignature) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::to_signature(&self) -> core::result::Result<bitcoin::taproot::Signature, bitcoin::taproot::SigFromSliceError>
+pub fn bitcoin::taproot::serialized_signature::SerializedSignature::write_to<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::transaction::effective_value(fee_rate: bitcoin::blockdata::fee_rate::FeeRate, satisfaction_weight: bitcoin::blockdata::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin::transaction::predict_weight<I, O>(inputs: I, output_script_lens: O) -> bitcoin::blockdata::weight::Weight where I: core::iter::traits::collect::IntoIterator<Item = bitcoin::blockdata::transaction::InputWeightPrediction>, O: core::iter::traits::collect::IntoIterator<Item = usize>
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::PubkeyHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::WPubkeyHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::bip32::XKeyIdentifier) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin::blockdata::script::ScriptHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::sha256::Hash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_hashes::sha256::Hash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256::Hash::from(hashtype: bitcoin::blockdata::script::WScriptHash) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256d::Hash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_hashes::sha256d::Hash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::LegacySighash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::SegwitV0Sighash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::bip158::FilterHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::bip158::FilterHeader) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::BlockHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::TxMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::WitnessCommitment) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::block::WitnessMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::transaction::Txid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin::blockdata::transaction::Wtxid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>::from(hashtype: bitcoin::TapSighash) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>::from(hashtype: bitcoin::taproot::TapNodeHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>::from(hashtype: bitcoin::taproot::TapLeafHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>::from(hashtype: bitcoin::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
+pub fn bitcoin_units::amount::Amount::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::amount::Amount::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::amount::Amount::div(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn bool::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
+pub fn bool::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn core::convert::Infallible::input_len(&self) -> usize
+pub fn core::num::error::ParseIntError::from(value: bitcoin::error::ParseIntError) -> Self
+pub fn i16::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i16::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i32::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i32::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i64::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i64::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn i8::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn i8::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn secp256k1::key::Keypair::from(pair: bitcoin::key::TweakedKeypair) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pair: bitcoin::key::TweakedPublicKey) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pk: bitcoin::CompressedPublicKey) -> Self
+pub fn secp256k1::key::XOnlyPublicKey::from(pk: bitcoin::PublicKey) -> secp256k1::key::XOnlyPublicKey
+pub fn u16::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u16::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u32::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u32::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u32::from(cnum: bitcoin::bip32::ChildNumber) -> Self
+pub fn u32::from(sequence: bitcoin::blockdata::transaction::Sequence) -> u32
+pub fn u64::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u64::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn u64::from(flags: bitcoin::p2p::ServiceFlags) -> Self
+pub fn u64::from(value: bitcoin::blockdata::fee_rate::FeeRate) -> Self
+pub fn u64::from(value: bitcoin::blockdata::weight::Weight) -> Self
+pub fn u64::mul(self, rhs: bitcoin::blockdata::weight::Weight) -> Self::Output
+pub fn u8::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn u8::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub mod bitcoin
+pub mod bitcoin::absolute
+pub mod bitcoin::address
+pub mod bitcoin::address::error
+pub mod bitcoin::amount
+pub mod bitcoin::base58
+pub mod bitcoin::bip152
+pub mod bitcoin::bip158
+pub mod bitcoin::bip32
+pub mod bitcoin::block
+pub mod bitcoin::blockdata
+pub mod bitcoin::blockdata::block
+pub mod bitcoin::blockdata::constants
+pub mod bitcoin::blockdata::fee_rate
+pub mod bitcoin::blockdata::locktime
+pub mod bitcoin::blockdata::locktime::absolute
+pub mod bitcoin::blockdata::locktime::relative
+pub mod bitcoin::blockdata::opcodes
+pub mod bitcoin::blockdata::opcodes::all
+pub mod bitcoin::blockdata::script
+pub mod bitcoin::blockdata::script::witness_program
+pub mod bitcoin::blockdata::script::witness_version
+pub mod bitcoin::blockdata::transaction
+pub mod bitcoin::blockdata::weight
+pub mod bitcoin::blockdata::witness
+pub mod bitcoin::consensus
+pub mod bitcoin::consensus::encode
+pub mod bitcoin::consensus::params
+pub mod bitcoin::constants
+pub mod bitcoin::ecdsa
+pub mod bitcoin::error
+pub mod bitcoin::hash_types
+pub mod bitcoin::key
+pub mod bitcoin::locktime
+pub mod bitcoin::locktime::absolute
+pub mod bitcoin::locktime::relative
+pub mod bitcoin::merkle_tree
+pub mod bitcoin::network
+pub mod bitcoin::opcodes
+pub mod bitcoin::opcodes::all
+pub mod bitcoin::p2p
+pub mod bitcoin::policy
+pub mod bitcoin::pow
+pub mod bitcoin::psbt
+pub mod bitcoin::psbt::raw
+pub mod bitcoin::psbt::serialize
+pub mod bitcoin::relative
+pub mod bitcoin::script
+pub mod bitcoin::script::witness_program
+pub mod bitcoin::script::witness_version
+pub mod bitcoin::sighash
+pub mod bitcoin::sign_message
+pub mod bitcoin::string
+pub mod bitcoin::taproot
+pub mod bitcoin::taproot::merkle_branch
+pub mod bitcoin::taproot::serialized_signature
+pub mod bitcoin::transaction
+pub mod bitcoin::witness
+pub mod bitcoin::witness_program
+pub mod bitcoin::witness_version
+pub static bitcoin::blockdata::opcodes::OP_0: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_FALSE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_NOP2: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_NOP3: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::blockdata::opcodes::OP_TRUE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_0: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_FALSE: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_NOP2: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_NOP3: bitcoin::blockdata::opcodes::Opcode
+pub static bitcoin::opcodes::OP_TRUE: bitcoin::blockdata::opcodes::Opcode
+pub struct bitcoin::Block
+pub struct bitcoin::BlockHash(_)
+pub struct bitcoin::CompactTarget(_)
+pub struct bitcoin::CompressedPublicKey(pub secp256k1::key::PublicKey)
+pub struct bitcoin::FeeRate(_)
+pub struct bitcoin::FilterHash(_)
+pub struct bitcoin::FilterHeader(_)
+pub struct bitcoin::LegacySighash(_)
+pub struct bitcoin::MerkleBlock
+pub struct bitcoin::Opcode
+pub struct bitcoin::OutPoint
+pub struct bitcoin::PrivateKey
+pub struct bitcoin::Psbt
+pub struct bitcoin::PubkeyHash(_)
+pub struct bitcoin::PublicKey
+pub struct bitcoin::ScriptBuf(_)
+pub struct bitcoin::ScriptHash(_)
+pub struct bitcoin::SegwitV0Sighash(_)
+pub struct bitcoin::Sequence(pub u32)
+pub struct bitcoin::TapBranchTag
+pub struct bitcoin::TapLeafHash(_)
+pub struct bitcoin::TapLeafTag
+pub struct bitcoin::TapNodeHash(_)
+pub struct bitcoin::TapSighash(_)
+pub struct bitcoin::TapSighashTag
+pub struct bitcoin::TapTweakHash(_)
+pub struct bitcoin::TapTweakTag
+pub struct bitcoin::Target(_)
+pub struct bitcoin::Transaction
+pub struct bitcoin::TxIn
+pub struct bitcoin::TxMerkleNode(_)
+pub struct bitcoin::TxOut
+pub struct bitcoin::Txid(_)
+pub struct bitcoin::VarInt(pub u64)
+pub struct bitcoin::WPubkeyHash(_)
+pub struct bitcoin::WScriptHash(_)
+pub struct bitcoin::Weight(_)
+pub struct bitcoin::Witness
+pub struct bitcoin::WitnessCommitment(_)
+pub struct bitcoin::WitnessMerkleNode(_)
+pub struct bitcoin::WitnessProgram
+pub struct bitcoin::Work(_)
+pub struct bitcoin::Wtxid(_)
+pub struct bitcoin::XKeyIdentifier(_)
+pub struct bitcoin::absolute::Height(_)
+pub struct bitcoin::absolute::ParseHeightError(_)
+pub struct bitcoin::absolute::ParseTimeError(_)
+pub struct bitcoin::absolute::Time(_)
+pub struct bitcoin::bip152::BlockTransactions
+pub struct bitcoin::bip152::BlockTransactionsRequest
+pub struct bitcoin::bip152::HeaderAndShortIds
+pub struct bitcoin::bip152::PrefilledTransaction
+pub struct bitcoin::bip152::ShortId(_)
+pub struct bitcoin::bip158::BitStreamReader<'a, R: core::marker::Sized>
+pub struct bitcoin::bip158::BitStreamWriter<'a, W>
+pub struct bitcoin::bip158::BlockFilter
+pub struct bitcoin::bip158::BlockFilterReader
+pub struct bitcoin::bip158::BlockFilterWriter<'a, W>
+pub struct bitcoin::bip158::FilterHash(_)
+pub struct bitcoin::bip158::FilterHeader(_)
+pub struct bitcoin::bip158::GcsFilterReader
+pub struct bitcoin::bip158::GcsFilterWriter<'a, W>
+pub struct bitcoin::bip32::ChainCode(_)
+pub struct bitcoin::bip32::DerivationPath(_)
+pub struct bitcoin::bip32::DerivationPathIterator<'a>
+pub struct bitcoin::bip32::Fingerprint(_)
+pub struct bitcoin::bip32::XKeyIdentifier(_)
+pub struct bitcoin::bip32::Xpriv
+pub struct bitcoin::bip32::Xpub
+pub struct bitcoin::block::Block
+pub struct bitcoin::block::BlockHash(_)
+pub struct bitcoin::block::Header
+pub struct bitcoin::block::TxMerkleNode(_)
+pub struct bitcoin::block::Version(_)
+pub struct bitcoin::block::WitnessCommitment(_)
+pub struct bitcoin::block::WitnessMerkleNode(_)
+pub struct bitcoin::blockdata::FeeRate(_)
+pub struct bitcoin::blockdata::Weight(_)
+pub struct bitcoin::blockdata::block::Block
+pub struct bitcoin::blockdata::block::BlockHash(_)
+pub struct bitcoin::blockdata::block::Header
+pub struct bitcoin::blockdata::block::TxMerkleNode(_)
+pub struct bitcoin::blockdata::block::Version(_)
+pub struct bitcoin::blockdata::block::WitnessCommitment(_)
+pub struct bitcoin::blockdata::block::WitnessMerkleNode(_)
+pub struct bitcoin::blockdata::constants::ChainHash(_)
+pub struct bitcoin::blockdata::fee_rate::FeeRate(_)
+pub struct bitcoin::blockdata::locktime::absolute::Height(_)
+pub struct bitcoin::blockdata::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin::blockdata::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin::blockdata::locktime::absolute::Time(_)
+pub struct bitcoin::blockdata::locktime::relative::Height(_)
+pub struct bitcoin::blockdata::locktime::relative::Time(_)
+pub struct bitcoin::blockdata::opcodes::Opcode
+pub struct bitcoin::blockdata::script::Builder(_, _)
+pub struct bitcoin::blockdata::script::Bytes<'a>(_)
+pub struct bitcoin::blockdata::script::InstructionIndices<'a>
+pub struct bitcoin::blockdata::script::Instructions<'a>
+pub struct bitcoin::blockdata::script::PushBytesBuf(_)
+pub struct bitcoin::blockdata::script::PushBytesError
+pub struct bitcoin::blockdata::script::ScriptBuf(_)
+pub struct bitcoin::blockdata::script::ScriptHash(_)
+pub struct bitcoin::blockdata::script::WScriptHash(_)
+pub struct bitcoin::blockdata::script::witness_program::WitnessProgram
+pub struct bitcoin::blockdata::transaction::InputWeightPrediction
+pub struct bitcoin::blockdata::transaction::OutPoint
+pub struct bitcoin::blockdata::transaction::Sequence(pub u32)
+pub struct bitcoin::blockdata::transaction::Transaction
+pub struct bitcoin::blockdata::transaction::TxIn
+pub struct bitcoin::blockdata::transaction::TxOut
+pub struct bitcoin::blockdata::transaction::Txid(_)
+pub struct bitcoin::blockdata::transaction::Version(pub i32)
+pub struct bitcoin::blockdata::transaction::Wtxid(_)
+pub struct bitcoin::blockdata::weight::Weight(_)
+pub struct bitcoin::blockdata::witness::Iter<'a>
+pub struct bitcoin::blockdata::witness::Witness
+pub struct bitcoin::consensus::encode::CheckedData
+pub struct bitcoin::consensus::encode::VarInt(pub u64)
+pub struct bitcoin::constants::ChainHash(_)
+pub struct bitcoin::ecdsa::SerializedSignature
+pub struct bitcoin::ecdsa::Signature
+pub struct bitcoin::hash_types::BlockHash(_)
+pub struct bitcoin::hash_types::FilterHash(_)
+pub struct bitcoin::hash_types::FilterHeader(_)
+pub struct bitcoin::hash_types::TxMerkleNode(_)
+pub struct bitcoin::hash_types::Txid(_)
+pub struct bitcoin::hash_types::WitnessCommitment(_)
+pub struct bitcoin::hash_types::WitnessMerkleNode(_)
+pub struct bitcoin::hash_types::Wtxid(_)
+pub struct bitcoin::key::CompressedPublicKey(pub secp256k1::key::PublicKey)
+pub struct bitcoin::key::PrivateKey
+pub struct bitcoin::key::PubkeyHash(_)
+pub struct bitcoin::key::PublicKey
+pub struct bitcoin::key::SortKey(_)
+pub struct bitcoin::key::TweakedKeypair(_)
+pub struct bitcoin::key::TweakedPublicKey(_)
+pub struct bitcoin::key::WPubkeyHash(_)
+pub struct bitcoin::locktime::absolute::Height(_)
+pub struct bitcoin::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin::locktime::absolute::Time(_)
+pub struct bitcoin::locktime::relative::Height(_)
+pub struct bitcoin::locktime::relative::Time(_)
+pub struct bitcoin::merkle_tree::MerkleBlock
+pub struct bitcoin::merkle_tree::PartialMerkleTree
+pub struct bitcoin::opcodes::Opcode
+pub struct bitcoin::p2p::Magic(_)
+pub struct bitcoin::p2p::ServiceFlags(_)
+pub struct bitcoin::pow::CompactTarget(_)
+pub struct bitcoin::pow::Target(_)
+pub struct bitcoin::pow::Work(_)
+pub struct bitcoin::psbt::Input
+pub struct bitcoin::psbt::Output
+pub struct bitcoin::psbt::Psbt
+pub struct bitcoin::psbt::PsbtSighashType
+pub struct bitcoin::psbt::raw::Key
+pub struct bitcoin::psbt::raw::Pair
+pub struct bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+pub struct bitcoin::relative::Height(_)
+pub struct bitcoin::relative::Time(_)
+pub struct bitcoin::script::Builder(_, _)
+pub struct bitcoin::script::Bytes<'a>(_)
+pub struct bitcoin::script::InstructionIndices<'a>
+pub struct bitcoin::script::Instructions<'a>
+pub struct bitcoin::script::PushBytesBuf(_)
+pub struct bitcoin::script::PushBytesError
+pub struct bitcoin::script::ScriptBuf(_)
+pub struct bitcoin::script::ScriptHash(_)
+pub struct bitcoin::script::WScriptHash(_)
+pub struct bitcoin::script::witness_program::WitnessProgram
+pub struct bitcoin::sighash::Annex<'a>(_)
+pub struct bitcoin::sighash::LegacySighash(_)
+pub struct bitcoin::sighash::ScriptPath<'s>
+pub struct bitcoin::sighash::SegwitV0Sighash(_)
+pub struct bitcoin::sighash::SighashCache<T: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>>
+pub struct bitcoin::sighash::TapSighash(_)
+pub struct bitcoin::sighash::TapSighashTag
+pub struct bitcoin::taproot::ControlBlock
+pub struct bitcoin::taproot::FutureLeafVersion(_)
+pub struct bitcoin::taproot::LeafNode
+pub struct bitcoin::taproot::LeafNodes<'a>
+pub struct bitcoin::taproot::NodeInfo
+pub struct bitcoin::taproot::ScriptLeaf<'leaf>
+pub struct bitcoin::taproot::ScriptLeaves<'tree>
+pub struct bitcoin::taproot::Signature
+pub struct bitcoin::taproot::TapBranchTag
+pub struct bitcoin::taproot::TapLeafHash(_)
+pub struct bitcoin::taproot::TapLeafTag
+pub struct bitcoin::taproot::TapNodeHash(_)
+pub struct bitcoin::taproot::TapTree(_)
+pub struct bitcoin::taproot::TapTweakHash(_)
+pub struct bitcoin::taproot::TapTweakTag
+pub struct bitcoin::taproot::TaprootBuilder
+pub struct bitcoin::taproot::TaprootMerkleBranch(_)
+pub struct bitcoin::taproot::TaprootSpendInfo
+pub struct bitcoin::taproot::merkle_branch::IntoIter(_)
+pub struct bitcoin::taproot::merkle_branch::TaprootMerkleBranch(_)
+pub struct bitcoin::taproot::serialized_signature::IntoIter
+pub struct bitcoin::taproot::serialized_signature::SerializedSignature
+pub struct bitcoin::transaction::InputWeightPrediction
+pub struct bitcoin::transaction::OutPoint
+pub struct bitcoin::transaction::Sequence(pub u32)
+pub struct bitcoin::transaction::Transaction
+pub struct bitcoin::transaction::TxIn
+pub struct bitcoin::transaction::TxOut
+pub struct bitcoin::transaction::Txid(_)
+pub struct bitcoin::transaction::Version(pub i32)
+pub struct bitcoin::transaction::Wtxid(_)
+pub struct bitcoin::witness::Iter<'a>
+pub struct bitcoin::witness::Witness
+pub struct bitcoin::witness_program::WitnessProgram
+pub trait bitcoin::address::NetworkValidation: sealed::NetworkValidation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub trait bitcoin::bip32::IntoDerivationPath
+pub trait bitcoin::blockdata::script::PushBytesErrorReport
+pub trait bitcoin::consensus::Decodable: core::marker::Sized
+pub trait bitcoin::consensus::Encodable
+pub trait bitcoin::consensus::ReadExt: bitcoin_io::Read
+pub trait bitcoin::consensus::WriteExt: bitcoin_io::Write
+pub trait bitcoin::consensus::encode::Decodable: core::marker::Sized
+pub trait bitcoin::consensus::encode::Encodable
+pub trait bitcoin::consensus::encode::ReadExt: bitcoin_io::Read
+pub trait bitcoin::consensus::encode::WriteExt: bitcoin_io::Write
+pub trait bitcoin::key::TapTweak
+pub trait bitcoin::psbt::GetKey
+pub trait bitcoin::script::PushBytesErrorReport
+pub trait bitcoin::string::FromHexStr: core::marker::Sized
+pub type &'a bitcoin::bip32::DerivationPath::IntoIter = core::slice::iter::Iter<'a, bitcoin::bip32::ChildNumber>
+pub type &'a bitcoin::bip32::DerivationPath::Item = &'a bitcoin::bip32::ChildNumber
+pub type &'a bitcoin::blockdata::script::PushBytes::Error = bitcoin::blockdata::script::PushBytesError
+pub type &'a bitcoin::blockdata::witness::Witness::IntoIter = bitcoin::blockdata::witness::Iter<'a>
+pub type &'a bitcoin::blockdata::witness::Witness::Item = &'a [u8]
+pub type &'a bitcoin::ecdsa::SerializedSignature::IntoIter = core::slice::iter::Iter<'a, u8>
+pub type &'a bitcoin::ecdsa::SerializedSignature::Item = &'a u8
+pub type &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = core::slice::iter::Iter<'a, bitcoin::taproot::TapNodeHash>
+pub type &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = &'a bitcoin::taproot::TapNodeHash
+pub type &'a bitcoin::taproot::serialized_signature::SerializedSignature::IntoIter = core::slice::iter::Iter<'a, u8>
+pub type &'a bitcoin::taproot::serialized_signature::SerializedSignature::Item = &'a u8
+pub type &'a mut bitcoin::blockdata::script::PushBytes::Error = bitcoin::blockdata::script::PushBytesError
+pub type &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = core::slice::iter::IterMut<'a, bitcoin::taproot::TapNodeHash>
+pub type &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = &'a mut bitcoin::taproot::TapNodeHash
+pub type alloc::collections::btree::map::BTreeMap<bitcoin::PublicKey, bitcoin::PrivateKey>::Error = bitcoin::psbt::GetKeyError
+pub type alloc::collections::btree::set::BTreeSet<bitcoin::bip32::Xpriv>::Error = bitcoin::psbt::GetKeyError
+pub type bitcoin::CompressedPublicKey::Err = bitcoin::key::Error
+pub type bitcoin::CompressedPublicKey::Error = bitcoin::key::UncompressedPubkeyError
+pub type bitcoin::EcdsaSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::LegacySighash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::LegacySighash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::LegacySighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::LegacySighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::PrivateKey::Err = bitcoin::key::Error
+pub type bitcoin::PrivateKey::Output = [u8]
+pub type bitcoin::PubkeyHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::PubkeyHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::PubkeyHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::PubkeyHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::PublicKey::Err = bitcoin::key::Error
+pub type bitcoin::SegwitV0Sighash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::SegwitV0Sighash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::SegwitV0Sighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::SegwitV0Sighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::TapSighash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::TapSighash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::TapSighash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::TapSighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::TapSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::WPubkeyHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::WPubkeyHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::WPubkeyHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::WPubkeyHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::Err = bitcoin::address::error::ParseError
+pub type bitcoin::address::AddressType::Err = bitcoin::address::error::UnknownAddressTypeError
+pub type bitcoin::bip152::ShortId::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip152::ShortId::Error = core::array::TryFromSliceError
+pub type bitcoin::bip152::ShortId::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip158::FilterHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip158::FilterHash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip158::FilterHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip158::FilterHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip158::FilterHeader::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip158::FilterHeader::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip158::FilterHeader::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip158::FilterHeader::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip32::ChainCode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::ChainCode::Error = core::array::TryFromSliceError
+pub type bitcoin::bip32::ChainCode::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::ChildNumber::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::DerivationPath::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::DerivationPath::Output = <alloc::vec::Vec<bitcoin::bip32::ChildNumber> as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::DerivationPathIterator<'a>::Item = bitcoin::bip32::DerivationPath
+pub type bitcoin::bip32::ExtendendPrivKey = bitcoin::bip32::Xpriv
+pub type bitcoin::bip32::ExtendendPubKey = bitcoin::bip32::Xpub
+pub type bitcoin::bip32::Fingerprint::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::Fingerprint::Error = core::array::TryFromSliceError
+pub type bitcoin::bip32::Fingerprint::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::bip32::KeySource = (bitcoin::bip32::Fingerprint, bitcoin::bip32::DerivationPath)
+pub type bitcoin::bip32::XKeyIdentifier::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::bip32::XKeyIdentifier::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::bip32::XKeyIdentifier::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::bip32::XKeyIdentifier::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::bip32::Xpriv::Err = bitcoin::bip32::Error
+pub type bitcoin::bip32::Xpriv::Error = bitcoin::psbt::GetKeyError
+pub type bitcoin::bip32::Xpub::Err = bitcoin::bip32::Error
+pub type bitcoin::blockdata::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::BlockHash::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::BlockHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::BlockHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::TxMerkleNode::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::TxMerkleNode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::TxMerkleNode::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::WitnessCommitment::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::WitnessCommitment::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::WitnessCommitment::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::block::WitnessMerkleNode::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::constants::ChainHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::constants::ChainHash::Error = core::array::TryFromSliceError
+pub type bitcoin::blockdata::constants::ChainHash::Output = <[u8] as core::ops::index::Index<I>>::Output
+pub type bitcoin::blockdata::fee_rate::FeeRate::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::fee_rate::FeeRate::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::fee_rate::FeeRate::Output = bitcoin_units::amount::Amount
+pub type bitcoin::blockdata::locktime::absolute::Height::Err = bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub type bitcoin::blockdata::locktime::absolute::Height::Error = bitcoin::blockdata::locktime::absolute::ParseHeightError
+pub type bitcoin::blockdata::locktime::absolute::LockTime::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::absolute::LockTime::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::absolute::Time::Err = bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub type bitcoin::blockdata::locktime::absolute::Time::Error = bitcoin::blockdata::locktime::absolute::ParseTimeError
+pub type bitcoin::blockdata::locktime::relative::Height::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Height::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Time::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::locktime::relative::Time::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::script::Bytes<'_>::Item = u8
+pub type bitcoin::blockdata::script::InstructionIndices<'a>::Item = core::result::Result<(usize, bitcoin::blockdata::script::Instruction<'a>), bitcoin::blockdata::script::Error>
+pub type bitcoin::blockdata::script::Instructions<'a>::Item = core::result::Result<bitcoin::blockdata::script::Instruction<'a>, bitcoin::blockdata::script::Error>
+pub type bitcoin::blockdata::script::PushBytes::Output = bitcoin::blockdata::script::PushBytes
+pub type bitcoin::blockdata::script::PushBytes::Output = u8
+pub type bitcoin::blockdata::script::PushBytes::Owned = bitcoin::blockdata::script::PushBytesBuf
+pub type bitcoin::blockdata::script::PushBytesBuf::Error = bitcoin::blockdata::script::PushBytesError
+pub type bitcoin::blockdata::script::PushBytesBuf::Target = bitcoin::blockdata::script::PushBytes
+pub type bitcoin::blockdata::script::Script::Output = bitcoin::blockdata::script::Script
+pub type bitcoin::blockdata::script::Script::Owned = bitcoin::blockdata::script::ScriptBuf
+pub type bitcoin::blockdata::script::ScriptBuf::Target = bitcoin::blockdata::script::Script
+pub type bitcoin::blockdata::script::ScriptHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::script::ScriptHash::Engine = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::script::ScriptHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::script::ScriptHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::script::WScriptHash::Bytes = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::script::WScriptHash::Engine = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::script::WScriptHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::script::WScriptHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Err = bitcoin::blockdata::script::witness_version::FromStrError
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Error = bitcoin::blockdata::script::witness_version::TryFromError
+pub type bitcoin::blockdata::script::witness_version::WitnessVersion::Error = bitcoin::blockdata::script::witness_version::TryFromInstructionError
+pub type bitcoin::blockdata::transaction::OutPoint::Err = bitcoin::blockdata::transaction::ParseOutPointError
+pub type bitcoin::blockdata::transaction::Sequence::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::transaction::Sequence::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::transaction::Txid::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::transaction::Txid::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::transaction::Txid::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::blockdata::transaction::Wtxid::Engine = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::blockdata::transaction::Wtxid::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::blockdata::transaction::Wtxid::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::blockdata::weight::Weight::Err = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::weight::Weight::Error = bitcoin::error::ParseIntError
+pub type bitcoin::blockdata::weight::Weight::Output = bitcoin::blockdata::weight::Weight
+pub type bitcoin::blockdata::weight::Weight::Output = bitcoin_units::amount::Amount
+pub type bitcoin::blockdata::weight::Weight::Output = u64
+pub type bitcoin::blockdata::witness::Iter<'a>::Item = &'a [u8]
+pub type bitcoin::blockdata::witness::Witness::Output = [u8]
+pub type bitcoin::ecdsa::SerializedSignature::Target = [u8]
+pub type bitcoin::ecdsa::Signature::Err = bitcoin::ecdsa::Error
+pub type bitcoin::key::TapTweak::TweakedAux
+pub type bitcoin::key::TapTweak::TweakedKey
+pub type bitcoin::key::UntweakedKeypair = secp256k1::key::Keypair
+pub type bitcoin::key::UntweakedKeypair::TweakedAux = bitcoin::key::TweakedKeypair
+pub type bitcoin::key::UntweakedKeypair::TweakedKey = bitcoin::key::TweakedKeypair
+pub type bitcoin::key::UntweakedPublicKey = secp256k1::key::XOnlyPublicKey
+pub type bitcoin::key::UntweakedPublicKey::TweakedAux = (bitcoin::key::TweakedPublicKey, secp256k1::key::Parity)
+pub type bitcoin::key::UntweakedPublicKey::TweakedKey = bitcoin::key::TweakedPublicKey
+pub type bitcoin::network::Network::Err = bitcoin::network::ParseNetworkError
+pub type bitcoin::network::Network::Error = bitcoin::network::UnknownChainHashError
+pub type bitcoin::network::Network::Error = bitcoin::p2p::UnknownMagicError
+pub type bitcoin::p2p::Magic::Err = bitcoin::p2p::ParseMagicError
+pub type bitcoin::p2p::ServiceFlags::Output = bitcoin::p2p::ServiceFlags
+pub type bitcoin::pow::CompactTarget::Error = bitcoin::error::ParseIntError
+pub type bitcoin::pow::Work::Output = bitcoin::pow::Work
+pub type bitcoin::psbt::GetKey::Error: core::fmt::Debug
+pub type bitcoin::psbt::PsbtSighashType::Err = bitcoin::sighash::SighashTypeParseError
+pub type bitcoin::psbt::SigningErrors = alloc::collections::btree::map::BTreeMap<usize, bitcoin::psbt::SignError>
+pub type bitcoin::psbt::SigningKeys = alloc::collections::btree::map::BTreeMap<usize, alloc::vec::Vec<bitcoin::PublicKey>>
+pub type bitcoin::psbt::raw::ProprietaryKey<Subtype>::Error = bitcoin::psbt::Error
+pub type bitcoin::psbt::raw::ProprietaryType = u8
+pub type bitcoin::string::FromHexStr::Error
+pub type bitcoin::taproot::LeafNodes<'a>::Item = &'a bitcoin::taproot::LeafNode
+pub type bitcoin::taproot::NodeInfo::Error = bitcoin::taproot::IncompleteBuilderError
+pub type bitcoin::taproot::ScriptLeaves<'tree>::Item = bitcoin::taproot::ScriptLeaf<'tree>
+pub type bitcoin::taproot::Signature::Error = bitcoin::taproot::SigFromSliceError
+pub type bitcoin::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapLeafHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapLeafHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapLeafHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::TapNodeHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapNodeHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapNodeHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapNodeHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::TapTree::Error = bitcoin::taproot::HiddenNodesError
+pub type bitcoin::taproot::TapTree::Error = bitcoin::taproot::IncompleteBuilderError
+pub type bitcoin::taproot::TapTweakHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin::taproot::TapTweakHash::Engine = <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine
+pub type bitcoin::taproot::TapTweakHash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin::taproot::TapTweakHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin::taproot::merkle_branch::IntoIter::Item = bitcoin::taproot::TapNodeHash
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Error = bitcoin::taproot::TaprootError
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = bitcoin::taproot::merkle_branch::IntoIter
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = bitcoin::taproot::TapNodeHash
+pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Target = [bitcoin::taproot::TapNodeHash]
+pub type bitcoin::taproot::serialized_signature::IntoIter::Item = u8
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::IntoIter = bitcoin::taproot::serialized_signature::IntoIter
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::Item = u8
+pub type bitcoin::taproot::serialized_signature::SerializedSignature::Target = [u8]
+pub type bitcoin_units::amount::Amount::Output = bitcoin::blockdata::fee_rate::FeeRate
+pub type u64::Output = bitcoin::blockdata::weight::Weight
+pub use bitcoin::Amount
+pub use bitcoin::Denomination
+pub use bitcoin::SignedAmount
+pub use bitcoin::XOnlyPublicKey
+pub use bitcoin::amount::Amount
+pub use bitcoin::amount::CheckedSum
+pub use bitcoin::amount::Denomination
+pub use bitcoin::amount::Display
+pub use bitcoin::amount::ParseAmountError
+pub use bitcoin::amount::SignedAmount
+pub use bitcoin::key::Keypair
+pub use bitcoin::key::Parity
+pub use bitcoin::key::Secp256k1
+pub use bitcoin::key::Verification
+pub use bitcoin::key::XOnlyPublicKey
+pub use bitcoin::key::constants
+pub use bitcoin::key::secp256k1

--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -1,0 +1,910 @@
+#[non_exhaustive] pub struct bitcoin_hashes::FromSliceError
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T: bitcoin_hashes::sha256t::Tag>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::FromSliceError
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
+impl core::error::Error for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Midstate
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl hex_conservative::parse::FromHex for bitcoin_hashes::sha256::Midstate
+impl schemars::JsonSchema for bitcoin_hashes::hash160::Hash
+impl schemars::JsonSchema for bitcoin_hashes::ripemd160::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha1::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha256::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha256d::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha512::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha512_256::Hash
+impl schemars::JsonSchema for bitcoin_hashes::siphash24::Hash
+impl serde::ser::Serialize for bitcoin_hashes::hash160::Hash
+impl serde::ser::Serialize for bitcoin_hashes::ripemd160::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha1::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256::Midstate
+impl serde::ser::Serialize for bitcoin_hashes::sha256d::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha512::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha512_256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::siphash24::Hash
+impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine
+impl std::io::Write for bitcoin_hashes::sha1::HashEngine
+impl std::io::Write for bitcoin_hashes::sha256::HashEngine
+impl std::io::Write for bitcoin_hashes::sha512::HashEngine
+impl std::io::Write for bitcoin_hashes::siphash24::HashEngine
+impl<'de, T: bitcoin_hashes::Hash + serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
+impl<'de, T: bitcoin_hashes::sha256t::Tag> serde::de::Deserialize<'de> for bitcoin_hashes::sha256t::Hash<T>
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::hash160::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::ripemd160::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha1::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256::Midstate
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256d::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512_256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::siphash24::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::hash160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::ripemd160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha1::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256d::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512_256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::siphash24::Hash
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + schemars::JsonSchema> schemars::JsonSchema for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + serde::ser::Serialize> serde::ser::Serialize for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::borrow::Borrow<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<usize> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> schemars::JsonSchema for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> serde::ser::Serialize for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
+impl<T: core::cmp::Eq + bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_hashes::hmac::HmacMidState::inner: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub bitcoin_hashes::hmac::HmacMidState::outer: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::Hash::LEN: usize
+pub const bitcoin_hashes::hash160::Hash::N: usize
+pub const bitcoin_hashes::hmac::Hmac<T>::LEN: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::Hash::LEN: usize
+pub const bitcoin_hashes::ripemd160::Hash::N: usize
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::serde_macros::serde_details::SerdeHash::N: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::Hash::LEN: usize
+pub const bitcoin_hashes::sha1::Hash::N: usize
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::Hash::LEN: usize
+pub const bitcoin_hashes::sha256::Hash::N: usize
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Midstate::N: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::Hash::LEN: usize
+pub const bitcoin_hashes::sha256d::Hash::N: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::Hash<T>::LEN: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::N: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::Hash::LEN: usize
+pub const bitcoin_hashes::sha512::Hash::N: usize
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::Hash::LEN: usize
+pub const bitcoin_hashes::sha512_256::Hash::N: usize
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::Hash::LEN: usize
+pub const bitcoin_hashes::siphash24::Hash::N: usize
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub extern crate bitcoin_hashes::hex
+pub extern crate bitcoin_hashes::serde
+pub fn bitcoin_hashes::FromSliceError::clone(&self) -> bitcoin_hashes::FromSliceError
+pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSliceError) -> bool
+pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::FromSliceError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hash160::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::hash160::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::hash160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFrom<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeTo<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: usize) -> &u8
+pub fn bitcoin_hashes::hmac::Hmac<T>::is_referenceable() -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::hmac::Hmac<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::Hash>::Engine, oengine: <T as bitcoin_hashes::Hash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::ripemd160::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::ripemd160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::deserialize<'de, D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha1::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha1::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha1::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Midstate, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Err> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin_hashes::sha256::Midstate::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Midstate::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256d::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256d::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha256d::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256t::Hash<T>::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha256t::Hash<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha512::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512_256::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha512_256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::siphash24::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::siphash24::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::siphash24::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::default() -> Self
+pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::midstate(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::borrow_slice_impl!
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::hex_fmt_impl!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::serde_macros::serde_details
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate(pub [u8; 32])
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::fmt::Debug + core::fmt::Display + core::fmt::LowerHex + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeFrom<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeTo<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::Range<usize>, Output = [u8]> + core::ops::index::Index<usize, Output = u8> + core::borrow::Borrow<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone + core::default::Default
+pub trait bitcoin_hashes::serde_macros::serde_details::SerdeHash where Self: core::marker::Sized + core::str::traits::FromStr + core::fmt::Display + core::ops::index::Index<usize, Output = u8> + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]>, <Self as core::str::traits::FromStr>::Err: core::fmt::Display
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
+pub type bitcoin_hashes::Hash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::hash160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8]
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = u8
+pub type bitcoin_hashes::hmac::HmacEngine<T>::MidState = bitcoin_hashes::hmac::HmacMidState<T>
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::ripemd160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::ripemd160::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha1::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::HashEngine::MidState = bitcoin_hashes::sha256::Midstate
+pub type bitcoin_hashes::sha256::Midstate::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Midstate::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512_256::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::siphash24::HashEngine::MidState = bitcoin_hashes::siphash24::State

--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -1,0 +1,778 @@
+#[non_exhaustive] pub struct bitcoin_hashes::FromSliceError
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T: bitcoin_hashes::sha256t::Tag>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::FromSliceError
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Midstate
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl hex_conservative::parse::FromHex for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::hash160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::ripemd160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha1::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256d::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512_256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::siphash24::Hash
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::borrow::Borrow<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<usize> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
+impl<T: core::cmp::Eq + bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_hashes::hmac::HmacMidState::inner: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub bitcoin_hashes::hmac::HmacMidState::outer: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::Hash::LEN: usize
+pub const bitcoin_hashes::hmac::Hmac<T>::LEN: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::Hash::LEN: usize
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::Hash::LEN: usize
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::Hash::LEN: usize
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::Hash::LEN: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::Hash<T>::LEN: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::Hash::LEN: usize
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::Hash::LEN: usize
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::Hash::LEN: usize
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub extern crate bitcoin_hashes::hex
+pub fn bitcoin_hashes::FromSliceError::clone(&self) -> bitcoin_hashes::FromSliceError
+pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSliceError) -> bool
+pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFrom<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeTo<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: usize) -> &u8
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::Hash>::Engine, oengine: <T as bitcoin_hashes::Hash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Err> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin_hashes::sha256::Midstate::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::default() -> Self
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::midstate(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::borrow_slice_impl!
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::hex_fmt_impl!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate(pub [u8; 32])
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::fmt::Debug + core::fmt::Display + core::fmt::LowerHex + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeFrom<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeTo<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::Range<usize>, Output = [u8]> + core::ops::index::Index<usize, Output = u8> + core::borrow::Borrow<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone + core::default::Default
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
+pub type bitcoin_hashes::Hash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::hash160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8]
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = u8
+pub type bitcoin_hashes::hmac::HmacEngine<T>::MidState = bitcoin_hashes::hmac::HmacMidState<T>
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::ripemd160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::ripemd160::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha1::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::HashEngine::MidState = bitcoin_hashes::sha256::Midstate
+pub type bitcoin_hashes::sha256::Midstate::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Midstate::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512_256::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::siphash24::HashEngine::MidState = bitcoin_hashes::siphash24::State

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -1,0 +1,778 @@
+#[non_exhaustive] pub struct bitcoin_hashes::FromSliceError
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T: bitcoin_hashes::sha256t::Tag>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::FromSliceError
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Midstate
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl hex_conservative::parse::FromHex for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::hash160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::ripemd160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha1::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256d::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512_256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::siphash24::Hash
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::borrow::Borrow<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<usize> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
+impl<T: core::cmp::Eq + bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_hashes::hmac::HmacMidState::inner: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub bitcoin_hashes::hmac::HmacMidState::outer: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::Hash::LEN: usize
+pub const bitcoin_hashes::hmac::Hmac<T>::LEN: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::Hash::LEN: usize
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::Hash::LEN: usize
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::Hash::LEN: usize
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::Hash::LEN: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::Hash<T>::LEN: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::Hash::LEN: usize
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::Hash::LEN: usize
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::Hash::LEN: usize
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub extern crate bitcoin_hashes::hex
+pub fn bitcoin_hashes::FromSliceError::clone(&self) -> bitcoin_hashes::FromSliceError
+pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSliceError) -> bool
+pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFrom<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeTo<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: usize) -> &u8
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::Hash>::Engine, oengine: <T as bitcoin_hashes::Hash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Err> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin_hashes::sha256::Midstate::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::default() -> Self
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::midstate(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::borrow_slice_impl!
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::hex_fmt_impl!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate(pub [u8; 32])
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::fmt::Debug + core::fmt::Display + core::fmt::LowerHex + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeFrom<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeTo<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::Range<usize>, Output = [u8]> + core::ops::index::Index<usize, Output = u8> + core::borrow::Borrow<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone + core::default::Default
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
+pub type bitcoin_hashes::Hash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::hash160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8]
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = u8
+pub type bitcoin_hashes::hmac::HmacEngine<T>::MidState = bitcoin_hashes::hmac::HmacMidState<T>
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::ripemd160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::ripemd160::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha1::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::HashEngine::MidState = bitcoin_hashes::sha256::Midstate
+pub type bitcoin_hashes::sha256::Midstate::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Midstate::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512_256::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::siphash24::HashEngine::MidState = bitcoin_hashes::siphash24::State

--- a/api/io/all-features.txt
+++ b/api/io/all-features.txt
@@ -1,0 +1,119 @@
+#[non_exhaustive] pub enum bitcoin_io::ErrorKind
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
+impl bitcoin_io::Error
+impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::cmp::Eq for bitcoin_io::ErrorKind
+impl core::cmp::PartialEq for bitcoin_io::ErrorKind
+impl core::convert::From<bitcoin_io::Error> for std::io::error::Error
+impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
+impl core::convert::From<std::io::error::Error> for bitcoin_io::Error
+impl core::error::Error for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::ErrorKind
+impl core::fmt::Display for bitcoin_io::Error
+impl core::hash::Hash for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Error
+impl core::marker::Send for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Sink
+impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Error
+impl core::marker::Sync for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Sink
+impl core::marker::Unpin for bitcoin_io::Error
+impl core::marker::Unpin for bitcoin_io::ErrorKind
+impl core::marker::Unpin for bitcoin_io::Sink
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Sink
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Sink
+impl std::io::Write for bitcoin_io::Sink
+impl<'a, R: bitcoin_io::BufRead + core::marker::Sized> bitcoin_io::BufRead for bitcoin_io::Take<'a, R>
+impl<'a, R: bitcoin_io::Read + core::marker::Sized> bitcoin_io::Read for bitcoin_io::Take<'a, R>
+impl<'a, R: core::marker::Sized> core::marker::Send for bitcoin_io::Take<'a, R> where R: core::marker::Send
+impl<'a, R: core::marker::Sized> core::marker::Sync for bitcoin_io::Take<'a, R> where R: core::marker::Sync
+impl<'a, R: core::marker::Sized> core::marker::Unpin for bitcoin_io::Take<'a, R>
+impl<'a, R: core::marker::Sized> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Take<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Take<'a, R>
+impl<R: std::io::BufRead + bitcoin_io::Read + core::marker::Sized> bitcoin_io::BufRead for R
+impl<R: std::io::Read> bitcoin_io::Read for R
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
+impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_io::Cursor<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<W: std::io::Write> bitcoin_io::Write for W
+pub bitcoin_io::ErrorKind::AddrInUse
+pub bitcoin_io::ErrorKind::AddrNotAvailable
+pub bitcoin_io::ErrorKind::AlreadyExists
+pub bitcoin_io::ErrorKind::BrokenPipe
+pub bitcoin_io::ErrorKind::ConnectionAborted
+pub bitcoin_io::ErrorKind::ConnectionRefused
+pub bitcoin_io::ErrorKind::ConnectionReset
+pub bitcoin_io::ErrorKind::Interrupted
+pub bitcoin_io::ErrorKind::InvalidData
+pub bitcoin_io::ErrorKind::InvalidInput
+pub bitcoin_io::ErrorKind::NotConnected
+pub bitcoin_io::ErrorKind::NotFound
+pub bitcoin_io::ErrorKind::Other
+pub bitcoin_io::ErrorKind::PermissionDenied
+pub bitcoin_io::ErrorKind::TimedOut
+pub bitcoin_io::ErrorKind::UnexpectedEof
+pub bitcoin_io::ErrorKind::WouldBlock
+pub bitcoin_io::ErrorKind::WriteZero
+pub fn R::consume(&mut self, amount: usize)
+pub fn R::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn R::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn W::flush(&mut self) -> core::result::Result<(), bitcoin_io::Error>
+pub fn W::write(&mut self, buf: &[u8]) -> core::result::Result<usize, bitcoin_io::Error>
+pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
+pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
+pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
+pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Error::cause(&self) -> core::option::Option<&dyn core::error::Error>
+pub fn bitcoin_io::Error::description(&self) -> &str
+pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::Error::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_io::Error::from(kind: bitcoin_io::ErrorKind) -> bitcoin_io::Error
+pub fn bitcoin_io::Error::from(o: std::io::error::Error) -> bitcoin_io::Error
+pub fn bitcoin_io::Error::get_ref(&self) -> core::option::Option<&(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>
+pub fn bitcoin_io::Error::kind(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::Error::new<E>(kind: bitcoin_io::ErrorKind, error: E) -> bitcoin_io::Error where E: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>>
+pub fn bitcoin_io::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_io::ErrorKind::clone(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::ErrorKind::eq(&self, other: &bitcoin_io::ErrorKind) -> bool
+pub fn bitcoin_io::ErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::ErrorKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Read::read_to_limit(&mut self, buf: &mut alloc::vec::Vec<u8>, limit: u64) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_io::Sink::write_all(&mut self, &[u8]) -> std::io::error::Result<()>
+pub fn bitcoin_io::Take<'a, R>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Take<'a, R>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Take<'a, R>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Write::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::sink() -> bitcoin_io::Sink
+pub fn std::io::error::Error::from(o: bitcoin_io::Error) -> std::io::error::Error
+pub macro bitcoin_io::impl_write!
+pub mod bitcoin_io
+pub struct bitcoin_io::Cursor<T>
+pub struct bitcoin_io::Error
+pub struct bitcoin_io::Sink
+pub struct bitcoin_io::Take<'a, R: bitcoin_io::Read + core::marker::Sized>
+pub trait bitcoin_io::BufRead: bitcoin_io::Read
+pub trait bitcoin_io::Read
+pub trait bitcoin_io::Write
+pub type bitcoin_io::Result<T> = core::result::Result<T, bitcoin_io::Error>

--- a/api/io/alloc-only.txt
+++ b/api/io/alloc-only.txt
@@ -1,0 +1,114 @@
+#[non_exhaustive] pub enum bitcoin_io::ErrorKind
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
+impl bitcoin_io::BufRead for &[u8]
+impl bitcoin_io::Error
+impl bitcoin_io::Read for &[u8]
+impl bitcoin_io::Write for alloc::vec::Vec<u8>
+impl bitcoin_io::Write for bitcoin_io::Sink
+impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::cmp::Eq for bitcoin_io::ErrorKind
+impl core::cmp::PartialEq for bitcoin_io::ErrorKind
+impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::ErrorKind
+impl core::fmt::Display for bitcoin_io::Error
+impl core::hash::Hash for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Error
+impl core::marker::Send for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Sink
+impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Error
+impl core::marker::Sync for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Sink
+impl core::marker::Unpin for bitcoin_io::Error
+impl core::marker::Unpin for bitcoin_io::ErrorKind
+impl core::marker::Unpin for bitcoin_io::Sink
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Sink
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Sink
+impl<'a, R: bitcoin_io::BufRead + core::marker::Sized> bitcoin_io::BufRead for bitcoin_io::Take<'a, R>
+impl<'a, R: bitcoin_io::Read + core::marker::Sized> bitcoin_io::Read for bitcoin_io::Take<'a, R>
+impl<'a, R: core::marker::Sized> core::marker::Send for bitcoin_io::Take<'a, R> where R: core::marker::Send
+impl<'a, R: core::marker::Sized> core::marker::Sync for bitcoin_io::Take<'a, R> where R: core::marker::Sync
+impl<'a, R: core::marker::Sized> core::marker::Unpin for bitcoin_io::Take<'a, R>
+impl<'a, R: core::marker::Sized> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Take<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Take<'a, R>
+impl<'a> bitcoin_io::Write for &'a mut [u8]
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
+impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_io::Cursor<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_io::ErrorKind::AddrInUse
+pub bitcoin_io::ErrorKind::AddrNotAvailable
+pub bitcoin_io::ErrorKind::AlreadyExists
+pub bitcoin_io::ErrorKind::BrokenPipe
+pub bitcoin_io::ErrorKind::ConnectionAborted
+pub bitcoin_io::ErrorKind::ConnectionRefused
+pub bitcoin_io::ErrorKind::ConnectionReset
+pub bitcoin_io::ErrorKind::Interrupted
+pub bitcoin_io::ErrorKind::InvalidData
+pub bitcoin_io::ErrorKind::InvalidInput
+pub bitcoin_io::ErrorKind::NotConnected
+pub bitcoin_io::ErrorKind::NotFound
+pub bitcoin_io::ErrorKind::Other
+pub bitcoin_io::ErrorKind::PermissionDenied
+pub bitcoin_io::ErrorKind::TimedOut
+pub bitcoin_io::ErrorKind::UnexpectedEof
+pub bitcoin_io::ErrorKind::WouldBlock
+pub bitcoin_io::ErrorKind::WriteZero
+pub fn &'a mut [u8]::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &'a mut [u8]::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &[u8]::consume(&mut self, amount: usize)
+pub fn &[u8]::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn &[u8]::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn alloc::vec::Vec<u8>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn alloc::vec::Vec<u8>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
+pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
+pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
+pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::Error::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_io::Error::from(kind: bitcoin_io::ErrorKind) -> bitcoin_io::Error
+pub fn bitcoin_io::Error::get_ref(&self) -> core::option::Option<&(dyn core::fmt::Debug + core::marker::Send + core::marker::Sync + 'static)>
+pub fn bitcoin_io::Error::kind(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::Error::new<E: sealed::IntoBoxDynDebug>(kind: bitcoin_io::ErrorKind, error: E) -> bitcoin_io::Error
+pub fn bitcoin_io::ErrorKind::clone(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::ErrorKind::eq(&self, other: &bitcoin_io::ErrorKind) -> bool
+pub fn bitcoin_io::ErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::ErrorKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Read::read_to_limit(&mut self, buf: &mut alloc::vec::Vec<u8>, limit: u64) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Sink::write_all(&mut self, &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Take<'a, R>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Take<'a, R>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Take<'a, R>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Write::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::sink() -> bitcoin_io::Sink
+pub macro bitcoin_io::impl_write!
+pub mod bitcoin_io
+pub struct bitcoin_io::Cursor<T>
+pub struct bitcoin_io::Error
+pub struct bitcoin_io::Sink
+pub struct bitcoin_io::Take<'a, R: bitcoin_io::Read + core::marker::Sized>
+pub trait bitcoin_io::BufRead: bitcoin_io::Read
+pub trait bitcoin_io::Read
+pub trait bitcoin_io::Write
+pub type bitcoin_io::Result<T> = core::result::Result<T, bitcoin_io::Error>

--- a/api/io/no-features.txt
+++ b/api/io/no-features.txt
@@ -1,0 +1,108 @@
+#[non_exhaustive] pub enum bitcoin_io::ErrorKind
+impl bitcoin_io::BufRead for &[u8]
+impl bitcoin_io::Error
+impl bitcoin_io::Read for &[u8]
+impl bitcoin_io::Write for bitcoin_io::Sink
+impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::cmp::Eq for bitcoin_io::ErrorKind
+impl core::cmp::PartialEq for bitcoin_io::ErrorKind
+impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::ErrorKind
+impl core::fmt::Display for bitcoin_io::Error
+impl core::hash::Hash for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Error
+impl core::marker::Send for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Sink
+impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Error
+impl core::marker::Sync for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Sink
+impl core::marker::Unpin for bitcoin_io::Error
+impl core::marker::Unpin for bitcoin_io::ErrorKind
+impl core::marker::Unpin for bitcoin_io::Sink
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Sink
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Sink
+impl<'a, R: bitcoin_io::BufRead + core::marker::Sized> bitcoin_io::BufRead for bitcoin_io::Take<'a, R>
+impl<'a, R: bitcoin_io::Read + core::marker::Sized> bitcoin_io::Read for bitcoin_io::Take<'a, R>
+impl<'a, R: core::marker::Sized> core::marker::Send for bitcoin_io::Take<'a, R> where R: core::marker::Send
+impl<'a, R: core::marker::Sized> core::marker::Sync for bitcoin_io::Take<'a, R> where R: core::marker::Sync
+impl<'a, R: core::marker::Sized> core::marker::Unpin for bitcoin_io::Take<'a, R>
+impl<'a, R: core::marker::Sized> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Take<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Take<'a, R>
+impl<'a> bitcoin_io::Write for &'a mut [u8]
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
+impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_io::Cursor<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_io::ErrorKind::AddrInUse
+pub bitcoin_io::ErrorKind::AddrNotAvailable
+pub bitcoin_io::ErrorKind::AlreadyExists
+pub bitcoin_io::ErrorKind::BrokenPipe
+pub bitcoin_io::ErrorKind::ConnectionAborted
+pub bitcoin_io::ErrorKind::ConnectionRefused
+pub bitcoin_io::ErrorKind::ConnectionReset
+pub bitcoin_io::ErrorKind::Interrupted
+pub bitcoin_io::ErrorKind::InvalidData
+pub bitcoin_io::ErrorKind::InvalidInput
+pub bitcoin_io::ErrorKind::NotConnected
+pub bitcoin_io::ErrorKind::NotFound
+pub bitcoin_io::ErrorKind::Other
+pub bitcoin_io::ErrorKind::PermissionDenied
+pub bitcoin_io::ErrorKind::TimedOut
+pub bitcoin_io::ErrorKind::UnexpectedEof
+pub bitcoin_io::ErrorKind::WouldBlock
+pub bitcoin_io::ErrorKind::WriteZero
+pub fn &'a mut [u8]::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &'a mut [u8]::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &[u8]::consume(&mut self, amount: usize)
+pub fn &[u8]::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn &[u8]::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
+pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
+pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
+pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::Error::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_io::Error::from(kind: bitcoin_io::ErrorKind) -> bitcoin_io::Error
+pub fn bitcoin_io::Error::kind(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::ErrorKind::clone(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::ErrorKind::eq(&self, other: &bitcoin_io::ErrorKind) -> bool
+pub fn bitcoin_io::ErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::ErrorKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Sink::write_all(&mut self, &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Take<'a, R>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Take<'a, R>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Take<'a, R>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Write::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::sink() -> bitcoin_io::Sink
+pub macro bitcoin_io::impl_write!
+pub mod bitcoin_io
+pub struct bitcoin_io::Cursor<T>
+pub struct bitcoin_io::Error
+pub struct bitcoin_io::Sink
+pub struct bitcoin_io::Take<'a, R: bitcoin_io::Read + core::marker::Sized>
+pub trait bitcoin_io::BufRead: bitcoin_io::Read
+pub trait bitcoin_io::Read
+pub trait bitcoin_io::Write
+pub type bitcoin_io::Result<T> = core::result::Result<T, bitcoin_io::Error>

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1,0 +1,391 @@
+#[non_exhaustive] pub enum bitcoin_units::ParseAmountError
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseAmountError
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+impl bitcoin_units::amount::Amount
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::OutOfRangeError
+impl bitcoin_units::amount::SignedAmount
+impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::amount::Amount
+impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::amount::SignedAmount
+impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::amount::Amount
+impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::amount::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::Amount
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::Amount
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::SignedAmount
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Ord for bitcoin_units::amount::Amount
+impl core::cmp::Ord for bitcoin_units::amount::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::Amount
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::PartialOrd for bitcoin_units::amount::Amount
+impl core::cmp::PartialOrd for bitcoin_units::amount::SignedAmount
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::default::Default for bitcoin_units::amount::Amount
+impl core::default::Default for bitcoin_units::amount::SignedAmount
+impl core::error::Error for bitcoin_units::amount::OutOfRangeError
+impl core::error::Error for bitcoin_units::amount::ParseAmountError
+impl core::error::Error for bitcoin_units::amount::ParseDenominationError
+impl core::error::Error for bitcoin_units::amount::ParseError
+impl core::error::Error for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::error::Error for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::Amount
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::SignedAmount
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::amount::Amount
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::SignedAmount
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
+impl core::hash::Hash for bitcoin_units::amount::Amount
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::amount::SignedAmount
+impl core::iter::traits::accum::Sum for bitcoin_units::amount::Amount
+impl core::iter::traits::accum::Sum for bitcoin_units::amount::SignedAmount
+impl core::marker::Copy for bitcoin_units::amount::Amount
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::amount::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::Amount
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::amount::Amount
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::SignedAmount
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::Amount
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::SignedAmount
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
+impl core::ops::arith::Add for bitcoin_units::amount::Amount
+impl core::ops::arith::Add for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::AddAssign for bitcoin_units::amount::Amount
+impl core::ops::arith::AddAssign for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Div<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Div<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Mul<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Mul<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Rem<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Rem<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Sub for bitcoin_units::amount::Amount
+impl core::ops::arith::Sub for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::SubAssign for bitcoin_units::amount::Amount
+impl core::ops::arith::SubAssign for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::str::traits::FromStr for bitcoin_units::amount::Amount
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::amount::SignedAmount
+impl serde::ser::Serialize for bitcoin_units::amount::Amount
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::amount::Amount
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::Amount>
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::SignedAmount>
+pub bitcoin_units::ParseAmountError::InputTooLarge
+pub bitcoin_units::ParseAmountError::InvalidCharacter(char)
+pub bitcoin_units::ParseAmountError::InvalidFormat
+pub bitcoin_units::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
+pub bitcoin_units::ParseAmountError::TooPrecise
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::MilliSatoshi
+pub bitcoin_units::amount::Denomination::NanoBitcoin
+pub bitcoin_units::amount::Denomination::PicoBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseAmountError::InputTooLarge
+pub bitcoin_units::amount::ParseAmountError::InvalidCharacter(char)
+pub bitcoin_units::amount::ParseAmountError::InvalidFormat
+pub bitcoin_units::amount::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
+pub bitcoin_units::amount::ParseAmountError::TooPrecise
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub bitcoin_units::amount::ParseError::Amount(bitcoin_units::amount::ParseAmountError)
+pub bitcoin_units::amount::ParseError::Denomination(bitcoin_units::amount::ParseDenominationError)
+pub const bitcoin_units::amount::Amount::MAX: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::MAX_MONEY: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::MIN: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::ONE_BTC: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::ONE_SAT: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::SIZE: usize
+pub const bitcoin_units::amount::Amount::ZERO: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::amount::SignedAmount::MAX: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::MAX_MONEY: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::MIN: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ONE_BTC: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ONE_SAT: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ZERO: bitcoin_units::amount::SignedAmount
+pub const fn bitcoin_units::amount::Amount::from_int_btc(btc: u64) -> bitcoin_units::amount::Amount
+pub const fn bitcoin_units::amount::Amount::from_sat(satoshi: u64) -> bitcoin_units::amount::Amount
+pub const fn bitcoin_units::amount::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::amount::SignedAmount
+pub extern crate bitcoin_units::serde
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::Amount::add(self, rhs: bitcoin_units::amount::Amount) -> Self::Output
+pub fn bitcoin_units::amount::Amount::add_assign(&mut self, other: bitcoin_units::amount::Amount)
+pub fn bitcoin_units::amount::Amount::checked_add(self, rhs: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_div(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_sub(self, rhs: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::clone(&self) -> bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::Amount::cmp(&self, other: &bitcoin_units::amount::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::amount::Amount::default() -> Self
+pub fn bitcoin_units::amount::Amount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::Amount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::Amount::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::amount::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::amount::Amount::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::amount::Amount::eq(&self, other: &bitcoin_units::amount::Amount) -> bool
+pub fn bitcoin_units::amount::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Amount::fmt_value_in(self, f: &mut dyn core::fmt::Write, denom: bitcoin_units::amount::Denomination) -> core::fmt::Result
+pub fn bitcoin_units::amount::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::amount::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::amount::Amount::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::amount::Amount::partial_cmp(&self, other: &bitcoin_units::amount::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::amount::Amount::rem(self, modulus: u64) -> Self
+pub fn bitcoin_units::amount::Amount::rem_assign(&mut self, modulus: u64)
+pub fn bitcoin_units::amount::Amount::ser_btc<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::Amount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::Amount::ser_sat<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::Amount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::Amount::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::amount::Amount::sub(self, rhs: bitcoin_units::amount::Amount) -> Self::Output
+pub fn bitcoin_units::amount::Amount::sub_assign(&mut self, other: bitcoin_units::amount::Amount)
+pub fn bitcoin_units::amount::Amount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::amount::Amount::to_btc(self) -> f64
+pub fn bitcoin_units::amount::Amount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::amount::Amount::to_sat(self) -> u64
+pub fn bitcoin_units::amount::Amount::to_signed(self) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::amount::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::amount::Amount::type_prefix(private::Token) -> &'static str
+pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(&self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(&self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(&self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::ParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::SignedAmount::abs(self) -> bitcoin_units::amount::SignedAmount
+pub fn bitcoin_units::amount::SignedAmount::add(self, rhs: bitcoin_units::amount::SignedAmount) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::add_assign(&mut self, other: bitcoin_units::amount::SignedAmount)
+pub fn bitcoin_units::amount::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_add(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_sub(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::clone(&self) -> bitcoin_units::amount::SignedAmount
+pub fn bitcoin_units::amount::SignedAmount::cmp(&self, other: &bitcoin_units::amount::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::amount::SignedAmount::default() -> Self
+pub fn bitcoin_units::amount::SignedAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::amount::SignedAmount::eq(&self, other: &bitcoin_units::amount::SignedAmount) -> bool
+pub fn bitcoin_units::amount::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::SignedAmount::fmt_value_in(self, f: &mut dyn core::fmt::Write, denom: bitcoin_units::amount::Denomination) -> core::fmt::Result
+pub fn bitcoin_units::amount::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::amount::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::amount::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::amount::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::amount::SignedAmount::partial_cmp(&self, other: &bitcoin_units::amount::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::amount::SignedAmount::positive_sub(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::rem(self, modulus: i64) -> Self
+pub fn bitcoin_units::amount::SignedAmount::rem_assign(&mut self, modulus: i64)
+pub fn bitcoin_units::amount::SignedAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::amount::SignedAmount::sub(self, rhs: bitcoin_units::amount::SignedAmount) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::sub_assign(&mut self, other: bitcoin_units::amount::SignedAmount)
+pub fn bitcoin_units::amount::SignedAmount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::amount::SignedAmount::to_btc(self) -> f64
+pub fn bitcoin_units::amount::SignedAmount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::amount::SignedAmount::to_sat(self) -> i64
+pub fn bitcoin_units::amount::SignedAmount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::amount::SignedAmount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::amount::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::amount::SignedAmount::type_prefix(private::Token) -> &'static str
+pub fn bitcoin_units::amount::SignedAmount::unsigned_abs(self) -> bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::type_prefix(private::Token) -> &'static str
+pub fn bitcoin_units::amount::serde::as_btc::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub mod bitcoin_units::amount::serde
+pub mod bitcoin_units::amount::serde::as_btc
+pub mod bitcoin_units::amount::serde::as_btc::opt
+pub mod bitcoin_units::amount::serde::as_sat
+pub mod bitcoin_units::amount::serde::as_sat::opt
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub trait bitcoin_units::amount::CheckedSum<R>: private::SumSeal<R>
+pub trait bitcoin_units::amount::serde::SerdeAmount: core::marker::Copy + core::marker::Sized
+pub trait bitcoin_units::amount::serde::SerdeAmountForOpt: core::marker::Copy + core::marker::Sized + bitcoin_units::amount::serde::SerdeAmount
+pub type bitcoin_units::amount::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::amount::Amount::Output = bitcoin_units::amount::Amount
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
+pub type bitcoin_units::amount::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::amount::SignedAmount::Output = bitcoin_units::amount::SignedAmount

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1,0 +1,335 @@
+#[non_exhaustive] pub enum bitcoin_units::ParseAmountError
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseAmountError
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+impl bitcoin_units::amount::Amount
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::OutOfRangeError
+impl bitcoin_units::amount::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::Amount
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::Amount
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::SignedAmount
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Ord for bitcoin_units::amount::Amount
+impl core::cmp::Ord for bitcoin_units::amount::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::Amount
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::PartialOrd for bitcoin_units::amount::Amount
+impl core::cmp::PartialOrd for bitcoin_units::amount::SignedAmount
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::default::Default for bitcoin_units::amount::Amount
+impl core::default::Default for bitcoin_units::amount::SignedAmount
+impl core::fmt::Debug for bitcoin_units::amount::Amount
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::SignedAmount
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::amount::Amount
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::SignedAmount
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
+impl core::hash::Hash for bitcoin_units::amount::Amount
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::amount::SignedAmount
+impl core::iter::traits::accum::Sum for bitcoin_units::amount::Amount
+impl core::iter::traits::accum::Sum for bitcoin_units::amount::SignedAmount
+impl core::marker::Copy for bitcoin_units::amount::Amount
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::amount::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::Amount
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::amount::Amount
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::SignedAmount
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::Amount
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::SignedAmount
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
+impl core::ops::arith::Add for bitcoin_units::amount::Amount
+impl core::ops::arith::Add for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::AddAssign for bitcoin_units::amount::Amount
+impl core::ops::arith::AddAssign for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Div<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Div<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Mul<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Mul<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Rem<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Rem<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Sub for bitcoin_units::amount::Amount
+impl core::ops::arith::Sub for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::SubAssign for bitcoin_units::amount::Amount
+impl core::ops::arith::SubAssign for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::str::traits::FromStr for bitcoin_units::amount::Amount
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::amount::SignedAmount
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::Amount>
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::SignedAmount>
+pub bitcoin_units::ParseAmountError::InputTooLarge
+pub bitcoin_units::ParseAmountError::InvalidCharacter(char)
+pub bitcoin_units::ParseAmountError::InvalidFormat
+pub bitcoin_units::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
+pub bitcoin_units::ParseAmountError::TooPrecise
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::MilliSatoshi
+pub bitcoin_units::amount::Denomination::NanoBitcoin
+pub bitcoin_units::amount::Denomination::PicoBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseAmountError::InputTooLarge
+pub bitcoin_units::amount::ParseAmountError::InvalidCharacter(char)
+pub bitcoin_units::amount::ParseAmountError::InvalidFormat
+pub bitcoin_units::amount::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
+pub bitcoin_units::amount::ParseAmountError::TooPrecise
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub bitcoin_units::amount::ParseError::Amount(bitcoin_units::amount::ParseAmountError)
+pub bitcoin_units::amount::ParseError::Denomination(bitcoin_units::amount::ParseDenominationError)
+pub const bitcoin_units::amount::Amount::MAX: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::MAX_MONEY: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::MIN: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::ONE_BTC: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::ONE_SAT: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::SIZE: usize
+pub const bitcoin_units::amount::Amount::ZERO: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::amount::SignedAmount::MAX: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::MAX_MONEY: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::MIN: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ONE_BTC: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ONE_SAT: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ZERO: bitcoin_units::amount::SignedAmount
+pub const fn bitcoin_units::amount::Amount::from_int_btc(btc: u64) -> bitcoin_units::amount::Amount
+pub const fn bitcoin_units::amount::Amount::from_sat(satoshi: u64) -> bitcoin_units::amount::Amount
+pub const fn bitcoin_units::amount::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::amount::SignedAmount
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::Amount::add(self, rhs: bitcoin_units::amount::Amount) -> Self::Output
+pub fn bitcoin_units::amount::Amount::add_assign(&mut self, other: bitcoin_units::amount::Amount)
+pub fn bitcoin_units::amount::Amount::checked_add(self, rhs: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_div(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_sub(self, rhs: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::clone(&self) -> bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::Amount::cmp(&self, other: &bitcoin_units::amount::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::amount::Amount::default() -> Self
+pub fn bitcoin_units::amount::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::amount::Amount::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::amount::Amount::eq(&self, other: &bitcoin_units::amount::Amount) -> bool
+pub fn bitcoin_units::amount::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Amount::fmt_value_in(self, f: &mut dyn core::fmt::Write, denom: bitcoin_units::amount::Denomination) -> core::fmt::Result
+pub fn bitcoin_units::amount::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::amount::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::amount::Amount::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::amount::Amount::partial_cmp(&self, other: &bitcoin_units::amount::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::amount::Amount::rem(self, modulus: u64) -> Self
+pub fn bitcoin_units::amount::Amount::rem_assign(&mut self, modulus: u64)
+pub fn bitcoin_units::amount::Amount::sub(self, rhs: bitcoin_units::amount::Amount) -> Self::Output
+pub fn bitcoin_units::amount::Amount::sub_assign(&mut self, other: bitcoin_units::amount::Amount)
+pub fn bitcoin_units::amount::Amount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::amount::Amount::to_btc(self) -> f64
+pub fn bitcoin_units::amount::Amount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::amount::Amount::to_sat(self) -> u64
+pub fn bitcoin_units::amount::Amount::to_signed(self) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::amount::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(&self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(&self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(&self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::SignedAmount::abs(self) -> bitcoin_units::amount::SignedAmount
+pub fn bitcoin_units::amount::SignedAmount::add(self, rhs: bitcoin_units::amount::SignedAmount) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::add_assign(&mut self, other: bitcoin_units::amount::SignedAmount)
+pub fn bitcoin_units::amount::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_add(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_sub(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::clone(&self) -> bitcoin_units::amount::SignedAmount
+pub fn bitcoin_units::amount::SignedAmount::cmp(&self, other: &bitcoin_units::amount::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::amount::SignedAmount::default() -> Self
+pub fn bitcoin_units::amount::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::amount::SignedAmount::eq(&self, other: &bitcoin_units::amount::SignedAmount) -> bool
+pub fn bitcoin_units::amount::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::SignedAmount::fmt_value_in(self, f: &mut dyn core::fmt::Write, denom: bitcoin_units::amount::Denomination) -> core::fmt::Result
+pub fn bitcoin_units::amount::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::amount::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::amount::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::amount::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::amount::SignedAmount::partial_cmp(&self, other: &bitcoin_units::amount::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::amount::SignedAmount::positive_sub(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::rem(self, modulus: i64) -> Self
+pub fn bitcoin_units::amount::SignedAmount::rem_assign(&mut self, modulus: i64)
+pub fn bitcoin_units::amount::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::amount::SignedAmount::sub(self, rhs: bitcoin_units::amount::SignedAmount) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::sub_assign(&mut self, other: bitcoin_units::amount::SignedAmount)
+pub fn bitcoin_units::amount::SignedAmount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::amount::SignedAmount::to_btc(self) -> f64
+pub fn bitcoin_units::amount::SignedAmount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::amount::SignedAmount::to_sat(self) -> i64
+pub fn bitcoin_units::amount::SignedAmount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::amount::SignedAmount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::amount::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::amount::SignedAmount::unsigned_abs(self) -> bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub trait bitcoin_units::amount::CheckedSum<R>: private::SumSeal<R>
+pub type bitcoin_units::amount::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::amount::Amount::Output = bitcoin_units::amount::Amount
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
+pub type bitcoin_units::amount::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::amount::SignedAmount::Output = bitcoin_units::amount::SignedAmount

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1,0 +1,323 @@
+#[non_exhaustive] pub enum bitcoin_units::ParseAmountError
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseAmountError
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+impl bitcoin_units::amount::Amount
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::OutOfRangeError
+impl bitcoin_units::amount::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::Amount
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::Amount
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::SignedAmount
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Ord for bitcoin_units::amount::Amount
+impl core::cmp::Ord for bitcoin_units::amount::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::Amount
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::PartialOrd for bitcoin_units::amount::Amount
+impl core::cmp::PartialOrd for bitcoin_units::amount::SignedAmount
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::default::Default for bitcoin_units::amount::Amount
+impl core::default::Default for bitcoin_units::amount::SignedAmount
+impl core::fmt::Debug for bitcoin_units::amount::Amount
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::SignedAmount
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::amount::Amount
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::SignedAmount
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
+impl core::hash::Hash for bitcoin_units::amount::Amount
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::amount::SignedAmount
+impl core::iter::traits::accum::Sum for bitcoin_units::amount::Amount
+impl core::iter::traits::accum::Sum for bitcoin_units::amount::SignedAmount
+impl core::marker::Copy for bitcoin_units::amount::Amount
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::amount::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::Amount
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::amount::Amount
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::SignedAmount
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::Amount
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::SignedAmount
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
+impl core::ops::arith::Add for bitcoin_units::amount::Amount
+impl core::ops::arith::Add for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::AddAssign for bitcoin_units::amount::Amount
+impl core::ops::arith::AddAssign for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Div<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Div<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Mul<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Mul<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Rem<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Rem<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::amount::Amount
+impl core::ops::arith::Sub for bitcoin_units::amount::Amount
+impl core::ops::arith::Sub for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::SubAssign for bitcoin_units::amount::Amount
+impl core::ops::arith::SubAssign for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::str::traits::FromStr for bitcoin_units::amount::Amount
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::amount::SignedAmount
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::Amount>
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::SignedAmount>
+pub bitcoin_units::ParseAmountError::InputTooLarge
+pub bitcoin_units::ParseAmountError::InvalidCharacter(char)
+pub bitcoin_units::ParseAmountError::InvalidFormat
+pub bitcoin_units::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
+pub bitcoin_units::ParseAmountError::TooPrecise
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::MilliSatoshi
+pub bitcoin_units::amount::Denomination::NanoBitcoin
+pub bitcoin_units::amount::Denomination::PicoBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseAmountError::InputTooLarge
+pub bitcoin_units::amount::ParseAmountError::InvalidCharacter(char)
+pub bitcoin_units::amount::ParseAmountError::InvalidFormat
+pub bitcoin_units::amount::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
+pub bitcoin_units::amount::ParseAmountError::TooPrecise
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub bitcoin_units::amount::ParseError::Amount(bitcoin_units::amount::ParseAmountError)
+pub bitcoin_units::amount::ParseError::Denomination(bitcoin_units::amount::ParseDenominationError)
+pub const bitcoin_units::amount::Amount::MAX: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::MAX_MONEY: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::MIN: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::ONE_BTC: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::ONE_SAT: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Amount::SIZE: usize
+pub const bitcoin_units::amount::Amount::ZERO: bitcoin_units::amount::Amount
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::amount::SignedAmount::MAX: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::MAX_MONEY: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::MIN: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ONE_BTC: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ONE_SAT: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::amount::SignedAmount::ZERO: bitcoin_units::amount::SignedAmount
+pub const fn bitcoin_units::amount::Amount::from_int_btc(btc: u64) -> bitcoin_units::amount::Amount
+pub const fn bitcoin_units::amount::Amount::from_sat(satoshi: u64) -> bitcoin_units::amount::Amount
+pub const fn bitcoin_units::amount::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::amount::SignedAmount
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::Amount::add(self, rhs: bitcoin_units::amount::Amount) -> Self::Output
+pub fn bitcoin_units::amount::Amount::add_assign(&mut self, other: bitcoin_units::amount::Amount)
+pub fn bitcoin_units::amount::Amount::checked_add(self, rhs: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_div(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::checked_sub(self, rhs: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::Amount>
+pub fn bitcoin_units::amount::Amount::clone(&self) -> bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::Amount::cmp(&self, other: &bitcoin_units::amount::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::amount::Amount::default() -> Self
+pub fn bitcoin_units::amount::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::amount::Amount::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::amount::Amount::eq(&self, other: &bitcoin_units::amount::Amount) -> bool
+pub fn bitcoin_units::amount::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Amount::fmt_value_in(self, f: &mut dyn core::fmt::Write, denom: bitcoin_units::amount::Denomination) -> core::fmt::Result
+pub fn bitcoin_units::amount::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::amount::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::amount::Amount::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::amount::Amount::partial_cmp(&self, other: &bitcoin_units::amount::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::amount::Amount::rem(self, modulus: u64) -> Self
+pub fn bitcoin_units::amount::Amount::rem_assign(&mut self, modulus: u64)
+pub fn bitcoin_units::amount::Amount::sub(self, rhs: bitcoin_units::amount::Amount) -> Self::Output
+pub fn bitcoin_units::amount::Amount::sub_assign(&mut self, other: bitcoin_units::amount::Amount)
+pub fn bitcoin_units::amount::Amount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::amount::Amount::to_sat(self) -> u64
+pub fn bitcoin_units::amount::Amount::to_signed(self) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(&self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(&self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(&self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::SignedAmount::abs(self) -> bitcoin_units::amount::SignedAmount
+pub fn bitcoin_units::amount::SignedAmount::add(self, rhs: bitcoin_units::amount::SignedAmount) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::add_assign(&mut self, other: bitcoin_units::amount::SignedAmount)
+pub fn bitcoin_units::amount::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_add(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::checked_sub(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::clone(&self) -> bitcoin_units::amount::SignedAmount
+pub fn bitcoin_units::amount::SignedAmount::cmp(&self, other: &bitcoin_units::amount::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::amount::SignedAmount::default() -> Self
+pub fn bitcoin_units::amount::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::amount::SignedAmount::eq(&self, other: &bitcoin_units::amount::SignedAmount) -> bool
+pub fn bitcoin_units::amount::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::SignedAmount::fmt_value_in(self, f: &mut dyn core::fmt::Write, denom: bitcoin_units::amount::Denomination) -> core::fmt::Result
+pub fn bitcoin_units::amount::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::amount::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::amount::SignedAmount, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::amount::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::amount::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::amount::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::amount::SignedAmount::partial_cmp(&self, other: &bitcoin_units::amount::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::amount::SignedAmount::positive_sub(self, rhs: bitcoin_units::amount::SignedAmount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
+pub fn bitcoin_units::amount::SignedAmount::rem(self, modulus: i64) -> Self
+pub fn bitcoin_units::amount::SignedAmount::rem_assign(&mut self, modulus: i64)
+pub fn bitcoin_units::amount::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::amount::SignedAmount::sub(self, rhs: bitcoin_units::amount::SignedAmount) -> Self::Output
+pub fn bitcoin_units::amount::SignedAmount::sub_assign(&mut self, other: bitcoin_units::amount::SignedAmount)
+pub fn bitcoin_units::amount::SignedAmount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::amount::SignedAmount::to_sat(self) -> i64
+pub fn bitcoin_units::amount::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::amount::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::amount::SignedAmount::unsigned_abs(self) -> bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub trait bitcoin_units::amount::CheckedSum<R>: private::SumSeal<R>
+pub type bitcoin_units::amount::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::amount::Amount::Output = bitcoin_units::amount::Amount
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
+pub type bitcoin_units::amount::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::amount::SignedAmount::Output = bitcoin_units::amount::SignedAmount

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -68,15 +68,18 @@ generate_api_files() {
 # Check if there are changes (dirty git index) to the `api/` directory. 
 check_for_changes() {
     pushd "$REPO_DIR" > /dev/null
+
     if [[ $(git status --porcelain api) ]]; then
         git diff --color=always
 
         echo
         echo "You have introduced changes to the public API, commit the changes to api/ currently in your working directory" >&2
         exit 1
+
     else
         echo "No changes to the current public API"
     fi
+
     popd > /dev/null
 }
 

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -73,6 +73,7 @@ check_for_changes() {
 
         echo
         echo "You have introduced changes to the public API, commit the changes to api/ currently in your working directory" >&2
+        exit 1
     else
         echo "No changes to the current public API"
     fi

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Checks the public API of crates, exits with non-zero if there are currently
+# changes to the public API not already committed to in the various api/*.txt
+# files.
+
+set -ex
+
+REPO_DIR=$(git rev-parse --show-toplevel)
+API_DIR="$REPO_DIR/api"
+
+CARGO="cargo +nightly public-api --simplified"
+# `sort -n -u` doesn't work for some reason.
+SORT="sort --numeric-sort"
+
+# Sort order is effected by locale. See `man sort`.
+# > Set LC_ALL=C to get the traditional sort order that uses native byte values.
+export LC_ALL=C
+
+main() {
+    # cargo public-api uses nightly so the toolchain must be available.
+    if ! cargo +nightly --version > /dev/null; then
+        echo "script requires a nightly toolchain to be installed (possibly >= nightly-2023-05-24)" >&2
+        exit 1
+    fi
+
+    generate_api_files_bitcoin
+
+    # These ones have an "alloc" feature we want to check.
+    generate_api_files "hashes"
+    generate_api_files "units"
+    generate_api_files "io"
+
+    check_for_changes
+}
+
+generate_api_files_bitcoin() {
+    local crate="bitcoin"
+
+    pushd "$REPO_DIR/$crate" > /dev/null
+
+    $CARGO | $SORT | uniq > "$API_DIR/$crate/default-features.txt"
+    $CARGO --no-default-features | $SORT | uniq > "$API_DIR/$crate/no-features.txt"
+    $CARGO --all-features | $SORT | uniq > "$API_DIR/$crate/all-features.txt"
+
+    popd > /dev/null
+}
+
+# Uses `CARGO` to generate API files in the specified crate.
+#
+# Files:
+#
+# - no-features.txt
+# - alloc-only.txt
+# - all-features.txt
+generate_api_files() {
+    local crate=$1
+
+    pushd "$REPO_DIR/$crate" > /dev/null
+
+    $CARGO --no-default-features | $SORT | uniq > "$API_DIR/$crate/no-features.txt"
+    $CARGO --no-default-features --features=alloc | $SORT | uniq > "$API_DIR/$crate/alloc-only.txt"
+    $CARGO --all-features | $SORT | uniq > "$API_DIR/$crate/all-features.txt"
+
+    popd > /dev/null
+}
+
+# Check if there are changes (dirty git index) to the `api/` directory. 
+check_for_changes() {
+    pushd "$REPO_DIR" > /dev/null
+    if [[ $(git status --porcelain api) ]]; then
+        git diff --color=always
+
+        echo
+        echo "You have introduced changes to the public API, commit the changes to api/ currently in your working directory" >&2
+    else
+        echo "No changes to the current public API"
+    fi
+    popd > /dev/null
+}
+
+#
+# Main script
+#
+main "$@"
+exit 0

--- a/justfile
+++ b/justfile
@@ -32,3 +32,7 @@ sane: lint
 # Update the recent and minimal lock files.
 update-lock-files:
   contrib/update-lock-files.sh
+
+# Check for API changes.
+check-api:
+ contrib/check-for-api-changes.sh


### PR DESCRIPTION
Add a script that checks the public API of `hashes` and `bitcoin`. Document how to use it during development. Call it in CI. Do not add it to githooks because the githooks because its expected to be run per PR not per commit.

Now includes a `just` command to run the script: `just check-api`

### Implied workflow change

This PR imposes workflow changes, it may trigger your anti-authoritarian side.

Explicitly: all PRs that change the public API of `bitcoin`, `hashes`, `io`, or `units` must contain changes to the api text files. 

Suggestion: We add the patch updating api text files as a separate patch at the end of each PR so we can haggle over it separately from the actual code changes.

Fix: #1875