### PR TITLE
Remove default impl from transaction version

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -980,10 +980,6 @@ impl Version {
     pub fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
 }
 
-impl Default for Version {
-    fn default() -> Version { Version::TWO }
-}
-
 impl Encodable for Version {
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         self.0.consensus_encode(w)
@@ -1942,7 +1938,7 @@ mod tests {
             ];
 
         let empty_transaction_weight = Transaction {
-            version: Version::default(),
+            version: Version::TWO,
             lock_time: absolute::LockTime::ZERO,
             input: vec![],
             output: vec![],

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1463,7 +1463,7 @@ mod tests {
     #[rustfmt::skip] // Allow long function call `taproot_signature_hash`.
     fn test_sighash_errors() {
         let dumb_tx = Transaction {
-            version: transaction::Version::default(),
+            version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
             input: vec![TxIn::default()],
             output: vec![],


### PR DESCRIPTION
There is no logical default for the transaction version number, there is only pre-bip68 (v1) and post-bip68 (v2). Uses should specify the version they want not rely on us making the choice.

(I originally added this impl to support testing, this was in hindsight the wrong thing to do, props to Sanket for noticing.)

Discussed in https://github.com/rust-bitcoin/rust-bitcoin/pull/2006#discussion_r1335180077