### PR TITLE
Bugfix: Script::count_sigops should not return a Result

### DIFF
--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -616,7 +616,7 @@ fn test_script_get_sigop_count() {
             .push_opcode(OP_EQUAL)
             .into_script()
             .count_sigops(),
-        Ok(0)
+        0
     );
     assert_eq!(
         Builder::new()
@@ -627,7 +627,7 @@ fn test_script_get_sigop_count() {
             .push_opcode(OP_CHECKSIG)
             .into_script()
             .count_sigops(),
-        Ok(1)
+        1
     );
     assert_eq!(
         Builder::new()
@@ -639,7 +639,7 @@ fn test_script_get_sigop_count() {
             .push_opcode(OP_PUSHNUM_1)
             .into_script()
             .count_sigops(),
-        Ok(1)
+        1
     );
     let multi = Builder::new()
         .push_opcode(OP_PUSHNUM_1)
@@ -649,8 +649,8 @@ fn test_script_get_sigop_count() {
         .push_opcode(OP_PUSHNUM_3)
         .push_opcode(OP_CHECKMULTISIG)
         .into_script();
-    assert_eq!(multi.count_sigops(), Ok(3));
-    assert_eq!(multi.count_sigops_legacy(), Ok(20));
+    assert_eq!(multi.count_sigops(), 3);
+    assert_eq!(multi.count_sigops_legacy(), 20);
     let multi_verify = Builder::new()
         .push_opcode(OP_PUSHNUM_1)
         .push_slice([3; 33])
@@ -660,8 +660,8 @@ fn test_script_get_sigop_count() {
         .push_opcode(OP_CHECKMULTISIGVERIFY)
         .push_opcode(OP_PUSHNUM_1)
         .into_script();
-    assert_eq!(multi_verify.count_sigops(), Ok(3));
-    assert_eq!(multi_verify.count_sigops_legacy(), Ok(20));
+    assert_eq!(multi_verify.count_sigops(), 3);
+    assert_eq!(multi_verify.count_sigops_legacy(), 20);
     let multi_nopushnum_pushdata = Builder::new()
         .push_opcode(OP_PUSHNUM_1)
         .push_slice([3; 33])
@@ -669,8 +669,8 @@ fn test_script_get_sigop_count() {
         .push_slice([3; 33])
         .push_opcode(OP_CHECKMULTISIG)
         .into_script();
-    assert_eq!(multi_nopushnum_pushdata.count_sigops(), Ok(20));
-    assert_eq!(multi_nopushnum_pushdata.count_sigops_legacy(), Ok(20));
+    assert_eq!(multi_nopushnum_pushdata.count_sigops(), 20);
+    assert_eq!(multi_nopushnum_pushdata.count_sigops_legacy(), 20);
     let multi_nopushnum_op = Builder::new()
         .push_opcode(OP_PUSHNUM_1)
         .push_slice([3; 33])
@@ -678,8 +678,8 @@ fn test_script_get_sigop_count() {
         .push_opcode(OP_DROP)
         .push_opcode(OP_CHECKMULTISIG)
         .into_script();
-    assert_eq!(multi_nopushnum_op.count_sigops(), Ok(20));
-    assert_eq!(multi_nopushnum_op.count_sigops_legacy(), Ok(20));
+    assert_eq!(multi_nopushnum_op.count_sigops(), 20);
+    assert_eq!(multi_nopushnum_op.count_sigops_legacy(), 20);
 }
 
 #[test]


### PR DESCRIPTION
When implementing some tests for the Transaction PR, I noticed that there were coinbase transactions that would pass Bitcoin Core parsing and fail my code.

It turns out that the Script parsing for sigops calls `break`  to exit the loop and returns the current n value whenever there is an EarlyEndOfScript error.

See this comment: https://github.com/rust-bitcoin/rust-bitcoin/pull/2073#issuecomment-1722403687 for some links to the relevant source.

