### PR TITLE
Add max standard tx weight constant to transaction

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -678,6 +678,10 @@ impl cmp::Ord for Transaction {
 }
 
 impl Transaction {
+    /// Maximum transaction weight for Bitcoin Core 25.0.
+    // https://github.com/bitcoin/bitcoin/blob/44b05bf3fef2468783dcebf651654fdd30717e7e/src/policy/policy.h#L27
+    pub const MAX_STANDARD_WEIGHT: Weight = Weight::from_wu(400_000);
+
     /// Computes a "normalized TXID" which does not include any signatures.
     ///
     /// This gives a way to identify a transaction that is "the same" as


### PR DESCRIPTION
Add a constant for the max transaction weight.  Similar to [max block weight](https://github.com/yancyribbens/rust-bitcoin/blob/1b009b809ba2f282d88153cc32e390f1bbd4773c/bitcoin/src/blockdata/weight.rs#L35).  This value is pulled from core  [here](https://github.com/bitcoin/bitcoin/blob/44b05bf3fef2468783dcebf651654fdd30717e7e/src/policy/policy.h#L27)