### PR TITLE
Fixes #2011: Customize Debug implementation of `absolute::LockTime`

### DIFF
--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -67,7 +67,7 @@ pub const LOCK_TIME_THRESHOLD: u32 = 500_000_000;
 /// };
 /// ```
 #[allow(clippy::derive_ord_xor_partial_ord)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LockTime {
     /// A block height lock time value.
     ///
@@ -290,6 +290,17 @@ impl PartialOrd for LockTime {
             (Blocks(ref a), Blocks(ref b)) => a.partial_cmp(b),
             (Seconds(ref a), Seconds(ref b)) => a.partial_cmp(b),
             (_, _) => None,
+        }
+    }
+}
+
+impl fmt::Debug for LockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use LockTime::*;
+
+        match *self {
+            Blocks(ref h) => write!(f, "{} blocks", h),
+            Seconds(ref t) => write!(f, "{} seconds", t),
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-bitcoin/rust-bitcoin/issues/2011.

This PR aims to make the "pretty print" of `absolute::LockTime` prettier by printing `X blocks` and `X seconds` for `Blocks` and `Seconds` respectively instead of the default Enum printing.