### PR TITLE
Upgrade secp dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -38,7 +38,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "bitcoinconsensus",
  "core2",
  "hex-conservative",
@@ -67,21 +67,6 @@ name = "bitcoin-internals"
 version = "0.2.0"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
 ]
 
 [[package]]
@@ -359,11 +344,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
  "serde",
@@ -371,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "09e67c467c38fd24bd5499dc9a18183b31575c12ee549197e3e20d57aa4fe3b7"
 dependencies = [
  "cc",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -37,7 +37,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "bitcoinconsensus",
  "core2",
  "hex-conservative",
@@ -66,21 +66,6 @@ name = "bitcoin-internals"
 version = "0.2.0"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
 ]
 
 [[package]]
@@ -348,11 +333,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
  "serde",
@@ -360,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "09e67c467c38fd24bd5499dc9a18183b31575c12ee549197e3e20d57aa4fe3b7"
 dependencies = [
  "cc",
 ]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -38,7 +38,7 @@ internals = { package = "bitcoin-internals", version = "0.2.0" }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 bech32 = { version = "0.10.0-beta", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false }
-secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
+secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes"] }
 hex_lit = "0.1.1"
 
 base64 = { version = "0.21.3", optional = true }

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -46,8 +46,8 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, value: u64) {
         .expect("failed to compute sighash");
     println!("Segwit p2wpkh sighash: {:x}", sighash);
     // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-    let msg =
-        secp256k1::Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long");
+    let msg = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
+        .expect("sighash is 32 bytes long");
     println!("Message is {:x}", msg);
     let secp = secp256k1::Secp256k1::verification_only();
     secp.verify_ecdsa(&msg, &sig.sig, &pk.inner).unwrap();

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -45,9 +45,7 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, value: u64) {
         .p2wpkh_signature_hash(inp_idx, &spk, Amount::from_sat(value), sig.hash_ty)
         .expect("failed to compute sighash");
     println!("Segwit p2wpkh sighash: {:x}", sighash);
-    // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-    let msg = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
-        .expect("sighash is 32 bytes long");
+    let msg = secp256k1::Message::from_digest(sighash.to_byte_array());
     println!("Message is {:x}", msg);
     let secp = secp256k1::Secp256k1::verification_only();
     secp.verify_ecdsa(&msg, &sig.sig, &pk.inner).unwrap();

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -739,9 +739,7 @@ fn sign_psbt_taproot(
         Some(_) => keypair, // no tweak for script spend
     };
 
-    // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-    let msg = secp256k1::Message::from_digest_slice(hash.as_byte_array())
-        .expect("tap sighash is 32 bytes long");
+    let msg = secp256k1::Message::from_digest(hash.to_byte_array());
     let sig = secp.sign_schnorr(&msg, &keypair);
 
     let final_signature = taproot::Signature { sig, hash_ty };

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -733,15 +733,15 @@ fn sign_psbt_taproot(
     hash_ty: TapSighashType,
     secp: &Secp256k1<secp256k1::All>,
 ) {
-    let keypair = secp256k1::KeyPair::from_seckey_slice(secp, secret_key.as_ref()).unwrap();
+    let keypair = secp256k1::Keypair::from_seckey_slice(secp, secret_key.as_ref()).unwrap();
     let keypair = match leaf_hash {
         None => keypair.tap_tweak(secp, psbt_input.tap_merkle_root).to_inner(),
         Some(_) => keypair, // no tweak for script spend
     };
 
     // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-    let msg =
-        secp256k1::Message::from_slice(hash.as_byte_array()).expect("tap sighash is 32 bytes long");
+    let msg = secp256k1::Message::from_digest_slice(hash.as_byte_array())
+        .expect("tap sighash is 32 bytes long");
     let sig = secp.sign_schnorr(&msg, &keypair);
 
     let final_signature = taproot::Signature { sig, hash_ty };

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -21,7 +21,7 @@ use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 use serde;
 
 use crate::base58;
-use crate::crypto::key::{self, KeyPair, PrivateKey, PublicKey};
+use crate::crypto::key::{self, Keypair, PrivateKey, PublicKey};
 use crate::internal_macros::impl_bytes_newtype;
 use crate::io::Write;
 use crate::network::Network;
@@ -579,8 +579,8 @@ impl Xpriv {
 
     /// Constructs BIP340 keypair for Schnorr signatures and Taproot use matching the internal
     /// secret key representation.
-    pub fn to_keypair<C: secp256k1::Signing>(self, secp: &Secp256k1<C>) -> KeyPair {
-        KeyPair::from_seckey_slice(secp, &self.private_key[..])
+    pub fn to_keypair<C: secp256k1::Signing>(self, secp: &Secp256k1<C>) -> Keypair {
+        Keypair::from_seckey_slice(secp, &self.private_key[..])
             .expect("BIP32 internal private key representation is broken")
     }
 

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -507,17 +507,27 @@ impl fmt::Display for TweakedPublicKey {
 }
 
 /// Untweaked BIP-340 key pair
-pub type UntweakedKeyPair = KeyPair;
+#[deprecated(since = "0.31.0", note = "use UntweakedKeypair instead")]
+#[allow(deprecated)]
+pub type UntweakedKeyPair = UntweakedKeypair;
+
+/// Untweaked BIP-340 key pair
+pub type UntweakedKeypair = KeyPair;
+
+/// Tweaked BIP-340 key pair
+#[deprecated(since = "0.31.0", note = "use TweakedKeypair instead")]
+#[allow(deprecated)]
+pub type TweakedKeyPair = TweakedKeypair;
 
 /// Tweaked BIP-340 key pair
 ///
 /// # Examples
 /// ```
 /// # #[cfg(feature = "rand-std")] {
-/// # use bitcoin::key::{KeyPair, TweakedKeyPair, TweakedPublicKey};
+/// # use bitcoin::key::{KeyPair, TweakedKeypair, TweakedPublicKey};
 /// # use bitcoin::secp256k1::{rand, Secp256k1};
 /// # let secp = Secp256k1::new();
-/// # let keypair = TweakedKeyPair::dangerous_assume_tweaked(KeyPair::new(&secp, &mut rand::thread_rng()));
+/// # let keypair = TweakedKeypair::dangerous_assume_tweaked(KeyPair::new(&secp, &mut rand::thread_rng()));
 /// // There are various conversion methods available to get a tweaked pubkey from a tweaked keypair.
 /// let (_pk, _parity) = keypair.public_parts();
 /// let _pk  = TweakedPublicKey::from_keypair(keypair);
@@ -528,7 +538,7 @@ pub type UntweakedKeyPair = KeyPair;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct TweakedKeyPair(KeyPair);
+pub struct TweakedKeypair(KeyPair);
 
 /// A trait for tweaking BIP340 key types (x-only public keys and key pairs).
 pub trait TapTweak {
@@ -593,9 +603,9 @@ impl TapTweak for UntweakedPublicKey {
     fn dangerous_assume_tweaked(self) -> TweakedPublicKey { TweakedPublicKey(self) }
 }
 
-impl TapTweak for UntweakedKeyPair {
-    type TweakedAux = TweakedKeyPair;
-    type TweakedKey = TweakedKeyPair;
+impl TapTweak for UntweakedKeypair {
+    type TweakedAux = TweakedKeypair;
+    type TweakedKey = TweakedKeypair;
 
     /// Tweaks private and public keys within an untweaked [`KeyPair`] with corresponding public key
     /// value and optional script tree merkle root.
@@ -613,20 +623,20 @@ impl TapTweak for UntweakedKeyPair {
         self,
         secp: &Secp256k1<C>,
         merkle_root: Option<TapNodeHash>,
-    ) -> TweakedKeyPair {
+    ) -> TweakedKeypair {
         let (pubkey, _parity) = XOnlyPublicKey::from_keypair(&self);
         let tweak = TapTweakHash::from_key_and_tweak(pubkey, merkle_root).to_scalar();
         let tweaked = self.add_xonly_tweak(secp, &tweak).expect("Tap tweak failed");
-        TweakedKeyPair(tweaked)
+        TweakedKeypair(tweaked)
     }
 
-    fn dangerous_assume_tweaked(self) -> TweakedKeyPair { TweakedKeyPair(self) }
+    fn dangerous_assume_tweaked(self) -> TweakedKeypair { TweakedKeypair(self) }
 }
 
 impl TweakedPublicKey {
     /// Returns the [`TweakedPublicKey`] for `keypair`.
     #[inline]
-    pub fn from_keypair(keypair: TweakedKeyPair) -> Self {
+    pub fn from_keypair(keypair: TweakedKeypair) -> Self {
         let (xonly, _parity) = keypair.0.x_only_public_key();
         TweakedPublicKey(xonly)
     }
@@ -651,20 +661,20 @@ impl TweakedPublicKey {
     pub fn serialize(&self) -> [u8; constants::SCHNORR_PUBLIC_KEY_SIZE] { self.0.serialize() }
 }
 
-impl TweakedKeyPair {
-    /// Creates a new [`TweakedKeyPair`] from a [`KeyPair`]. No tweak is applied, consider
+impl TweakedKeypair {
+    /// Creates a new [`TweakedKeypair`] from a [`KeyPair`]. No tweak is applied, consider
     /// calling `tap_tweak` on an [`UntweakedKeyPair`] instead of using this constructor.
     ///
     /// This method is dangerous and can lead to loss of funds if used incorrectly.
     /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
     #[inline]
-    pub fn dangerous_assume_tweaked(pair: KeyPair) -> TweakedKeyPair { TweakedKeyPair(pair) }
+    pub fn dangerous_assume_tweaked(pair: KeyPair) -> TweakedKeypair { TweakedKeypair(pair) }
 
     /// Returns the underlying key pair.
     #[inline]
     pub fn to_inner(self) -> KeyPair { self.0 }
 
-    /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeyPair`].
+    /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeypair`].
     #[inline]
     pub fn public_parts(&self) -> (TweakedPublicKey, Parity) {
         let (xonly, parity) = self.0.x_only_public_key();
@@ -677,14 +687,14 @@ impl From<TweakedPublicKey> for XOnlyPublicKey {
     fn from(pair: TweakedPublicKey) -> Self { pair.0 }
 }
 
-impl From<TweakedKeyPair> for KeyPair {
+impl From<TweakedKeypair> for KeyPair {
     #[inline]
-    fn from(pair: TweakedKeyPair) -> Self { pair.0 }
+    fn from(pair: TweakedKeypair) -> Self { pair.0 }
 }
 
-impl From<TweakedKeyPair> for TweakedPublicKey {
+impl From<TweakedKeypair> for TweakedPublicKey {
     #[inline]
-    fn from(pair: TweakedKeyPair) -> Self { TweakedPublicKey::from_keypair(pair) }
+    fn from(pair: TweakedKeypair) -> Self { TweakedPublicKey::from_keypair(pair) }
 }
 /// A key-related error.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -14,7 +14,7 @@ use hex::FromHex;
 use internals::write_err;
 #[cfg(feature = "rand-std")]
 pub use secp256k1::rand;
-pub use secp256k1::{self, constants, KeyPair, Parity, Secp256k1, Verification, XOnlyPublicKey};
+pub use secp256k1::{self, constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::crypto::ecdsa;
 use crate::network::Network;
@@ -512,7 +512,7 @@ impl fmt::Display for TweakedPublicKey {
 pub type UntweakedKeyPair = UntweakedKeypair;
 
 /// Untweaked BIP-340 key pair
-pub type UntweakedKeypair = KeyPair;
+pub type UntweakedKeypair = Keypair;
 
 /// Tweaked BIP-340 key pair
 #[deprecated(since = "0.31.0", note = "use TweakedKeypair instead")]
@@ -524,10 +524,10 @@ pub type TweakedKeyPair = TweakedKeypair;
 /// # Examples
 /// ```
 /// # #[cfg(feature = "rand-std")] {
-/// # use bitcoin::key::{KeyPair, TweakedKeypair, TweakedPublicKey};
+/// # use bitcoin::key::{Keypair, TweakedKeypair, TweakedPublicKey};
 /// # use bitcoin::secp256k1::{rand, Secp256k1};
 /// # let secp = Secp256k1::new();
-/// # let keypair = TweakedKeypair::dangerous_assume_tweaked(KeyPair::new(&secp, &mut rand::thread_rng()));
+/// # let keypair = TweakedKeypair::dangerous_assume_tweaked(Keypair::new(&secp, &mut rand::thread_rng()));
 /// // There are various conversion methods available to get a tweaked pubkey from a tweaked keypair.
 /// let (_pk, _parity) = keypair.public_parts();
 /// let _pk  = TweakedPublicKey::from_keypair(keypair);
@@ -538,7 +538,7 @@ pub type TweakedKeyPair = TweakedKeypair;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct TweakedKeypair(KeyPair);
+pub struct TweakedKeypair(Keypair);
 
 /// A trait for tweaking BIP340 key types (x-only public keys and key pairs).
 pub trait TapTweak {
@@ -548,7 +548,7 @@ pub trait TapTweak {
     type TweakedKey;
 
     /// Tweaks an untweaked key with corresponding public key value and optional script tree merkle
-    /// root. For the [`KeyPair`] type this also tweaks the private key in the pair.
+    /// root. For the [`Keypair`] type this also tweaks the private key in the pair.
     ///
     /// This is done by using the equation Q = P + H(P|c)G, where
     ///  * Q is the tweaked public key
@@ -607,7 +607,7 @@ impl TapTweak for UntweakedKeypair {
     type TweakedAux = TweakedKeypair;
     type TweakedKey = TweakedKeypair;
 
-    /// Tweaks private and public keys within an untweaked [`KeyPair`] with corresponding public key
+    /// Tweaks private and public keys within an untweaked [`Keypair`] with corresponding public key
     /// value and optional script tree merkle root.
     ///
     /// This is done by tweaking private key within the pair using the equation q = p + H(P|c), where
@@ -662,17 +662,17 @@ impl TweakedPublicKey {
 }
 
 impl TweakedKeypair {
-    /// Creates a new [`TweakedKeypair`] from a [`KeyPair`]. No tweak is applied, consider
-    /// calling `tap_tweak` on an [`UntweakedKeyPair`] instead of using this constructor.
+    /// Creates a new [`TweakedKeypair`] from a [`Keypair`]. No tweak is applied, consider
+    /// calling `tap_tweak` on an [`UntweakedKeypair`] instead of using this constructor.
     ///
     /// This method is dangerous and can lead to loss of funds if used incorrectly.
     /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
     #[inline]
-    pub fn dangerous_assume_tweaked(pair: KeyPair) -> TweakedKeypair { TweakedKeypair(pair) }
+    pub fn dangerous_assume_tweaked(pair: Keypair) -> TweakedKeypair { TweakedKeypair(pair) }
 
     /// Returns the underlying key pair.
     #[inline]
-    pub fn to_inner(self) -> KeyPair { self.0 }
+    pub fn to_inner(self) -> Keypair { self.0 }
 
     /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeypair`].
     #[inline]
@@ -687,7 +687,7 @@ impl From<TweakedPublicKey> for XOnlyPublicKey {
     fn from(pair: TweakedPublicKey) -> Self { pair.0 }
 }
 
-impl From<TweakedKeypair> for KeyPair {
+impl From<TweakedKeypair> for Keypair {
     #[inline]
     fn from(pair: TweakedKeypair) -> Self { pair.0 }
 }
@@ -1076,7 +1076,7 @@ mod tests {
         use secp256k1::rand;
 
         let secp = Secp256k1::new();
-        let kp = KeyPair::new(&secp, &mut rand::thread_rng());
+        let kp = Keypair::new(&secp, &mut rand::thread_rng());
 
         let _ = PublicKey::new(kp);
         let _ = PublicKey::new_uncompressed(kp);

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1743,7 +1743,7 @@ mod tests {
             };
 
             // tests
-            let keypair = secp256k1::KeyPair::from_secret_key(secp, &internal_priv_key);
+            let keypair = secp256k1::Keypair::from_secret_key(secp, &internal_priv_key);
             let (internal_key, _parity) = XOnlyPublicKey::from_keypair(&keypair);
             let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
             let tweaked_keypair = keypair.add_xonly_tweak(secp, &tweak.to_scalar()).unwrap();
@@ -1763,7 +1763,7 @@ mod tests {
                 .unwrap();
 
             // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-            let msg = secp256k1::Message::from_slice(sighash.as_byte_array())
+            let msg = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
                 .expect("sighash is 32 bytes long");
             let key_spend_sig = secp.sign_schnorr_with_aux_rand(&msg, &tweaked_keypair, &[0u8; 32]);
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1762,9 +1762,7 @@ mod tests {
                 .taproot_signature_hash(tx_ind, &Prevouts::All(&utxos), None, None, hash_ty)
                 .unwrap();
 
-            // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-            let msg = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
-                .expect("sighash is 32 bytes long");
+            let msg = secp256k1::Message::from_digest(sighash.to_byte_array());
             let key_spend_sig = secp.sign_schnorr_with_aux_rand(&msg, &tweaked_keypair, &[0u8; 32]);
 
             assert_eq!(expected.internal_pubkey, internal_key);

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -8,7 +8,7 @@
 use core::fmt;
 
 use internals::write_err;
-pub use secp256k1::{self, constants, KeyPair, Parity, Secp256k1, Verification, XOnlyPublicKey};
+pub use secp256k1::{self, constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::prelude::*;
 use crate::sighash::{InvalidSighashTypeError, TapSighashType};

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -405,56 +405,31 @@ impl Psbt {
         match self.output_type(input_index)? {
             Bare => {
                 let sighash = cache.legacy_signature_hash(input_index, spk, hash_ty.to_u32())?;
-                // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-                Ok((
-                    Message::from_digest_slice(sighash.as_byte_array())
-                        .expect("sighash is 32 bytes long"),
-                    hash_ty,
-                ))
+                Ok((Message::from_digest(sighash.to_byte_array()), hash_ty))
             }
             Sh => {
                 let script_code =
                     input.redeem_script.as_ref().ok_or(SignError::MissingRedeemScript)?;
                 let sighash =
                     cache.legacy_signature_hash(input_index, script_code, hash_ty.to_u32())?;
-                // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-                Ok((
-                    Message::from_digest_slice(sighash.as_byte_array())
-                        .expect("sighash is 32 bytes long"),
-                    hash_ty,
-                ))
+                Ok((Message::from_digest(sighash.to_byte_array()), hash_ty))
             }
             Wpkh => {
                 let sighash = cache.p2wpkh_signature_hash(input_index, spk, utxo.value, hash_ty)?;
-                // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-                Ok((
-                    Message::from_digest_slice(sighash.as_byte_array())
-                        .expect("sighash is 32 bytes long"),
-                    hash_ty,
-                ))
+                Ok((Message::from_digest(sighash.to_byte_array()), hash_ty))
             }
             ShWpkh => {
                 let redeem_script = input.redeem_script.as_ref().expect("checked above");
                 let sighash =
                     cache.p2wpkh_signature_hash(input_index, redeem_script, utxo.value, hash_ty)?;
-                // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-                Ok((
-                    Message::from_digest_slice(sighash.as_byte_array())
-                        .expect("sighash is 32 bytes long"),
-                    hash_ty,
-                ))
+                Ok((Message::from_digest(sighash.to_byte_array()), hash_ty))
             }
             Wsh | ShWsh => {
                 let witness_script =
                     input.witness_script.as_ref().ok_or(SignError::MissingWitnessScript)?;
                 let sighash =
                     cache.p2wsh_signature_hash(input_index, witness_script, utxo.value, hash_ty)?;
-                // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-                Ok((
-                    Message::from_digest_slice(sighash.as_byte_array())
-                        .expect("sighash is 32 bytes long"),
-                    hash_ty,
-                ))
+                Ok((Message::from_digest(sighash.to_byte_array()), hash_ty))
             }
             Tr => {
                 // This PSBT signing API is WIP, taproot to come shortly.

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -407,7 +407,8 @@ impl Psbt {
                 let sighash = cache.legacy_signature_hash(input_index, spk, hash_ty.to_u32())?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }
@@ -418,7 +419,8 @@ impl Psbt {
                     cache.legacy_signature_hash(input_index, script_code, hash_ty.to_u32())?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }
@@ -426,7 +428,8 @@ impl Psbt {
                 let sighash = cache.p2wpkh_signature_hash(input_index, spk, utxo.value, hash_ty)?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }
@@ -436,7 +439,8 @@ impl Psbt {
                     cache.p2wpkh_signature_hash(input_index, redeem_script, utxo.value, hash_ty)?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }
@@ -447,7 +451,8 @@ impl Psbt {
                     cache.p2wsh_signature_hash(input_index, witness_script, utxo.value, hash_ty)?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -132,7 +132,7 @@ mod message_signing {
             msg_hash: sha256d::Hash,
         ) -> Result<PublicKey, MessageSignatureError> {
             // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-            let msg = secp256k1::Message::from_slice(msg_hash.as_byte_array())
+            let msg = secp256k1::Message::from_digest_slice(msg_hash.as_byte_array())
                 .expect("sh256d hash is 32 bytes long");
 
             let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
@@ -232,7 +232,7 @@ mod tests {
         let message = "rust-bitcoin MessageSignature test";
         let msg_hash = super::signed_msg_hash(message);
         // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-        let msg = secp256k1::Message::from_slice(msg_hash.as_byte_array())
+        let msg = secp256k1::Message::from_digest_slice(msg_hash.as_byte_array())
             .expect("sh256d hash is 32 bytes long");
 
         let privkey = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -131,10 +131,7 @@ mod message_signing {
             secp_ctx: &secp256k1::Secp256k1<C>,
             msg_hash: sha256d::Hash,
         ) -> Result<PublicKey, MessageSignatureError> {
-            // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-            let msg = secp256k1::Message::from_digest_slice(msg_hash.as_byte_array())
-                .expect("sh256d hash is 32 bytes long");
-
+            let msg = secp256k1::Message::from_digest(msg_hash.to_byte_array());
             let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
             Ok(PublicKey { inner: pubkey, compressed: self.compressed })
         }
@@ -231,10 +228,7 @@ mod tests {
         let secp = secp256k1::Secp256k1::new();
         let message = "rust-bitcoin MessageSignature test";
         let msg_hash = super::signed_msg_hash(message);
-        // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-        let msg = secp256k1::Message::from_digest_slice(msg_hash.as_byte_array())
-            .expect("sh256d hash is 32 bytes long");
-
+        let msg = secp256k1::Message::from_digest(msg_hash.to_byte_array());
         let privkey = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());
         let secp_sig = secp.sign_ecdsa_recoverable(&msg, &privkey);
         let signature = super::MessageSignature { signature: secp_sig, compressed: true };


### PR DESCRIPTION
Upgrade the `secp256k1` dependency to the newly released `v0.28.0`.
    
FTR this includes two simple changes:
- Use `Message::from_digest_slice` instead of `Message::from_slice`.
- Use `secp256k1::Keypair` instead of `secp256k1::KeyPair`.

But to stay in line with the keypair change we deprecate and rename the tweaked alias.