### PR TITLE
Remove private hex test macro

### DIFF
--- a/bitcoin/src/base58.rs
+++ b/bitcoin/src/base58.rs
@@ -245,8 +245,9 @@ impl std::error::Error for Error {
 
 #[cfg(test)]
 mod tests {
+    use hex::test_hex_unwrap as hex;
+
     use super::*;
-    use crate::internal_macros::hex;
 
     #[test]
     fn test_base58_encode() {

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -554,12 +554,12 @@ impl<'a, W: io::Write> BitStreamWriter<'a, W> {
 mod test {
     use std::collections::HashMap;
 
+    use hex::test_hex_unwrap as hex;
     use serde_json::Value;
 
     use super::*;
     use crate::consensus::encode::deserialize;
     use crate::hash_types::BlockHash;
-    use crate::internal_macros::hex;
     use crate::ScriptBuf;
 
     #[test]

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -877,11 +877,11 @@ impl From<&Xpub> for XKeyIdentifier {
 mod tests {
     use core::str::FromStr;
 
+    use hex::test_hex_unwrap as hex;
     use secp256k1::{self, Secp256k1};
 
     use super::ChildNumber::{Hardened, Normal};
     use super::*;
-    use crate::internal_macros::hex;
     use crate::network::Network::{self, Bitcoin};
 
     #[test]

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -442,11 +442,10 @@ impl std::error::Error for ValidationError {
 
 #[cfg(test)]
 mod tests {
-    use hex::FromHex;
+    use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::internal_macros::hex;
 
     #[test]
     fn test_coinbase_and_bip34() {

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -194,11 +194,12 @@ impl ChainHash {
 mod test {
     use core::str::FromStr;
 
+    use hex::test_hex_unwrap as hex;
+
     use super::*;
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::transaction;
     use crate::consensus::encode::serialize;
-    use crate::internal_macros::hex;
     use crate::network::Network;
 
     #[test]

--- a/bitcoin/src/blockdata/fee_rate.rs
+++ b/bitcoin/src/blockdata/fee_rate.rs
@@ -228,9 +228,10 @@ mod tests {
 
     #[test]
     fn fee_convenience_functions_agree() {
+        use hex::test_hex_unwrap as hex;
+
         use crate::blockdata::transaction::Transaction;
         use crate::consensus::Decodable;
-        use crate::internal_macros::hex;
 
         const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1415,14 +1415,13 @@ impl InputWeightPrediction {
 mod tests {
     use core::str::FromStr;
 
-    use hex::FromHex;
+    use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::*;
     use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::script::ScriptBuf;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::internal_macros::hex;
     use crate::sighash::EcdsaSighashType;
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -558,9 +558,10 @@ impl From<Vec<&[u8]>> for Witness {
 
 #[cfg(test)]
 mod test {
+    use hex::test_hex_unwrap as hex;
+
     use super::*;
     use crate::consensus::{deserialize, serialize};
-    use crate::internal_macros::hex;
     use crate::Transaction;
 
     fn append_u32_vec(mut v: Vec<u8>, n: &[u32]) -> Vec<u8> {
@@ -657,7 +658,7 @@ mod test {
             hex!("304402207c800d698f4b0298c5aac830b822f011bb02df41eb114ade9a6702f364d5e39c0220366900d2a60cab903e77ef7dd415d46509b1f78ac78906e3296f495aa1b1b541");
         let sig = secp256k1::ecdsa::Signature::from_der(&sig_bytes).unwrap();
         let mut witness = Witness::default();
-        let signature = ecdsa::Signature { sig, hash_ty: EcdsaSighashType::All };
+        let signature = crate::ecdsa::Signature { sig, hash_ty: EcdsaSighashType::All };
         witness.push_ecdsa_signature(&signature);
         let expected_witness = vec![hex!(
             "304402207c800d698f4b0298c5aac830b822f011bb02df41eb114ade9a6702f364d5e39c0220366900d2a60cab903e77ef7dd415d46509b1f78ac78906e3296f495aa1b1b54101")

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1258,14 +1258,13 @@ mod tests {
     use std::str::FromStr;
 
     use hashes::HashEngine;
-    use hex::FromHex;
+    use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::*;
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::transaction;
     use crate::consensus::deserialize;
     use crate::crypto::sighash::{LegacySighash, TapSighash};
-    use crate::internal_macros::hex;
     use crate::taproot::TapLeafHash;
 
     extern crate serde_json;

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -44,16 +44,6 @@ macro_rules! impl_consensus_encoding {
     );
 }
 pub(crate) use impl_consensus_encoding;
-// We use test_macros module to keep things organised, re-export everything for ease of use.
-#[cfg(test)]
-pub(crate) use test_macros::*;
-
-#[cfg(test)]
-mod test_macros {
-
-    macro_rules! hex (($hex:expr) => (<Vec<u8> as $crate::hex::FromHex>::from_hex($hex).unwrap()));
-    pub(crate) use hex;
-}
 
 /// Implements several traits for byte-based newtypes.
 /// Implements:

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -531,6 +531,7 @@ impl std::error::Error for MerkleBlockError {
 mod tests {
     #[cfg(feature = "rand-std")]
     use hashes::Hash;
+    use hex::test_hex_unwrap as hex;
     #[cfg(feature = "rand-std")]
     use secp256k1::rand::prelude::*;
 
@@ -538,7 +539,6 @@ mod tests {
     use crate::consensus::encode::{deserialize, serialize};
     #[cfg(feature = "rand-std")]
     use crate::hash_types::TxMerkleNode;
-    use crate::internal_macros::hex;
     use crate::{Block, Txid};
 
     #[cfg(feature = "rand-std")]

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -306,11 +306,10 @@ mod test {
     use core::str::FromStr;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-    use hex::FromHex;
+    use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::{AddrV2, AddrV2Message, Address};
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::internal_macros::hex;
     use crate::p2p::ServiceFlags;
 
     #[test]

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -540,6 +540,7 @@ mod test {
 
     use hashes::sha256d::Hash;
     use hashes::Hash as HashTrait;
+    use hex::test_hex_unwrap as hex;
 
     use super::message_network::{Reject, RejectReason, VersionMessage};
     use super::{CommandString, NetworkMessage, RawNetworkMessage, *};
@@ -548,7 +549,6 @@ mod test {
     use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::Transaction;
     use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
-    use crate::internal_macros::hex;
     use crate::network::Network;
     use crate::p2p::address::{AddrV2, AddrV2Message, Address};
     use crate::p2p::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -145,10 +145,10 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 #[cfg(test)]
 mod tests {
     use hashes::Hash;
+    use hex::test_hex_unwrap as hex;
 
     use super::{GetBlocksMessage, GetHeadersMessage, Vec};
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::internal_macros::hex;
 
     #[test]
     fn getblocks_message_test() {

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -142,10 +142,10 @@ impl_consensus_encoding!(Reject, message, ccode, reason, hash);
 #[cfg(test)]
 mod tests {
     use hashes::sha256d;
+    use hex::test_hex_unwrap as hex;
 
     use super::{Reject, RejectReason, VersionMessage};
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::internal_macros::hex;
     use crate::p2p::ServiceFlags;
 
     #[test]

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1000,6 +1000,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use hashes::{hash160, ripemd160, sha256, Hash};
+    use hex::test_hex_unwrap as hex;
     use secp256k1::{self, Secp256k1};
     #[cfg(feature = "rand-std")]
     use secp256k1::{All, SecretKey};
@@ -1010,7 +1011,6 @@ mod tests {
     use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut};
     use crate::blockdata::witness::Witness;
-    use crate::internal_macros::hex;
     use crate::network::Network::Bitcoin;
     use crate::psbt::map::{Input, Output};
     use crate::psbt::raw;

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -1565,7 +1565,7 @@ mod test {
 
     #[cfg(feature = "serde")]
     use {
-        crate::internal_macros::hex,
+        hex::test_hex_unwrap as hex,
         serde_test::Configure,
         serde_test::{assert_tokens, Token},
     };


### PR DESCRIPTION
We have this macro in `hex-conservative` now, remove the version here.

This patch does not change the public API and only touches test code.