### PR TITLE
rename bitcoin-private to bitcoin-internals

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -37,7 +37,7 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
- "bitcoin-private",
+ "bitcoin-internals",
  "bitcoin_hashes",
  "bitcoinconsensus",
  "core2",
@@ -62,14 +62,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-private"
+name = "bitcoin-internals"
 version = "0.1.0"
 
 [[package]]
 name = "bitcoin_hashes"
 version = "0.12.0"
 dependencies = [
- "bitcoin-private",
+ "bitcoin-internals",
  "core2",
  "schemars",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -36,7 +36,7 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
- "bitcoin-private",
+ "bitcoin-internals",
  "bitcoin_hashes",
  "bitcoinconsensus",
  "core2",
@@ -61,14 +61,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-private"
+name = "bitcoin-internals"
 version = "0.1.0"
 
 [[package]]
 name = "bitcoin_hashes"
 version = "0.12.0"
 dependencies = [
- "bitcoin-private",
+ "bitcoin-internals",
  "core2",
  "schemars",
  "serde",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 This security policy applies to the "core" crates in the rust-bitcoin ecosystem, which are
-`bitcoin`, `secp256k1`, `bitcoin_hashes` and `bitcoin-private`. These crates deal with
+`bitcoin`, `secp256k1`, `bitcoin_hashes` and `bitcoin-internals`. These crates deal with
 cryptography and cryptographic algorithms, and as such, are likely locations for security
 vulnerabilities to crop up.
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-internals = { package = "bitcoin-private", version = "0.1.0", path = "../internals" }
+internals = { package = "bitcoin-internals", version = "0.1.0", path = "../internals" }
 bech32 = { version = "0.9.0", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.12.0", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -38,7 +38,7 @@ publish_dry_run() {
     if [ "$crate" == "hashes" ]; then
         cargo publish -p "bitcoin_hashes" --dry-run
     elif [ "$crate" == "internals" ]; then
-        cargo publish -p "bitcoin-private" --dry-run
+        cargo publish -p "bitcoin-internals" --dry-run
     elif [ "$crate" == "bitcoin" ]; then
         cargo publish -p "bitcoin" --dry-run
     fi

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -23,7 +23,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-internals = { path = "../internals", package = "bitcoin-private", version = "0.1.0" }
+internals = { path = "../internals", package = "bitcoin-internals", version = "0.1.0" }
 
 core2 = { version = "0.3.0", default_features = false, optional = true }
 schemars = { version = "0.8.3", optional = true }

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "bitcoin-private"
+name = "bitcoin-internals"
 version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
-documentation = "https://docs.rs/bitcoin-private"
+documentation = "https://docs.rs/bitcoin-internals"
 description = "Internal types and macros used by rust-bitcoin ecosystem"
 categories = ["cryptography::cryptocurrencies"]
 keywords = ["internal"]


### PR DESCRIPTION
Since we now have control over the name on crates.io.