### PR TITLE
Use minimum deps for MSRV build

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,12 @@ For more information please see `./CONTRIBUTING.md`.
 
 This library should always compile with any combination of features on **Rust 1.48.0**.
 
-To build with the MSRV you will need to pin `serde` (if you have the feature enabled)
+To build with the MSRV, you will need to use the Cargo-minimal.lock file.  **Note:** the MSRV will not get the latest dependency updates.
 
 ```
-# serde 1.0.157 uses syn 2.0 which requires edition 2021
-cargo update -p serde_json --precise 1.0.99
-cargo update -p serde --precise 1.0.156
-cargo update -p quote --precise 1.0.30
-cargo update -p proc-macro2 --precise 1.0.63
-cargo update -p serde_test --precise 1.0.175
+cp Cargo-minimal.lock Cargo.lock
+cargo build
 ```
-
-The above commands are sourced from `./contrib/test.sh`.
 
 ## External dependencies
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -6,23 +6,13 @@ CRATES="bitcoin hashes internals fuzz"
 DEPS="recent minimal"
 MSRV="1\.48\.0"
 
-# Test pinned versions.
+# Test MSRV.
 if cargo --version | grep ${MSRV}; then
-    cargo update -p serde_json --precise 1.0.99
-    cargo update -p serde --precise 1.0.156
-    cargo update -p quote --precise 1.0.30
-    cargo update -p proc-macro2 --precise 1.0.63
-    cargo update -p serde_test --precise 1.0.175
-    # Have to pin this so we can pin `schemars_derive`
-    cargo update -p schemars --precise 0.8.12
-    # schemars_derive 0.8.13 uses edition 2021
-    cargo update -p schemars_derive --precise 0.8.12
-    # memcrh 2.6.0 uses edition 2021
-    cargo update -p memchr --precise 2.5.0
 
-    cargo update -p bitcoin:0.30.1 --precise 0.30.0
+    # Copy minimum dependencies.
+    cp Cargo-minimal.lock Cargo.lock
 
-    # Build MSRV with pinned versions.
+    # Check MSRV with minimum dependencies.
     cargo check --all-features --all-targets
 fi
 


### PR DESCRIPTION
Marking as a draft for now since there may be some reasons not to do this I don't know about.

Proc-macro2 released version [1.0.67](https://github.com/dtolnay/proc-macro2/commit/a803dd15053e144606f362b86d4472fa35af428b) a few days ago which broke the ability to `cargo update` using MSRV.  Since it's no longer possible to go from `Cargo-minimal.lock` to `Cargo-recent.lock` using `cargo update`, I don't know a way to fix the pins, since cargo can't seem to resolve the dependencies.  `Proc-macro2` depends on `syn 2.0.33` which requires `rustc +1.56`.  Instead, just use `Cargo-minimal.lock` instead of the pins.  The downside is that the MSRV will be using outdated dependencies which maybe means it's better to update the MSRV instead? 