### PR TITLE
Move and rename `XpubIdentifier`

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -6,6 +6,8 @@
 //! at <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>.
 //!
 
+#![allow(deprecated)] // Remove once we remove XpubIdentifier.
+
 use core::convert::TryInto;
 use core::default::Default;
 use core::ops::Index;
@@ -54,7 +56,11 @@ impl_bytes_newtype!(Fingerprint, 4);
 
 hash_newtype! {
     /// XpubIdentifier as defined in BIP-32.
+    #[deprecated(since = "0.0.0-NEXT-RELEASE", note = "use XKeyIdentifier instead")]
     pub struct XpubIdentifier(hash160::Hash);
+
+    /// Extended key identifier as defined in BIP-32.
+    pub struct XKeyIdentifier(hash160::Hash);
 }
 
 /// Extended private key
@@ -676,7 +682,7 @@ impl Xpriv {
     }
 
     /// Returns the HASH160 of the public key belonging to the xpriv
-    pub fn identifier<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> XpubIdentifier {
+    pub fn identifier<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>) -> XKeyIdentifier {
         Xpub::from_priv(secp, self).identifier()
     }
 
@@ -807,10 +813,10 @@ impl Xpub {
     }
 
     /// Returns the HASH160 of the chaincode
-    pub fn identifier(&self) -> XpubIdentifier {
-        let mut engine = XpubIdentifier::engine();
+    pub fn identifier(&self) -> XKeyIdentifier {
+        let mut engine = XKeyIdentifier::engine();
         engine.write_all(&self.public_key.serialize()).expect("engines don't error");
-        XpubIdentifier::from_engine(engine)
+        XKeyIdentifier::from_engine(engine)
     }
 
     /// Returns the first four bytes of the identifier
@@ -859,12 +865,12 @@ impl FromStr for Xpub {
     }
 }
 
-impl From<Xpub> for XpubIdentifier {
-    fn from(key: Xpub) -> XpubIdentifier { key.identifier() }
+impl From<Xpub> for XKeyIdentifier {
+    fn from(key: Xpub) -> XKeyIdentifier { key.identifier() }
 }
 
-impl From<&Xpub> for XpubIdentifier {
-    fn from(key: &Xpub) -> XpubIdentifier { key.identifier() }
+impl From<&Xpub> for XKeyIdentifier {
+    fn from(key: &Xpub) -> XKeyIdentifier { key.identifier() }
 }
 
 #[cfg(test)]

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -12,7 +12,7 @@ use core::ops::Index;
 use core::str::FromStr;
 use core::{fmt, slice};
 
-use hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine};
+use hashes::{hash160, hash_newtype, sha512, Hash, HashEngine, Hmac, HmacEngine};
 use internals::{impl_array_newtype, write_err};
 use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 #[cfg(feature = "serde")]
@@ -20,7 +20,6 @@ use serde;
 
 use crate::base58;
 use crate::crypto::key::{self, KeyPair, PrivateKey, PublicKey};
-use crate::hash_types::XpubIdentifier;
 use crate::internal_macros::impl_bytes_newtype;
 use crate::io::Write;
 use crate::network::Network;
@@ -52,6 +51,11 @@ impl ChainCode {
 pub struct Fingerprint([u8; 4]);
 impl_array_newtype!(Fingerprint, u8, 4);
 impl_bytes_newtype!(Fingerprint, 4);
+
+hash_newtype! {
+    /// XpubIdentifier as defined in BIP-32.
+    pub struct XpubIdentifier(hash160::Hash);
+}
 
 /// Extended private key
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -52,7 +52,7 @@ pub use newtypes::*;
 
 #[rustfmt::skip]
 mod newtypes {
-    use hashes::{sha256d, hash160, hash_newtype};
+    use hashes::{sha256d, hash_newtype};
 
     hash_newtype! {
         /// A bitcoin transaction hash/transaction ID.
@@ -75,8 +75,6 @@ mod newtypes {
         pub struct WitnessMerkleNode(sha256d::Hash);
         /// A hash corresponding to the witness structure commitment in the coinbase transaction
         pub struct WitnessCommitment(sha256d::Hash);
-        /// XpubIdentifier as defined in BIP-32.
-        pub struct XpubIdentifier(hash160::Hash);
 
         /// Filter hash, as defined in BIP-157
         pub struct FilterHash(sha256d::Hash);

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -129,7 +129,7 @@ use core2::io;
 
 pub use crate::address::{Address, AddressType};
 pub use crate::amount::{Amount, Denomination, SignedAmount};
-pub use crate::bip32::XpubIdentifier;
+pub use crate::bip32::XKeyIdentifier;
 pub use crate::blockdata::block::{self, Block};
 pub use crate::blockdata::fee_rate::FeeRate;
 pub use crate::blockdata::locktime::{self, absolute, relative};

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -129,6 +129,7 @@ use core2::io;
 
 pub use crate::address::{Address, AddressType};
 pub use crate::amount::{Amount, Denomination, SignedAmount};
+pub use crate::bip32::XpubIdentifier;
 pub use crate::blockdata::block::{self, Block};
 pub use crate::blockdata::fee_rate::FeeRate;
 pub use crate::blockdata::locktime::{self, absolute, relative};
@@ -147,7 +148,6 @@ pub use crate::crypto::key::{
 pub use crate::crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag};
 pub use crate::hash_types::{
     BlockHash, FilterHash, FilterHeader, TxMerkleNode, Txid, WitnessCommitment, Wtxid,
-    XpubIdentifier,
 };
 pub use crate::merkle_tree::MerkleBlock;
 pub use crate::network::Network;


### PR DESCRIPTION
- Patch 1: Move the hash to the `bip32` module where it is used, as we have done with other hashes recently (and re-export it at crate root).
- Patch 2: Rename the hash to `XKeyIdentifier` as discussed in #2014

Fix: #2014 