### PR TITLE
Drop `core2` requirement

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -39,8 +39,8 @@ dependencies = [
  "bincode",
  "bitcoin-internals",
  "bitcoin_hashes 0.13.0",
+ "bitcoin_io",
  "bitcoinconsensus",
- "core2",
  "hex-conservative",
  "hex_lit",
  "mutagen",
@@ -89,13 +89,20 @@ name = "bitcoin_hashes"
 version = "0.13.0"
 dependencies = [
  "bitcoin-internals",
- "core2",
+ "bitcoin_io",
  "hex-conservative",
  "schemars",
  "serde",
  "serde_json",
  "serde_test",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "bitcoin_io"
+version = "0.1.0"
+dependencies = [
+ "core2",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -38,8 +38,8 @@ dependencies = [
  "bincode",
  "bitcoin-internals",
  "bitcoin_hashes 0.13.0",
+ "bitcoin_io",
  "bitcoinconsensus",
- "core2",
  "hex-conservative",
  "hex_lit",
  "mutagen",
@@ -88,13 +88,20 @@ name = "bitcoin_hashes"
 version = "0.13.0"
 dependencies = [
  "bitcoin-internals",
- "core2",
+ "bitcoin_io",
  "hex-conservative",
  "schemars",
  "serde",
  "serde_json",
  "serde_test",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "bitcoin_io"
+version = "0.1.0"
+dependencies = [
+ "core2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["bitcoin", "hashes", "internals", "fuzz"]
+members = ["bitcoin", "hashes", "internals", "fuzz", "io"]
 
 [patch.crates-io.bitcoin]
 path = "bitcoin"
@@ -9,3 +9,6 @@ path = "hashes"
 
 [patch.crates-io.bitcoin-internals]
 path = "internals"
+
+[patch.crates-io.bitcoin_io]
+path = "io"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -26,8 +26,8 @@ bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
 # The no-std feature doesn't disable std - you need to turn off the std feature for that by disabling default.
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
-std = ["secp256k1/std", "hashes/std", "bech32/std", "internals/std", "hex/std"]
-no-std = ["core2", "hashes/alloc", "hashes/core2", "secp256k1/alloc", "hex/alloc", "hex/core2"]
+std = ["secp256k1/std", "bitcoin_io/std", "hashes/std", "bech32/std", "internals/std", "hex/std"]
+no-std = ["hashes/alloc", "hashes/core2", "bitcoin_io/core2", "bitcoin_io/alloc", "secp256k1/alloc", "hex/alloc", "hex/core2"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -41,12 +41,12 @@ hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = fa
 secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
 hex_lit = "0.1.1"
 
+bitcoin_io = { version = "0.1", default-features = false }
+
 base64 = { version = "0.21.3", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
 bitcoinconsensus = { version = "0.20.2-0.5.0", default-features = false, optional = true }
 
-# There is no reason to use this dependency directly, it is activated by the "no-std" feature.
-core2 = { version = "0.3.2", default-features = false, features = ["alloc"], optional = true }
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -27,7 +27,7 @@ bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
 std = ["secp256k1/std", "bitcoin_io/std", "hashes/std", "bech32/std", "internals/std", "hex/std"]
-no-std = ["hashes/alloc", "hashes/core2", "bitcoin_io/core2", "bitcoin_io/alloc", "secp256k1/alloc", "hex/alloc", "hex/core2"]
+no-std = ["hashes/alloc", "secp256k1/alloc", "hex/alloc", "hex/core2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -17,7 +17,6 @@ panic-halt = "0.2.0"
 alloc-cortex-m = "0.4.1"
 bitcoin = { path="../", default-features = false, features = ["no-std", "secp-lowmemory"] }
 
-
 [[bin]]
 name = "embedded"
 test = false
@@ -33,3 +32,6 @@ path = "../../hashes"
 
 [patch.crates-io.bitcoin-internals]
 path = "../../internals"
+
+[patch.crates-io.bitcoin_io]
+path = "../../io"

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -269,9 +269,7 @@ impl GcsFilterReader {
         I::Item: Borrow<[u8]>,
         R: io::Read + ?Sized,
     {
-        let mut decoder = reader;
-        let n_elements: VarInt = Decodable::consensus_decode(&mut decoder).unwrap_or(VarInt(0));
-        let reader = &mut decoder;
+        let n_elements: VarInt = Decodable::consensus_decode(reader).unwrap_or(VarInt(0));
         // map hashes to [0, n_elements << grp]
         let nm = n_elements.0 * self.m;
         let mut mapped =
@@ -314,9 +312,7 @@ impl GcsFilterReader {
         I::Item: Borrow<[u8]>,
         R: io::Read + ?Sized,
     {
-        let mut decoder = reader;
-        let n_elements: VarInt = Decodable::consensus_decode(&mut decoder).unwrap_or(VarInt(0));
-        let reader = &mut decoder;
+        let n_elements: VarInt = Decodable::consensus_decode(reader).unwrap_or(VarInt(0));
         // map hashes to [0, n_elements << grp]
         let nm = n_elements.0 * self.m;
         let mut mapped =
@@ -440,7 +436,7 @@ impl GcsFilter {
     /// Golomb-Rice decodes a number from a bit stream (parameter 2^k).
     fn golomb_rice_decode<R>(&self, reader: &mut BitStreamReader<R>) -> Result<u64, io::Error>
     where
-        R: io::Read,
+        R: io::Read + ?Sized,
     {
         let mut q = 0u64;
         while reader.read(1)? == 1 {
@@ -457,13 +453,13 @@ impl GcsFilter {
 }
 
 /// Bitwise stream reader.
-pub struct BitStreamReader<'a, R> {
+pub struct BitStreamReader<'a, R: ?Sized> {
     buffer: [u8; 1],
     offset: u8,
     reader: &'a mut R,
 }
 
-impl<'a, R: io::Read> BitStreamReader<'a, R> {
+impl<'a, R: io::Read + ?Sized> BitStreamReader<'a, R> {
     /// Creates a new [`BitStreamReader`] that reads bitwise from a given `reader`.
     pub fn new(reader: &'a mut R) -> BitStreamReader<'a, R> {
         BitStreamReader { buffer: [0u8], reader, offset: 8 }

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -391,7 +391,7 @@ impl<'a, W: io::Write> GcsFilterWriter<'a, W> {
         mapped.sort_unstable();
 
         // write number of elements as varint
-        let mut wrote = VarInt::from(mapped.len()).consensus_encode(&mut self.writer)?;
+        let mut wrote = VarInt::from(mapped.len()).consensus_encode(self.writer)?;
 
         // write out deltas of sorted values into a Golonb-Rice coded bit stream
         let mut writer = BitStreamWriter::new(self.writer);

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -616,7 +616,7 @@ mod benches {
 
     use super::Block;
     use crate::consensus::{deserialize, Decodable, Encodable};
-    use crate::EmptyWrite;
+    use crate::io::sink;
 
     #[bench]
     pub fn bench_stream_reader(bh: &mut Bencher) {
@@ -653,7 +653,7 @@ mod benches {
         let block: Block = deserialize(&raw_block[..]).unwrap();
 
         bh.iter(|| {
-            let size = block.consensus_encode(&mut EmptyWrite);
+            let size = block.consensus_encode(&mut sink());
             black_box(&size);
         });
     }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1812,7 +1812,7 @@ mod benches {
 
     use super::Transaction;
     use crate::consensus::{deserialize, Encodable};
-    use crate::EmptyWrite;
+    use crate::io::sink;
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
@@ -1847,7 +1847,7 @@ mod benches {
         let tx: Transaction = deserialize(&raw_tx).unwrap();
 
         bh.iter(|| {
-            let size = tx.consensus_encode(&mut EmptyWrite);
+            let size = tx.consensus_encode(&mut sink());
             black_box(&size);
         });
     }

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -317,7 +317,7 @@ pub trait Decodable: Sized {
     /// instead.
     #[inline]
     fn consensus_decode<R: io::Read + ?Sized>(reader: &mut R) -> Result<Self, Error> {
-        Self::consensus_decode_from_finite_reader(reader.take(MAX_VEC_SIZE as u64).by_ref())
+        Self::consensus_decode_from_finite_reader(&mut reader.take(MAX_VEC_SIZE as u64))
     }
 }
 

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -642,11 +642,11 @@ impl_vec!((u32, Address));
 #[cfg(feature = "std")]
 impl_vec!(AddrV2Message);
 
-pub(crate) fn consensus_encode_with_size<W: io::Write>(
+pub(crate) fn consensus_encode_with_size<W: io::Write + ?Sized>(
     data: &[u8],
-    mut w: W,
+    w: &mut W,
 ) -> Result<usize, io::Error> {
-    let vi_len = VarInt(data.len() as u64).consensus_encode(&mut w)?;
+    let vi_len = VarInt(data.len() as u64).consensus_encode(w)?;
     w.emit_slice(data)?;
     Ok(vi_len + data.len())
 }

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -661,8 +661,8 @@ struct ReadBytesFromFiniteReaderOpts {
 /// This function relies on reader being bound in amount of data
 /// it returns for OOM protection. See [`Decodable::consensus_decode_from_finite_reader`].
 #[inline]
-fn read_bytes_from_finite_reader<D: io::Read>(
-    mut d: D,
+fn read_bytes_from_finite_reader<D: io::Read + ?Sized>(
+    d: &mut D,
     mut opts: ReadBytesFromFiniteReaderOpts,
 ) -> Result<Vec<u8>, Error> {
     let mut ret = vec![];
@@ -1233,7 +1233,7 @@ mod tests {
         for chunk_size in 1..20 {
             assert_eq!(
                 read_bytes_from_finite_reader(
-                    io::Cursor::new(&data),
+                    &mut io::Cursor::new(&data),
                     ReadBytesFromFiniteReaderOpts { len: data.len(), chunk_size }
                 )
                 .unwrap(),

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -752,7 +752,6 @@ mod tests {
 
     use super::*;
     use crate::address::Address;
-    use crate::io;
     use crate::network::Network::{Bitcoin, Testnet};
 
     #[test]
@@ -895,6 +894,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn pubkey_read_write() {
         const N_KEYS: usize = 20;
         let keys: Vec<_> = (0..N_KEYS).map(|i| random_key(i as u8)).collect();
@@ -904,8 +904,10 @@ mod tests {
             k.write_into(&mut v).expect("writing into vec");
         }
 
+        // Note that we must temporarily use std::io::Cursor here until libsecp256k1 converts to
+        // bitcoin_io.
         let mut dec_keys = vec![];
-        let mut cursor = io::Cursor::new(&v);
+        let mut cursor = std::io::Cursor::new(&v);
         for _ in 0..N_KEYS {
             dec_keys.push(PublicKey::read_from(&mut cursor).expect("reading from vec"));
         }
@@ -914,11 +916,11 @@ mod tests {
 
         // sanity checks
         assert!(PublicKey::read_from(&mut cursor).is_err());
-        assert!(PublicKey::read_from(io::Cursor::new(&[])).is_err());
-        assert!(PublicKey::read_from(io::Cursor::new(&[0; 33][..])).is_err());
-        assert!(PublicKey::read_from(io::Cursor::new(&[2; 32][..])).is_err());
-        assert!(PublicKey::read_from(io::Cursor::new(&[0; 65][..])).is_err());
-        assert!(PublicKey::read_from(io::Cursor::new(&[4; 64][..])).is_err());
+        assert!(PublicKey::read_from(std::io::Cursor::new(&[])).is_err());
+        assert!(PublicKey::read_from(std::io::Cursor::new(&[0; 33][..])).is_err());
+        assert!(PublicKey::read_from(std::io::Cursor::new(&[2; 32][..])).is_err());
+        assert!(PublicKey::read_from(std::io::Cursor::new(&[0; 65][..])).is_err());
+        assert!(PublicKey::read_from(std::io::Cursor::new(&[4; 64][..])).is_err());
     }
 
     #[test]

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -894,7 +894,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn pubkey_read_write() {
         const N_KEYS: usize = 20;
         let keys: Vec<_> = (0..N_KEYS).map(|i| random_key(i as u8)).collect();
@@ -907,7 +906,7 @@ mod tests {
         // Note that we must temporarily use std::io::Cursor here until libsecp256k1 converts to
         // bitcoin_io.
         let mut dec_keys = vec![];
-        let mut cursor = std::io::Cursor::new(&v);
+        let mut cursor = io::Cursor::new(&v);
         for _ in 0..N_KEYS {
             dec_keys.push(PublicKey::read_from(&mut cursor).expect("reading from vec"));
         }
@@ -916,11 +915,11 @@ mod tests {
 
         // sanity checks
         assert!(PublicKey::read_from(&mut cursor).is_err());
-        assert!(PublicKey::read_from(std::io::Cursor::new(&[])).is_err());
-        assert!(PublicKey::read_from(std::io::Cursor::new(&[0; 33][..])).is_err());
-        assert!(PublicKey::read_from(std::io::Cursor::new(&[2; 32][..])).is_err());
-        assert!(PublicKey::read_from(std::io::Cursor::new(&[0; 65][..])).is_err());
-        assert!(PublicKey::read_from(std::io::Cursor::new(&[4; 64][..])).is_err());
+        assert!(PublicKey::read_from(io::Cursor::new(&[])).is_err());
+        assert!(PublicKey::read_from(io::Cursor::new(&[0; 33][..])).is_err());
+        assert!(PublicKey::read_from(io::Cursor::new(&[2; 32][..])).is_err());
+        assert!(PublicKey::read_from(io::Cursor::new(&[0; 65][..])).is_err());
+        assert!(PublicKey::read_from(io::Cursor::new(&[4; 64][..])).is_err());
     }
 
     #[test]

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -68,7 +68,7 @@ impl PublicKey {
     }
 
     /// Write the public key into a writer
-    pub fn write_into<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+    pub fn write_into<W: io::Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         self.with_serialized(|bytes| writer.write_all(bytes))
     }
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -585,7 +585,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
     /// [`io::Write`] trait.
     pub fn taproot_encode_signing_data_to<Write: io::Write, T: Borrow<TxOut>>(
         &mut self,
-        mut writer: Write,
+        writer: &mut Write,
         input_index: usize,
         prevouts: &Prevouts<T>,
         annex: Option<Annex>,
@@ -597,18 +597,18 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         let (sighash, anyone_can_pay) = sighash_type.split_anyonecanpay_flag();
 
         // epoch
-        0u8.consensus_encode(&mut writer)?;
+        0u8.consensus_encode(writer)?;
 
         // * Control:
         // hash_type (1).
-        (sighash_type as u8).consensus_encode(&mut writer)?;
+        (sighash_type as u8).consensus_encode(writer)?;
 
         // * Transaction Data:
         // nVersion (4): the nVersion of the transaction.
-        self.tx.borrow().version.consensus_encode(&mut writer)?;
+        self.tx.borrow().version.consensus_encode(writer)?;
 
         // nLockTime (4): the nLockTime of the transaction.
-        self.tx.borrow().lock_time.consensus_encode(&mut writer)?;
+        self.tx.borrow().lock_time.consensus_encode(writer)?;
 
         // If the hash_type & 0x80 does not equal SIGHASH_ANYONECANPAY:
         //     sha_prevouts (32): the SHA256 of the serialization of all input outpoints.
@@ -616,16 +616,16 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         //     sha_scriptpubkeys (32): the SHA256 of the serialization of all spent output scriptPubKeys.
         //     sha_sequences (32): the SHA256 of the serialization of all input nSequence.
         if !anyone_can_pay {
-            self.common_cache().prevouts.consensus_encode(&mut writer)?;
-            self.taproot_cache(prevouts.get_all()?).amounts.consensus_encode(&mut writer)?;
-            self.taproot_cache(prevouts.get_all()?).script_pubkeys.consensus_encode(&mut writer)?;
-            self.common_cache().sequences.consensus_encode(&mut writer)?;
+            self.common_cache().prevouts.consensus_encode(writer)?;
+            self.taproot_cache(prevouts.get_all()?).amounts.consensus_encode(writer)?;
+            self.taproot_cache(prevouts.get_all()?).script_pubkeys.consensus_encode(writer)?;
+            self.common_cache().sequences.consensus_encode(writer)?;
         }
 
         // If hash_type & 3 does not equal SIGHASH_NONE or SIGHASH_SINGLE:
         //     sha_outputs (32): the SHA256 of the serialization of all outputs in CTxOut format.
         if sighash != TapSighashType::None && sighash != TapSighashType::Single {
-            self.common_cache().outputs.consensus_encode(&mut writer)?;
+            self.common_cache().outputs.consensus_encode(writer)?;
         }
 
         // * Data about this input:
@@ -638,7 +638,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         if leaf_hash_code_separator.is_some() {
             spend_type |= 2u8;
         }
-        spend_type.consensus_encode(&mut writer)?;
+        spend_type.consensus_encode(writer)?;
 
         // If hash_type & 0x80 equals SIGHASH_ANYONECANPAY:
         //      outpoint (36): the COutPoint of this input (32-byte hash + 4-byte little-endian).
@@ -652,12 +652,12 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                     inputs_size: self.tx.borrow().input.len(),
                 })?;
             let previous_output = prevouts.get(input_index)?;
-            txin.previous_output.consensus_encode(&mut writer)?;
-            previous_output.value.consensus_encode(&mut writer)?;
-            previous_output.script_pubkey.consensus_encode(&mut writer)?;
-            txin.sequence.consensus_encode(&mut writer)?;
+            txin.previous_output.consensus_encode(writer)?;
+            previous_output.value.consensus_encode(writer)?;
+            previous_output.script_pubkey.consensus_encode(writer)?;
+            txin.sequence.consensus_encode(writer)?;
         } else {
-            (input_index as u32).consensus_encode(&mut writer)?;
+            (input_index as u32).consensus_encode(writer)?;
         }
 
         // If an annex is present (the lowest bit of spend_type is set):
@@ -667,7 +667,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
             let mut enc = sha256::Hash::engine();
             annex.consensus_encode(&mut enc)?;
             let hash = sha256::Hash::from_engine(enc);
-            hash.consensus_encode(&mut writer)?;
+            hash.consensus_encode(writer)?;
         }
 
         // * Data about this output:
@@ -685,7 +685,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                 })?
                 .consensus_encode(&mut enc)?;
             let hash = sha256::Hash::from_engine(enc);
-            hash.consensus_encode(&mut writer)?;
+            hash.consensus_encode(writer)?;
         }
 
         //     if (scriptpath):
@@ -693,9 +693,9 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         //         ss += bytes([0])
         //         ss += struct.pack("<i", codeseparator_pos)
         if let Some((hash, code_separator_pos)) = leaf_hash_code_separator {
-            hash.as_byte_array().consensus_encode(&mut writer)?;
-            KEY_VERSION_0.consensus_encode(&mut writer)?;
-            code_separator_pos.consensus_encode(&mut writer)?;
+            hash.as_byte_array().consensus_encode(writer)?;
+            KEY_VERSION_0.consensus_encode(writer)?;
+            code_separator_pos.consensus_encode(writer)?;
         }
 
         Ok(())
@@ -769,7 +769,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
     #[deprecated(since = "0.31.0", note = "use segwit_v0_encode_signing_data_to instead")]
     pub fn segwit_encode_signing_data_to<Write: io::Write>(
         &mut self,
-        writer: Write,
+        writer: &mut Write,
         input_index: usize,
         script_code: &Script,
         value: Amount,
@@ -786,7 +786,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
     /// [`Self::p2wpkh_signature_hash`] and [`SighashCache::p2wsh_signature_hash`].)
     pub fn segwit_v0_encode_signing_data_to<Write: io::Write>(
         &mut self,
-        mut writer: Write,
+        writer: &mut Write,
         input_index: usize,
         script_code: &Script,
         value: Amount,
@@ -796,21 +796,21 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
 
         let (sighash, anyone_can_pay) = sighash_type.split_anyonecanpay_flag();
 
-        self.tx.borrow().version.consensus_encode(&mut writer)?;
+        self.tx.borrow().version.consensus_encode(writer)?;
 
         if !anyone_can_pay {
-            self.segwit_cache().prevouts.consensus_encode(&mut writer)?;
+            self.segwit_cache().prevouts.consensus_encode(writer)?;
         } else {
-            zero_hash.consensus_encode(&mut writer)?;
+            zero_hash.consensus_encode(writer)?;
         }
 
         if !anyone_can_pay
             && sighash != EcdsaSighashType::Single
             && sighash != EcdsaSighashType::None
         {
-            self.segwit_cache().sequences.consensus_encode(&mut writer)?;
+            self.segwit_cache().sequences.consensus_encode(writer)?;
         } else {
-            zero_hash.consensus_encode(&mut writer)?;
+            zero_hash.consensus_encode(writer)?;
         }
 
         {
@@ -820,14 +820,14 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                     inputs_size: self.tx.borrow().input.len(),
                 })?;
 
-            txin.previous_output.consensus_encode(&mut writer)?;
-            script_code.consensus_encode(&mut writer)?;
-            value.consensus_encode(&mut writer)?;
-            txin.sequence.consensus_encode(&mut writer)?;
+            txin.previous_output.consensus_encode(writer)?;
+            script_code.consensus_encode(writer)?;
+            value.consensus_encode(writer)?;
+            txin.sequence.consensus_encode(writer)?;
         }
 
         if sighash != EcdsaSighashType::Single && sighash != EcdsaSighashType::None {
-            self.segwit_cache().outputs.consensus_encode(&mut writer)?;
+            self.segwit_cache().outputs.consensus_encode(writer)?;
         } else if sighash == EcdsaSighashType::Single && input_index < self.tx.borrow().output.len()
         {
             let mut single_enc = LegacySighash::engine();
@@ -838,8 +838,8 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
             writer.write_all(&zero_hash[..])?;
         }
 
-        self.tx.borrow().lock_time.consensus_encode(&mut writer)?;
-        sighash_type.to_u32().consensus_encode(&mut writer)?;
+        self.tx.borrow().lock_time.consensus_encode(writer)?;
+        sighash_type.to_u32().consensus_encode(writer)?;
         Ok(())
     }
 
@@ -930,7 +930,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
     /// that must be handled by the caller (see [`EncodeSigningDataResult::is_sighash_single_bug`]).
     pub fn legacy_encode_signing_data_to<Write: io::Write, U: Into<u32>>(
         &self,
-        writer: Write,
+        writer: &mut Write,
         input_index: usize,
         script_pubkey: &Script,
         sighash_type: U,
@@ -957,7 +957,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
 
         fn encode_signing_data_to_inner<Write: io::Write>(
             self_: &Transaction,
-            mut writer: Write,
+            writer: &mut Write,
             input_index: usize,
             script_pubkey: &Script,
             sighash_type: u32,
@@ -1018,8 +1018,8 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                 _ => unreachable!(),
             };
             // hash the result
-            tx.consensus_encode(&mut writer)?;
-            sighash_type.to_le_bytes().consensus_encode(&mut writer)?;
+            tx.consensus_encode(writer)?;
+            sighash_type.to_le_bytes().consensus_encode(writer)?;
             Ok(())
         }
 

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -34,7 +34,6 @@ macro_rules! impl_consensus_encoding {
             fn consensus_decode<R: $crate::io::Read + ?Sized>(
                 r: &mut R,
             ) -> Result<$thing, $crate::consensus::encode::Error> {
-                use crate::io::Read as _;
                 let mut r = r.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
                 Ok($thing {
                     $($field: $crate::consensus::Decodable::consensus_decode(&mut r)?),+

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -37,7 +37,7 @@ macro_rules! impl_consensus_encoding {
                 use crate::io::Read as _;
                 let mut r = r.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
                 Ok($thing {
-                    $($field: $crate::consensus::Decodable::consensus_decode(r.by_ref())?),+
+                    $($field: $crate::consensus::Decodable::consensus_decode(&mut r)?),+
                 })
             }
         }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -193,27 +193,3 @@ mod prelude {
 
     pub use hex::DisplayHex;
 }
-
-#[cfg(bench)]
-use bench::EmptyWrite;
-
-#[cfg(bench)]
-mod bench {
-    use core::fmt::Arguments;
-
-    use crate::io::{IoSlice, Result, Write};
-
-    #[derive(Default, Clone, Debug, PartialEq, Eq)]
-    pub struct EmptyWrite;
-
-    impl Write for EmptyWrite {
-        fn write(&mut self, buf: &[u8]) -> Result<usize> { Ok(buf.len()) }
-        fn write_vectored(&mut self, bufs: &[IoSlice]) -> Result<usize> {
-            Ok(bufs.iter().map(|s| s.len()).sum())
-        }
-        fn flush(&mut self) -> Result<()> { Ok(()) }
-
-        fn write_all(&mut self, _: &[u8]) -> Result<()> { Ok(()) }
-        fn write_fmt(&mut self, _: Arguments) -> Result<()> { Ok(()) }
-    }
-}

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -186,7 +186,7 @@ mod prelude {
     pub use std::collections::{BTreeMap, BTreeSet, btree_map, BinaryHeap};
 
     #[cfg(feature = "std")]
-    pub use std::io::sink;
+    pub use crate::io::sink;
 
     #[cfg(not(feature = "std"))]
     pub use crate::io_extras::sink;

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -111,9 +111,6 @@ pub mod sign_message;
 pub mod string;
 pub mod taproot;
 
-// May depend on crate features and we don't want to bother with it
-#[allow(unused)]
-use bitcoin_io::error::Error as StdError;
 use bitcoin_io::io;
 
 pub use crate::address::{Address, AddressType};

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -23,7 +23,7 @@
 //!                 deserialization.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
 //! * `no-std` - enables additional features required for this crate to be usable
-//!              without std. Does **not** disable `std`. Depends on `core2`.
+//!              without std. Does **not** disable `std`.
 //! * `bitcoinconsensus-std` - enables `std` in `bitcoinconsensus` and communicates it
 //!                            to this crate so it knows how to implement
 //!                            `std::error::Error`. At this time there's a hack to
@@ -65,9 +65,6 @@ pub extern crate bech32;
 #[cfg(feature = "bitcoinconsensus")]
 /// Bitcoin's libbitcoinconsensus with Rust binding.
 pub extern crate bitcoinconsensus;
-
-#[cfg(not(feature = "std"))]
-extern crate core2;
 
 /// Rust implementation of cryptographic hash function algorithems.
 pub extern crate hashes;
@@ -116,16 +113,8 @@ pub mod taproot;
 
 // May depend on crate features and we don't want to bother with it
 #[allow(unused)]
-#[cfg(feature = "std")]
-use std::error::Error as StdError;
-#[cfg(feature = "std")]
-use std::io;
-
-#[allow(unused)]
-#[cfg(not(feature = "std"))]
-use core2::error::Error as StdError;
-#[cfg(not(feature = "std"))]
-use core2::io;
+use bitcoin_io::error::Error as StdError;
+use bitcoin_io::io;
 
 pub use crate::address::{Address, AddressType};
 pub use crate::amount::{Amount, Denomination, SignedAmount};
@@ -160,6 +149,8 @@ pub use crate::taproot::{
 
 #[cfg(not(feature = "std"))]
 mod io_extras {
+    use crate::io;
+
     /// A writer which will move data into the void.
     pub struct Sink {
         _priv: (),
@@ -168,12 +159,12 @@ mod io_extras {
     /// Creates an instance of a writer which will successfully consume all data.
     pub const fn sink() -> Sink { Sink { _priv: () } }
 
-    impl core2::io::Write for Sink {
+    impl io::Write for Sink {
         #[inline]
-        fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> { Ok(buf.len()) }
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
 
         #[inline]
-        fn flush(&mut self) -> core2::io::Result<()> { Ok(()) }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
     }
 }
 

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -116,7 +116,7 @@ impl fmt::Debug for Address {
 
 impl ToSocketAddrs for Address {
     type Iter = iter::Once<SocketAddr>;
-    fn to_socket_addrs(&self) -> Result<Self::Iter, io::Error> {
+    fn to_socket_addrs(&self) -> Result<Self::Iter, std::io::Error> {
         Ok(iter::once(self.socket_addr()?))
     }
 }
@@ -296,7 +296,7 @@ impl Decodable for AddrV2Message {
 
 impl ToSocketAddrs for AddrV2Message {
     type Iter = iter::Once<SocketAddr>;
-    fn to_socket_addrs(&self) -> Result<Self::Iter, io::Error> {
+    fn to_socket_addrs(&self) -> Result<Self::Iter, std::io::Error> {
         Ok(iter::once(self.socket_addr()?))
     }
 }

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -425,7 +425,7 @@ impl Decodable for HeaderDeserializationWrapper {
 
     #[inline]
     fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(r.take(MAX_MSG_SIZE as u64).by_ref())
+        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
     }
 }
 
@@ -530,7 +530,7 @@ impl Decodable for RawNetworkMessage {
 
     #[inline]
     fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(r.take(MAX_MSG_SIZE as u64).by_ref())
+        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
     }
 }
 

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -10,7 +10,6 @@ use core::convert::TryFrom;
 use core::{fmt, iter};
 
 use hashes::{sha256d, Hash};
-use io::Read as _;
 
 use crate::blockdata::{block, transaction};
 use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, VarInt};

--- a/bitcoin/src/p2p/message_bloom.rs
+++ b/bitcoin/src/p2p/message_bloom.rs
@@ -5,10 +5,9 @@
 //! This module describes BIP37 Connection Bloom filtering network messages.
 //!
 
-use std::io;
-
 use crate::consensus::{encode, Decodable, Encodable, ReadExt};
 use crate::internal_macros::impl_consensus_encoding;
+use crate::io;
 
 /// `filterload` message sets the current bloom filter
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -195,7 +195,7 @@ where
 }
 
 // core2 doesn't have read_to_end
-pub(crate) fn read_to_end<D: io::Read>(mut d: D) -> Result<Vec<u8>, io::Error> {
+pub(crate) fn read_to_end<D: io::Read + ?Sized>(d: &mut D) -> Result<Vec<u8>, io::Error> {
     let mut result = vec![];
     let mut buf = [0u8; 64];
     loop {

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -161,7 +161,8 @@ where
     fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let prefix = Vec::<u8>::consensus_decode(r)?;
         let subtype = Subtype::from(r.read_u8()?);
-        let key = read_to_end(r)?;
+        let mut key = Vec::new();
+        r.read_to_end(&mut key)?;
 
         Ok(ProprietaryKey { prefix, subtype, key })
     }
@@ -192,19 +193,4 @@ where
 
         Ok(deserialize(&key.key)?)
     }
-}
-
-// core2 doesn't have read_to_end
-pub(crate) fn read_to_end<D: io::Read + ?Sized>(d: &mut D) -> Result<Vec<u8>, io::Error> {
-    let mut result = vec![];
-    let mut buf = [0u8; 64];
-    loop {
-        match d.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => result.extend_from_slice(&buf[0..n]),
-            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
-            Err(e) => return Err(e),
-        };
-    }
-    Ok(result)
 }

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -1106,7 +1106,7 @@ impl TaprootMerkleBranch {
     /// # Returns
     ///
     /// The number of bytes written to the writer.
-    pub fn encode<Write: io::Write>(&self, mut writer: Write) -> io::Result<usize> {
+    pub fn encode<Write: io::Write>(&self, writer: &mut Write) -> io::Result<usize> {
         for hash in self.0.iter() {
             writer.write_all(hash.as_ref())?;
         }
@@ -1234,12 +1234,12 @@ impl ControlBlock {
     /// # Returns
     ///
     /// The number of bytes written to the writer.
-    pub fn encode<Write: io::Write>(&self, mut writer: Write) -> io::Result<usize> {
+    pub fn encode<Write: io::Write>(&self, writer: &mut Write) -> io::Result<usize> {
         let first_byte: u8 =
             i32::from(self.output_key_parity) as u8 | self.leaf_version.to_consensus();
         writer.write_all(&[first_byte])?;
         writer.write_all(&self.internal_key.serialize())?;
-        self.merkle_branch.encode(&mut writer)?;
+        self.merkle_branch.encode(writer)?;
         Ok(self.size())
     }
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -14,11 +14,11 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "internals/std", "hex/std"]
+std = ["alloc", "internals/std", "hex/std", "bitcoin_io/std"]
 alloc = ["internals/alloc", "hex/alloc"]
 serde-std = ["serde/std"]
 # If you want I/O you must enable either "std" or "core2".
-core2 = ["actual-core2", "hex/core2"]
+core2 = ["bitcoin_io/core2", "hex/core2"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
 
@@ -30,12 +30,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 internals = { package = "bitcoin-internals", version = "0.2.0" }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 
+bitcoin_io = { version = "0.1", default-features = false, optional = true }
+
 schemars = { version = "0.8.3", optional = true }
 # Only enable this if you explicitly do not want to use "std", otherwise enable "serde-std".
 serde = { version = "1.0", default-features = false, optional = true }
-
-# Do NOT use this feature! Use the "core2" feature instead.
-actual-core2 = { package = "core2", version = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -17,8 +17,6 @@ default = ["std"]
 std = ["alloc", "internals/std", "hex/std", "bitcoin_io/std"]
 alloc = ["internals/alloc", "hex/alloc"]
 serde-std = ["serde/std"]
-# If you want I/O you must enable either "std" or "core2".
-core2 = ["bitcoin_io/core2", "hex/core2"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
 
@@ -30,7 +28,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 internals = { package = "bitcoin-internals", version = "0.2.0" }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 
-bitcoin_io = { version = "0.1", default-features = false, optional = true }
+bitcoin_io = { version = "0.1", default-features = false }
 
 schemars = { version = "0.8.3", optional = true }
 # Only enable this if you explicitly do not want to use "std", otherwise enable "serde-std".

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="serde serde-std std alloc"
+FEATURES="serde serde-std std alloc bitcoin_io/alloc bitcoin_io/core2 bitcoin_io/std"
 
 cargo --version
 rustc --version

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="serde serde-std std core2 alloc"
+FEATURES="serde serde-std std alloc"
 
 cargo --version
 rustc --version

--- a/hashes/embedded/Cargo.toml
+++ b/hashes/embedded/Cargo.toml
@@ -19,7 +19,7 @@ cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 alloc-cortex-m = { version = "0.4.1", optional = true }
 bitcoin_hashes = { path="../", default-features = false, features = ["core2"] }
-core2 = { version = "0.3.0", default_features = false }
+bitcoin_io = { path = "../../io", default_features = false }
 
 [[bin]]
 name = "embedded"
@@ -33,3 +33,6 @@ lto = true # better optimizations
 
 [patch.crates-io.bitcoin-internals]
 path = "../../internals"
+
+[patch.crates-io.bitcoin_io]
+path = "../../io"

--- a/hashes/embedded/src/main.rs
+++ b/hashes/embedded/src/main.rs
@@ -10,7 +10,7 @@ extern crate bitcoin_hashes;
 #[cfg(feature = "alloc")] use alloc::string::ToString;
 
 use bitcoin_hashes::{sha256, Hash, HashEngine};
-use core2::io::Write;
+use bitcoin_io::io::Write;
 use core::str::FromStr;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};

--- a/hashes/extended_tests/schemars/Cargo.toml
+++ b/hashes/extended_tests/schemars/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = "1.0"
 
 [patch.crates-io.bitcoin-internals]
 path = "../../../internals"
+
+[patch.crates-io.bitcoin_io]
+path = "../../../io"

--- a/hashes/src/impls.rs
+++ b/hashes/src/impls.rs
@@ -5,65 +5,69 @@
 //! Implementations of traits defined in `std` / `core2` and not in `core`.
 //!
 
-use crate::{hmac, io, ripemd160, sha1, sha256, sha512, siphash24, HashEngine};
+use bitcoin_io::impl_write;
 
-impl io::Write for sha1::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+use crate::{hmac, ripemd160, sha1, sha256, sha512, siphash24, HashEngine};
 
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.input(buf);
+impl_write!(
+    sha1::HashEngine,
+    |us: &mut sha1::HashEngine, buf| {
+        us.input(buf);
         Ok(buf.len())
-    }
-}
+    },
+    |_us| { Ok(()) }
+);
 
-impl io::Write for sha256::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
-
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.input(buf);
+impl_write!(
+    sha256::HashEngine,
+    |us: &mut sha256::HashEngine, buf| {
+        us.input(buf);
         Ok(buf.len())
-    }
-}
+    },
+    |_us| { Ok(()) }
+);
 
-impl io::Write for sha512::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
-
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.input(buf);
+impl_write!(
+    sha512::HashEngine,
+    |us: &mut sha512::HashEngine, buf| {
+        us.input(buf);
         Ok(buf.len())
-    }
-}
+    },
+    |_us| { Ok(()) }
+);
 
-impl io::Write for ripemd160::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
-
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.input(buf);
+impl_write!(
+    ripemd160::HashEngine,
+    |us: &mut ripemd160::HashEngine, buf| {
+        us.input(buf);
         Ok(buf.len())
-    }
-}
+    },
+    |_us| { Ok(()) }
+);
 
-impl io::Write for siphash24::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
-
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.input(buf);
+impl_write!(
+    siphash24::HashEngine,
+    |us: &mut siphash24::HashEngine, buf| {
+        us.input(buf);
         Ok(buf.len())
-    }
-}
+    },
+    |_us| { Ok(()) }
+);
 
-impl<T: crate::Hash> io::Write for hmac::HmacEngine<T> {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
-
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.input(buf);
+impl_write!(
+    hmac::HmacEngine<T>,
+    |us: &mut hmac::HmacEngine<T>, buf| {
+        us.input(buf);
         Ok(buf.len())
-    }
-}
+    },
+    |_us| { Ok(()) },
+    T: crate::Hash
+);
 
 #[cfg(test)]
 mod tests {
-    use super::io::Write;
+    use bitcoin_io::io::Write;
+
     use crate::{hash160, hmac, ripemd160, sha1, sha256, sha256d, sha512, siphash24, Hash};
 
     macro_rules! write_test {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -115,7 +115,6 @@ pub mod serde_macros;
 pub mod cmp;
 pub mod hash160;
 pub mod hmac;
-#[cfg(feature = "bitcoin_io")]
 mod impls;
 pub mod ripemd160;
 pub mod sha1;

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -128,9 +128,6 @@ pub mod siphash24;
 
 use core::{borrow, fmt, hash, ops};
 
-// You get I/O if you enable "std" or "core2" (as well as during testing).
-#[cfg(feature = "bitcoin_io")]
-use bitcoin_io::io;
 pub use hmac::{Hmac, HmacEngine};
 
 /// A hashing engine which bytes can be serialized into.

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -79,8 +79,6 @@
 // Instead of littering the codebase for non-fuzzing code just globally allow.
 #![cfg_attr(hashes_fuzz, allow(dead_code, unused_imports))]
 
-#[cfg(all(not(test), not(feature = "std"), feature = "core2"))]
-extern crate actual_core2 as core2;
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
 #[cfg(any(test, feature = "std"))]
@@ -117,7 +115,7 @@ pub mod serde_macros;
 pub mod cmp;
 pub mod hash160;
 pub mod hmac;
-#[cfg(any(test, feature = "std", feature = "core2"))]
+#[cfg(feature = "bitcoin_io")]
 mod impls;
 pub mod ripemd160;
 pub mod sha1;
@@ -129,12 +127,10 @@ pub mod sha512_256;
 pub mod siphash24;
 
 use core::{borrow, fmt, hash, ops};
-// You get I/O if you enable "std" or "core2" (as well as during testing).
-#[cfg(any(test, feature = "std"))]
-use std::io;
 
-#[cfg(all(not(test), not(feature = "std"), feature = "core2"))]
-use core2::io;
+// You get I/O if you enable "std" or "core2" (as well as during testing).
+#[cfg(feature = "bitcoin_io")]
+use bitcoin_io::io;
 pub use hmac::{Hmac, HmacEngine};
 
 /// A hashing engine which bytes can be serialized into.

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["tests", "contrib"]
 [features]
 default = ["std"]
 std = []
-alloc = ["core2/alloc"]
+alloc = []
 
 [dependencies]
 core2 = { version = "0.3", default-features = false, optional = true }

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bitcoin_io"
+version = "0.1.0"
+authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+documentation = "https://docs.rs/bitcoin_io/"
+description = "Simple I/O traits for no-std (and std) environments"
+categories = ["no-std"]
+keywords = [ "io", "no-std" ]
+readme = "README.md"
+edition = "2018"
+exclude = ["tests", "contrib"]
+
+[features]
+default = ["std"]
+std = []
+alloc = ["core2/alloc"]
+
+[dependencies]
+core2 = { version = "0.3", default-features = false, optional = true }

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -36,7 +36,7 @@ pub mod io {
     compile_error!("At least one of std or core2 must be enabled");
 
     #[cfg(feature = "std")]
-    pub use std::io::{Read, Write, Cursor, Take, IoSlice, Error, ErrorKind, Result};
+    pub use std::io::{Read, Write, sink, Cursor, Take, Error, ErrorKind, Result};
 
     #[cfg(not(feature = "std"))]
     pub use core2::io::{Read, Write, Cursor, Take, Error, ErrorKind, Result};

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -18,14 +18,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(all(not(feature = "std"), not(feature = "core2")))]
-compile_error!("At least one of std or core2 must be enabled");
-
-#[cfg(feature = "std")]
-pub use std::error;
-#[cfg(not(feature = "std"))]
-pub use core2::error;
-
 #[cfg(any(feature = "alloc", feature = "std"))]
 extern crate alloc;
 
@@ -33,15 +25,198 @@ extern crate alloc;
 /// [`std::io`] for more info.
 pub mod io {
     use core::convert::TryInto;
+    use core::fmt::{Debug, Display, Formatter};
+    #[cfg(any(feature = "alloc", feature = "std"))]
+    use alloc::boxed::Box;
 
-    #[cfg(all(not(feature = "std"), not(feature = "core2")))]
-    compile_error!("At least one of std or core2 must be enabled");
+    #[derive(Debug)]
+    pub struct Error {
+        kind: ErrorKind,
+
+        #[cfg(feature = "std")]
+        error: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+        #[cfg(all(feature = "alloc", not(feature = "std")))]
+        error: Option<Box<dyn Debug + Send + Sync + 'static>>,
+    }
+    impl Error {
+        #[cfg(feature = "std")]
+        pub fn new<E>(kind: ErrorKind, error: E) -> Error where
+            E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>
+        {
+            Self { kind, error: Some(error.into()) }
+        }
+        #[cfg(all(feature = "alloc", not(feature = "std")))]
+        pub fn new<E>(kind: ErrorKind, error: E) -> Error where
+            E: Into<Box<dyn Debug + Send + Sync + 'static>>
+        {
+            Self { kind, error: Some(error.into()) }
+        }
+
+        pub fn kind(&self) -> ErrorKind {
+            self.kind
+        }
+    }
+
+    impl From<ErrorKind> for Error {
+        fn from(kind: ErrorKind) -> Error {
+            Self {
+                kind,
+                #[cfg(any(feature = "std", feature = "alloc"))]
+                error: None,
+            }
+        }
+    }
+
+    impl Display for Error {
+        fn fmt(&self, fmt: &mut Formatter) -> core::result::Result<(), core::fmt::Error> {
+            fmt.write_fmt(format_args!("I/O Error: {}", self.kind.description()))?;
+            #[cfg(any(feature = "alloc", feature = "std"))]
+            if let Some(e) = &self.error {
+                fmt.write_fmt(format_args!(". {:?}", e))?;
+            }
+            Ok(())
+        }
+    }
 
     #[cfg(feature = "std")]
-    pub use std::io::{Error, ErrorKind, Result};
+    impl std::error::Error for Error {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.error.as_ref().and_then(|e| e.as_ref().source())
+        }
+        #[allow(deprecated)]
+        fn description(&self) -> &str {
+            match self.error.as_ref() {
+                Some(e) => e.description(),
+                None => self.kind.description()
+            }
+        }
+        #[allow(deprecated)]
+        fn cause(&self) -> Option<&dyn std::error::Error> {
+            self.error.as_ref().and_then(|e| e.as_ref().cause())
+        }
+    }
 
-    #[cfg(not(feature = "std"))]
-    pub use core2::io::{Error, ErrorKind, Result};
+    impl Error {
+        #[cfg(feature = "std")]
+        pub fn get_ref(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
+            self.error.as_ref().map(|e| &**e)
+        }
+        #[cfg(all(feature = "alloc", not(feature = "std")))]
+        pub fn get_ref(&self) -> Option<&(dyn Debug + Send + Sync + 'static)> {
+            self.error.as_ref().map(|e| &**e)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl From<std::io::Error> for Error {
+        fn from(o: std::io::Error) -> Error {
+            Self {
+                kind: ErrorKind::from_std(o.kind()),
+                error: o.into_inner(),
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl From<Error> for std::io::Error {
+        fn from(o: Error) -> std::io::Error {
+            if let Some(err) = o.error {
+                std::io::Error::new(o.kind.to_std(), err)
+            } else {
+                o.kind.to_std().into()
+            }
+        }
+    }
+
+    #[cfg(all(feature = "core2", not(feature = "std")))]
+    impl From<core2::io::Error> for Error {
+        fn from(o: core2::io::Error) -> Error {
+            Self {
+                kind: ErrorKind::from_core2(o.kind()),
+                #[cfg(feature = "alloc")]
+                error: Some(Box::new(o.into_inner())),
+            }
+        }
+    }
+
+    #[cfg(all(feature = "core2", not(feature = "std")))]
+    impl From<Error> for core2::io::Error {
+        fn from(o: Error) -> core2::io::Error {
+            o.kind.to_core2().into()
+        }
+    }
+
+    macro_rules! define_errorkind {
+        ($($kind: ident),*) => {
+            #[non_exhaustive]
+            #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+            /// A minimal subset of [`std::io::ErrorKind`] which is used for [`Error`]. Note that, as with
+            /// [`std::io`], only [`Self::Interrupted`] has defined semantics in this crate, all other
+            /// variants are provided here only to provide higher-fidelity conversions to and from
+            /// [`std::io::Error`].
+            pub enum ErrorKind {
+                $($kind),*
+            }
+
+            impl ErrorKind {
+                fn description(&self) -> &'static str {
+                    match self {
+                        $(Self::$kind => stringify!($kind)),*
+                    }
+                }
+                #[cfg(feature = "std")]
+                fn to_std(&self) -> std::io::ErrorKind {
+                    match self {
+                        $(Self::$kind => std::io::ErrorKind::$kind),*
+                    }
+                }
+                #[cfg(feature = "std")]
+                fn from_std(o: std::io::ErrorKind) -> ErrorKind {
+                    match o {
+                        $(std::io::ErrorKind::$kind => ErrorKind::$kind),*,
+                        _ => ErrorKind::Other
+                    }
+                }
+
+                #[cfg(all(feature = "core2", not(feature = "std")))]
+                fn to_core2(&self) -> core2::io::ErrorKind {
+                    match self {
+                        $(Self::$kind => core2::io::ErrorKind::$kind),*
+                    }
+                }
+                #[cfg(all(feature = "core2", not(feature = "std")))]
+                fn from_core2(o: core2::io::ErrorKind) -> ErrorKind {
+                    match o {
+                        $(core2::io::ErrorKind::$kind => ErrorKind::$kind),*,
+                        _ => ErrorKind::Other
+                    }
+                }
+            }
+        }
+    }
+
+    define_errorkind!(
+        NotFound,
+        PermissionDenied,
+        ConnectionRefused,
+        ConnectionReset,
+        ConnectionAborted,
+        NotConnected,
+        AddrInUse,
+        AddrNotAvailable,
+        BrokenPipe,
+        AlreadyExists,
+        WouldBlock,
+        InvalidInput,
+        InvalidData,
+        TimedOut,
+        WriteZero,
+        Interrupted,
+        UnexpectedEof,
+        Other
+    );
+
+    pub type Result<T> = core::result::Result<T, Error>;
 
     /// A generic trait describing an input stream. See [`std::io::Read`] for more info.
     pub trait Read {
@@ -51,7 +226,7 @@ pub mod io {
             while !buf.is_empty() {
                 match self.read(buf) {
                     Ok(0) =>
-                        return Err(Error::new(ErrorKind::UnexpectedEof, "")),
+                        return Err(ErrorKind::UnexpectedEof.into()),
                     Ok(len) => {
                         buf = &mut buf[len..];
                     },
@@ -103,7 +278,7 @@ pub mod io {
     impl<R: std::io::Read> Read for R {
         #[inline]
         fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-            <R as std::io::Read>::read(self, buf)
+            Ok(<R as std::io::Read>::read(self, buf)?)
         }
     }
 
@@ -111,7 +286,7 @@ pub mod io {
     impl<R: core2::io::Read> Read for R {
         #[inline]
         fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-            <R as core2::io::Read>::read(self, buf)
+            Ok(<R as core2::io::Read>::read(self, buf)?)
         }
     }
 
@@ -155,7 +330,7 @@ pub mod io {
             while !buf.is_empty() {
                 match self.write(buf) {
                     Ok(0) =>
-                        return Err(Error::new(ErrorKind::UnexpectedEof, "")),
+                        return Err(ErrorKind::UnexpectedEof.into()),
                     Ok(len) => {
                         buf = &buf[len..];
                     },
@@ -171,11 +346,11 @@ pub mod io {
     impl<W: std::io::Write> Write for W {
         #[inline]
         fn write(&mut self, buf: &[u8]) -> Result<usize> {
-            <W as std::io::Write>::write(self, buf)
+            Ok(<W as std::io::Write>::write(self, buf)?)
         }
         #[inline]
         fn flush(&mut self) -> Result<()> {
-            <W as std::io::Write>::flush(self)
+            Ok(<W as std::io::Write>::flush(self)?)
         }
     }
 
@@ -183,11 +358,11 @@ pub mod io {
     impl<W: core2::io::Write> Write for W {
         #[inline]
         fn write(&mut self, buf: &[u8]) -> Result<usize> {
-            <W as core2::io::Write>::write(self, buf)
+            Ok(<W as core2::io::Write>::write(self, buf)?)
         }
         #[inline]
         fn flush(&mut self) -> Result<()> {
-            <W as core2::io::Write>::flush(self)
+            Ok(<W as core2::io::Write>::flush(self)?)
         }
     }
 

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -87,3 +87,87 @@ pub mod io {
         }
     }
 }
+
+#[doc(hidden)]
+#[cfg(feature = "core2")]
+/// Re-export core2 for the below macro
+pub use core2 as _core2;
+
+#[doc(hidden)]
+#[cfg(feature = "std")]
+/// Re-export std for the below macro
+pub use std as _std;
+
+#[macro_export]
+/// Because we cannot provide a blanket implementation of [`std::io::Write`] for all implementers
+/// of this crate's `io::Write` trait, we provide this macro instead.
+///
+/// This macro will implement `Write` given a `write` and `flush` fn, either by implementing the
+/// crate's native `io::Write` trait directly, or a more generic trait from `std` or `core2` for
+/// users using those features. In any case, this crate's `io::Write` feature will be implemented
+/// for the given type, even if indirectly.
+#[cfg(not(any(feature = "core2", feature = "std")))]
+macro_rules! impl_write {
+    ($ty: ty, $write_fn: expr, $flush_fn: expr $(, $bounded_ty: ident : $bounds: path),*) => {
+        impl<$($bounded_ty: $bounds),*> $crate::io::Write for $ty {
+            #[inline]
+            fn write(&mut self, buf: &[u8]) -> $crate::io::Result<usize> {
+                $write_fn(self, buf)
+            }
+            #[inline]
+            fn flush(&mut self) -> $crate::io::Result<()> {
+                $flush_fn(self)
+            }
+        }
+    }
+}
+
+
+#[macro_export]
+/// Because we cannot provide a blanket implementation of [`std::io::Write`] for all implementers
+/// of this crate's `io::Write` trait, we provide this macro instead.
+///
+/// This macro will implement `Write` given a `write` and `flush` fn, either by implementing the
+/// crate's native `io::Write` trait directly, or a more generic trait from `std` or `core2` for
+/// users using those features. In any case, this crate's `io::Write` feature will be implemented
+/// for the given type, even if indirectly.
+#[cfg(feature = "std")]
+macro_rules! impl_write {
+    ($ty: ty, $write_fn: expr, $flush_fn: expr $(, $bounded_ty: ident : $bounds: path),*) => {
+        impl<$($bounded_ty: $bounds),*> $crate::_std::io::Write for $ty {
+            #[inline]
+            fn write(&mut self, buf: &[u8]) -> $crate::_std::io::Result<usize> {
+                $write_fn(self, buf)
+            }
+            #[inline]
+            fn flush(&mut self) -> $crate::_std::io::Result<()> {
+                $flush_fn(self)
+            }
+        }
+    }
+}
+
+
+#[macro_export]
+/// Because we cannot provide a blanket implementation of [`std::io::Write`] for all implementers
+/// of this crate's `io::Write` trait, we provide this macro instead.
+///
+/// This macro will implement `Write` given a `write` and `flush` fn, either by implementing the
+/// crate's native `io::Write` trait directly, or a more generic trait from `std` or `core2` for
+/// users using those features. In any case, this crate's `io::Write` feature will be implemented
+/// for the given type, even if indirectly.
+#[cfg(all(feature = "core2", not(feature = "std")))]
+macro_rules! impl_write {
+    ($ty: ty, $write_fn: expr, $flush_fn: expr $(, $bounded_ty: ident : $bounds: path),*) => {
+        impl<$($bounded_ty: $bounds),*> $crate::_core2::io::Write for $ty {
+            #[inline]
+            fn write(&mut self, buf: &[u8]) -> $crate::_core2::io::Result<usize> {
+                $write_fn(self, buf)
+            }
+            #[inline]
+            fn flush(&mut self) -> $crate::_core2::io::Result<()> {
+                $flush_fn(self)
+            }
+        }
+    }
+}

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -36,10 +36,54 @@ pub mod io {
     compile_error!("At least one of std or core2 must be enabled");
 
     #[cfg(feature = "std")]
-    pub use std::io::{Read, Write, sink, Cursor, Take, Error, ErrorKind, Result};
+    pub use std::io::{Read, sink, Cursor, Take, Error, ErrorKind, Result};
 
     #[cfg(not(feature = "std"))]
-    pub use core2::io::{Read, Write, Cursor, Take, Error, ErrorKind, Result};
+    pub use core2::io::{Read, Cursor, Take, Error, ErrorKind, Result};
 
+    /// A generic trait describing an output stream. See [`std::io::Write`] for more info.
+    pub trait Write {
+        fn write(&mut self, buf: &[u8]) -> Result<usize>;
+        fn flush(&mut self) -> Result<()>;
 
+        #[inline]
+        fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
+            while !buf.is_empty() {
+                match self.write(buf) {
+                    Ok(0) =>
+                        return Err(Error::new(ErrorKind::UnexpectedEof, "")),
+                    Ok(len) => {
+                        buf = &buf[len..];
+                    },
+                    Err(e) if e.kind() == ErrorKind::Interrupted => {},
+                    Err(e) => return Err(e),
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl<W: std::io::Write> Write for W {
+        #[inline]
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            <W as std::io::Write>::write(self, buf)
+        }
+        #[inline]
+        fn flush(&mut self) -> Result<()> {
+            <W as std::io::Write>::flush(self)
+        }
+    }
+
+    #[cfg(all(feature = "core2", not(feature = "std")))]
+    impl<W: core2::io::Write> Write for W {
+        #[inline]
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            <W as core2::io::Write>::write(self, buf)
+        }
+        #[inline]
+        fn flush(&mut self) -> Result<()> {
+            <W as core2::io::Write>::flush(self)
+        }
+    }
 }

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -32,14 +32,70 @@ extern crate alloc;
 /// Standard I/O stream definitions which are API-equivalent to `std`'s `io` module. See
 /// [`std::io`] for more info.
 pub mod io {
+    use core::convert::TryInto;
+
     #[cfg(all(not(feature = "std"), not(feature = "core2")))]
     compile_error!("At least one of std or core2 must be enabled");
 
     #[cfg(feature = "std")]
-    pub use std::io::{Read, Cursor, Take, Error, ErrorKind, Result};
+    pub use std::io::{Cursor, Error, ErrorKind, Result};
 
     #[cfg(not(feature = "std"))]
-    pub use core2::io::{Read, Cursor, Take, Error, ErrorKind, Result};
+    pub use core2::io::{Cursor, Error, ErrorKind, Result};
+
+    /// A generic trait describing an input stream. See [`std::io::Read`] for more info.
+    pub trait Read {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+        #[inline]
+        fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
+            while !buf.is_empty() {
+                match self.read(buf) {
+                    Ok(0) =>
+                        return Err(Error::new(ErrorKind::UnexpectedEof, "")),
+                    Ok(len) => {
+                        buf = &mut buf[len..];
+                    },
+                    Err(e) if e.kind() == ErrorKind::Interrupted => {},
+                    Err(e) => return Err(e),
+                }
+            }
+            Ok(())
+        }
+        #[inline]
+        fn take(&mut self, limit: u64) -> Take<Self> {
+            Take { reader: self, remaining: limit }
+        }
+    }
+
+    pub struct Take<'a, R: Read + ?Sized> {
+        reader: &'a mut R,
+        remaining: u64,
+    }
+    impl<'a, R: Read + ?Sized> Read for Take<'a, R> {
+        #[inline]
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            let len = core::cmp::min(buf.len(), self.remaining.try_into().unwrap_or(buf.len()));
+            let read = self.reader.read(&mut buf[..len])?;
+            self.remaining -= read.try_into().unwrap_or(self.remaining);
+            Ok(read)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl<R: std::io::Read> Read for R {
+        #[inline]
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            <R as std::io::Read>::read(self, buf)
+        }
+    }
+
+    #[cfg(all(feature = "core2", not(feature = "std")))]
+    impl<R: core2::io::Read> Read for R {
+        #[inline]
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            <R as core2::io::Read>::read(self, buf)
+        }
+    }
 
     /// A generic trait describing an output stream. See [`std::io::Write`] for more info.
     pub trait Write {

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -1,0 +1,32 @@
+//! Rust-Bitcoin IO Library
+//!
+//! Because the core `std::io` module is not yet exposed in `no-std` Rust, building `no-std`
+//! applications which require reading and writing objects via standard traits is not generally
+//! possible. While there is ongoing work to improve this situation, this module is not likely to
+//! be available for applications with broad rustc version support for some time.
+//!
+//! Thus, this library exists to export a minmal version of `std::io`'s traits which `no-std`
+//! applications may need. With the `std` feature, these traits are also implemented for the
+//! `std::io` traits, allowing standard objects to be used wherever the traits from this crate are
+//! required.
+//!
+//! This traits are not one-for-one drop-ins, but are as close as possible while still implementing
+//! `std::io`'s traits without unnecessary complexity.
+//!
+//! Further, with the `core2` feature, if the `std` feature is not set, the crate traits will be
+//! implemented for `core2`'s `io` traits as well.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(not(feature = "std"), not(feature = "core2")))]
+compile_error!("At least one of std or core2 must be enabled");
+
+#[cfg(feature = "std")]
+pub use std::io;
+#[cfg(feature = "std")]
+pub use std::error;
+
+#[cfg(not(feature = "std"))]
+pub use core2::io;
+#[cfg(not(feature = "std"))]
+pub use core2::error;

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -36,7 +36,7 @@ pub mod io {
     compile_error!("At least one of std or core2 must be enabled");
 
     #[cfg(feature = "std")]
-    pub use std::io::{Read, sink, Cursor, Take, Error, ErrorKind, Result};
+    pub use std::io::{Read, Cursor, Take, Error, ErrorKind, Result};
 
     #[cfg(not(feature = "std"))]
     pub use core2::io::{Read, Cursor, Take, Error, ErrorKind, Result};
@@ -86,6 +86,44 @@ pub mod io {
             <W as core2::io::Write>::flush(self)
         }
     }
+
+    /// A sink to which all writes succeed. See [`std::io::Sink`] for more info.
+    pub struct Sink;
+    #[cfg(not(any(feature = "core2", feature = "std")))]
+    impl Write for Sink {
+        #[inline]
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            Ok(buf.len())
+        }
+        #[inline]
+        fn write_all(&mut self, _: &[u8]) -> Result<()> { Ok(()) }
+        #[inline]
+        fn flush(&mut self) -> Result<()> { Ok(()) }
+    }
+    #[cfg(feature = "std")]
+    impl std::io::Write for Sink {
+        #[inline]
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        #[inline]
+        fn write_all(&mut self, _: &[u8]) -> std::io::Result<()> { Ok(()) }
+        #[inline]
+        fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+    }
+    #[cfg(all(feature = "core2", not(feature = "std")))]
+    impl core2::io::Write for Sink {
+        #[inline]
+        fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
+            Ok(buf.len())
+        }
+        #[inline]
+        fn write_all(&mut self, _: &[u8]) -> core2::io::Result<()> { Ok(()) }
+        #[inline]
+        fn flush(&mut self) -> core2::io::Result<()> { Ok(()) }
+    }
+    /// Returns a sink to which all writes succeed. See [`std::io::sink`] for more info.
+    pub fn sink() -> Sink { Sink }
 }
 
 #[doc(hidden)]

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -22,11 +22,24 @@
 compile_error!("At least one of std or core2 must be enabled");
 
 #[cfg(feature = "std")]
-pub use std::io;
-#[cfg(feature = "std")]
 pub use std::error;
-
-#[cfg(not(feature = "std"))]
-pub use core2::io;
 #[cfg(not(feature = "std"))]
 pub use core2::error;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+extern crate alloc;
+
+/// Standard I/O stream definitions which are API-equivalent to `std`'s `io` module. See
+/// [`std::io`] for more info.
+pub mod io {
+    #[cfg(all(not(feature = "std"), not(feature = "core2")))]
+    compile_error!("At least one of std or core2 must be enabled");
+
+    #[cfg(feature = "std")]
+    pub use std::io::{Read, Write, Cursor, Take, IoSlice, Error, ErrorKind, Result};
+
+    #[cfg(not(feature = "std"))]
+    pub use core2::io::{Read, Write, Cursor, Take, Error, ErrorKind, Result};
+
+
+}


### PR DESCRIPTION
This is a followup to  #2066 which drops the `core2` requirements. Its blocked on `secp256k1` and `hex-conservative` dropping their `core2` requirements.