### PR TITLE
fix(CI): `rust-toolchain` stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,9 @@ jobs:
       - name: Checkout Crate
         uses: actions/checkout@v3
       - name: Checkout Toolchain
-        uses: dtolnay/rust-toolchain@1.48.0
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.48.0"
       - name: Running test script
         env:
           DO_FEATURE_MATRIX: true


### PR DESCRIPTION
- sets `dtolnay/rust-toolchain` to `stable`
- delegates the `toolchain` to `1.48.0` as GitHub action input

This will make the rust-toolchain to always run in the `stable` branch with the toolchain version being handled in the action. It will appease dependabot and we can change at any time the `toolchain` action input.

Discussed in https://github.com/rust-bitcoin/rust-bitcoin/pull/2055