### PR TITLE
Add trait bounds on Tag

### DIFF
--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -6,19 +6,23 @@
 use core::marker::PhantomData;
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::str;
 
 use crate::{sha256, FromSliceError};
 
 type HashEngine = sha256::HashEngine;
 
 /// Trait representing a tag that can be used as a context for SHA256t hashes.
-pub trait Tag {
+///
+/// This trait is usually implemented on an empty struct, however you likely just want to use
+/// `sha256t_hash_newtype!` which handles this trait for you.
+pub trait Tag: Copy + Clone + PartialOrd + Ord + PartialEq + Eq + core::hash::Hash {
     /// Returns a hash engine that is pre-tagged and is ready to be used for the data.
     fn engine() -> sha256::HashEngine;
 }
 
 /// Output of the SHA256t hash function.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Hash<T: Tag>([u8; 32], PhantomData<T>);
 
@@ -35,29 +39,6 @@ impl<T: Tag> Hash<T> {
     fn internal_new(arr: [u8; 32]) -> Self { Hash(arr, Default::default()) }
 
     fn internal_engine() -> HashEngine { T::engine() }
-}
-
-impl<T: Tag> Copy for Hash<T> {}
-impl<T: Tag> Clone for Hash<T> {
-    fn clone(&self) -> Self { *self }
-}
-impl<T: Tag> PartialEq for Hash<T> {
-    fn eq(&self, other: &Hash<T>) -> bool { self.0 == other.0 }
-}
-impl<T: Tag> Eq for Hash<T> {}
-impl<T: Tag> Default for Hash<T> {
-    fn default() -> Self { Hash([0; 32], PhantomData) }
-}
-impl<T: Tag> PartialOrd for Hash<T> {
-    fn partial_cmp(&self, other: &Hash<T>) -> Option<cmp::Ordering> {
-        Some(cmp::Ord::cmp(self, other))
-    }
-}
-impl<T: Tag> Ord for Hash<T> {
-    fn cmp(&self, other: &Hash<T>) -> cmp::Ordering { cmp::Ord::cmp(&self.0, &other.0) }
-}
-impl<T: Tag> core::hash::Hash for Hash<T> {
-    fn hash<H: core::hash::Hasher>(&self, h: &mut H) { self.0.hash(h) }
 }
 
 crate::internal_macros::hash_trait_impls!(256, true, T: Tag);


### PR DESCRIPTION
Currently we manually implement the commonly derived traits on `sha256t::Hash` because of the `Tag` trait. Instead we can just add trait bounds to the `Tag` trait and then derive the impls.

#### Note

Came about because I was annoyed at myself for not digging deeper during #2029. 