### PR TITLE
Rename PartiallySignedTransaction to Psbt

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -140,6 +140,7 @@ pub use crate::hash_types::{
 pub use crate::merkle_tree::MerkleBlock;
 pub use crate::network::constants::Network;
 pub use crate::pow::{CompactTarget, Target, Work};
+pub use crate::psbt::Psbt;
 
 #[cfg(not(feature = "std"))]
 mod io_extras {

--- a/bitcoin/src/psbt/macros.rs
+++ b/bitcoin/src/psbt/macros.rs
@@ -3,7 +3,7 @@
 #[allow(unused_macros)]
 macro_rules! hex_psbt {
     ($s:expr) => {
-        <$crate::psbt::PartiallySignedTransaction>::deserialize(
+        <$crate::psbt::Psbt>::deserialize(
             &<$crate::prelude::Vec<u8> as $crate::hashes::hex::FromHex>::from_hex($s).unwrap(),
         )
     };

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -9,7 +9,7 @@ use crate::consensus::{encode, Decodable};
 use crate::io::{self, Cursor, Read};
 use crate::prelude::*;
 use crate::psbt::map::Map;
-use crate::psbt::{raw, Error, PartiallySignedTransaction};
+use crate::psbt::{raw, Error, Psbt};
 
 /// Type: Unsigned Transaction PSBT_GLOBAL_UNSIGNED_TX = 0x00
 const PSBT_GLOBAL_UNSIGNED_TX: u8 = 0x00;
@@ -20,7 +20,7 @@ const PSBT_GLOBAL_VERSION: u8 = 0xFB;
 /// Type: Proprietary Use Type PSBT_GLOBAL_PROPRIETARY = 0xFC
 const PSBT_GLOBAL_PROPRIETARY: u8 = 0xFC;
 
-impl Map for PartiallySignedTransaction {
+impl Map for Psbt {
     fn get_pairs(&self) -> Vec<raw::Pair> {
         let mut rv: Vec<raw::Pair> = Default::default();
 
@@ -70,7 +70,7 @@ impl Map for PartiallySignedTransaction {
     }
 }
 
-impl PartiallySignedTransaction {
+impl Psbt {
     pub(crate) fn decode_global<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let mut r = r.take(MAX_VEC_SIZE as u64);
         let mut tx: Option<Transaction> = None;
@@ -200,7 +200,7 @@ impl PartiallySignedTransaction {
         }
 
         if let Some(tx) = tx {
-            Ok(PartiallySignedTransaction {
+            Ok(Psbt {
                 unsigned_tx: tx,
                 version: version.unwrap_or(0),
                 xpub: xpub_map,

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -12,7 +12,6 @@ use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use secp256k1::{self, XOnlyPublicKey};
 
 use super::map::{Input, Map, Output, PsbtSighashType};
-use super::Psbt;
 use crate::bip32::{ChildNumber, Fingerprint, KeySource};
 use crate::blockdata::script::ScriptBuf;
 use crate::blockdata::transaction::{Transaction, TxOut};
@@ -21,7 +20,7 @@ use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, 
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
 use crate::prelude::*;
-use crate::psbt::{Error, PartiallySignedTransaction};
+use crate::psbt::{Error, Psbt};
 use crate::taproot::{
     ControlBlock, LeafVersion, TapLeafHash, TapNodeHash, TapTree, TaprootBuilder,
 };
@@ -39,7 +38,7 @@ pub(crate) trait Deserialize: Sized {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error>;
 }
 
-impl PartiallySignedTransaction {
+impl Psbt {
     /// Serialize a value as bytes in hex.
     pub fn serialize_hex(&self) -> String { self.serialize().to_lower_hex_string() }
 
@@ -451,6 +450,6 @@ mod tests {
     #[should_panic(expected = "InvalidMagic")]
     fn invalid_vector_1() {
         let hex_psbt = b"0200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf6000000006a473044022070b2245123e6bf474d60c5b50c043d4c691a5d2435f09a34a7662a9dc251790a022001329ca9dacf280bdf30740ec0390422422c81cb45839457aeb76fc12edd95b3012102657d118d3357b8e0f4c2cd46db7b39f6d9c38d9a70abcb9b2de5dc8dbfe4ce31feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300";
-        PartiallySignedTransaction::deserialize(hex_psbt).unwrap();
+        Psbt::deserialize(hex_psbt).unwrap();
     }
 }

--- a/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
@@ -1,8 +1,7 @@
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
-    let psbt: Result<bitcoin::psbt::PartiallySignedTransaction, _> =
-        bitcoin::psbt::Psbt::deserialize(data);
+    let psbt: Result<bitcoin::psbt::Psbt, _> = bitcoin::psbt::Psbt::deserialize(data);
     match psbt {
         Err(_) => {}
         Ok(psbt) => {


### PR DESCRIPTION
Last release we added a type alias for `Psbt`, now lets just rename the type and be done with it.

Includes re-export at the crate root because `bitcoin::Psbt` is clear and obvious.