### PR TITLE
This library is not solely dependent on Rust

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -6,9 +6,9 @@
 //! primitives. It is designed for Rust programs built to work with the Bitcoin
 //! network.
 //!
-//! It is also written entirely in Rust to illustrate the benefits of strong type
-//! safety, including ownership and lifetime, for financial and/or cryptographic
-//! software.
+//! Except for its dependency on libsecp256k1 (and optionally libbitcoinconsensus),
+//! this library is written entirely in Rust. It illustrates the benefits of
+//! strong type safety, including ownership and lifetime, for financial and/or cryptographic software.
 //!
 //! See README.md for detailed documentation about development and supported
 //! environments.


### PR DESCRIPTION
Fix: #1867


 Docs claim this library is pure rust but it depends on libsecp256k1 (and optionally libbitcoinconsensus)
So, I changed the lib.rs file accordingly.
