### PR TITLE
Remove docsrs attributes

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -65,7 +65,6 @@ pub struct ExtendedPrivKey {
 crate::serde_utils::serde_string_impl!(ExtendedPrivKey, "a BIP-32 extended private key");
 
 #[cfg(not(feature = "std"))]
-#[cfg_attr(docsrs, doc(cfg(not(feature = "std"))))]
 impl fmt::Debug for ExtendedPrivKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("ExtendedPrivKey")

--- a/hashes/src/serde_macros.rs
+++ b/hashes/src/serde_macros.rs
@@ -135,7 +135,6 @@ macro_rules! serde_impl(
 /// Does an "empty" serde implementation for the configuration without serde feature.
 #[macro_export]
 #[cfg(not(feature = "serde"))]
-#[cfg_attr(docsrs, doc(cfg(not(feature = "serde"))))]
 macro_rules! serde_impl(
         ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => ()
 );

--- a/internals/src/parse.rs
+++ b/internals/src/parse.rs
@@ -4,7 +4,7 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_try_from_stringly {
-    ($from:ty, $to:ty, $error:ty, $func:expr $(, $attr:meta)?) => {
+    ($from:ty, $to:ty, $error:ty, $func:expr) => {
         $(#[$attr])?
         impl core::convert::TryFrom<$from> for $to {
             type Error = $error;
@@ -44,11 +44,11 @@ macro_rules! impl_parse {
         impl_try_from_stringly!(&str);
 
         #[cfg(feature = "alloc")]
-        impl_try_from_stringly!(alloc::string::String, $type, $error, $func, cfg_attr(docsrs, doc(feature = "alloc")));
+        impl_try_from_stringly!(alloc::string::String, $type, $error, $func);
         #[cfg(feature = "alloc")]
-        impl_try_from_stringly!(alloc::borrow::Cow<'_, str>, $type, $error, $func, cfg_attr(docsrs, doc(feature = "alloc")));
+        impl_try_from_stringly!(alloc::borrow::Cow<'_, str>, $type, $error, $func);
         #[cfg(feature = "alloc")]
-        impl_try_from_stringly!(alloc::boxed::Box<str>, $type, $error, $func, cfg_attr(docsrs, doc(feature = "alloc")));
+        impl_try_from_stringly!(alloc::boxed::Box<str>, $type, $error, $func);
     }
 }
 
@@ -63,7 +63,6 @@ macro_rules! impl_parse_and_serde {
 
         // We don't use `serde_string_impl` because we want to avoid allocating input.
         #[cfg(feature = "serde")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl<'de> $crate::serde::Deserialize<'de> for $type {
             fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
             where
@@ -96,7 +95,6 @@ macro_rules! impl_parse_and_serde {
         }
 
         #[cfg(feature = "serde")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl $crate::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where


### PR DESCRIPTION
Somehow when we started using `doc_auto_cfg` we forgot to remove a bunch of docsrs attributes.