### PR TITLE
Remove doc(hidden) from error conversion functions

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -148,12 +148,10 @@ impl std::error::Error for Error {
     }
 }
 
-#[doc(hidden)]
 impl From<base58::Error> for Error {
     fn from(e: base58::Error) -> Error { Error::Base58(e) }
 }
 
-#[doc(hidden)]
 impl From<bech32::Error> for Error {
     fn from(e: bech32::Error) -> Error { Error::Bech32(e) }
 }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -779,7 +779,6 @@ impl From<UintError> for Error {
 }
 
 #[cfg(feature = "bitcoinconsensus")]
-#[doc(hidden)]
 impl From<bitcoinconsensus::Error> for Error {
     fn from(err: bitcoinconsensus::Error) -> Error { Error::BitcoinConsensus(err) }
 }

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -93,7 +93,6 @@ impl std::error::Error for Error {
     }
 }
 
-#[doc(hidden)]
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self { Error::Io(error) }
 }

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -65,17 +65,14 @@ impl std::error::Error for Error {
     }
 }
 
-#[doc(hidden)]
 impl From<base58::Error> for Error {
     fn from(e: base58::Error) -> Error { Error::Base58(e) }
 }
 
-#[doc(hidden)]
 impl From<secp256k1::Error> for Error {
     fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
 }
 
-#[doc(hidden)]
 impl From<hex::Error> for Error {
     fn from(e: hex::Error) -> Self { Error::Hex(e) }
 }

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -203,7 +203,6 @@ impl std::error::Error for Error {
     }
 }
 
-#[doc(hidden)]
 impl From<hashes::FromSliceError> for Error {
     fn from(e: hashes::FromSliceError) -> Error { Error::HashParse(e) }
 }

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -68,7 +68,6 @@ mod message_signing {
         }
     }
 
-    #[doc(hidden)]
     impl From<secp256k1::Error> for MessageSignatureError {
         fn from(e: secp256k1::Error) -> MessageSignatureError {
             MessageSignatureError::InvalidEncoding(e)


### PR DESCRIPTION
Give people access to the error type conversion docs, its no harm and it may be useful when the compiler does not give enough information.


Done based on discussion here: https://github.com/rust-bitcoin/rust-bitcoin/pull/1846#discussion_r1209583520