### PR TITLE
Hijack crypto

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -46,6 +46,8 @@ core2 = { version = "0.3.2", default-features = false, features = ["alloc"], opt
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
+vanadium_sdk = { path = "../../../../rust-sdk" }
+
 [dev-dependencies]
 serde_json = "1.0.0"
 serde_test = "1.0.19"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -36,8 +36,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 internals = { package = "bitcoin-internals", version = "0.1.0", path = "../internals" }
 bech32 = { version = "0.9.0", default-features = false }
-hashes = { package = "bitcoin_hashes", version = "0.12.0", default-features = false }
-secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false }
+secp256k1 = { path = "../../rust-secp256k1", default-features = false, features = ["bitcoin_hashes"] }
 hex_lit = "0.1.1"
 
 base64 = { version = "0.13.0", optional = true }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -26,6 +26,8 @@ use crate::io::Write;
 use crate::network::constants::Network;
 use crate::prelude::*;
 
+use vanadium_sdk;
+
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainCode([u8; 32]);
@@ -706,12 +708,18 @@ impl ExtendedPubKey {
         match i {
             ChildNumber::Hardened { .. } => Err(Error::CannotDeriveFromHardenedKey),
             ChildNumber::Normal { index: n } => {
-                let mut hmac_engine: HmacEngine<sha512::Hash> =
-                    HmacEngine::new(&self.chain_code[..]);
-                hmac_engine.input(&self.public_key.serialize()[..]);
-                hmac_engine.input(&n.to_be_bytes());
+                // let mut hmac_engine: HmacEngine<sha512::Hash> =
+                //     HmacEngine::new(&self.chain_code[..]);
+                // hmac_engine.input(&self.public_key.serialize()[..]);
+                // hmac_engine.input(&n.to_be_bytes());
 
-                let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
+                // let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
+
+                let mut hmac_data: Vec<u8> = Vec::new();
+                hmac_data.extend_from_slice(&self.public_key.serialize()[..]);
+                hmac_data.extend_from_slice(&n.to_be_bytes());
+
+                let hmac_result: Hmac<sha512::Hash> = Hmac::from_byte_array(vanadium_sdk::crypto::hmac_sha512(&self.chain_code[..], &hmac_data));
 
                 let private_key = secp256k1::SecretKey::from_slice(&hmac_result[..32])?;
                 let chain_code = ChainCode::from_hmac(hmac_result);

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -77,6 +77,10 @@ pub extern crate secp256k1;
 #[macro_use]
 extern crate actual_serde as serde;
 
+// Used in vnd-bitcoin to replace native crypto implementations with corresponding functions
+// based on the Vanadium sdk (which are based on ecalls).
+extern crate vanadium_sdk;
+
 #[cfg(test)]
 #[macro_use]
 mod test_macros;


### PR DESCRIPTION
Use vanadium-sdk for sha256 used when generating addresses, and hmac-sha512 computations used in bip32 derivations, replacing the native implementations from rust-bitcoin.