### PR TITLE
CI: Add `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
Fixes #2051.

This does not touch Rust code or Cargo workflows.
It creates a dependabot update only restricted to `"github-actions"`.

We are using outdated `actions/checkout`, `actions/cache` (`v2` in some and `v3` in others were the must up-to-date is `v4`).

For the `dtolnay/rust-toolchain@1.48.0` in
https://github.com/rust-bitcoin/rust-bitcoin/blob/f8d7bcfce2b301870b1df23e6f508e8dd7942d10/.github/workflows/rust.yml#L77
it would not touch it only if there is a `1.48.X` increase in `X`.

For the `actions-rs/toolchain@v1` in https://github.com/rust-bitcoin/rust-bitcoin/blob/f8d7bcfce2b301870b1df23e6f508e8dd7942d10/.github/workflows/fuzz.yml#L50 it will only update if we have `actions-rs/toolchain@vX` increase in `X`.

**And to stress that again, it will ⚠️ create PRs and we would need to approve them ⚠️ (they would be subject to the same merge policy) to instantiate the proposed dependabots into `master`.**