### PR TITLE
Fix base weight redo

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -295,7 +295,7 @@ impl Block {
 
     /// Returns the stripped size of the block.
     pub fn stripped_size(&self) -> usize {
-        let txs_size: usize = self.txdata.iter().map(Transaction::strippedsize).sum();
+        let txs_size: usize = self.txdata.iter().map(Transaction::stripped_size).sum();
         self.base_size() + txs_size
     }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -208,7 +208,8 @@ pub struct TxIn {
 
 impl TxIn {
     /// The weight of a `TxIn` excluding the `script_sig` and `witness`.
-    pub const BASE_WEIGHT: Weight = Weight::from_wu(32 + 4 + 4);
+    pub const BASE_WEIGHT: Weight =
+        Weight::from_vb_const(OutPoint::SIZE as u64 + Sequence::SIZE as u64);
 
     /// Returns true if this input enables the [`absolute::LockTime`] (aka `nLockTime`) of its
     /// [`Transaction`].

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -51,6 +51,14 @@ pub struct OutPoint {
 crate::serde_utils::serde_struct_human_string_impl!(OutPoint, "an OutPoint", txid, vout);
 
 impl OutPoint {
+    /// The size of an OutPoint.
+    ///
+    /// ### Bitcoin Core References
+    ///
+    /// * [COutPoint hash size (32 bytes)](https://github.com/bitcoin/bitcoin/blob/adc0921ea19f3b06878df6b22393fec519ed8f91/src/primitives/transaction.h#L79)
+    /// * [COutPoint n size (4 bytes)](https://github.com/bitcoin/bitcoin/blob/adc0921ea19f3b06878df6b22393fec519ed8f91/src/primitives/transaction.h#L39)
+    pub const SIZE: usize = 32 + 4;
+
     /// Creates a new [`OutPoint`].
     #[inline]
     pub fn new(txid: Txid, vout: u32) -> OutPoint { OutPoint { txid, vout } }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -286,6 +286,12 @@ impl Default for TxIn {
 pub struct Sequence(pub u32);
 
 impl Sequence {
+    /// The size of a Sequence.
+    ///
+    /// ### Bitcoin Core Reference
+    ///
+    /// * [nSequence size (4 bytes)](https://github.com/bitcoin/bitcoin/blob/adc0921ea19f3b06878df6b22393fec519ed8f91/src/primitives/transaction.h#L39)
+    pub const SIZE: usize = 32 + 4;
     /// The maximum allowable sequence number.
     ///
     /// This sequence number disables absolute lock time and replace-by-fee.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -712,31 +712,31 @@ impl Transaction {
 
     /// Returns the size of this transaction excluding the witness data.
     #[deprecated(since = "0.31.0", note = "Use Transaction::stripped_size() instead")]
-    pub fn strippedsize(&self) -> usize { Self::stripped_size(self).to_wu() as usize }
+    pub fn strippedsize(&self) -> usize { Self::stripped_size(self) }
 
     /// Returns the size of this transaction excluding the witness data.
-    pub fn stripped_size(&self) -> Weight {
-        let mut input_size: Weight = Weight::ZERO;
+    pub fn stripped_size(&self) -> usize {
+        let mut input_size = 0;
         for input in &self.input {
-            input_size += TxIn::BASE_WEIGHT
-                + Weight::from_wu_usize(VarInt(input.script_sig.len() as u64).len())
-                + Weight::from_wu_usize(input.script_sig.len());
+            input_size += 32 + 4 + 4 + // outpoint (32+4) + nSequence
+                VarInt(input.script_sig.len() as u64).len() +
+                input.script_sig.len();
         }
-        let mut output_size = Weight::ZERO;
+        let mut output_size = 0;
         for output in &self.output {
-            output_size += Weight::from_wu(8)+ // value
-                Weight::from_wu_usize(VarInt(output.script_pubkey.len() as u64).len()) +
-                Weight::from_wu_usize(output.script_pubkey.len());
+            output_size += 8 + // value
+                VarInt(output.script_pubkey.len() as u64).len() +
+                output.script_pubkey.len();
         }
-        let non_input_size: Weight =
+        let non_input_size =
         // version:
-        Weight::from_wu(4)+
+        4 +
         // count varints:
-        Weight::from_wu_usize(VarInt(self.input.len() as u64).len()) +
-        Weight::from_wu_usize(VarInt(self.output.len() as u64).len()) +
+        VarInt(self.input.len() as u64).len() +
+        VarInt(self.output.len() as u64).len() +
         output_size +
         // lock_time
-        Weight::from_wu(4);
+        4;
         non_input_size + input_size
     }
 
@@ -1397,7 +1397,7 @@ mod tests {
         assert_eq!(realtx.weight().to_wu() as usize, tx_bytes.len() * WITNESS_SCALE_FACTOR);
         assert_eq!(realtx.size(), tx_bytes.len());
         assert_eq!(realtx.vsize(), tx_bytes.len());
-        assert_eq!(realtx.stripped_size(), Weight::from_wu_usize(tx_bytes.len()));
+        assert_eq!(realtx.stripped_size(), tx_bytes.len());
         assert_eq!(realtx.scaled_size(4), Weight::from_wu(772));
     }
 
@@ -1444,20 +1444,18 @@ mod tests {
         //     weight = WITNESS_SCALE_FACTOR * stripped_size + witness_size
         // then,
         //     stripped_size = (weight - size) / (WITNESS_SCALE_FACTOR - 1)
-        let expected_strippedsize: Weight = Weight::from_wu(
-            (EXPECTED_WEIGHT - Weight::from_wu_usize(tx_bytes.len()))
-                / (Weight::from_wu_usize(WITNESS_SCALE_FACTOR - 1)),
-        );
+        let expected_strippedsize =
+            (EXPECTED_WEIGHT.to_wu() as usize - tx_bytes.len()) / (WITNESS_SCALE_FACTOR - 1);
         assert_eq!(realtx.stripped_size(), expected_strippedsize);
         // Construct a transaction without the witness data.
         let mut tx_without_witness = realtx;
         tx_without_witness.input.iter_mut().for_each(|input| input.witness.clear());
         assert_eq!(
-            tx_without_witness.weight(),
-            expected_strippedsize.scale_by_witness_factor().unwrap()
+            tx_without_witness.weight().to_wu() as usize,
+            expected_strippedsize * WITNESS_SCALE_FACTOR
         );
-        assert_eq!(Weight::from_wu_usize(tx_without_witness.size()), expected_strippedsize);
-        assert_eq!(Weight::from_wu_usize(tx_without_witness.vsize()), expected_strippedsize);
+        assert_eq!(tx_without_witness.size(), expected_strippedsize);
+        assert_eq!(tx_without_witness.vsize(), expected_strippedsize);
         assert_eq!(tx_without_witness.stripped_size(), expected_strippedsize);
         assert_eq!(tx_without_witness.scaled_size(1), Weight::from_wu(83));
     }

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -54,6 +54,21 @@ impl Weight {
         vb.checked_mul(Self::WITNESS_SCALE_FACTOR).map(Weight::from_wu)
     }
 
+    /// Constructs `Weight` from virtual bytes in const context.
+    pub const fn from_vb_const(vb: u64) -> Weight {
+        match vb.checked_mul(Self::WITNESS_SCALE_FACTOR) {
+            Some(weight) => Weight(weight),
+            None => {
+                // TODO replace with panic!() when MSRV = 1.57+
+                #[allow(unconditional_panic)]
+                // disabling this lint until panic!() can be used.
+                #[allow(clippy::let_unit_value)]
+                let _int_overflow_scaling_weight = [(); 0][1];
+                Weight(0)
+            }
+        }
+    }
+
     /// Constructs `Weight` from virtual bytes without an overflow check.
     pub const fn from_vb_unchecked(vb: u64) -> Self { Weight::from_wu(vb * 4) }
 


### PR DESCRIPTION
Fix the base weight calculation of a `TxIn`.  I also added some constants for `OutPoint` size and `Sequence` to be used in the calculation (instead of magic numbers).