### PR TITLE
hashes: Remove duplicate entry

### DIFF
--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -6,7 +6,6 @@ bumped the Minimum Supported Rust Version across the `rust-bitcoin` ecosystem to
 
 * Bump MSRV to 1.48.0 [#1729](https://github.com/rust-bitcoin/rust-bitcoin/pull/1729).
 * Depend on new `hex-conservative` crate and remove `hex` module [#1883](https://github.com/rust-bitcoin/rust-bitcoin/pull/1833).
-* Convert enum `crate::Error` to struct `crate::FromSliceError`.
 * Make `sha256t_hash_newtype!` evocative of the output [#1773](https://github.com/rust-bitcoin/rust-bitcoin/pull/1773).
 * Implement computing SHA256 in const context [#1769](https://github.com/rust-bitcoin/rust-bitcoin/pull/1769).
 * Add `from_bytes_ref` and `from_bytes_mut` to all hash types [#1761](https://github.com/rust-bitcoin/rust-bitcoin/pull/1761).


### PR DESCRIPTION
We accidentally mentioned an error change twice, remove the entry without the PR link.