### PR TITLE
Use standard set of error derives where possible

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -51,7 +51,7 @@ use crate::prelude::*;
 use crate::taproot::TapNodeHash;
 
 /// Address error.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error.

--- a/bitcoin/src/base58.rs
+++ b/bitcoin/src/base58.rs
@@ -217,7 +217,7 @@ impl<T: Default + Copy> SmallVec<T> {
 }
 
 /// An error that might occur during base58 decoding.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Invalid character encountered.

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -19,7 +19,7 @@ use crate::prelude::*;
 use crate::{block, io, Block, BlockHash, Transaction};
 
 /// A BIP-152 error
-#[derive(Clone, PartialEq, Eq, Debug, Copy, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// An unknown version number was used.
@@ -318,7 +318,7 @@ impl Decodable for BlockTransactionsRequest {
 
 /// A transaction index is requested that is out of range from the
 /// corresponding block.
-#[derive(Clone, PartialEq, Eq, Debug, Copy, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TxIndexOutOfRangeError(u64);
 
 impl fmt::Display for TxIndexOutOfRangeError {

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -448,7 +448,7 @@ impl fmt::Debug for DerivationPath {
 pub type KeySource = (Fingerprint, DerivationPath);
 
 /// A BIP32 error
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// A pk->pk derivation was attempted on a hardened key

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -391,7 +391,7 @@ impl std::error::Error for Bip34Error {
 }
 
 /// A block validation error.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValidationError {
     /// The header hash is not below the target.
     BadProofOfWork,

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -600,7 +600,7 @@ impl From<ParseIntError> for Error {
 }
 
 /// An error that occurs when converting a `u32` to a lock time variant.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConversionError {
     /// The expected timelock unit, height (blocks) or time (seconds).
     unit: LockTimeUnit,
@@ -646,7 +646,7 @@ impl fmt::Display for LockTimeUnit {
 }
 
 /// Errors than occur when operating on lock times.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum OperationError {
     /// Cannot compare different lock time units (height vs time).

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -298,7 +298,7 @@ impl fmt::Display for Time {
 }
 
 /// Errors related to relative lock times.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Input time in seconds was too large to be encoded to a 16 bit 512 second interval.

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -670,7 +670,7 @@ pub(super) fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Re
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
 /// would help you.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Something did a non-minimal push; for more information see

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -369,7 +369,7 @@ mod error {
 
     /// Error returned on attempt to create too large `PushBytes`.
     #[allow(unused)]
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct PushBytesError {
         never: core::convert::Infallible,
     }
@@ -391,7 +391,7 @@ mod error {
     use core::fmt;
 
     /// Error returned on attempt to create too large `PushBytes`.
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct PushBytesError {
         /// How long the input was.
         pub(super) len: usize,

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -91,7 +91,7 @@ impl fmt::Display for OutPoint {
 }
 
 /// An error in parsing an OutPoint.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ParseOutPointError {
     /// Error in TXID part.

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -101,11 +101,11 @@ pub mod hex {
     // TODO: statically prove impossible cases
 
     /// Error returned when a hex string decoder can't be created.
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct DecodeInitError(hex::HexToBytesError);
 
     /// Error returned when a hex string contains invalid characters.
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct DecodeError(hex::HexToBytesError);
 
     /// Hex decoder state.

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -184,7 +184,7 @@ impl<'a> IntoIterator for &'a SerializedSignature {
 }
 
 /// A key-related error.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Hex decoding error

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -24,7 +24,7 @@ use crate::taproot::{TapNodeHash, TapTweakHash};
 use crate::{base58, io};
 
 /// A key-related error.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Base58 encoding error

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -199,7 +199,7 @@ impl str::FromStr for TapSighashType {
 }
 
 /// Possible errors in computing the signature message.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// Could happen only by using `*_encode_signing_*` methods with custom writers, engines writers
@@ -531,7 +531,7 @@ impl_std_error!(NonStandardSighashType);
 /// Error returned for failure during parsing one of the sighash types.
 ///
 /// This is currently returned for unrecognized sighash strings.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SighashTypeParseError {
     /// The unrecognized string we attempted to parse.
     pub unrecognized: String,

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -60,7 +60,7 @@ impl Signature {
 /// An error constructing a [`taproot::Signature`] from a byte slice.
 ///
 /// [`taproot::Signature`]: crate::crypto::taproot::Signature
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SigFromSliceError {
     /// Invalid signature hash type.

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -457,7 +457,7 @@ impl Decodable for PartialMerkleTree {
 }
 
 /// An error when verifying the merkle block.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum MerkleBlockError {
     /// Merkle root in the header doesn't match to the root calculated from partial merkle tree.

--- a/bitcoin/src/network/constants.rs
+++ b/bitcoin/src/network/constants.rs
@@ -310,7 +310,7 @@ impl Magic {
 }
 
 /// An error in parsing magic bytes.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseMagicError {
     /// The error that occurred when parsing the string.
     error: hex::HexToArrayError,

--- a/bitcoin/src/network/message.rs
+++ b/bitcoin/src/network/message.rs
@@ -128,7 +128,7 @@ impl Decodable for CommandString {
 /// Error returned when a command string is invalid.
 ///
 /// This is currently returned for command strings longer than 12.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandStringError {
     cow: Cow<'static, str>,
 }

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -18,7 +18,7 @@ use crate::prelude::*;
 /// Note that this is larger than the type from `core` so if it's passed through a deep call stack
 /// in a performance-critical application you may want to box it or throw away the context by
 /// converting to `core` type.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseIntError {
     input: String,
     // for displaying - see Display impl with nice error message below

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -707,7 +707,7 @@ impl<T: Into<u128>> From<T> for U256 {
 }
 
 /// Error from `TryFrom<signed type>` implementations, occurs when input is negative.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TryFromError(i128);
 
 impl fmt::Display for TryFromError {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -659,6 +659,7 @@ pub enum SigningAlgorithm {
 
 /// Errors encountered while calculating the sighash message.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[non_exhaustive]
 pub enum SignError {
     /// Input index out of bounds (actual index, maximum index allowed).
     IndexOutOfBounds(usize, usize),

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -575,7 +575,7 @@ impl_get_key_for_map!(BTreeMap);
 impl_get_key_for_map!(HashMap);
 
 /// Errors when getting a key.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum GetKeyError {
     /// A bip32 error.
@@ -658,7 +658,7 @@ pub enum SigningAlgorithm {
 }
 
 /// Errors encountered while calculating the sighash message.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SignError {
     /// Input index out of bounds (actual index, maximum index allowed).
@@ -696,7 +696,7 @@ impl fmt::Display for SignError {
         use self::SignError::*;
 
         match *self {
-            IndexOutOfBounds(ind, len) => {
+            IndexOutOfBounds(ref ind, ref len) => {
                 write!(f, "index {}, psbt input len: {}", ind, len)
             }
             InvalidSighashType => write!(f, "invalid sighash type"),
@@ -707,7 +707,7 @@ impl fmt::Display for SignError {
             MismatchedAlgoKey => write!(f, "signing algorithm and key type does not match"),
             NotEcdsa => write!(f, "attempted to ECDSA sign an non-ECDSA input"),
             NotWpkh => write!(f, "the scriptPubkey is not a P2WPKH script"),
-            SighashComputation(e) => write!(f, "sighash: {}", e),
+            SighashComputation(ref e) => write!(f, "sighash: {}", e),
             UnknownOutputType => write!(f, "unable to determine the output type"),
             KeyNotFound => write!(f, "unable to find key"),
             WrongSigningAlgorithm =>

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -30,7 +30,7 @@ mod message_signing {
     use crate::prelude::*;
 
     /// An error used for dealing with Bitcoin Signed Messages.
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum MessageSignatureError {
         /// Signature is expected to be 65 bytes.

--- a/bitcoin/src/string.rs
+++ b/bitcoin/src/string.rs
@@ -35,7 +35,7 @@ pub trait FromHexStr: Sized {
 }
 
 /// Hex parsing error
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FromHexError<E> {
     /// The input was not a valid hex string, contains the error that occurred while parsing.
     ParseHex(E),

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -1435,7 +1435,7 @@ impl<'de> serde::Deserialize<'de> for LeafVersion {
 }
 
 /// Detailed error type for taproot builder.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TaprootBuilderError {
     /// Merkle tree depth must not be more than 128.
@@ -1491,7 +1491,7 @@ impl std::error::Error for TaprootBuilderError {
 }
 
 /// Detailed error type for taproot utilities.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TaprootError {
     /// Proof size must be a multiple of 32.


### PR DESCRIPTION
This is a redo of #1961 without changing `io::Error` to `io::ErrorKind` and just leaving errors with an IO error in them with only `#[derive(Debug)]`.