### PR TITLE
Remove dependency on `hex_lit`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -42,7 +42,6 @@ dependencies = [
  "bitcoinconsensus",
  "core2",
  "hex-conservative",
- "hex_lit",
  "mutagen",
  "secp256k1",
  "serde",
@@ -149,12 +148,6 @@ checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 dependencies = [
  "core2",
 ]
-
-[[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "honggfuzz"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -41,7 +41,6 @@ dependencies = [
  "bitcoinconsensus",
  "core2",
  "hex-conservative",
- "hex_lit",
  "mutagen",
  "secp256k1",
  "serde",
@@ -148,12 +147,6 @@ checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 dependencies = [
  "core2",
 ]
-
-[[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "honggfuzz"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,6 @@ hex = { package = "hex-conservative", version = "0.1.1", default-features = fals
 bech32 = { version = "0.10.0-beta", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false }
 secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes"] }
-hex_lit = "0.1.1"
 
 base64 = { version = "0.21.3", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -1,6 +1,6 @@
 use bitcoin::hashes::Hash;
 use bitcoin::{consensus, ecdsa, sighash, Amount, PublicKey, Script, ScriptBuf, Transaction};
-use hex_lit::hex;
+use hex::test_hex_unwrap as hex;
 
 //These are real blockchain transactions examples of computing sighash for:
 // - P2WPKH

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -843,7 +843,7 @@ fn segwit_redeem_hash(pubkey_hash: &PubkeyHash) -> crate::hashes::hash160::Hash 
 mod tests {
     use core::str::FromStr;
 
-    use hex_lit::hex;
+    use hex::test_hex_unwrap as hex;
     use secp256k1::XOnlyPublicKey;
 
     use super::*;

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -7,10 +7,11 @@
 //! single transaction.
 //!
 
+use core::convert::TryFrom;
 use core::default::Default;
 
 use hashes::{sha256d, Hash};
-use hex_lit::hex;
+use hex::test_hex_unwrap as hex;
 use internals::impl_array_newtype;
 
 use crate::blockdata::block::{self, Block};
@@ -22,6 +23,8 @@ use crate::blockdata::witness::Witness;
 use crate::internal_macros::impl_bytes_newtype;
 use crate::network::Network;
 use crate::pow::CompactTarget;
+use crate::prelude::Vec;
+use crate::script::PushBytesBuf;
 use crate::Amount;
 
 /// How many seconds between blocks we expect on average.
@@ -84,7 +87,7 @@ fn bitcoin_genesis_tx() -> Transaction {
     });
 
     // Outputs
-    let script_bytes = hex!("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
+    let script_bytes = PushBytesBuf::try_from(hex!("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f")).expect("hex is valid length");
     let out_script =
         script::Builder::new().push_slice(script_bytes).push_opcode(OP_CHECKSIG).into_script();
     ret.output.push(TxOut { value: Amount::from_sat(50 * 100_000_000), script_pubkey: out_script });

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
+use core::convert::TryFrom;
 use core::str::FromStr;
 
 use hashes::Hash;
-use hex_lit::hex;
+use hex::test_hex_unwrap as hex;
 
 use super::*;
 use crate::blockdata::opcodes;
@@ -187,10 +188,11 @@ fn script_x_only_key() {
 #[test]
 fn script_builder() {
     // from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in my mempool when I wrote the test
+    let bytes = PushBytesBuf::try_from(hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19")).unwrap();
     let script = Builder::new()
         .push_opcode(OP_DUP)
         .push_opcode(OP_HASH160)
-        .push_slice(hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
+        .push_slice(bytes)
         .push_opcode(OP_EQUALVERIFY)
         .push_opcode(OP_CHECKSIG)
         .into_script();
@@ -223,7 +225,10 @@ fn script_generators() {
 
     // Test data are taken from the second output of
     // 2ccb3a1f745eb4eefcf29391460250adda5fab78aaddb902d25d3cd97d9d8e61 transaction
-    let data = hex!("aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a");
+    let data = PushBytesBuf::try_from(hex!(
+        "aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a"
+    ))
+    .unwrap();
     let op_return = ScriptBuf::new_op_return(data);
     assert!(op_return.is_op_return());
     assert_eq!(

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -2121,7 +2121,7 @@ mod tests {
 
 #[cfg(bench)]
 mod benches {
-    use hex_lit::hex;
+    use hex::test_hex_unwrap as hex;
     use test::{black_box, Bencher};
 
     use super::Transaction;


### PR DESCRIPTION
We have a macro in `hex_conservative` that can parse hex strings, it differs from `hex_lit` in that it uses heap allocated memory instead of the stack.
    
Note also this PR uses the macro in non-test code but when we wrote it in `hex-conservative` we called it `test_hex_unwrap`.
    
Remove the dependency on `hex_lit` and use the macro from `hex-conservative`.
 
Fix: #1987
