### PR TITLE
Update docs and format test file

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ cargo update -p proc-macro2 --precise 1.0.63
 cargo update -p serde_test --precise 1.0.175
 ```
 
+The above commands are sourced from `./contrib/test.sh`.
+
 ## External dependencies
 
 We integrate with a few external libraries, most notably `serde`. These

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -22,25 +22,25 @@ fi
 
 for dep in $DEPS
 do
-	cp "Cargo-$dep.lock" Cargo.lock
-	for crate in ${CRATES}
-	do
-	    (
-		cd "$crate"
-		./contrib/test.sh
-	    )
-	done
-	if [ "$dep" = recent ];
-	then
-		# We always test committed dependencies but we want to warn if they could've been updated
-		cargo update
-		if diff Cargo-recent.lock Cargo.lock;
-		then
-			echo Dependencies are up to date
-		else
-			echo "::warning file=Cargo-recent.lock::Dependencies could be updated"
-		fi
-	fi
+    cp "Cargo-$dep.lock" Cargo.lock
+    for crate in ${CRATES}
+    do
+        (
+            cd "$crate"
+            ./contrib/test.sh
+        )
+    done
+    if [ "$dep" = recent ];
+    then
+        # We always test committed dependencies but we want to warn if they could've been updated
+        cargo update
+        if diff Cargo-recent.lock Cargo.lock;
+        then
+            echo Dependencies are up to date
+        else
+            echo "::warning file=Cargo-recent.lock::Dependencies could be updated"
+        fi
+    fi
 done
 
 exit 0


### PR DESCRIPTION
A rollup of two simple commits.  1) add a line to point developers to the CI test where the deps are tested and 2) replace tabs with spaces (spaces are used everywhere else) in `contrib/test.sh`.