### PR TITLE
Rename `HashParse` error variant to `InvalidHash`

### DIFF
--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -56,8 +56,8 @@ pub enum Error {
     },
     /// Unable to parse as a standard sighash type.
     NonStandardSighashType(u32),
-    /// Parsing errors from bitcoin_hashes
-    HashParse(hashes::FromSliceError),
+    /// Invalid hash when parsing slice.
+    InvalidHash(hashes::FromSliceError),
     /// The pre-image must hash to the correponding psbt hash
     InvalidPreimageHashPair {
         /// Hash-type
@@ -131,7 +131,7 @@ impl fmt::Display for Error {
             ),
             Error::NonStandardSighashType(ref sht) =>
                 write!(f, "non-standard sighash type: {}", sht),
-            Error::HashParse(ref e) => write_err!(f, "hash parse error"; e),
+            Error::InvalidHash(ref e) => write_err!(f, "invalid hash when parsing slice"; e),
             Error::InvalidPreimageHashPair { ref preimage, ref hash, ref hash_type } => {
                 // directly using debug forms of psbthash enums
                 write!(f, "Preimage {:?} does not match {:?} hash {:?}", preimage, hash_type, hash)
@@ -167,7 +167,7 @@ impl std::error::Error for Error {
         use self::Error::*;
 
         match self {
-            HashParse(e) => Some(e),
+            InvalidHash(e) => Some(e),
             ConsensusEncoding(e) => Some(e),
             Io(e) => Some(e),
             InvalidMagic
@@ -204,7 +204,7 @@ impl std::error::Error for Error {
 }
 
 impl From<hashes::FromSliceError> for Error {
-    fn from(e: hashes::FromSliceError) -> Error { Error::HashParse(e) }
+    fn from(e: hashes::FromSliceError) -> Error { Error::InvalidHash(e) }
 }
 
 impl From<encode::Error> for Error {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1408,9 +1408,12 @@ mod tests {
             assert_eq!(err.to_string(), "invalid xonly public key");
             let err = hex_psbt!("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a01000000225120030da4fce4f7db28c2cb2951631e003713856597fe963882cb500e68112cca63000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b6924214022cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b094089756aa3739ccc689ec0fcf3a360be32cc0b59b16e93a1e8bb4605726b2ca7a3ff706c4176649632b2cc68e1f912b8a578e3719ce7710885c7a966f49bcd43cb0000").unwrap_err();
             #[cfg(feature = "std")]
-            assert_eq!(err.to_string(), "hash parse error");
+            assert_eq!(err.to_string(), "invalid hash when parsing slice");
             #[cfg(not(feature = "std"))]
-            assert_eq!(err.to_string(), "hash parse error: invalid slice length 33 (expected 32)");
+            assert_eq!(
+                err.to_string(),
+                "invalid hash when parsing slice: invalid slice length 33 (expected 32)"
+            );
             let err = hex_psbt!("70736274ff01005e02000000019bd48765230bf9a72e662001f972556e54f0c6f97feb56bcb5600d817f6995260100000000ffffffff0148e6052a01000000225120030da4fce4f7db28c2cb2951631e003713856597fe963882cb500e68112cca63000000000001012b00f2052a01000000225120c2247efbfd92ac47f6f40b8d42d169175a19fa9fa10e4a25d7f35eb4dd85b69241142cb13ac68248de806aa6a3659cf3c03eb6821d09c8114a4e868febde865bb6d2cd970e15f53fc0c82f950fd560ffa919b76172be017368a89913af074f400b094289756aa3739ccc689ec0fcf3a360be32cc0b59b16e93a1e8bb4605726b2ca7a3ff706c4176649632b2cc68e1f912b8a578e3719ce7710885c7a966f49bcd43cb01010000").unwrap_err();
             #[cfg(feature = "std")]
             assert_eq!(err.to_string(), "invalid taproot signature");


### PR DESCRIPTION
Recently we changed the inner type of this variant and the name became stale because it is caused by a from slice constructor not from parsing.