### PR TITLE
CI: Fx pinning

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -13,6 +13,12 @@ if cargo --version | grep ${MSRV}; then
     cargo update -p quote --precise 1.0.30
     cargo update -p proc-macro2 --precise 1.0.63
     cargo update -p serde_test --precise 1.0.175
+    # Have to pin this so we can pin `schemars_derive`
+    cargo update -p schemars --precise 0.8.12
+    # schemars_derive 0.8.13 uses edition 2021
+    cargo update -p schemars_derive --precise 0.8.12
+    # memcrh 2.6.0 uses edition 2021
+    cargo update -p memchr --precise 2.5.0
 
     cargo update -p bitcoin:0.30.1 --precise 0.30.0
 


### PR DESCRIPTION
More crates broke our MSRV by using edition 2021 without doing a major release, pin them in the CI script.

Other open PRs need this to get past CI.