### PR TITLE
Add `Witness::p2tr_key_spend` function

### DIFF
--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -76,7 +76,7 @@ fn main() {
 
     // Update the witness stack.
     let signature = bitcoin::taproot::Signature { signature, sighash_type };
-    sighasher.witness_mut(input_index).unwrap().push(&signature.to_vec());
+    *sighasher.witness_mut(input_index).unwrap() = Witness::p2tr_key_spend(&signature);
 
     // Get the signed transaction.
     let tx = sighasher.into_transaction();

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -14,7 +14,7 @@ use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::crypto::ecdsa;
 use crate::prelude::*;
-use crate::taproot::TAPROOT_ANNEX_PREFIX;
+use crate::taproot::{self, TAPROOT_ANNEX_PREFIX};
 use crate::{Script, VarInt};
 
 /// The Witness is the data used to unlock bitcoin since the [segwit upgrade].
@@ -245,6 +245,13 @@ impl Witness {
         let mut witness = Witness::new();
         witness.push_slice(&signature.serialize());
         witness.push_slice(&pubkey.serialize());
+        witness
+    }
+
+    /// Creates a witness required to do a key path spend of a P2TR output.
+    pub fn p2tr_key_spend(signature: &taproot::Signature) -> Witness {
+        let mut witness = Witness::new();
+        witness.push_slice(&signature.serialize());
         witness
     }
 


### PR DESCRIPTION
Add a function for creating the witness when doing a key path spend for a P2TR output.
    
This mirrors what we did for P2WPKH when adding `Witness::p2wpkh`.
     
Includes update to the taproot signing example to use the new constructor.
