### PR TITLE
Manually implement `JsonSchema`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -46,7 +46,6 @@ dependencies = [
  "mutagen",
  "secp256k1",
  "serde",
- "serde_derive",
  "serde_json",
  "serde_test",
 ]

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -310,21 +310,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6ab463ae35acccb5cba66c0084c985257b797d288b6050cc2f6ac1b266cb78"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902fdfbcf871ae8f653bddf4b2c05905ddaabc08f69d32a915787e3be0d31356"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
 ]
 
 [[package]]
@@ -379,17 +366,6 @@ name = "serde_derive"
 version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -299,21 +299,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
 ]
 
 [[package]]
@@ -368,17 +355,6 @@ name = "serde_derive"
 version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -45,7 +45,6 @@ dependencies = [
  "mutagen",
  "secp256k1",
  "serde",
- "serde_derive",
  "serde_json",
  "serde_test",
 ]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -53,7 +53,6 @@ actual-serde = { package = "serde", version = "1.0.103", default-features = fals
 [dev-dependencies]
 serde_json = "1.0.0"
 serde_test = "1.0.19"
-serde_derive = "1.0.103"
 bincode = "1.3.1"
 
 [target.'cfg(mutate)'.dev-dependencies]

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -465,9 +465,9 @@ impl<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> io::Read for IterReader<E
 /// To (de)serialize a field using consensus encoding you can write e.g.:
 ///
 /// ```
+/// # use actual_serde::{Serialize, Deserialize};
 /// use bitcoin::Transaction;
 /// use bitcoin::consensus;
-/// use serde_derive::{Serialize, Deserialize};
 ///
 /// #[derive(Serialize, Deserialize)]
 /// # #[serde(crate = "actual_serde")]

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -13,10 +13,7 @@ if cargo --version | grep ${MSRV}; then
     cargo update -p quote --precise 1.0.30
     cargo update -p proc-macro2 --precise 1.0.63
     cargo update -p serde_test --precise 1.0.175
-    # Have to pin this so we can pin `schemars_derive`
     cargo update -p schemars --precise 0.8.12
-    # schemars_derive 0.8.13 uses edition 2021
-    cargo update -p schemars_derive --precise 0.8.12
     # byteorder 1.5.0 uses edition 2021
     cargo update -p byteorder --precise 1.4.3
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -30,8 +30,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 
 bitcoin-io = { version = "0.1", default-features = false, optional = true }
-
-schemars = { version = "0.8.3", optional = true }
+schemars = { version = "0.8.3", default-features = false, optional = true }
 # Only enable this if you explicitly do not want to use "std", otherwise enable "serde-std".
 serde = { version = "1.0", default-features = false, optional = true }
 

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -17,8 +17,7 @@ use crate::{ripemd160, sha256, FromSliceError};
 crate::internal_macros::hash_type! {
     160,
     false,
-    "Output of the Bitcoin HASH160 hash function. (RIPEMD160(SHA256))",
-    "crate::util::json_hex_string::len_20"
+    "Output of the Bitcoin HASH160 hash function. (RIPEMD160(SHA256))"
 }
 
 type HashEngine = sha256::HashEngine;

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -17,10 +17,19 @@ use crate::{FromSliceError, Hash, HashEngine};
 
 /// A hash computed from a RFC 2104 HMAC. Parameterized by the underlying hash function.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schemars", schemars(transparent))]
 #[repr(transparent)]
 pub struct Hmac<T: Hash>(T);
+
+#[cfg(feature = "schemars")]
+impl<T: Hash + schemars::JsonSchema> schemars::JsonSchema for Hmac<T> {
+    fn is_referenceable() -> bool { <T as schemars::JsonSchema>::is_referenceable() }
+
+    fn schema_name() -> std::string::String { <T as schemars::JsonSchema>::schema_name() }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <T as schemars::JsonSchema>::json_schema(gen)
+    }
+}
 
 impl<T: Hash + str::FromStr> str::FromStr for Hmac<T> {
     type Err = <T as str::FromStr>::Err;

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -13,8 +13,7 @@ use crate::{FromSliceError, HashEngine as _};
 crate::internal_macros::hash_type! {
     160,
     false,
-    "Output of the RIPEMD160 hash function.",
-    "crate::util::json_hex_string::len_20"
+    "Output of the RIPEMD160 hash function."
 }
 
 #[cfg(not(hashes_fuzz))]

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -13,8 +13,7 @@ use crate::{FromSliceError, HashEngine as _};
 crate::internal_macros::hash_type! {
     160,
     false,
-    "Output of the SHA1 hash function.",
-    "crate::util::json_hex_string::len_20"
+    "Output of the SHA1 hash function."
 }
 
 fn from_engine(mut e: HashEngine) -> Hash {

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -17,8 +17,7 @@ use crate::{hex, sha256d, FromSliceError, HashEngine as _};
 crate::internal_macros::hash_type! {
     256,
     false,
-    "Output of the SHA256 hash function.",
-    "crate::util::json_hex_string::len_32"
+    "Output of the SHA256 hash function."
 }
 
 #[cfg(not(hashes_fuzz))]

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -12,8 +12,7 @@ use crate::{sha256, FromSliceError};
 crate::internal_macros::hash_type! {
     256,
     true,
-    "Output of the SHA256d hash function.",
-    "crate::util::json_hex_string::len_32"
+    "Output of the SHA256d hash function."
 }
 
 type HashEngine = sha256::HashEngine;

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -27,7 +27,13 @@ impl<T: Tag> schemars::JsonSchema for Hash<T> {
     fn schema_name() -> String { "Hash".to_owned() }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        crate::util::json_hex_string::len_32(gen)
+        let mut schema: schemars::schema::SchemaObject = <String>::json_schema(gen).into();
+        schema.string = Some(Box::new(schemars::schema::StringValidation {
+            max_length: Some(32 * 2),
+            min_length: Some(32 * 2),
+            pattern: Some("[0-9a-fA-F]+".to_owned()),
+        }));
+        schema.into()
     }
 }
 
@@ -169,7 +175,6 @@ mod tests {
     ];
 
     #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
-    #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     pub struct TestHashTag;
 
     impl sha256t::Tag for TestHashTag {
@@ -177,6 +182,21 @@ mod tests {
             // The TapRoot TapLeaf midstate.
             let midstate = sha256::Midstate::from_byte_array(TEST_MIDSTATE);
             sha256::HashEngine::from_midstate(midstate, 64)
+        }
+    }
+
+    #[cfg(feature = "schemars")]
+    impl schemars::JsonSchema for TestHashTag {
+        fn schema_name() -> String { "Hash".to_owned() }
+
+        fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+            let mut schema: schemars::schema::SchemaObject = <String>::json_schema(gen).into();
+            schema.string = Some(Box::new(schemars::schema::StringValidation {
+                max_length: Some(64 * 2),
+                min_length: Some(64 * 2),
+                pattern: Some("[0-9a-fA-F]+".to_owned()),
+            }));
+            schema.into()
         }
     }
 

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -13,8 +13,7 @@ use crate::{FromSliceError, HashEngine as _};
 crate::internal_macros::hash_type! {
     512,
     false,
-    "Output of the SHA512 hash function.",
-    "crate::util::json_hex_string::len_64"
+    "Output of the SHA512 hash function."
 }
 
 #[cfg(not(hashes_fuzz))]

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -16,7 +16,7 @@ use crate::{sha512, FromSliceError};
 crate::internal_macros::hash_type! {
     256,
     false,
-    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>. ",
+    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>.",
     "crate::util::json_hex_string::len_32"
 }
 

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -16,8 +16,7 @@ use crate::{sha512, FromSliceError};
 crate::internal_macros::hash_type! {
     256,
     false,
-    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>.",
-    "crate::util::json_hex_string::len_32"
+    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>."
 }
 
 fn from_engine(e: HashEngine) -> Hash {

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -12,8 +12,7 @@ use crate::{FromSliceError, Hash as _, HashEngine as _};
 crate::internal_macros::hash_type! {
     64,
     false,
-    "Output of the SipHash24 hash function.",
-    "crate::util::json_hex_string::len_8"
+    "Output of the SipHash24 hash function."
 }
 
 #[cfg(not(hashes_fuzz))]

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -386,30 +386,6 @@ macro_rules! hash_newtype_known_attrs {
     ($($ignore:tt)*) => {};
 }
 
-#[cfg(feature = "schemars")]
-pub mod json_hex_string {
-    use schemars::gen::SchemaGenerator;
-    use schemars::schema::{Schema, SchemaObject};
-    use schemars::JsonSchema;
-    macro_rules! define_custom_hex {
-        ($name:ident, $len:expr) => {
-            pub fn $name(gen: &mut SchemaGenerator) -> Schema {
-                let mut schema: SchemaObject = <String>::json_schema(gen).into();
-                schema.string = Some(Box::new(schemars::schema::StringValidation {
-                    max_length: Some($len * 2),
-                    min_length: Some($len * 2),
-                    pattern: Some("[0-9a-fA-F]+".to_owned()),
-                }));
-                schema.into()
-            }
-        };
-    }
-    define_custom_hex!(len_8, 8);
-    define_custom_hex!(len_20, 20);
-    define_custom_hex!(len_32, 32);
-    define_custom_hex!(len_64, 64);
-}
-
 #[cfg(test)]
 mod test {
     use crate::{sha256, Hash};


### PR DESCRIPTION
Done while investigating removal of `serde_derive` dependency.

- Patch 1: Do trivial dev-dep removal
- Patch 2: Manually implement `JsonSchema` and remove default dependencies from "schemars" dependency (transitively depends on `serde_derive`)