### PR TITLE
Fill in deprecated since NEXT-RELEASE placeholder

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -941,7 +941,7 @@ impl Transaction {
     }
 
     /// Checks if this is a coinbase transaction.
-    #[deprecated(since = "0.0.0-NEXT-RELEASE", note = "use is_coinbase instead")]
+    #[deprecated(since = "0.31.0", note = "use is_coinbase instead")]
     pub fn is_coin_base(&self) -> bool { self.is_coinbase() }
 
     /// Returns `true` if the transaction itself opted in to be BIP-125-replaceable (RBF).


### PR DESCRIPTION
As we gear up for the v0.31.0 release we can fill in the NEXT-RELEASE placeholders.