### PR TITLE
Rename `opcodes::All` to `Opcode`

### DIFF
--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -55,6 +55,17 @@ macro_rules! all_opcodes {
             )*
         }
 
+        /// Push an empty array onto the stack.
+        pub static OP_0: All = OP_PUSHBYTES_0;
+        /// Empty stack is also FALSE.
+        pub static OP_FALSE: All = OP_PUSHBYTES_0;
+        /// Number 1 is also TRUE.
+        pub static OP_TRUE: All = OP_PUSHNUM_1;
+        /// Previously called OP_NOP2.
+        pub static OP_NOP2: All = OP_CLTV;
+        /// Previously called OP_NOP3.
+        pub static OP_NOP3: All = OP_CSV;
+
         impl fmt::Display for All {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                  match *self {
@@ -443,17 +454,6 @@ impl serde::Serialize for All {
         serializer.serialize_str(&self.to_string())
     }
 }
-
-/// Push an empty array onto the stack.
-pub static OP_0: All = OP_PUSHBYTES_0;
-/// Empty stack is also FALSE.
-pub static OP_FALSE: All = OP_PUSHBYTES_0;
-/// Number 1 is also TRUE.
-pub static OP_TRUE: All = OP_PUSHNUM_1;
-/// Previously called OP_NOP2.
-pub static OP_NOP2: All = OP_CLTV;
-/// Previously called OP_NOP3.
-pub static OP_NOP3: All = OP_CSV;
 
 /// Broad categories of opcodes with similar behavior.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -51,10 +51,10 @@ macro_rules! all_opcodes {
         /// constants are guaranteed to begin with OP_.
         pub mod all {
             use super::All;
-                $(
-                    #[doc = $doc]
-                    pub const $op: All = All { code: $val};
-                )*
+            $(
+                #[doc = $doc]
+                pub const $op: All = All { code: $val};
+            )*
         }
 
         impl fmt::Display for All {
@@ -66,7 +66,6 @@ macro_rules! all_opcodes {
                 }
             }
         }
