### PR TITLE
Rename `Script::empty` to `Script::new`

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -80,6 +80,10 @@ impl ToOwned for Script {
 }
 
 impl Script {
+    /// Creates a new empty script.
+    #[inline]
+    pub fn new() -> &'static Script { Script::from_bytes(&[]) }
+
     /// Treat byte slice as `Script`
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> &Script {
@@ -109,10 +113,6 @@ impl Script {
     /// Returns the script data as a mutable byte slice.
     #[inline]
     pub fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self.0 }
-
-    /// Creates a new empty script.
-    #[inline]
-    pub fn empty() -> &'static Script { Script::from_bytes(&[]) }
 
     /// Creates a new script builder
     pub fn builder() -> Builder { Builder::new() }

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -423,7 +423,7 @@ fn script_asm() {
 
 #[test]
 fn script_buf_collect() {
-    assert_eq!(&core::iter::empty::<Instruction<'_>>().collect::<ScriptBuf>(), Script::empty());
+    assert_eq!(&core::iter::empty::<Instruction<'_>>().collect::<ScriptBuf>(), Script::new());
     let script = ScriptBuf::from_hex("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").unwrap();
     assert_eq!(script.instructions().collect::<Result<ScriptBuf, _>>().unwrap(), script);
 }

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1062,7 +1062,7 @@ impl<R: BorrowMut<Transaction>> SighashCache<R> {
     ///
     /// let mut sig_hasher = SighashCache::new(&mut tx_to_sign);
     /// for inp in 0..input_count {
-    ///     let prevout_script = Script::empty();
+    ///     let prevout_script = Script::new();
     ///     let _sighash = sig_hasher.segwit_signature_hash(inp, prevout_script, Amount::ONE_SAT, EcdsaSighashType::All);
     ///     // ... sign the sighash
     ///     sig_hasher.witness_mut(inp).unwrap().push(&Vec::new());
@@ -1364,7 +1364,7 @@ mod tests {
             })
         );
         assert_eq!(
-            c.legacy_signature_hash(10, Script::empty(), 0u32),
+            c.legacy_signature_hash(10, Script::new(), 0u32),
             Err(Error::IndexOutOfInputsBounds {
                 index: 10,
                 inputs_size: 1


### PR DESCRIPTION
The `empty` constructor is mis-named for the following reasons:

- Non-uniform with `ScriptBuf::new`
- Non-standard with respect to stdlib which uses `Path::new` and `PathBuf::new` (on which we based the `Scritp`/`ScriptBuf`)

Rename the function to `new`, put it at the top of the impl block while we are at it.