### PR TITLE
Feature: Psbt fee checks

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -82,7 +82,7 @@ fn main() -> Result<()> {
     let finalized = online.finalize_psbt(signed)?;
 
     // You can use `bt sendrawtransaction` to broadcast the extracted transaction.
-    let tx = finalized.extract_tx();
+    let tx = finalized.extract_tx_unchecked_fee_rate();
     tx.verify(|_| Some(previous_output())).expect("failed to verify transaction");
 
     let hex = encode::serialize_hex(&tx);

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -319,7 +319,7 @@ fn generate_bip86_key_spend_tx(
     });
 
     // EXTRACTOR
-    let tx = psbt.extract_tx();
+    let tx = psbt.extract_tx_unchecked_fee_rate();
     tx.verify(|_| {
         Some(TxOut {
             value: from_amount,
@@ -553,7 +553,7 @@ impl BenefactorWallet {
             });
 
             // EXTRACTOR
-            let tx = psbt.extract_tx();
+            let tx = psbt.extract_tx_unchecked_fee_rate();
             tx.verify(|_| {
                 Some(TxOut { value: input_value, script_pubkey: output_script_pubkey.clone() })
             })
@@ -695,7 +695,7 @@ impl BeneficiaryWallet {
         });
 
         // EXTRACTOR
-        let tx = psbt.extract_tx();
+        let tx = psbt.extract_tx_unchecked_fee_rate();
         tx.verify(|_| {
             Some(TxOut { value: input_value, script_pubkey: input_script_pubkey.clone() })
         })

--- a/bitcoin/src/blockdata/fee_rate.rs
+++ b/bitcoin/src/blockdata/fee_rate.rs
@@ -119,7 +119,7 @@ impl FeeRate {
 impl fmt::Display for FeeRate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
-            write!(f, "{} sat/kwu", self.0)
+            write!(f, "{}.00 sat/vbyte", self.to_sat_per_vb_ceil())
         } else {
             fmt::Display::fmt(&self.0, f)
         }

--- a/bitcoin/src/psbt/macros.rs
+++ b/bitcoin/src/psbt/macros.rs
@@ -9,6 +9,52 @@ macro_rules! hex_psbt {
     };
 }
 
+#[cfg(test)]
+macro_rules! psbt_with_values {
+    ($input:expr, $output:expr) => {
+        Psbt {
+            unsigned_tx: Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![TxIn {
+                    previous_output: OutPoint {
+                        txid: "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126"
+                            .parse()
+                            .unwrap(),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+                    witness: Witness::default(),
+                }],
+                output: vec![TxOut {
+                    value: Amount::from_sat($output),
+                    script_pubkey: ScriptBuf::from_hex(
+                        "a9143545e6e33b832c47050f24d3eeb93c9c03948bc787",
+                    )
+                    .unwrap(),
+                }],
+            },
+            xpub: Default::default(),
+            version: 0,
+            proprietary: BTreeMap::new(),
+            unknown: BTreeMap::new(),
+
+            inputs: vec![Input {
+                witness_utxo: Some(TxOut {
+                    value: Amount::from_sat($input),
+                    script_pubkey: ScriptBuf::from_hex(
+                        "a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587",
+                    )
+                    .unwrap(),
+                }),
+                ..Default::default()
+            }],
+            outputs: vec![],
+        }
+    };
+}
+
 macro_rules! combine {
     ($thing:ident, $slf:ident, $other:ident) => {
         if let (&None, Some($thing)) = (&$slf.$thing, $other.$thing) {

--- a/bitcoin/tests/psbt.rs
+++ b/bitcoin/tests/psbt.rs
@@ -380,7 +380,7 @@ fn finalize(psbt: Psbt) -> Psbt {
 fn extract_transaction(psbt: Psbt) -> Transaction {
     let expected_tx_hex = include_str!("data/extract_tx_hex");
 
-    let tx = psbt.extract_tx();
+    let tx = psbt.extract_tx_unchecked_fee_rate();
 
     let got = serialize_hex(&tx);
     assert_eq!(got, expected_tx_hex);


### PR DESCRIPTION
Closes #2061

These new methods on Psbt will add checks for high fees by default. The threshold for "high fees" is currently set to 25000 sat/vbyte, which is about 20x higher than the highest next block fees seen on the "Mempool" website.

The primary goal of this change is to prevent users of the library from accidentally sending absurd amounts of fees.

(ie. Recently in September 2023 there was a transaction that sent an absurd amount of fees and made news in the Bitcoin world. Luckily the mining pool gave it back, but some might not be so lucky.)

There are variants of the method that allow for users to set their own "absurd" threshold using a `FeeRate` value. And there is a method that performs no checks, and the method name is alarming enough to draw attention in a review, so at least developers will be aware of the concept.