### PR TITLE
Make Encodable/Decodable usage uniform

### DIFF
--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -642,12 +642,12 @@ impl_vec!((u32, Address));
 #[cfg(feature = "std")]
 impl_vec!(AddrV2Message);
 
-pub(crate) fn consensus_encode_with_size<S: io::Write>(
+pub(crate) fn consensus_encode_with_size<W: io::Write>(
     data: &[u8],
-    mut s: S,
+    mut w: W,
 ) -> Result<usize, io::Error> {
-    let vi_len = VarInt(data.len() as u64).consensus_encode(&mut s)?;
-    s.emit_slice(data)?;
+    let vi_len = VarInt(data.len() as u64).consensus_encode(&mut w)?;
+    w.emit_slice(data)?;
     Ok(vi_len + data.len())
 }
 

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -141,7 +141,7 @@ pub enum AddrV2 {
 }
 
 impl Encodable for AddrV2 {
-    fn consensus_encode<W: io::Write + ?Sized>(&self, e: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         fn encode_addr<W: io::Write + ?Sized>(
             w: &mut W,
             network: u8,
@@ -154,13 +154,13 @@ impl Encodable for AddrV2 {
             Ok(len)
         }
         Ok(match *self {
-            AddrV2::Ipv4(ref addr) => encode_addr(e, 1, &addr.octets())?,
-            AddrV2::Ipv6(ref addr) => encode_addr(e, 2, &addr.octets())?,
-            AddrV2::TorV2(ref bytes) => encode_addr(e, 3, bytes)?,
-            AddrV2::TorV3(ref bytes) => encode_addr(e, 4, bytes)?,
-            AddrV2::I2p(ref bytes) => encode_addr(e, 5, bytes)?,
-            AddrV2::Cjdns(ref addr) => encode_addr(e, 6, &addr.octets())?,
-            AddrV2::Unknown(network, ref bytes) => encode_addr(e, network, bytes)?,
+            AddrV2::Ipv4(ref addr) => encode_addr(w, 1, &addr.octets())?,
+            AddrV2::Ipv6(ref addr) => encode_addr(w, 2, &addr.octets())?,
+            AddrV2::TorV2(ref bytes) => encode_addr(w, 3, bytes)?,
+            AddrV2::TorV3(ref bytes) => encode_addr(w, 4, bytes)?,
+            AddrV2::I2p(ref bytes) => encode_addr(w, 5, bytes)?,
+            AddrV2::Cjdns(ref addr) => encode_addr(w, 6, &addr.octets())?,
+            AddrV2::Unknown(network, ref bytes) => encode_addr(w, network, bytes)?,
         })
     }
 }


### PR DESCRIPTION
One encodes to a writer and decodes from a reader, most of the time in the consensus `Encodable`/`Decodable` traits we use generic `R`/`W` and variable `r`/`w` but there are other places that use other characters.

While touching these lines note also that there are a bunch of unneeded `mut`s, I'm not sure why since usually between the compiler and the linter `mut` is handled correctly.

Make implementations of `Encodable` and `Decodable` uniform by:
- Use R/W and r/w for trait and variable name
- Remove unneeded mut

(This is split out of #1891 to assist review.)