### PR TITLE
bitcoin/bip32: add DerivationPath::to_u32_vec

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -412,6 +412,20 @@ impl DerivationPath {
         new_path.0.extend_from_slice(path.as_ref());
         new_path
     }
+
+    /// Returns the derivation path as a vector of u32 integers.
+    /// Unhardened elements are copied as is.
+    /// 0x80000000 is added to the hardened elements.
+    ///
+    /// ```
+    /// use bitcoin::bip32::DerivationPath;
+    /// use std::str::FromStr;
+    ///
+    /// let path = DerivationPath::from_str("m/84'/0'/0'/0/1").unwrap();
+    /// const HARDENED: u32 = 0x80000000;
+    /// assert_eq!(path.to_u32_vec(), vec![84 + HARDENED, HARDENED, HARDENED, 0, 1]);
+    /// ```
+    pub fn to_u32_vec(&self) -> Vec<u32> { self.into_iter().map(|&el| el.into()).collect() }
 }
 
 impl fmt::Display for DerivationPath {


### PR DESCRIPTION
This is useful to pass the keypath to other libraries which expect it to be represented with a list of u32 ints.

Fixes #1944