### PR TITLE
hashes: Release `v0.13.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -38,7 +38,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.13.0",
  "bitcoinconsensus",
  "core2",
  "hex-conservative",
@@ -70,8 +70,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
 dependencies = [
  "bitcoin-internals",
  "core2",
@@ -396,7 +411,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
  "rand",
  "secp256k1-sys",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -37,7 +37,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.13.0",
  "bitcoinconsensus",
  "core2",
  "hex-conservative",
@@ -69,8 +69,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
 dependencies = [
  "bitcoin-internals",
  "core2",
@@ -385,7 +400,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
  "rand",
  "secp256k1-sys",
  "serde",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -37,7 +37,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 internals = { package = "bitcoin-internals", version = "0.2.0" }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 bech32 = { version = "0.9.0", default-features = false }
-hashes = { package = "bitcoin_hashes", version = "0.12.0", default-features = false }
+hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
 hex_lit = "0.1.1"
 

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -36,9 +36,12 @@ then
     duplicate_dependencies=$(
         # Only show the actual duplicated deps, not their reverse tree, then
         # whitelist the 'syn' crate which is duplicated but it's not our fault.
+        #
+        # Whitelist `bitcoin_hashes` while we release it and until secp v0.28.0 comes out.
         cargo tree  --target=all --all-features --duplicates \
             | grep '^[0-9A-Za-z]' \
             | grep -v 'syn' \
+            | grep -v 'bitcoin_hashes' \
             | wc -l
                           )
     if [ "$duplicate_dependencies" -ne 0 ]; then

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -1,6 +1,18 @@
-# Unreleased
+# 0.13.0 - 2023-06-29
 
+The main improvement in this version is removal of the `hex` module in favour of the new
+[`hex-conservative`](https://crates.io/crates/hex-conservative) crate (which we wrote). We also
+bumped the Minimum Supported Rust Version across the `rust-bitcoin` ecosystem to v1.48
+
+* Bump MSRV to 1.48.0 [#1729](https://github.com/rust-bitcoin/rust-bitcoin/pull/1729).
+* Depend on new `hex-conservative` crate and remove `hex` module [#1883](https://github.com/rust-bitcoin/rust-bitcoin/pull/1833).
 * Convert enum `crate::Error` to struct `crate::FromSliceError`.
+* Make `sha256t_hash_newtype!` evocative of the output [#1773](https://github.com/rust-bitcoin/rust-bitcoin/pull/1773).
+* Implement computing SHA256 in const context [#1769](https://github.com/rust-bitcoin/rust-bitcoin/pull/1769).
+* Add `from_bytes_ref` and `from_bytes_mut` to all hash types [#1761](https://github.com/rust-bitcoin/rust-bitcoin/pull/1761).
+* Rename `crate::Error` to `crate::FromSliceError` [#1873](https://github.com/rust-bitcoin/rust-bitcoin/pull/1873).
+* Add simd sha256 intrinsics for x86 machines [#1962](https://github.com/rust-bitcoin/rust-bitcoin/pull/1962).
+* Introduce the "small-hash" feature for `bitcoin_hashes` [#1990](https://github.com/rust-bitcoin/rust-bitcoin/pull/1990).
 
 # 0.12.0 - 2023-03-05
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"


### PR DESCRIPTION
In preparation for `hashes` release, bump the version. Depend on new version in `rust-bitcoin`.

Note the `bitcoin-private` addition to the lock files is because we temporarily have two `bitcoin_hashes` dependencies and the secp one (v.0.12.0) depends on `bitcoin-private`.