### PR TITLE
Introduce a basic justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ cargo test
 Please refer to the [`cargo` documentation](https://doc.rust-lang.org/stable/cargo/) for more
 detailed instructions.
 
+### Just
+
+We support [`just`](https://just.systems/man/en/) for running dev workflow commands. Run `just` from
+your shell to see list available sub-commands.
+
 ### Building the docs
 
 We build docs with the nightly toolchain, you may wish to use the following shell alias to check

--- a/justfile
+++ b/justfile
@@ -1,0 +1,18 @@
+default:
+  @just --list
+
+# Cargo build everything.
+build:
+  cargo build --workspace --all-targets --all-features
+
+# Cargo check everything.
+check:
+  cargo check --workspace --all-targets --all-features
+
+# Lint everything.
+lint:
+  cargo clippy --workspace --all-targets --all-features -- --deny warnings
+
+# Check the formatting
+format:
+  cargo +nightly fmt --all --check


### PR DESCRIPTION
Introduce usage of `just` by adding a basic `justfile`.

If this goes in we can add various script invocations to it plus other useful things that often get red CI runs (eg, checking no-std).