### PR TITLE
Document the base64 dependency

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -41,6 +41,7 @@ hashes = { package = "bitcoin_hashes", version = "0.12.0", default-features = fa
 secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
 hex_lit = "0.1.1"
 
+# Subsequent versions require edition 2021 (requires Rust 1.56).
 base64 = { version = "0.13.0", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
 bitcoinconsensus = { version = "0.20.2-0.5.0", default-features = false, optional = true }


### PR DESCRIPTION
To save other devs wondering why we use the current version add a comment to the `base64` dependency.