### PR TITLE
Add signing methods to TapSighash and introduce SegwitScriptCode

### DIFF
--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -575,7 +575,7 @@ impl TapSighash {
         // Prepare secp256k1 message. This unwrap never panics since the sighash
         // is always 32 bytes.
         let msg = secp256k1::Message::from_slice(self.as_ref()).unwrap();
-        secp.sign_schnorr(&msg, &keypair)
+        secp.sign_schnorr(&msg, keypair)
     }
 }
 


### PR DESCRIPTION
This is a PR for https://github.com/rust-bitcoin/rust-bitcoin/issues/1903#issuecomment-1580729899 (@Kixunil)

It took me some attempts but after understanding the codebase a little better I managed to complete this in a simple, straightforward manner. Changes:

* Deprecate `p2wpkh_script_code` and introduce `segwit_script_code`, which returns the newtype `SegwitScriptCode`.
  * `p2wpkh_script_code` now wraps over `segwit_script_code`, but only returns `Some(...)` if the script is `v0_p2wpk`, which replicates existing behavior.
  * `segwit_script_code` handles `v0_p2wpk` in a specific manner, but accepts any other script as-is.
* Add `SighashCache::segwit_script_code_signature_hash`, which takes `SegwitScriptCode` as argument. Deprecate existing `segwit_signature_hash`.
* Add Schnorr signing methods directly to `TapSighash`.
  * _Should there also be methods for `*_with_aux_data`?_
* Add/update tests.
* Note that in PSBT, the `PartiallySignedTransaction::sighash_ecdsa` explicitly checks for the expected script, even though `segwit_script_code` now handles all scripts. I basically just replicated the existing behavior here.

Small note: in [BIP143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki) about `scriptCode` it states:

> For P2WSH witness program,
>
> * if the witnessScript does not contain any OP_CODESEPARATOR, the scriptCode is the witnessScript serialized as scripts inside CTxOut.
> * if the witnessScript contains any OP_CODESEPARATOR, the scriptCode is the witnessScript but removing everything up to and including the last executed OP_CODESEPARATOR before the signature checking opcode being executed, serialized as scripts inside CTxOut. (The exact semantics is demonstrated in the examples below)

This is not handled at all anywhere, afaik. Should it? OP_CODESEPARATOR is generally discouraged anyway, I've read.

Btw, while all the tests pass, I tried to import this branch into my/our project but it seems like there have been quite a bit of changes between `master` and what's on `crates.io`, getting compilation errors... looking into this.

EDIT:

If you like this design pattern then I can also add signing methods to `LegacySighash` and `SegwitV0Sighash`. Probably in a separate PR.