### PR TITLE
Fix links in docs

### DIFF
--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -70,11 +70,11 @@ const PSBT_IN_PROPRIETARY: u8 = 0xFC;
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Input {
     /// The non-witness transaction this input spends from. Should only be
-    /// [std::option::Option::Some] for inputs which spend non-segwit outputs or
+    /// `Option::Some` for inputs which spend non-segwit outputs or
     /// if it is unknown whether an input spends a segwit output.
     pub non_witness_utxo: Option<Transaction>,
     /// The transaction output this input spends from. Should only be
-    /// [std::option::Option::Some] for inputs which spend segwit outputs,
+    /// `Option::Some` for inputs which spend segwit outputs,
     /// including P2SH embedded ones.
     pub witness_utxo: Option<TxOut>,
     /// A map from public keys to their corresponding signature as would be

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -127,7 +127,7 @@ macro_rules! engine_input_impl(
 /// You can add arbitrary doc comments or other attributes to the struct or it's field. Note that
 /// the macro already derives [`Copy`], [`Clone`], [`Eq`], [`PartialEq`],
 /// [`Hash`](core::hash::Hash), [`Ord`], [`PartialOrd`]. With the `serde` feature on, this also adds
-/// [`Serialize`](serde::Serialize) and [`Deserialize](serde::Deserialize) implementations.
+/// `Serialize` and `Deserialize` implementations.
 ///
 /// You can also define multiple newtypes within one macro call:
 ///


### PR DESCRIPTION
Two minor patches to fix up docs links. These were originally done as part of #1880 but are unrelated so pushing them up separately.