### PR TITLE
Fix: IndexOutOfBoundsError Display impl has values in wrong order

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -798,12 +798,12 @@ impl fmt::Display for IndexOutOfBoundsError {
             Inputs { ref index, ref length } => write!(
                 f,
                 "index {} is out-of-bounds for PSBT inputs vector length {}",
-                length, index
+                index, length
             ),
             TxInput { ref index, ref length } => write!(
                 f,
                 "index {} is out-of-bounds for PSBT unsigned tx input vector length {}",
-                length, index
+                index, length
             ),
         }
     }


### PR DESCRIPTION
Simple self explanatory fix.