### PR TITLE
Add a verify function to PublicKey

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -16,6 +16,7 @@ use internals::write_err;
 pub use secp256k1::rand;
 pub use secp256k1::{self, constants, KeyPair, Parity, Secp256k1, Verification, XOnlyPublicKey};
 
+use crate::crypto::ecdsa;
 use crate::hash_types::{PubkeyHash, WPubkeyHash};
 use crate::network::constants::Network;
 use crate::prelude::*;
@@ -250,6 +251,16 @@ impl PublicKey {
         sk: &PrivateKey,
     ) -> PublicKey {
         sk.public_key(secp)
+    }
+
+    /// Checks that `sig` is a valid ECDSA signature for `msg` using this public key.
+    pub fn verify<C: secp256k1::Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        msg: &secp256k1::Message,
+        sig: &ecdsa::Signature,
+    ) -> Result<(), Error> {
+        Ok(secp.verify_ecdsa(msg, &sig.sig, &self.inner)?)
     }
 }
 


### PR DESCRIPTION
Expose signature verification functionality for ECDSA signatures on the `PublicKey` type.

We should have an identical function on `XOnlyPublicKey` but this will have to be done in `secp2561`: https://github.com/rust-bitcoin/rust-secp256k1/pull/618

Idea from Kixunil: https://github.com/rust-bitcoin/rust-bitcoin/pull/1744#issuecomment-1534200841