### PR TITLE
Do not guarantee WASM with MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ cargo update -p serde_test --precise 1.0.175
 
 The above commands are sourced from `./contrib/test.sh`.
 
+### WASM
+
+We do not guarantee the MSRV works with WASM (and it probably doesn't).
+
 ## External dependencies
 
 We integrate with a few external libraries, most notably `serde`. These

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -40,6 +40,3 @@ actual-core2 = { package = "core2", version = "0.3.2", default-features = false,
 [dev-dependencies]
 serde_test = "1.0"
 serde_json = "1.0"
-
-[target.wasm32-unknown-unknown.dev-dependencies]
-wasm-bindgen-test = "0.3"

--- a/hashes/README.md
+++ b/hashes/README.md
@@ -23,6 +23,10 @@ cargo update -p serde --precise 1.0.156
 before building. (And if your code is a library, your downstream users will need to run these
 commands, and so on.)
 
+### WASM
+
+We do not guarantee the MSRV works with WASM (and it probably doesn't).
+
 ## Contributions
 
 Contributions are welcome, including additional hash function implementations.

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -78,6 +78,7 @@ fi
 if [ "$DO_WASM" = true ]; then
     clang --version &&
     CARGO_TARGET_DIR=wasm cargo install --force wasm-pack &&
+    printf '\n[target.wasm32-unknown-unknown.dev-dependencies]\nwasm-bindgen-test = "0.3"\n'
     printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml &&
     CC=clang-9 wasm-pack build &&
     CC=clang-9 wasm-pack test --node;


### PR DESCRIPTION
We currently only test WASM using the stable toolchain. This means we do not guarantee that WASM works with MSRV.

Currently the WASM build is breaking MSRV and there is such a knot of dependencies that I cannot figure out how to pin them.

Explicitly do not guarantee WASM works with MSRV by adding a section to the readme of `hashes` a well as the main workspace readme.

Remove the WASM related dev-dependencies from the `hashes` manifest and add them dynamically during the CI run.