### PR TITLE
Expose the hex macro for bench target

### DIFF
--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -45,10 +45,10 @@ macro_rules! impl_consensus_encoding {
 }
 pub(crate) use impl_consensus_encoding;
 // We use test_macros module to keep things organised, re-export everything for ease of use.
-#[cfg(test)]
+#[cfg(any(bench, test))]
 pub(crate) use test_macros::*;
 
-#[cfg(test)]
+#[cfg(any(bench, test))]
 mod test_macros {
 
     macro_rules! hex (($hex:expr) => (<Vec<u8> as hashes::hex::FromHex>::from_hex($hex).unwrap()));


### PR DESCRIPTION
We use `hex!` in bench code but the macro is only exposed when building the test target. Expose it for bench as well.

I have no idea how the benches are currently running in CI but looking at a [recent successful CI run](https://github.com/rust-bitcoin/rust-bitcoin/actions/runs/5491948563/jobs/10009001084?pr=1933) they are?

But if we try to use the benches cfg option in `miniscript` the bench build breaks in `bitcoin`. https://github.com/rust-bitcoin/rust-miniscript/pull/482

If my memory serves me correctly @RCasatta ran into this a while back someplace.

The error:

```
error[E0432]: unresolved import `crate::internal_macros::hex`
    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bitcoin-0.30.0/src/blockdata/transaction.rs:1916:9
     |
1916 |     use crate::internal_macros::hex;
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `hex` in `internal_macros
```