### PR TITLE
Improve `address` error handling

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Error code for the `address` module.
+
+use core::fmt;
+
+use internals::write_err;
+
+use super::{Address, NetworkUnchecked};
+use crate::blockdata::script::{witness_program, witness_version};
+use crate::{base58, Network};
+
+/// Address error.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum Error {
+    /// Base58 encoding error.
+    Base58(base58::Error),
+    /// Bech32 encoding error.
+    Bech32(bech32::Error),
+    /// The bech32 payload was empty.
+    EmptyBech32Payload,
+    /// The wrong checksum algorithm was used. See BIP-0350.
+    InvalidBech32Variant {
+        /// Bech32 variant that is required by the used Witness version.
+        expected: bech32::Variant,
+        /// The actual Bech32 variant encoded in the address representation.
+        found: bech32::Variant,
+    },
+    /// A witness version conversion/parsing error.
+    WitnessVersion(witness_version::Error),
+    /// A witness program error.
+    WitnessProgram(witness_program::Error),
+    /// An uncompressed pubkey was used where it is not allowed.
+    UncompressedPubkey,
+    /// Address size more than 520 bytes is not allowed.
+    ExcessiveScriptSize,
+    /// Script is not a p2pkh, p2sh or witness program.
+    UnrecognizedScript,
+    /// Address type is either invalid or not supported in rust-bitcoin.
+    UnknownAddressType(String),
+    /// Address's network differs from required one.
+    NetworkValidation {
+        /// Network that was required.
+        required: Network,
+        /// Network on which the address was found to be valid.
+        found: Network,
+        /// The address itself
+        address: Address<NetworkUnchecked>,
+    },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Base58(ref e) => write_err!(f, "base58 address encoding error"; e),
+            Error::Bech32(ref e) => write_err!(f, "bech32 address encoding error"; e),
+            Error::EmptyBech32Payload => write!(f, "the bech32 payload was empty"),
+            Error::InvalidBech32Variant { expected, found } => write!(
+                f,
+                "invalid bech32 checksum variant found {:?} when {:?} was expected",
+                found, expected
+            ),
+            Error::WitnessVersion(ref e) =>
+                write_err!(f, "witness version conversion/parsing error"; e),
+            Error::WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
+            Error::UncompressedPubkey =>
+                write!(f, "an uncompressed pubkey was used where it is not allowed"),
+            Error::ExcessiveScriptSize => write!(f, "script size exceed 520 bytes"),
+            Error::UnrecognizedScript =>
+                write!(f, "script is not a p2pkh, p2sh or witness program"),
+            Error::UnknownAddressType(ref s) => write!(
+                f,
+                "unknown address type: '{}' is either invalid or not supported in rust-bitcoin",
+                s
+            ),
+            Error::NetworkValidation { required, found, ref address } => {
+                write!(f, "address ")?;
+                address.fmt_internal(f)?; // Using fmt_internal in order to remove the "Address<NetworkUnchecked>(..)" wrapper
+                write!(
+                    f,
+                    " belongs to network {} which is different from required {}",
+                    found, required
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match self {
+            Base58(e) => Some(e),
+            Bech32(e) => Some(e),
+            WitnessVersion(e) => Some(e),
+            WitnessProgram(e) => Some(e),
+            EmptyBech32Payload
+            | InvalidBech32Variant { .. }
+            | UncompressedPubkey
+            | ExcessiveScriptSize
+            | UnrecognizedScript
+            | UnknownAddressType(_)
+            | NetworkValidation { .. } => None,
+        }
+    }
+}
+
+impl From<base58::Error> for Error {
+    fn from(e: base58::Error) -> Error { Error::Base58(e) }
+}
+
+impl From<bech32::Error> for Error {
+    fn from(e: bech32::Error) -> Error { Error::Bech32(e) }
+}
+
+impl From<witness_version::Error> for Error {
+    fn from(e: witness_version::Error) -> Error { Error::WitnessVersion(e) }
+}
+
+impl From<witness_program::Error> for Error {
+    fn from(e: witness_program::Error) -> Error { Error::WitnessProgram(e) }
+}

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -52,29 +52,29 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
         match *self {
-            Error::Base58(ref e) => write_err!(f, "base58 address encoding error"; e),
-            Error::Bech32(ref e) => write_err!(f, "bech32 address encoding error"; e),
-            Error::EmptyBech32Payload => write!(f, "the bech32 payload was empty"),
-            Error::InvalidBech32Variant { expected, found } => write!(
+            Base58(ref e) => write_err!(f, "base58 address encoding error"; e),
+            Bech32(ref e) => write_err!(f, "bech32 address encoding error"; e),
+            EmptyBech32Payload => write!(f, "the bech32 payload was empty"),
+            InvalidBech32Variant { expected, found } => write!(
                 f,
                 "invalid bech32 checksum variant found {:?} when {:?} was expected",
                 found, expected
             ),
-            Error::WitnessVersion(ref e) =>
-                write_err!(f, "witness version conversion/parsing error"; e),
-            Error::WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
-            Error::UncompressedPubkey =>
+            WitnessVersion(ref e) => write_err!(f, "witness version conversion/parsing error"; e),
+            WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
+            UncompressedPubkey =>
                 write!(f, "an uncompressed pubkey was used where it is not allowed"),
-            Error::ExcessiveScriptSize => write!(f, "script size exceed 520 bytes"),
-            Error::UnrecognizedScript =>
-                write!(f, "script is not a p2pkh, p2sh or witness program"),
-            Error::UnknownAddressType(ref s) => write!(
+            ExcessiveScriptSize => write!(f, "script size exceed 520 bytes"),
+            UnrecognizedScript => write!(f, "script is not a p2pkh, p2sh or witness program"),
+            UnknownAddressType(ref s) => write!(
                 f,
                 "unknown address type: '{}' is either invalid or not supported in rust-bitcoin",
                 s
             ),
-            Error::NetworkValidation { required, found, ref address } => {
+            NetworkValidation { required, found, ref address } => {
                 write!(f, "address ")?;
                 address.fmt_internal(f)?; // Using fmt_internal in order to remove the "Address<NetworkUnchecked>(..)" wrapper
                 write!(

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -92,11 +92,11 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
 
-        match self {
-            Base58(e) => Some(e),
-            Bech32(e) => Some(e),
-            WitnessVersion(e) => Some(e),
-            WitnessProgram(e) => Some(e),
+        match *self {
+            Base58(ref e) => Some(e),
+            Bech32(ref e) => Some(e),
+            WitnessVersion(ref e) => Some(e),
+            WitnessProgram(ref e) => Some(e),
             EmptyBech32Payload
             | InvalidBech32Variant { .. }
             | UncompressedPubkey

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -10,10 +10,59 @@ use super::{Address, NetworkUnchecked};
 use crate::blockdata::script::{witness_program, witness_version};
 use crate::{base58, Network};
 
-/// Address error.
+/// A general purpose address error.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub enum Error {
+    /// Parsing address from string failed.
+    Parse(ParseError),
+    /// A payload related error.
+    Payload(PayloadError),
+    /// Address is not valid for network.
+    RequireNetwork(RequireNetworkError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            Parse(ref e) => write_err!(f, "parsing address failed"; e),
+            Payload(ref e) => write_err!(f, "payload error"; e),
+            RequireNetwork(ref e) => write_err!(f, "require network"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match *self {
+            Parse(ref e) => Some(e),
+            Payload(ref e) => Some(e),
+            RequireNetwork(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(e: ParseError) -> Self { Self::Parse(e) }
+}
+
+impl From<PayloadError> for Error {
+    fn from(e: PayloadError) -> Self { Self::Payload(e) }
+}
+
+impl From<RequireNetworkError> for Error {
+    fn from(e: RequireNetworkError) -> Self { Self::RequireNetwork(e) }
+}
+
+/// Address parsing error.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum ParseError {
     /// Base58 encoding error.
     Base58(base58::Error),
     /// Bech32 encoding error.
@@ -31,28 +80,11 @@ pub enum Error {
     WitnessVersion(witness_version::Error),
     /// A witness program error.
     WitnessProgram(witness_program::Error),
-    /// An uncompressed pubkey was used where it is not allowed.
-    UncompressedPubkey,
-    /// Address size more than 520 bytes is not allowed.
-    ExcessiveScriptSize,
-    /// Script is not a p2pkh, p2sh or witness program.
-    UnrecognizedScript,
-    /// Address type is either invalid or not supported in rust-bitcoin.
-    UnknownAddressType(String),
-    /// Address's network differs from required one.
-    NetworkValidation {
-        /// Network that was required.
-        required: Network,
-        /// Network on which the address was found to be valid.
-        found: Network,
-        /// The address itself
-        address: Address<NetworkUnchecked>,
-    },
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Error::*;
+        use ParseError::*;
 
         match *self {
             Base58(ref e) => write_err!(f, "base58 address encoding error"; e),
@@ -65,15 +97,77 @@ impl fmt::Display for Error {
             ),
             WitnessVersion(ref e) => write_err!(f, "witness version conversion/parsing error"; e),
             WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use ParseError::*;
+
+        match *self {
+            Base58(ref e) => Some(e),
+            Bech32(ref e) => Some(e),
+            WitnessVersion(ref e) => Some(e),
+            WitnessProgram(ref e) => Some(e),
+            EmptyBech32Payload | InvalidBech32Variant { .. } => None,
+        }
+    }
+}
+
+impl From<base58::Error> for ParseError {
+    fn from(e: base58::Error) -> Self { Self::Base58(e) }
+}
+
+impl From<bech32::Error> for ParseError {
+    fn from(e: bech32::Error) -> Self { Self::Bech32(e) }
+}
+
+impl From<witness_version::Error> for ParseError {
+    fn from(e: witness_version::Error) -> Self { Self::WitnessVersion(e) }
+}
+
+impl From<witness_program::Error> for ParseError {
+    fn from(e: witness_program::Error) -> Self { Self::WitnessProgram(e) }
+}
+
+/// A payload related error.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum PayloadError {
+    /// A witness version conversion/parsing error.
+    WitnessVersion(witness_version::Error),
+    /// A witness program error.
+    WitnessProgram(witness_program::Error),
+    /// An uncompressed pubkey was used where it is not allowed.
+    UncompressedPubkey,
+    /// Address size more than 520 bytes is not allowed.
+    ExcessiveScriptSize,
+    /// Script is not a p2pkh, p2sh or witness program.
+    UnrecognizedScript,
+    /// Address's network differs from required one.
+    NetworkValidation {
+        /// Network that was required.
+        required: Network,
+        /// Network on which the address was found to be valid.
+        found: Network,
+        /// The address itself
+        address: Address<NetworkUnchecked>,
+    },
+}
+
+impl fmt::Display for PayloadError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use PayloadError::*;
+
+        match *self {
+            WitnessVersion(ref e) => write_err!(f, "witness version conversion/parsing error"; e),
+            WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
             UncompressedPubkey =>
                 write!(f, "an uncompressed pubkey was used where it is not allowed"),
             ExcessiveScriptSize => write!(f, "script size exceed 520 bytes"),
             UnrecognizedScript => write!(f, "script is not a p2pkh, p2sh or witness program"),
-            UnknownAddressType(ref s) => write!(
-                f,
-                "unknown address type: '{}' is either invalid or not supported in rust-bitcoin",
-                s
-            ),
             NetworkValidation { required, found, ref address } => {
                 write!(f, "address ")?;
                 address.fmt_internal(f)?; // Using fmt_internal in order to remove the "Address<NetworkUnchecked>(..)" wrapper
@@ -88,38 +182,37 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
+impl std::error::Error for PayloadError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use self::Error::*;
+        use self::PayloadError::*;
 
-        match *self {
-            Base58(ref e) => Some(e),
-            Bech32(ref e) => Some(e),
-            WitnessVersion(ref e) => Some(e),
-            WitnessProgram(ref e) => Some(e),
-            EmptyBech32Payload
-            | InvalidBech32Variant { .. }
-            | UncompressedPubkey
+        match self {
+            WitnessVersion(e) => Some(e),
+            WitnessProgram(e) => Some(e),
+            UncompressedPubkey
             | ExcessiveScriptSize
             | UnrecognizedScript
-            | UnknownAddressType(_)
             | NetworkValidation { .. } => None,
         }
     }
 }
 
-impl From<base58::Error> for Error {
-    fn from(e: base58::Error) -> Error { Error::Base58(e) }
+impl From<witness_version::Error> for PayloadError {
+    fn from(e: witness_version::Error) -> Self { Self::WitnessVersion(e) }
 }
 
-impl From<bech32::Error> for Error {
-    fn from(e: bech32::Error) -> Error { Error::Bech32(e) }
+impl From<witness_program::Error> for PayloadError {
+    fn from(e: witness_program::Error) -> Self { Self::WitnessProgram(e) }
 }
 
-impl From<witness_version::Error> for Error {
-    fn from(e: witness_version::Error) -> Error { Error::WitnessVersion(e) }
+/// Address is not valid for network.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct RequireNetworkError(pub Network);
+
+impl fmt::Display for RequireNetworkError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "address is not valid for the {} network", self.0)
+    }
 }
 
-impl From<witness_program::Error> for Error {
-    fn from(e: witness_program::Error) -> Error { Error::WitnessProgram(e) }
-}
+crate::error::impl_std_error!(RequireNetworkError);

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -33,7 +33,6 @@ use core::str::FromStr;
 
 use bech32;
 use hashes::{sha256, Hash, HashEngine};
-use internals::write_err;
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::base58;
@@ -41,8 +40,8 @@ use crate::blockdata::constants::{
     MAX_SCRIPT_ELEMENT_SIZE, PUBKEY_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST,
     SCRIPT_ADDRESS_PREFIX_MAIN, SCRIPT_ADDRESS_PREFIX_TEST,
 };
-use crate::blockdata::script::witness_program::{self, WitnessProgram};
-use crate::blockdata::script::witness_version::{self, WitnessVersion};
+use crate::blockdata::script::witness_program::WitnessProgram;
+use crate::blockdata::script::witness_version::WitnessVersion;
 use crate::blockdata::script::{self, Script, ScriptBuf};
 use crate::crypto::key::{PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
 use crate::hash_types::{PubkeyHash, ScriptHash};
@@ -50,119 +49,8 @@ use crate::network::constants::Network;
 use crate::prelude::*;
 use crate::taproot::TapNodeHash;
 
-/// Address error.
-#[derive(Debug, PartialEq, Eq, Clone)]
-#[non_exhaustive]
-pub enum Error {
-    /// Base58 encoding error.
-    Base58(base58::Error),
-    /// Bech32 encoding error.
-    Bech32(bech32::Error),
-    /// The bech32 payload was empty.
-    EmptyBech32Payload,
-    /// The wrong checksum algorithm was used. See BIP-0350.
-    InvalidBech32Variant {
-        /// Bech32 variant that is required by the used Witness version.
-        expected: bech32::Variant,
-        /// The actual Bech32 variant encoded in the address representation.
-        found: bech32::Variant,
-    },
-    /// A witness version conversion/parsing error.
-    WitnessVersion(witness_version::Error),
-    /// A witness program error.
-    WitnessProgram(witness_program::Error),
-    /// An uncompressed pubkey was used where it is not allowed.
-    UncompressedPubkey,
-    /// Address size more than 520 bytes is not allowed.
-    ExcessiveScriptSize,
-    /// Script is not a p2pkh, p2sh or witness program.
-    UnrecognizedScript,
-    /// Address type is either invalid or not supported in rust-bitcoin.
-    UnknownAddressType(String),
-    /// Address's network differs from required one.
-    NetworkValidation {
-        /// Network that was required.
-        required: Network,
-        /// Network on which the address was found to be valid.
-        found: Network,
-        /// The address itself
-        address: Address<NetworkUnchecked>,
-    },
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Base58(ref e) => write_err!(f, "base58 address encoding error"; e),
-            Error::Bech32(ref e) => write_err!(f, "bech32 address encoding error"; e),
-            Error::EmptyBech32Payload => write!(f, "the bech32 payload was empty"),
-            Error::InvalidBech32Variant { expected, found } => write!(
-                f,
-                "invalid bech32 checksum variant found {:?} when {:?} was expected",
-                found, expected
-            ),
-            Error::WitnessVersion(ref e) =>
-                write_err!(f, "witness version conversion/parsing error"; e),
-            Error::WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
-            Error::UncompressedPubkey =>
-                write!(f, "an uncompressed pubkey was used where it is not allowed"),
-            Error::ExcessiveScriptSize => write!(f, "script size exceed 520 bytes"),
-            Error::UnrecognizedScript =>
-                write!(f, "script is not a p2pkh, p2sh or witness program"),
-            Error::UnknownAddressType(ref s) => write!(
-                f,
-                "unknown address type: '{}' is either invalid or not supported in rust-bitcoin",
-                s
-            ),
-            Error::NetworkValidation { required, found, ref address } => {
-                write!(f, "address ")?;
-                address.fmt_internal(f)?; // Using fmt_internal in order to remove the "Address<NetworkUnchecked>(..)" wrapper
-                write!(
-                    f,
-                    " belongs to network {} which is different from required {}",
-                    found, required
-                )
-            }
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use self::Error::*;
-
-        match self {
-            Base58(e) => Some(e),
-            Bech32(e) => Some(e),
-            WitnessVersion(e) => Some(e),
-            WitnessProgram(e) => Some(e),
-            EmptyBech32Payload
-            | InvalidBech32Variant { .. }
-            | UncompressedPubkey
-            | ExcessiveScriptSize
-            | UnrecognizedScript
-            | UnknownAddressType(_)
-            | NetworkValidation { .. } => None,
-        }
-    }
-}
-
-impl From<base58::Error> for Error {
-    fn from(e: base58::Error) -> Error { Error::Base58(e) }
-}
-
-impl From<bech32::Error> for Error {
-    fn from(e: bech32::Error) -> Error { Error::Bech32(e) }
-}
-
-impl From<witness_version::Error> for Error {
-    fn from(e: witness_version::Error) -> Error { Error::WitnessVersion(e) }
-}
-
-impl From<witness_program::Error> for Error {
-    fn from(e: witness_program::Error) -> Error { Error::WitnessProgram(e) }
-}
+mod error;
+pub use self::error::*;
 
 /// The different types of addresses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
Improve the `address::Error` using ideas from @sanket1729 here: https://github.com/rust-bitcoin/rust-secp256k1/issues/633

EDIT: This proof-of-concept is now done by: https://github.com/rust-bitcoin/rust-bitcoin/pull/1971

This PR is now a proof of concept for a new way of providing error types to users of the library. Specifically

- Functions return specific error types that are either structs or enums where every variant is used
- Modules provide a general error type that includes a variant for each of the specific error types and `From` impls so users of the lib can call multiple functions from a module and use `?` if they do not wish to handle then specific errors. 

The `address` module is a good module to use to test this new idea out because it is in flux anyway and is complicated enough to need multiple errors. Note also that existence of the new `PayloadError` should make [upcoming work](#1908 ) to hide the `Payload` type easier.

## Notes

Since this PR introduces a new convention for error code please be picky about the small things, describe in the individual commit logs (eg, using `error` submodule, the import/export style). 