### PR TITLE
Fix clippy warnings

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -2361,8 +2361,7 @@ mod tests {
 
     #[test]
     fn disallow_confusing_forms() {
-        let confusing =
-            vec!["Msat", "Msats", "MSAT", "MSATS", "MSat", "MSats", "MBTC", "Mbtc", "PBTC"];
+        let confusing = ["Msat", "Msats", "MSAT", "MSATS", "MSat", "MSats", "MBTC", "Mbtc", "PBTC"];
         for denom in confusing.iter() {
             match Denomination::from_str(denom) {
                 Ok(_) => panic!("from_str should error for {}", denom),
@@ -2375,7 +2374,7 @@ mod tests {
     #[test]
     fn disallow_unknown_denomination() {
         // Non-exhaustive list of unknown forms.
-        let unknown = vec!["NBTC", "UBTC", "ABC", "abc", "cBtC", "Sat", "Sats"];
+        let unknown = ["NBTC", "UBTC", "ABC", "abc", "cBtC", "Sat", "Sats"];
         for denom in unknown.iter() {
             match Denomination::from_str(denom) {
                 Ok(_) => panic!("from_str should error for {}", denom),

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -616,7 +616,7 @@ mod test {
                 .unwrap());
 
             for script in txmap.values() {
-                let query = vec![script];
+                let query = [script];
                 if !script.is_empty() {
                     assert!(filter
                         .match_any(block_hash, &mut query.iter().map(|s| s.as_bytes()))

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -700,7 +700,7 @@ mod tests {
 
         let txid1 = txids[0];
         let txid2 = txids[1];
-        let txids = vec![txid1, txid2];
+        let txids = [txid1, txid2];
 
         let merkle_block = MerkleBlock::from_block_with_predicate(&block, |t| txids.contains(t));
 

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -39,7 +39,7 @@ impl<T: Tag> Hash<T> {
 
 impl<T: Tag> Copy for Hash<T> {}
 impl<T: Tag> Clone for Hash<T> {
-    fn clone(&self) -> Self { Hash(self.0, self.1) }
+    fn clone(&self) -> Self { *self }
 }
 impl<T: Tag> PartialEq for Hash<T> {
     fn eq(&self, other: &Hash<T>) -> bool { self.0 == other.0 }


### PR DESCRIPTION
A new version `clippy 0.1.72 (5680fa1 2023-08-23)` just came out and we get a two new warnings. Fix them up.