### PR TITLE
policy: Add refactor carve out

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ grammar fixes.
 
 Pull request merge requirements:
 - all CI test should pass,
-- at least two "accepts"/ACKs from the repository maintainers
+- at least two "accepts"/ACKs from the repository maintainers (see "refactor carve out").
 - no reasonable "rejects"/NACKs from anybody who reviewed the code.
 
 Current list of the project maintainers:
@@ -164,6 +164,15 @@ Current list of the project maintainers:
 - [Riccardo Casatta](https://github.com/RCasatta)
 - [Tobin Harding](https://github.com/tcharding)
 
+#### Refactor carve output
+
+The repository is going through heavy refactoring and "trivial" API redesign
+(eg, rename `Foo::empty` to `Foo::new`) as we push towards API stabilization. As
+such reviewers are either bored or overloaded with notifications, hence we have
+created a carve out to the 2-ACK rule.
+
+A PR may be considered for merge if it has a single ACK and has sat open for at
+least two weeks with no comments, questions, or NACKs.
 
 ## Coding conventions
 


### PR DESCRIPTION
I have managed to burn out or bore our reviewers/maintainers. Getting two acks is becoming increasingly difficult. I've pestered everyone to the limit that I feel socially comfortable doing so, and as such, am requesting a carve out to the 2-ACK before merge rule.

The primary justification is that I feel we should have a bit more of BDFL and a bit less total consensus if we are to push forwards.

### Example PRs where this change would apply

- https://github.com/rust-bitcoin/rust-bitcoin/pull/1925
- https://github.com/rust-bitcoin/rust-bitcoin/pull/1854
- https://github.com/rust-bitcoin/rust-bitcoin/pull/1862