### PR TITLE
DRAFT: Eliminate duplicate crypto types like PublicKey

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -8,7 +8,6 @@ use bitcoin::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKe
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::PublicKey;
 
 fn main() {
     // This example derives root xprv from a 32-byte seed,
@@ -53,6 +52,6 @@ fn main() {
     // manually creating indexes this time
     let zero = ChildNumber::from_normal_idx(0).unwrap();
     let public_key = xpub.derive_pub(&secp, &[zero, zero]).unwrap().public_key;
-    let address = Address::p2wpkh(&PublicKey::new(public_key), network).unwrap();
+    let address = Address::p2wpkh(&public_key, network).unwrap();
     println!("First receiving address: {}", address);
 }

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -1,4 +1,5 @@
-use bitcoin::{consensus, ecdsa, sighash, Amount, PublicKey, Script, ScriptBuf, Transaction};
+use bitcoin::{consensus, ecdsa, sighash, Amount, PublicKeyExt, Script, ScriptBuf, Transaction};
+use bitcoin::secp256k1::PublicKey;
 use hex_lit::hex;
 
 //These are real blockchain transactions examples of computing sighash for:
@@ -35,7 +36,7 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, value: u64) {
     //BIP-143: "The item 5 : For P2WPKH witness program, the scriptCode is 0x1976a914{20-byte-pubkey-hash}88ac"
     //this is nothing but a standard P2PKH script OP_DUP OP_HASH160 <pubKeyHash> OP_EQUALVERIFY OP_CHECKSIG:
     let pk = PublicKey::from_slice(pk_bytes).expect("failed to parse pubkey");
-    let wpkh = pk.wpubkey_hash().expect("compressed key");
+    let wpkh = pk.wpubkey_hash();
     println!("Script pubkey hash: {:x}", wpkh);
     let spk = ScriptBuf::new_v0_p2wpkh(&wpkh);
     let script_code = spk.p2wpkh_script_code().expect("spk is known to be p2wpkh");
@@ -48,7 +49,7 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, value: u64) {
     let msg = secp256k1::Message::from(sighash);
     println!("Message is {:x}", msg);
     let secp = secp256k1::Secp256k1::verification_only();
-    secp.verify_ecdsa(&msg, &sig.sig, &pk.inner).unwrap();
+    secp.verify_ecdsa(&msg, &sig.sig, &pk).unwrap();
 }
 
 /// Computes sighash for a legacy multisig transaction input that spends either a p2sh or a p2ms output.

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -690,7 +690,7 @@ impl ExtendedPubKey {
     }
 
     /// Constructs ECDSA compressed public key matching internal public key representation.
-    pub fn to_pub(self) -> PublicKey { PublicKey { compressed: true, inner: self.public_key } }
+    pub fn to_pub(self) -> PublicKey { self.public_key }
 
     /// Constructs BIP340 x-only public key for BIP-340 signatures and Taproot use matching
     /// the internal public key representation.

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -65,11 +65,12 @@ impl Builder {
 
     /// Adds instructions to push a public key onto the stack.
     pub fn push_key(self, key: &PublicKey) -> Builder {
-        if key.compressed {
-            self.push_slice(key.inner.serialize())
-        } else {
-            self.push_slice(key.inner.serialize_uncompressed())
-        }
+        self.push_slice(key.serialize())
+    }
+
+    /// Adds instructions to push a public key onto the stack.
+    pub fn push_key_uncompressed(self, key: &PublicKey) -> Builder {
+        self.push_slice(key.serialize_uncompressed())
     }
 
     /// Adds instructions to push an XOnly public key onto the stack.

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -37,10 +37,15 @@ fn script() {
     // keys
     const KEYSTR1: &str = "21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";
     let key = PublicKey::from_str(&KEYSTR1[2..]).unwrap();
-    script = script.push_key(&key); comp.extend_from_slice(&hex!(KEYSTR1)); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_key(&key);
+    comp.extend_from_slice(&hex!(KEYSTR1));
+    assert_eq!(script.as_bytes(), &comp[..]);
+    // uncompressed
     const KEYSTR2: &str = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
     let key = PublicKey::from_str(&KEYSTR2[2..]).unwrap();
-    script = script.push_key(&key); comp.extend_from_slice(&hex!(KEYSTR2)); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_key_uncompressed(&key);
+    comp.extend_from_slice(&hex!(KEYSTR2));
+    assert_eq!(script.as_bytes(), &comp[..]);
 
     // opcodes
     script = script.push_opcode(OP_CHECKSIG); comp.push(0xACu8); assert_eq!(script.as_bytes(), &comp[..]);
@@ -53,7 +58,7 @@ fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
     let key = PublicKey::from_str(key_str).unwrap();
     let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
-    assert_eq!(actual.to_vec(), key.to_bytes());
+    assert_eq!(actual.to_vec(), key.serialize());
 }
 
 #[test]
@@ -108,7 +113,7 @@ fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
     let key = PublicKey::from_str(compressed_key_str).unwrap();
     let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
-    assert_eq!(actual.to_vec(), key.to_bytes());
+    assert_eq!(actual.to_vec(), key.serialize());
 }
 
 #[test]
