### PR TITLE
Improve `crytpo::taproot` error type

### DIFF
--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -63,7 +63,7 @@ impl Signature {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    /// Base58 encoding error
+    /// Invalid signature hash type.
     InvalidSighashType(u8),
     /// Signature has valid size but does not parse correctly
     Secp256k1(secp256k1::Error),

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -31,7 +31,7 @@ impl Signature {
             64 => {
                 // default type
                 let sig =
-                    secp256k1::schnorr::Signature::from_slice(sl).map_err(Error::Secp256k1)?;
+                    secp256k1::schnorr::Signature::from_slice(sl)?;
                 Ok(Signature { sig, hash_ty: TapSighashType::Default })
             }
             65 => {
@@ -39,7 +39,7 @@ impl Signature {
                 let hash_ty = TapSighashType::from_consensus_u8(*hash_ty)
                     .map_err(|_| Error::InvalidSighashType(*hash_ty))?;
                 let sig =
-                    secp256k1::schnorr::Signature::from_slice(sig).map_err(Error::Secp256k1)?;
+                    secp256k1::schnorr::Signature::from_slice(sig)?;
                 Ok(Signature { sig, hash_ty })
             }
             len => Err(Error::InvalidSignatureSize(len)),

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -73,12 +73,13 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
         match *self {
-            Error::InvalidSighashType(hash_ty) =>
-                write!(f, "invalid signature hash type {}", hash_ty),
-            Error::Secp256k1(ref e) =>
+            InvalidSighashType(hash_ty) => write!(f, "invalid signature hash type {}", hash_ty),
+            Secp256k1(ref e) =>
                 write_err!(f, "taproot signature has correct len but is malformed"; e),
-            Error::InvalidSignatureSize(sz) => write!(f, "invalid taproot signature size: {}", sz),
+            InvalidSignatureSize(sz) => write!(f, "invalid taproot signature size: {}", sz),
         }
     }
 }
@@ -86,7 +87,7 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use self::Error::*;
+        use Error::*;
 
         match self {
             Secp256k1(e) => Some(e),

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -85,7 +85,7 @@ pub enum Error {
     /// Parsing error indicating invalid ECDSA signatures
     InvalidEcdsaSignature(crate::crypto::ecdsa::Error),
     /// Parsing error indicating invalid taproot signatures
-    InvalidTaprootSignature(crate::crypto::taproot::Error),
+    InvalidTaprootSignature(crate::crypto::taproot::SigFromSliceError),
     /// Parsing error indicating invalid control block
     InvalidControlBlock,
     /// Parsing error indicating invalid leaf version

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -258,10 +258,12 @@ impl Serialize for taproot::Signature {
 
 impl Deserialize for taproot::Signature {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        use taproot::SigFromSliceError::*;
+
         taproot::Signature::from_slice(bytes).map_err(|e| match e {
-            taproot::Error::InvalidSighashType(flag) => Error::NonStandardSighashType(flag as u32),
-            taproot::Error::InvalidSignatureSize(_) => Error::InvalidTaprootSignature(e),
-            taproot::Error::Secp256k1(..) => Error::InvalidTaprootSignature(e),
+            InvalidSighashType(flag) => Error::NonStandardSighashType(flag as u32),
+            InvalidSignatureSize(_) => Error::InvalidTaprootSignature(e),
+            Secp256k1(..) => Error::InvalidTaprootSignature(e),
         })
     }
 }

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -17,7 +17,7 @@ use secp256k1::{self, Scalar, Secp256k1};
 use crate::consensus::Encodable;
 use crate::crypto::key::{TapTweak, TweakedPublicKey, UntweakedPublicKey, XOnlyPublicKey};
 // Re-export these so downstream only has to use one `taproot` module.
-pub use crate::crypto::taproot::{Error, Signature};
+pub use crate::crypto::taproot::{SigFromSliceError, Signature};
 use crate::prelude::*;
 use crate::{io, Script, ScriptBuf};
 


### PR DESCRIPTION
First three patches are preparatory cleanup, last patch renames `crypto::taproot::Error` to `SigFromSliceError`. See commit log for justification of the `Sig` prefix.

Done as part of the great error cleanup.