### PR TITLE
Rename xpub and xpriv types

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::{env, process};
 
 use bitcoin::address::Address;
-use bitcoin::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey};
+use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
@@ -39,14 +39,14 @@ fn main() {
     let secp = Secp256k1::preallocated_new(buf.as_mut_slice()).unwrap();
 
     // calculate root key from seed
-    let root = ExtendedPrivKey::new_master(network, &seed).unwrap();
+    let root = Xpriv::new_master(network, &seed).unwrap();
     println!("Root key: {}", root);
 
     // derive child xpub
     let path = DerivationPath::from_str("m/84h/0h/0h").unwrap();
     let child = root.derive_priv(&secp, &path).unwrap();
     println!("Child at {}: {}", path, child);
-    let xpub = ExtendedPubKey::from_priv(&secp, &child);
+    let xpub = Xpub::from_priv(&secp, &child);
     println!("Public key at {}: {}", path, xpub);
 
     // generate first receiving address at m/0/0

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -78,7 +78,7 @@ const UTXO_3: P2trUtxo = P2trUtxo {
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
-use bitcoin::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey, Fingerprint};
+use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::consensus::encode;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
@@ -114,7 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tx_hex_string = encode::serialize_hex(&generate_bip86_key_spend_tx(
         &secp,
         // The master extended private key from the descriptor in step 4
-        ExtendedPrivKey::from_str(BENEFACTOR_XPRIV_STR)?,
+        Xpriv::from_str(BENEFACTOR_XPRIV_STR)?,
         // Set these fields with valid data for the UTXO from step 5 above
         UTXO_1,
         vec![
@@ -133,11 +133,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("START EXAMPLE 2 - Script path spending of inheritance UTXO\n");
 
     {
-        let beneficiary =
-            BeneficiaryWallet::new(ExtendedPrivKey::from_str(BENEFICIARY_XPRIV_STR)?)?;
+        let beneficiary = BeneficiaryWallet::new(Xpriv::from_str(BENEFICIARY_XPRIV_STR)?)?;
 
         let mut benefactor = BenefactorWallet::new(
-            ExtendedPrivKey::from_str(BENEFACTOR_XPRIV_STR)?,
+            Xpriv::from_str(BENEFACTOR_XPRIV_STR)?,
             beneficiary.master_xpub(),
         )?;
         let (tx, psbt) = benefactor.create_inheritance_funding_tx(
@@ -172,11 +171,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("START EXAMPLE 3 - Key path spending of inheritance UTXO\n");
 
     {
-        let beneficiary =
-            BeneficiaryWallet::new(ExtendedPrivKey::from_str(BENEFICIARY_XPRIV_STR)?)?;
+        let beneficiary = BeneficiaryWallet::new(Xpriv::from_str(BENEFICIARY_XPRIV_STR)?)?;
 
         let mut benefactor = BenefactorWallet::new(
-            ExtendedPrivKey::from_str(BENEFACTOR_XPRIV_STR)?,
+            Xpriv::from_str(BENEFACTOR_XPRIV_STR)?,
             beneficiary.master_xpub(),
         )?;
         let (tx, _) = benefactor.create_inheritance_funding_tx(
@@ -221,7 +219,7 @@ struct P2trUtxo<'a> {
 
 fn generate_bip86_key_spend_tx(
     secp: &secp256k1::Secp256k1<secp256k1::All>,
-    master_xpriv: ExtendedPrivKey,
+    master_xpriv: Xpriv,
     input_utxo: P2trUtxo,
     outputs: Vec<TxOut>,
 ) -> Result<Transaction, Box<dyn std::error::Error>> {
@@ -335,8 +333,8 @@ fn generate_bip86_key_spend_tx(
 /// A wallet that allows creating and spending from an inheritance directly via the key path for purposes
 /// of refreshing the inheritance timelock or changing other spending conditions.
 struct BenefactorWallet {
-    master_xpriv: ExtendedPrivKey,
-    beneficiary_xpub: ExtendedPubKey,
+    master_xpriv: Xpriv,
+    beneficiary_xpub: Xpub,
     current_spend_info: Option<TaprootSpendInfo>,
     next_psbt: Option<Psbt>,
     secp: Secp256k1<secp256k1::All>,
@@ -345,8 +343,8 @@ struct BenefactorWallet {
 
 impl BenefactorWallet {
     fn new(
-        master_xpriv: ExtendedPrivKey,
-        beneficiary_xpub: ExtendedPubKey,
+        master_xpriv: Xpriv,
+        beneficiary_xpub: Xpub,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self {
             master_xpriv,
@@ -615,18 +613,16 @@ impl BenefactorWallet {
 /// A wallet that allows spending from an inheritance locked to a P2TR UTXO via a script path
 /// after some expiry using CLTV.
 struct BeneficiaryWallet {
-    master_xpriv: ExtendedPrivKey,
+    master_xpriv: Xpriv,
     secp: secp256k1::Secp256k1<secp256k1::All>,
 }
 
 impl BeneficiaryWallet {
-    fn new(master_xpriv: ExtendedPrivKey) -> Result<Self, Box<dyn std::error::Error>> {
+    fn new(master_xpriv: Xpriv) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self { master_xpriv, secp: Secp256k1::new() })
     }
 
-    fn master_xpub(&self) -> ExtendedPubKey {
-        ExtendedPubKey::from_priv(&self.secp, &self.master_xpriv)
-    }
+    fn master_xpub(&self) -> Xpub { Xpub::from_priv(&self.secp, &self.master_xpriv) }
 
     fn spend_inheritance(
         &self,

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -4,7 +4,7 @@ use core::fmt;
 
 use internals::write_err;
 
-use crate::bip32::ExtendedPubKey;
+use crate::bip32::Xpub;
 use crate::blockdata::transaction::Transaction;
 use crate::consensus::encode;
 use crate::prelude::*;
@@ -69,7 +69,7 @@ pub enum Error {
     },
     /// Conflicting data during combine procedure:
     /// global extended public key has inconsistent key sources
-    CombineInconsistentKeySources(Box<ExtendedPubKey>),
+    CombineInconsistentKeySources(Box<Xpub>),
     /// Serialization error in bitcoin consensus-encoded structures
     ConsensusEncoding(encode::Error),
     /// Negative fee

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -2,7 +2,7 @@
 
 use core::convert::TryFrom;
 
-use crate::bip32::{ChildNumber, DerivationPath, ExtendedPubKey, Fingerprint};
+use crate::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
 use crate::blockdata::transaction::Transaction;
 use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::consensus::{encode, Decodable};
@@ -76,8 +76,7 @@ impl Psbt {
         let mut tx: Option<Transaction> = None;
         let mut version: Option<u32> = None;
         let mut unknowns: BTreeMap<raw::Key, Vec<u8>> = Default::default();
-        let mut xpub_map: BTreeMap<ExtendedPubKey, (Fingerprint, DerivationPath)> =
-            Default::default();
+        let mut xpub_map: BTreeMap<Xpub, (Fingerprint, DerivationPath)> = Default::default();
         let mut proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>> = Default::default();
 
         loop {
@@ -114,7 +113,7 @@ impl Psbt {
                         }
                         PSBT_GLOBAL_XPUB => {
                             if !pair.key.key.is_empty() {
-                                let xpub = ExtendedPubKey::decode(&pair.key.key)
+                                let xpub = Xpub::decode(&pair.key.key)
                                     .map_err(|_| Error::XPubKey(
                                         "Can't deserialize ExtendedPublicKey from global XPUB key data"
                                     ))?;

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use internals::write_err;
 use secp256k1::{Message, Secp256k1, Signing};
 
-use crate::bip32::{self, ExtendedPrivKey, ExtendedPubKey, KeySource};
+use crate::bip32::{self, KeySource, Xpriv, Xpub};
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::crypto::ecdsa;
 use crate::crypto::key::{PrivateKey, PublicKey};
@@ -44,7 +44,7 @@ pub struct Psbt {
     pub version: u32,
     /// A global map from extended public keys to the used key fingerprint and
     /// derivation path as defined by BIP 32.
-    pub xpub: BTreeMap<ExtendedPubKey, KeySource>,
+    pub xpub: BTreeMap<Xpub, KeySource>,
     /// Global proprietary key-value pairs.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq_byte_values"))]
     pub proprietary: BTreeMap<raw::ProprietaryKey, Vec<u8>>,
@@ -487,7 +487,7 @@ pub trait GetKey {
     ) -> Result<Option<PrivateKey>, Self::Error>;
 }
 
-impl GetKey for ExtendedPrivKey {
+impl GetKey for Xpriv {
     type Error = GetKeyError;
 
     fn get_key<C: Signing>(
@@ -520,7 +520,7 @@ pub type SigningErrors = BTreeMap<usize, SignError>;
 macro_rules! impl_get_key_for_set {
     ($set:ident) => {
 
-impl GetKey for $set<ExtendedPrivKey> {
+impl GetKey for $set<Xpriv> {
     type Error = GetKeyError;
 
     fn get_key<C: Signing>(
@@ -810,7 +810,7 @@ mod tests {
     use secp256k1::{All, SecretKey};
 
     use super::*;
-    use crate::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, KeySource};
+    use crate::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::{OutPoint, Sequence, Transaction, TxIn, TxOut};
@@ -857,7 +857,7 @@ mod tests {
 
         let mut hd_keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = Default::default();
 
-        let mut sk: ExtendedPrivKey = ExtendedPrivKey::new_master(Bitcoin, &seed).unwrap();
+        let mut sk: Xpriv = Xpriv::new_master(Bitcoin, &seed).unwrap();
 
         let fprint = sk.fingerprint(secp);
 
@@ -874,7 +874,7 @@ mod tests {
 
         sk = sk.derive_priv(secp, &dpath).unwrap();
 
-        let pk = ExtendedPubKey::from_priv(secp, &sk);
+        let pk = Xpub::from_priv(secp, &sk);
 
         hd_keypaths.insert(pk.public_key, (fprint, dpath.into()));
 
@@ -1019,7 +1019,7 @@ mod tests {
         let psbt = Psbt {
             version: 0,
             xpub: {
-                let xpub: ExtendedPubKey =
+                let xpub: Xpub =
                     "xpub661MyMwAqRbcGoRVtwfvzZsq2VBJR1LAHfQstHUoxqDorV89vRoMxUZ27kLrraAj6MPi\
                     QfrDb27gigC1VS1dBXi5jGpxmMeBXEkKkcXUTg4".parse().unwrap();
                 vec![(xpub, key_source)].into_iter().collect()

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -27,7 +27,7 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 
 use bincode::serialize;
-use bitcoin::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey, KeySource};
+use bitcoin::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
 use bitcoin::blockdata::locktime::{absolute, relative};
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::consensus::encode::deserialize;
@@ -155,7 +155,7 @@ fn serde_regression_address() {
 #[test]
 fn serde_regression_extended_priv_key() {
     let s = include_str!("data/serde/extended_priv_key");
-    let key = ExtendedPrivKey::from_str(s.trim()).unwrap();
+    let key = Xpriv::from_str(s.trim()).unwrap();
     let got = serialize(&key).unwrap();
     let want = include_bytes!("data/serde/extended_priv_key_bincode") as &[_];
     assert_eq!(got, want)
@@ -164,7 +164,7 @@ fn serde_regression_extended_priv_key() {
 #[test]
 fn serde_regression_extended_pub_key() {
     let s = include_str!("data/serde/extended_pub_key");
-    let key = ExtendedPubKey::from_str(s.trim()).unwrap();
+    let key = Xpub::from_str(s.trim()).unwrap();
     let got = serialize(&key).unwrap();
     let want = include_bytes!("data/serde/extended_pub_key_bincode") as &[_];
     assert_eq!(got, want)
@@ -269,7 +269,7 @@ fn serde_regression_psbt() {
         version: 0,
         xpub: {
             let s = include_str!("data/serde/extended_pub_key");
-            let xpub = ExtendedPubKey::from_str(s.trim()).unwrap();
+            let xpub = Xpub::from_str(s.trim()).unwrap();
             vec![(xpub, key_source)].into_iter().collect()
         },
         unsigned_tx: {


### PR DESCRIPTION
The BIP-32 extended public key and extended private key exist in the Bitcoin vernacular as xpub and xpriv. We can use these terms with no loss of clarity.

Rename our current BIP-32 types

- `ExtendedPubKey` to `Xpub`
- `ExtendedPrivKey` to `Xpriv`

This patch is a mechanical search-and-replace, followed by running the formatter, no other manual changes.