### PR TITLE
Fix incorrect comment in ci script

### DIFF
--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -25,7 +25,7 @@ fi
 
 # Pin dependencies as required if we are using MSRV toolchain.
 if cargo --version | grep "1\.48"; then
-    # 1.0.157 uses syn 2.0 which requires edition 2018
+    # 1.0.157 uses syn 2.0 which requires edition 2021
     cargo update -p serde --precise 1.0.156
 fi
 


### PR DESCRIPTION
MSRV build breaks because of edition _2021_ not 2018.