@@ -204,10 +209,10 @@ fn script_generators() {
             .unwrap();
     assert!(ScriptBuf::new_p2pk(&pubkey).is_p2pk());
 
-    let pubkey_hash = PubkeyHash::hash(&pubkey.inner.serialize());
+    let pubkey_hash = PubkeyHash::hash(&pubkey.serialize());
     assert!(ScriptBuf::new_p2pkh(&pubkey_hash).is_p2pkh());
 
-    let wpubkey_hash = WPubkeyHash::hash(&pubkey.inner.serialize());
+    let wpubkey_hash = WPubkeyHash::hash(&pubkey.serialize());
     assert!(ScriptBuf::new_v0_p2wpkh(&wpubkey_hash).is_v0_p2wpkh());
 
     let script = Builder::new().push_opcode(OP_NUMEQUAL).push_verify().into_script();

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -140,7 +140,7 @@ pub use crate::blockdata::weight::Weight;
 pub use crate::blockdata::witness::{self, Witness};
 pub use crate::blockdata::{constants, opcodes};
 pub use crate::consensus::encode::VarInt;
-pub use crate::crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, WPubkeyHash};
+pub use crate::crypto::key::{self, PrivateKey, PubkeyHash, PublicKeyExt, WPubkeyHash};
 pub use crate::crypto::{ecdsa, sighash};
 pub use crate::hash_types::{BlockHash, Txid, Wtxid};
 pub use crate::merkle_tree::MerkleBlock;

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -12,12 +12,12 @@ use core::{cmp, fmt};
 use std::collections::{HashMap, HashSet};
 
 use internals::write_err;
-use secp256k1::{Message, Secp256k1, Signing};
+use secp256k1::{Message, PublicKey, Secp256k1, Signing};
 
 use crate::bip32::{self, ExtendedPrivKey, ExtendedPubKey, KeySource};
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::crypto::ecdsa;
-use crate::crypto::key::{PrivateKey, PublicKey};
+use crate::crypto::key::PrivateKey;
 use crate::prelude::*;
 use crate::sighash::{self, EcdsaSighashType, SighashCache};
 use crate::Amount;
