### PR TITLE
Use hex_lit::hex in benches

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1985,11 +1985,11 @@ mod tests {
 
 #[cfg(bench)]
 mod benches {
+    use hex_lit::hex;
     use test::{black_box, Bencher};
 
     use super::Transaction;
     use crate::consensus::{deserialize, Encodable};
-    use crate::internal_macros::hex;
     use crate::EmptyWrite;
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";


### PR DESCRIPTION
Currently the test `hex` macro is only available when the `test` compiler configuration option is set but we are using it in benches code, this works for use because `cargo bench` sets `test` for the current crate, however it breaks downstream crates.

Fix: #1830