### PR TITLE
internals: Bump version to 0.2.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.1.0", path = "../internals" }
+internals = { package = "bitcoin-internals", version = "0.2.0", path = "../internals" }
 bech32 = { version = "0.9.0", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.12.0", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -23,7 +23,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-internals = { path = "../internals", package = "bitcoin-internals", version = "0.1.0" }
+internals = { path = "../internals", package = "bitcoin-internals", version = "0.2.0" }
 
 core2 = { version = "0.3.0", default_features = false, optional = true }
 schemars = { version = "0.8.3", optional = true }

--- a/internals/CHANGELOG.md
+++ b/internals/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.0 - 2023-06-20
+
+- [Rename crate](https://github.com/rust-bitcoin/rust-bitcoin/pull/1885) to `bitcoin-internals`
+- Add module to assist [alloc-free parse error handling](https://github.com/rust-bitcoin/rust-bitcoin/pull/1297)
+- Move various macros here.
+
 # 0.1.0 - 2023-03-08
 
 Split this crate out from the [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) crate.

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-internals"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
In preparation for release bump the version and add a changelog entry. Includes updating the dependency in `bitcoin` and `hashes`.
