### PR TITLE
WIP: Use the new error stuff from secp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ path = "hashes"
 
 [patch.crates-io.bitcoin-internals]
 path = "internals"
+
+[patch.crates-io.secp256k1]
+git = "https://github.com/tcharding/rust-secp256k1"
+branch = "07-26-new-error-handling-convention"

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -515,20 +515,18 @@ impl std::error::Error for Error {
     }
 }
 
+secp256k1::impl_from_for_all_crate_errors_for!(Error);
+
 impl From<key::Error> for Error {
     fn from(err: key::Error) -> Self {
         match err {
             key::Error::Base58(e) => Error::Base58(e),
             key::Error::Secp256k1(e) => Error::Secp256k1(e),
-            key::Error::InvalidKeyPrefix(_) => Error::Secp256k1(secp256k1::Error::InvalidPublicKey),
+            key::Error::InvalidKeyPrefix(_) => secp256k1::PublicKeyError.into(),
             key::Error::Hex(e) => Error::Hex(e),
             key::Error::InvalidHexLength(got) => Error::InvalidPublicKeyHexLength(got),
         }
     }
-}
-
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
 }
 
 impl From<base58::Error> for Error {
@@ -1171,7 +1169,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Secp256k1(InvalidSecretKey)")]
+    #[should_panic(expected = "Secp256k1(SecretKey(SecretKeyError))")]
     fn schnorr_broken_privkey_zeros() {
         /* this is how we generate key:
         let mut sk = secp256k1::key::ONE_KEY;
@@ -1199,7 +1197,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Secp256k1(InvalidSecretKey)")]
+    #[should_panic(expected = "Secp256k1(SecretKey(SecretKeyError))")]
     fn schnorr_broken_privkey_ffs() {
         // Xpriv having secret key set to all 0xFF's
         let xpriv_str = "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fENZ3QzxW";

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -39,7 +39,7 @@ impl Signature {
         let (hash_ty, sig) = sl.split_last().ok_or(Error::EmptySignature)?;
         let hash_ty = EcdsaSighashType::from_standard(*hash_ty as u32)
             .map_err(|_| Error::NonStandardSighashType(*hash_ty as u32))?;
-        let sig = secp256k1::ecdsa::Signature::from_der(sig).map_err(Error::Secp256k1)?;
+        let sig = secp256k1::ecdsa::Signature::from_der(sig)?;
         Ok(Signature { sig, hash_ty })
     }
 
@@ -222,9 +222,7 @@ impl std::error::Error for Error {
     }
 }
 
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
-}
+secp256k1::impl_from_for_all_crate_errors_for!(Error);
 
 impl From<NonStandardSighashType> for Error {
     fn from(err: NonStandardSighashType) -> Self { Error::NonStandardSighashType(err.0) }

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -66,12 +66,10 @@ impl std::error::Error for Error {
     }
 }
 
+secp256k1::impl_from_for_all_crate_errors_for!(Error);
+
 impl From<base58::Error> for Error {
     fn from(e: base58::Error) -> Error { Error::Base58(e) }
-}
-
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
 }
 
 impl From<hex::HexToArrayError> for Error {

--- a/bitcoin/src/crypto/key/error.rs
+++ b/bitcoin/src/crypto/key/error.rs
@@ -1,0 +1,60 @@
+//! Error code for the key module.
+
+use core::fmt;
+
+use internals::write_err;
+
+use crate::base58;
+
+/// A key-related error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Base58 encoding error
+    Base58(base58::Error),
+    /// secp256k1-related error
+    Secp256k1(secp256k1::Error),
+    /// Invalid key prefix error
+    InvalidKeyPrefix(u8),
+    /// Hex decoding error
+    Hex(hex::HexToArrayError),
+    /// `PublicKey` hex should be 66 or 130 digits long.
+    InvalidHexLength(usize),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Base58(ref e) => write_err!(f, "key base58 error"; e),
+            Error::Secp256k1(ref e) => write_err!(f, "key secp256k1 error"; e),
+            Error::InvalidKeyPrefix(ref b) => write!(f, "key prefix invalid: {}", b),
+            Error::Hex(ref e) => write_err!(f, "key hex decoding error"; e),
+            Error::InvalidHexLength(got) =>
+                write!(f, "PublicKey hex should be 66 or 130 digits long, got: {}", got),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match self {
+            Base58(e) => Some(e),
+            Secp256k1(e) => Some(e),
+            Hex(e) => Some(e),
+            InvalidKeyPrefix(_) | InvalidHexLength(_) => None,
+        }
+    }
+}
+
+secp256k1::impl_from_for_all_crate_errors_for!(Error);
+
+impl From<base58::Error> for Error {
+    fn from(e: base58::Error) -> Error { Error::Base58(e) }
+}
+
+impl From<hex::HexToArrayError> for Error {
+    fn from(e: hex::HexToArrayError) -> Self { Error::Hex(e) }
+}

--- a/bitcoin/src/crypto/key/error.rs
+++ b/bitcoin/src/crypto/key/error.rs
@@ -58,3 +58,61 @@ impl From<base58::Error> for Error {
 impl From<hex::HexToArrayError> for Error {
     fn from(e: hex::HexToArrayError) -> Self { Error::Hex(e) }
 }
+
+pub mod pubkey {
+    // TODO: Use proper imports.
+    use super::*;
+
+    /// A key-related error.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub enum Error {
+        /// Base58 encoding error
+        Base58(base58::Error),
+        /// secp256k1-related error
+        Secp256k1(secp256k1::PublicKeyError),
+        /// Invalid key prefix error
+        InvalidKeyPrefix(u8),
+        /// Hex decoding error
+        Hex(hex::HexToArrayError),
+        /// `PublicKey` hex should be 66 or 130 digits long.
+        InvalidHexLength(usize),
+    }
+
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match *self {
+                Error::Base58(ref e) => write_err!(f, "key base58 error"; e),
+                Error::Secp256k1(ref e) => write_err!(f, "key secp256k1 error"; e),
+                Error::InvalidKeyPrefix(ref b) => write!(f, "key prefix invalid: {}", b),
+                Error::Hex(ref e) => write_err!(f, "key hex decoding error"; e),
+                Error::InvalidHexLength(got) =>
+                    write!(f, "PublicKey hex should be 66 or 130 digits long, got: {}", got),
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for Error {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            use self::Error::*;
+
+            match self {
+                Base58(e) => Some(e),
+                Secp256k1(e) => Some(e),
+                Hex(e) => Some(e),
+                InvalidKeyPrefix(_) | InvalidHexLength(_) => None,
+            }
+        }
+    }
+
+    secp256k1::impl_from_for_all_crate_errors_for!(Error);
+
+    impl From<base58::Error> for Error {
+        fn from(e: base58::Error) -> Error { Error::Base58(e) }
+    }
+
+    impl From<hex::HexToArrayError> for Error {
+        fn from(e: hex::HexToArrayError) -> Self { Error::Hex(e) }
+    }
+}

--- a/bitcoin/src/crypto/key/mod.rs
+++ b/bitcoin/src/crypto/key/mod.rs
@@ -176,7 +176,7 @@ impl PublicKey {
     }
 
     /// Deserialize a public key from a slice
-    pub fn from_slice(data: &[u8]) -> Result<PublicKey, Error> {
+    pub fn from_slice(data: &[u8]) -> Result<PublicKey, self::error::pubkey::Error> {
         let compressed = match data.len() {
             33 => true,
             65 => false,

--- a/bitcoin/src/crypto/key/mod.rs
+++ b/bitcoin/src/crypto/key/mod.rs
@@ -11,7 +11,6 @@ use core::str::FromStr;
 
 use hashes::{hash160, Hash};
 use hex::FromHex;
-use internals::write_err;
 #[cfg(feature = "rand-std")]
 pub use secp256k1::rand;
 pub use secp256k1::{self, constants, KeyPair, Parity, Secp256k1, Verification, XOnlyPublicKey};
@@ -23,58 +22,8 @@ use crate::prelude::*;
 use crate::taproot::{TapNodeHash, TapTweakHash};
 use crate::{base58, io};
 
-/// A key-related error.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Error {
-    /// Base58 encoding error
-    Base58(base58::Error),
-    /// secp256k1-related error
-    Secp256k1(secp256k1::Error),
-    /// Invalid key prefix error
-    InvalidKeyPrefix(u8),
-    /// Hex decoding error
-    Hex(hex::HexToArrayError),
-    /// `PublicKey` hex should be 66 or 130 digits long.
-    InvalidHexLength(usize),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Base58(ref e) => write_err!(f, "key base58 error"; e),
-            Error::Secp256k1(ref e) => write_err!(f, "key secp256k1 error"; e),
-            Error::InvalidKeyPrefix(ref b) => write!(f, "key prefix invalid: {}", b),
-            Error::Hex(ref e) => write_err!(f, "key hex decoding error"; e),
-            Error::InvalidHexLength(got) =>
-                write!(f, "PublicKey hex should be 66 or 130 digits long, got: {}", got),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use self::Error::*;
-
-        match self {
-            Base58(e) => Some(e),
-            Secp256k1(e) => Some(e),
-            Hex(e) => Some(e),
-            InvalidKeyPrefix(_) | InvalidHexLength(_) => None,
-        }
-    }
-}
-
-secp256k1::impl_from_for_all_crate_errors_for!(Error);
-
-impl From<base58::Error> for Error {
-    fn from(e: base58::Error) -> Error { Error::Base58(e) }
-}
-
-impl From<hex::HexToArrayError> for Error {
-    fn from(e: hex::HexToArrayError) -> Self { Error::Hex(e) }
-}
+pub mod error;
+pub use self::error::Error;
 
 /// A Bitcoin ECDSA public key
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -96,6 +96,4 @@ impl std::error::Error for SigFromSliceError {
     }
 }
 
-impl From<secp256k1::Error> for SigFromSliceError {
-    fn from(e: secp256k1::Error) -> Self { SigFromSliceError::Secp256k1(e) }
-}
+secp256k1::impl_from_for_all_crate_errors_for!(SigFromSliceError);

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -79,7 +79,7 @@ pub enum Error {
     /// Parsing error indicating invalid public keys
     InvalidPublicKey(crate::crypto::key::Error),
     /// Parsing error indicating invalid secp256k1 public keys
-    InvalidSecp256k1PublicKey(secp256k1::Error),
+    InvalidSecp256k1PublicKey(secp256k1::PublicKeyError),
     /// Parsing error indicating invalid xonly public keys
     InvalidXOnlyPublicKey,
     /// Parsing error indicating invalid ECDSA signatures
@@ -213,4 +213,7 @@ impl From<encode::Error> for Error {
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self { Error::Io(e) }
+}
+impl From<secp256k1::PublicKeyError> for Error {
+    fn from(e: secp256k1::PublicKeyError) -> Error { Error::InvalidSecp256k1PublicKey(e) }
 }

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -151,7 +151,7 @@ impl Serialize for secp256k1::PublicKey {
 
 impl Deserialize for secp256k1::PublicKey {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        secp256k1::PublicKey::from_slice(bytes).map_err(Error::InvalidSecp256k1PublicKey)
+        Ok(secp256k1::PublicKey::from_slice(bytes)?)
     }
 }
 

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -68,11 +68,7 @@ mod message_signing {
         }
     }
 
-    impl From<secp256k1::Error> for MessageSignatureError {
-        fn from(e: secp256k1::Error) -> MessageSignatureError {
-            MessageSignatureError::InvalidEncoding(e)
-        }
-    }
+    secp256k1::impl_from_for_all_crate_errors_for!(MessageSignatureError, InvalidEncoding);
 
     /// A signature on a Bitcoin Signed Message.
     ///
@@ -113,9 +109,7 @@ mod message_signing {
             }
             // We just check this here so we can safely subtract further.
             if bytes[0] < 27 {
-                return Err(MessageSignatureError::InvalidEncoding(
-                    secp256k1::Error::InvalidRecoveryId,
-                ));
+                return Err(secp256k1::RecoveryIdError.into());
             };
             let recid = RecoveryId::from_i32(((bytes[0] - 27) & 0x03) as i32)?;
             Ok(MessageSignature {


### PR DESCRIPTION
Showcase usage of https://github.com/rust-bitcoin/rust-secp256k1/pull/635 

Uses the general error type although we can do better IMO if we use the new specific errors, but anyways, gives an idea of what 635 will do.

Note please the WIP patch I added to https://github.com/rust-bitcoin/rust-secp256k1/pull/635 while hacking on this.