### PR TITLE
CI: Pin serde_json for MSRV build

### DIFF
--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -26,6 +26,7 @@ fi
 # Pin dependencies as required if we are using MSRV toolchain.
 if cargo --version | grep "1\.48"; then
     # 1.0.157 uses syn 2.0 which requires edition 2021
+    cargo update -p serde_json --precise 1.0.99
     cargo update -p serde --precise 1.0.156
 fi
 

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -16,6 +16,7 @@ fi
 # Pin dependencies as required if we are using MSRV toolchain.
 if cargo --version | grep "1\.48"; then
     # 1.0.157 uses syn 2.0 which requires edition 2021
+    cargo update -p serde_json --precise 1.0.99
     cargo update -p serde --precise 1.0.156
 fi
 


### PR DESCRIPTION
Recent release of `serde_json` depends on `serde` 1.0.66 but we pin to 1.0.56

Pin `serde_json` for MSRV build to v1.0.99