### PR TITLE
Bump pinned version of proc-macro2

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -11,7 +11,7 @@ if cargo --version | grep ${MSRV}; then
     cargo update -p serde_json --precise 1.0.99
     cargo update -p serde --precise 1.0.156
     cargo update -p quote --precise 1.0.30
-    cargo update -p proc-macro2 --precise 1.0.63
+    cargo update -p proc-macro2 --precise 1.0.67
     cargo update -p serde_test --precise 1.0.175
     # Have to pin this so we can pin `schemars_derive`
     cargo update -p schemars --precise 0.8.12


### PR DESCRIPTION
I'm getting a CI failure for #2069

```
error: failed to select a version for the requirement `proc-macro2 = "^1.0.67"`
candidate versions found which didn't match: 1.0.63
location searched: crates.io index
required by package `syn v2.0.33`
    ... which is depended on by `wasm-bindgen-macro-support v0.2.87`
    ... which is depended on by `wasm-bindgen-macro v0.2.87`
    ... which is depended on by `wasm-bindgen v0.2.87`
    ... which is depended on by `console_error_panic_hook v0.1.7`
    ... which is depended on by `wasm-bindgen-test v0.3.37`
    ... which is depended on by `bitcoin_hashes v0.13.0 (/home/runner/work/rust-bitcoin/rust-bitcoin/hashes)`
    ... which is depended on by `bitcoin v0.30.0 (/home/runner/work/rust-bitcoin/rust-bitcoin/bitcoin)`
Error: Process completed with exit code 101.
```