-
     }
 }
 

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -40,8 +40,6 @@ use self::all::*;
 
 macro_rules! all_opcodes {
     ($($op:ident => $val:expr, $doc:expr);*) => {
-        // private import so we don't have to use `all::OP_FOO` in this file.
-
         /// Enables wildcard imports to bring into scope all opcodes and nothing else.
         ///
         /// The `all` module is provided so one can use a wildcard import `use bitcoin::opcodes::all::*` to

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -10,7 +10,7 @@ use hashes::Hash;
 use secp256k1::{Secp256k1, Verification};
 
 use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::{self};
+use crate::blockdata::opcodes::{self, Opcode};
 use crate::blockdata::script::witness_version::WitnessVersion;
 use crate::blockdata::script::{
     bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions, ScriptBuf,
@@ -166,7 +166,7 @@ impl Script {
     /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
     #[inline]
     pub fn witness_version(&self) -> Option<WitnessVersion> {
-        self.0.first().and_then(|opcode| WitnessVersion::try_from(opcodes::All::from(*opcode)).ok())
+        self.0.first().and_then(|opcode| WitnessVersion::try_from(Opcode::from(*opcode)).ok())
     }
 
     /// Checks whether a script pubkey is a P2SH output.
@@ -229,7 +229,7 @@ impl Script {
         if !(4..=42).contains(&script_len) {
             return false;
         }
-        let ver_opcode = opcodes::All::from(self.0[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
+        let ver_opcode = Opcode::from(self.0[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
         let push_opbyte = self.0[1]; // Second byte push opcode 2-40 bytes
         WitnessVersion::try_from(ver_opcode).is_ok()
             && push_opbyte >= OP_PUSHBYTES_2.to_u8()
@@ -286,7 +286,7 @@ impl Script {
 
         match self.0.first() {
             Some(b) => {
-                let first = opcodes::All::from(*b);
+                let first = Opcode::from(*b);
                 let class = first.classify(opcodes::ClassifyContext::Legacy);
 
                 class == ReturnOp || class == IllegalOp
@@ -475,14 +475,14 @@ impl Script {
     pub fn to_hex_string(&self) -> String { self.as_bytes().to_lower_hex_string() }
 
     /// Returns the first opcode of the script (if there is any).
-    pub fn first_opcode(&self) -> Option<opcodes::All> {
+    pub fn first_opcode(&self) -> Option<Opcode> {
         self.as_bytes().first().copied().map(From::from)
     }
 
     /// Iterates the script to find the last opcode.
     ///
     /// Returns `None` is the instruction is data push or if the script is empty.
-    pub(in crate::blockdata::script) fn last_opcode(&self) -> Option<opcodes::All> {
+    pub(in crate::blockdata::script) fn last_opcode(&self) -> Option<Opcode> {
         match self.instructions().last() {
             Some(Ok(Instruction::Op(op))) => Some(op),
             _ => None,

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,7 @@ use secp256k1::XOnlyPublicKey;
 
 use crate::blockdata::locktime::absolute;
 use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::{self};
+use crate::blockdata::opcodes::{self, Opcode};
 use crate::blockdata::script::{opcode_to_verify, write_scriptint, PushBytes, Script, ScriptBuf};
 use crate::blockdata::transaction::Sequence;
 use crate::key::PublicKey;
@@ -15,7 +15,7 @@ use crate::prelude::*;
 
 /// An Object which can be used to construct a script piece by piece.
 #[derive(PartialEq, Eq, Clone)]
-pub struct Builder(ScriptBuf, Option<opcodes::All>);
+pub struct Builder(ScriptBuf, Option<Opcode>);
 
 impl Builder {
     /// Creates a new empty script.
@@ -34,7 +34,7 @@ impl Builder {
     pub fn push_int(self, data: i64) -> Builder {
         // We can special-case -1, 1-16
         if data == -1 || (1..=16).contains(&data) {
-            let opcode = opcodes::All::from((data - 1 + opcodes::OP_TRUE.to_u8() as i64) as u8);
+            let opcode = Opcode::from((data - 1 + opcodes::OP_TRUE.to_u8() as i64) as u8);
             self.push_opcode(opcode)
         }
         // We can also special-case zero
@@ -78,7 +78,7 @@ impl Builder {
     }
 
     /// Adds a single opcode to the script.
-    pub fn push_opcode(mut self, data: opcodes::All) -> Builder {
+    pub fn push_opcode(mut self, data: Opcode) -> Builder {
         self.0.push_opcode(data);
         self.1 = Some(data);
         self

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -2,7 +2,7 @@
 
 use core::convert::TryInto;
 
-use crate::blockdata::opcodes;
+use crate::blockdata::opcodes::{self, Opcode};
 use crate::blockdata::script::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
 
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
@@ -11,12 +11,12 @@ pub enum Instruction<'a> {
     /// Push a bunch of data.
     PushBytes(&'a PushBytes),
     /// Some non-push opcode.
-    Op(opcodes::All),
+    Op(Opcode),
 }
 
 impl<'a> Instruction<'a> {
     /// Returns the opcode if the instruction is not a data push.
-    pub fn opcode(&self) -> Option<opcodes::All> {
+    pub fn opcode(&self) -> Option<Opcode> {
         match self {
             Instruction::Op(op) => Some(*op),
             Instruction::PushBytes(_) => None,
@@ -124,7 +124,7 @@ impl<'a> Iterator for Instructions<'a> {
 
         // classify parameter does not really matter here since we are only using
         // it for pushes and nums
-        match opcodes::All::from(byte).classify(opcodes::ClassifyContext::Legacy) {
+        match Opcode::from(byte).classify(opcodes::ClassifyContext::Legacy) {
             opcodes::Class::PushBytes(n) => {
                 // make sure safety argument holds across refactorings
                 let n: u32 = n;
@@ -152,7 +152,7 @@ impl<'a> Iterator for Instructions<'a> {
             opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA4) =>
                 self.next_push_data_len(PushDataLenLen::Four, 0x10000),
             // Everything else we can push right through
-            _ => Some(Ok(Instruction::Op(opcodes::All::from(byte)))),
+            _ => Some(Ok(Instruction::Op(Opcode::from(byte)))),
         }
     }
 

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -60,7 +60,7 @@ use hashes::{hash160, sha256};
 use serde;
 
 use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::{self};
+use crate::blockdata::opcodes::{self, Opcode};
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::prelude::*;
 use crate::{io, OutPoint};
@@ -236,7 +236,7 @@ fn read_uint_iter(data: &mut core::slice::Iter<'_, u8>, size: usize) -> Result<u
     }
 }
 
-fn opcode_to_verify(opcode: Option<opcodes::All>) -> Option<opcodes::All> {
+fn opcode_to_verify(opcode: Option<Opcode>) -> Option<Opcode> {
     opcode.and_then(|opcode| match opcode {
         OP_EQUAL => Some(OP_EQUALVERIFY),
         OP_NUMEQUAL => Some(OP_NUMEQUALVERIFY),
@@ -606,7 +606,7 @@ pub(super) fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Re
     // `iter` needs to be borrowed in `read_push_data_len`, so we have to use `while let` instead
     // of `for`.
     while let Some(byte) = iter.next() {
-        let opcode = opcodes::All::from(*byte);
+        let opcode = Opcode::from(*byte);
 
         let data_len = if let opcodes::Class::PushBytes(n) =
             opcode.classify(opcodes::ClassifyContext::Legacy)

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -6,7 +6,7 @@ use core::ops::Deref;
 use secp256k1::{Secp256k1, Verification};
 
 use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::{self};
+use crate::blockdata::opcodes::{self, Opcode};
 use crate::blockdata::script::witness_program::WitnessProgram;
 use crate::blockdata::script::witness_version::WitnessVersion;
 use crate::blockdata::script::{
@@ -176,7 +176,7 @@ impl ScriptBuf {
     pub fn into_bytes(self) -> Vec<u8> { self.0 }
 
     /// Adds a single opcode to the script.
-    pub fn push_opcode(&mut self, data: opcodes::All) { self.0.push(data.to_u8()); }
+    pub fn push_opcode(&mut self, data: Opcode) { self.0.push(data.to_u8()); }
 
     /// Adds instructions to push some arbitrary data onto the stack.
     pub fn push_slice<T: AsRef<PushBytes>>(&mut self, data: T) {
@@ -266,7 +266,7 @@ impl ScriptBuf {
     /// alternative.
     ///
     /// See the public fn [`Self::scan_and_push_verify`] to learn more.
-    pub(in crate::blockdata::script) fn push_verify(&mut self, last_opcode: Option<opcodes::All>) {
+    pub(in crate::blockdata::script) fn push_verify(&mut self, last_opcode: Option<Opcode>) {
         match opcode_to_verify(last_opcode) {
             Some(opcode) => {
                 self.0.pop();

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -13,8 +13,8 @@ use core::str::FromStr;
 
 use internals::write_err;
 
-use crate::blockdata::opcodes;
 use crate::blockdata::opcodes::all::*;
+use crate::blockdata::opcodes::Opcode;
 use crate::blockdata::script::Instruction;
 use crate::error::ParseIntError;
 
@@ -149,7 +149,7 @@ impl TryFrom<u8> for WitnessVersion {
     }
 }
 
-impl TryFrom<opcodes::All> for WitnessVersion {
+impl TryFrom<Opcode> for WitnessVersion {
     type Error = Error;
 
     /// Converts bitcoin script opcode into [`WitnessVersion`] variant.
@@ -162,7 +162,7 @@ impl TryFrom<opcodes::All> for WitnessVersion {
     ///
     /// If the opcode does not correspond to any witness version, errors with
     /// [`Error::Malformed`].
-    fn try_from(opcode: opcodes::All) -> Result<Self, Self::Error> {
+    fn try_from(opcode: Opcode) -> Result<Self, Self::Error> {
         match opcode.to_u8() {
             0 => Ok(WitnessVersion::V0),
             version if version >= OP_PUSHNUM_1.to_u8() && version <= OP_PUSHNUM_16.to_u8() =>
@@ -202,12 +202,12 @@ impl From<WitnessVersion> for bech32::u5 {
     }
 }
 
-impl From<WitnessVersion> for opcodes::All {
+impl From<WitnessVersion> for Opcode {
     /// Converts [`WitnessVersion`] instance into corresponding Bitcoin scriptopcode (`OP_0`..`OP_16`).
-    fn from(version: WitnessVersion) -> opcodes::All {
+    fn from(version: WitnessVersion) -> Opcode {
         match version {
             WitnessVersion::V0 => OP_PUSHBYTES_0,
-            no => opcodes::All::from(OP_PUSHNUM_1.to_u8() + no.to_num() - 1),
+            no => Opcode::from(OP_PUSHNUM_1.to_u8() + no.to_num() - 1),
         }
     }
 }


### PR DESCRIPTION
I may be missing something about the `All` type but it seems it can be re-named to `Opcode` with no loss of clarity.

The first few patches do some other clean ups, the last patch is the meat and potatoes.