@@ -276,7 +276,7 @@ impl Psbt {
         for (pk, key_source) in input.bip32_derivation.iter() {
             let sk = if let Ok(Some(sk)) = k.get_key(KeyRequest::Bip32(key_source.clone()), secp) {
                 sk
-            } else if let Ok(Some(sk)) = k.get_key(KeyRequest::Pubkey(PublicKey::new(*pk)), secp) {
+            } else if let Ok(Some(sk)) = k.get_key(KeyRequest::Pubkey(*pk), secp) {
                 sk
             } else {
                 continue;
@@ -853,8 +853,6 @@ mod tests {
         let psbt: Psbt = hex_psbt!("70736274ff01003302000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff000000000000420204bb0d5d0cca36e7b9c80f63bc04c1240babb83bcd2803ef7ac8b6e2af594291daec281e856c98d210c5ab14dfd5828761f8ee7d5f45ca21ad3e4c4b41b747a3a047304402204f67e2afb76142d44fae58a2495d33a3419daa26cd0db8d04f3452b63289ac0f022010762a9fb67e94cc5cad9026f6dc99ff7f070f4278d30fbc7d0c869dd38c7fe70100").unwrap();
 
         assert!(psbt.inputs[0].partial_sigs.len() == 1);
-        let pk = psbt.inputs[0].partial_sigs.iter().next().unwrap().0;
-        assert!(!pk.compressed);
     }
 
     #[test]

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -9,7 +9,7 @@
 use core::convert::{TryFrom, TryInto};
 
 use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
-use secp256k1::{self, XOnlyPublicKey};
+use secp256k1::{self, PublicKey, XOnlyPublicKey};
 
 use super::map::{Input, Map, Output, PsbtSighashType};
 use crate::bip32::{ChildNumber, Fingerprint, KeySource};
@@ -17,7 +17,6 @@ use crate::blockdata::script::ScriptBuf;
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::blockdata::witness::Witness;
 use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
-use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
 use crate::prelude::*;
 use crate::psbt::{Error, Psbt};
@@ -132,24 +131,10 @@ impl Deserialize for ScriptBuf {
 }
 
 impl Serialize for PublicKey {
-    fn serialize(&self) -> Vec<u8> {
-        let mut buf = Vec::new();
-        self.write_into(&mut buf).expect("vecs don't error");
-        buf
-    }
-}
-
-impl Deserialize for PublicKey {
-    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        PublicKey::from_slice(bytes).map_err(Error::InvalidPublicKey)
-    }
-}
-
-impl Serialize for secp256k1::PublicKey {
     fn serialize(&self) -> Vec<u8> { self.serialize().to_vec() }
 }
 
-impl Deserialize for secp256k1::PublicKey {
+impl Deserialize for PublicKey {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         secp256k1::PublicKey::from_slice(bytes).map_err(Error::InvalidSecp256k1PublicKey)
     }

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -21,11 +21,10 @@ mod message_signing {
 
     use hashes::sha256d;
     use internals::write_err;
-    use secp256k1;
+    use secp256k1::{self, PublicKey};
     use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 
     use crate::address::{Address, AddressType};
-    use crate::crypto::key::PublicKey;
     #[cfg(feature = "base64")]
     use crate::prelude::*;
 
@@ -133,8 +132,7 @@ mod message_signing {
             msg_hash: sha256d::Hash,
         ) -> Result<PublicKey, MessageSignatureError> {
             let msg = secp256k1::Message::from(msg_hash);
-            let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
-            Ok(PublicKey { inner: pubkey, compressed: self.compressed })
+            Ok(secp_ctx.recover_ecdsa(&msg, &self.signature)?)
         }
 
         /// Verify that the signature signs the message and was signed by the given address.

--- a/bitcoin/tests/psbt.rs
+++ b/bitcoin/tests/psbt.rs
@@ -12,9 +12,9 @@ use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::script::PushBytes;
-use bitcoin::secp256k1::{self, Secp256k1};
+use bitcoin::secp256k1::{self, PublicKey, Secp256k1};
 use bitcoin::{
-    absolute, Amount, Denomination, Network, OutPoint, PrivateKey, PublicKey, ScriptBuf, Sequence,
+    absolute, Amount, Denomination, Network, OutPoint, PrivateKey, ScriptBuf, Sequence,
     Transaction, TxIn, TxOut, Witness,
 };
 
@@ -285,7 +285,7 @@ fn bip32_derivation(
         let pk = PublicKey::from_str(pk).unwrap();
         let path = path.into_derivation_path().unwrap();
 
-        tree.insert(pk.inner, (fingerprint, path));
+        tree.insert(pk, (fingerprint, path));
     }
     tree
 }
@@ -331,7 +331,7 @@ fn parse_and_verify_keys(
 }
 
 /// Does the first signing according to the BIP, returns the signed PSBT. Verifies against BIP 174 test vector.
-fn signer_one_sign(psbt: Psbt, key_map: BTreeMap<bitcoin::PublicKey, PrivateKey>) -> Psbt {
+fn signer_one_sign(psbt: Psbt, key_map: BTreeMap<PublicKey, PrivateKey>) -> Psbt {
     let expected_psbt_hex = include_str!("data/sign_1_psbt_hex");
     let expected_psbt = hex_psbt!(expected_psbt_hex).unwrap();
 
@@ -342,7 +342,7 @@ fn signer_one_sign(psbt: Psbt, key_map: BTreeMap<bitcoin::PublicKey, PrivateKey>
 }
 
 /// Does the second signing according to the BIP, returns the signed PSBT. Verifies against BIP 174 test vector.
-fn signer_two_sign(psbt: Psbt, key_map: BTreeMap<bitcoin::PublicKey, PrivateKey>) -> Psbt {
+fn signer_two_sign(psbt: Psbt, key_map: BTreeMap<PublicKey, PrivateKey>) -> Psbt {
     let expected_psbt_hex = include_str!("data/sign_2_psbt_hex");
     let expected_psbt = hex_psbt!(expected_psbt_hex).unwrap();
 
@@ -408,7 +408,7 @@ fn combine_lexicographically() {
 }
 
 /// Signs `psbt` with `keys` if required.
-fn sign(mut psbt: Psbt, keys: BTreeMap<bitcoin::PublicKey, PrivateKey>) -> Psbt {
+fn sign(mut psbt: Psbt, keys: BTreeMap<PublicKey, PrivateKey>) -> Psbt {
     let secp = Secp256k1::new();
     psbt.sign(&keys, &secp).unwrap();
     psbt


### PR DESCRIPTION
Some of you with a good memory will think "here he goes again".. Well, here I go again :)

First commit eliminates `bitcoin::PublicKey`. I plan to replace `bitcoin::PrivateKey` with a `wif::Key` type that is not used elsewhere, just used for WIF format.

Then maybe I have some idea for signatures.

I'm currently on the move, though, so I might not have time for this immediatelly.