### PR TITLE
Tracking PR for release `v0.31.0`

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -38,7 +38,7 @@ internals = { package = "bitcoin-internals", version = "0.2.0" }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 bech32 = { version = "0.10.0-alpha", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false }
-secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
+secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes"] }
 hex_lit = "0.1.1"
 
 base64 = { version = "0.21.3", optional = true }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -46,8 +46,8 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, value: u64) {
         .expect("failed to compute sighash");
     println!("Segwit p2wpkh sighash: {:x}", sighash);
     // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-    let msg =
-        secp256k1::Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long");
+    let msg = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
+        .expect("sighash is 32 bytes long");
     println!("Message is {:x}", msg);
     let secp = secp256k1::Secp256k1::verification_only();
     secp.verify_ecdsa(&msg, &sig.sig, &pk.inner).unwrap();

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -736,15 +736,15 @@ fn sign_psbt_taproot(
     hash_ty: TapSighashType,
     secp: &Secp256k1<secp256k1::All>,
 ) {
-    let keypair = secp256k1::KeyPair::from_seckey_slice(secp, secret_key.as_ref()).unwrap();
+    let keypair = secp256k1::Keypair::from_seckey_slice(secp, secret_key.as_ref()).unwrap();
     let keypair = match leaf_hash {
         None => keypair.tap_tweak(secp, psbt_input.tap_merkle_root).to_inner(),
         Some(_) => keypair, // no tweak for script spend
     };
 
     // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-    let msg =
-        secp256k1::Message::from_slice(hash.as_byte_array()).expect("tap sighash is 32 bytes long");
+    let msg = secp256k1::Message::from_digest_slice(hash.as_byte_array())
+        .expect("tap sighash is 32 bytes long");
     let sig = secp.sign_schnorr(&msg, &keypair);
 
     let final_signature = taproot::Signature { sig, hash_ty };

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -21,7 +21,7 @@ use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 use serde;
 
 use crate::base58;
-use crate::crypto::key::{self, KeyPair, PrivateKey, PublicKey};
+use crate::crypto::key::{self, Keypair, PrivateKey, PublicKey};
 use crate::internal_macros::impl_bytes_newtype;
 use crate::io::Write;
 use crate::network::Network;
@@ -578,8 +578,8 @@ impl Xpriv {
 
     /// Constructs BIP340 keypair for Schnorr signatures and Taproot use matching the internal
     /// secret key representation.
-    pub fn to_keypair<C: secp256k1::Signing>(self, secp: &Secp256k1<C>) -> KeyPair {
-        KeyPair::from_seckey_slice(secp, &self.private_key[..])
+    pub fn to_keypair<C: secp256k1::Signing>(self, secp: &Secp256k1<C>) -> Keypair {
+        Keypair::from_seckey_slice(secp, &self.private_key[..])
             .expect("BIP32 internal private key representation is broken")
     }
 

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -507,17 +507,27 @@ impl fmt::Display for TweakedPublicKey {
 }
 
 /// Untweaked BIP-340 key pair
-pub type UntweakedKeyPair = KeyPair;
+#[deprecated(since = "0.31.0", note = "use UntweakedKeypair instead")]
+#[allow(deprecated)]
+pub type UntweakedKeyPair = UntweakedKeypair;
+
+/// Untweaked BIP-340 key pair
+pub type UntweakedKeypair = KeyPair;
+
+/// Tweaked BIP-340 key pair
+#[deprecated(since = "0.31.0", note = "use TweakedKeypair instead")]
+#[allow(deprecated)]
+pub type TweakedKeyPair = TweakedKeypair;
 
 /// Tweaked BIP-340 key pair
 ///
 /// # Examples
 /// ```
 /// # #[cfg(feature = "rand-std")] {
-/// # use bitcoin::key::{KeyPair, TweakedKeyPair, TweakedPublicKey};
+/// # use bitcoin::key::{KeyPair, TweakedKeypair, TweakedPublicKey};
 /// # use bitcoin::secp256k1::{rand, Secp256k1};
 /// # let secp = Secp256k1::new();
-/// # let keypair = TweakedKeyPair::dangerous_assume_tweaked(KeyPair::new(&secp, &mut rand::thread_rng()));
+/// # let keypair = TweakedKeypair::dangerous_assume_tweaked(KeyPair::new(&secp, &mut rand::thread_rng()));
 /// // There are various conversion methods available to get a tweaked pubkey from a tweaked keypair.
 /// let (_pk, _parity) = keypair.public_parts();
 /// let _pk  = TweakedPublicKey::from_keypair(keypair);
@@ -528,7 +538,7 @@ pub type UntweakedKeyPair = KeyPair;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct TweakedKeyPair(KeyPair);
+pub struct TweakedKeypair(KeyPair);
 
 /// A trait for tweaking BIP340 key types (x-only public keys and key pairs).
 pub trait TapTweak {
@@ -593,9 +603,9 @@ impl TapTweak for UntweakedPublicKey {
     fn dangerous_assume_tweaked(self) -> TweakedPublicKey { TweakedPublicKey(self) }
 }
 
-impl TapTweak for UntweakedKeyPair {
-    type TweakedAux = TweakedKeyPair;
-    type TweakedKey = TweakedKeyPair;
+impl TapTweak for UntweakedKeypair {
+    type TweakedAux = TweakedKeypair;
+    type TweakedKey = TweakedKeypair;
 
     /// Tweaks private and public keys within an untweaked [`KeyPair`] with corresponding public key
     /// value and optional script tree merkle root.
@@ -613,20 +623,20 @@ impl TapTweak for UntweakedKeyPair {
         self,
         secp: &Secp256k1<C>,
         merkle_root: Option<TapNodeHash>,
-    ) -> TweakedKeyPair {
+    ) -> TweakedKeypair {
         let (pubkey, _parity) = XOnlyPublicKey::from_keypair(&self);
         let tweak = TapTweakHash::from_key_and_tweak(pubkey, merkle_root).to_scalar();
         let tweaked = self.add_xonly_tweak(secp, &tweak).expect("Tap tweak failed");
-        TweakedKeyPair(tweaked)
+        TweakedKeypair(tweaked)
     }
 
-    fn dangerous_assume_tweaked(self) -> TweakedKeyPair { TweakedKeyPair(self) }
+    fn dangerous_assume_tweaked(self) -> TweakedKeypair { TweakedKeypair(self) }
 }
 
 impl TweakedPublicKey {
     /// Returns the [`TweakedPublicKey`] for `keypair`.
     #[inline]
-    pub fn from_keypair(keypair: TweakedKeyPair) -> Self {
+    pub fn from_keypair(keypair: TweakedKeypair) -> Self {
         let (xonly, _parity) = keypair.0.x_only_public_key();
         TweakedPublicKey(xonly)
     }
@@ -651,20 +661,20 @@ impl TweakedPublicKey {
     pub fn serialize(&self) -> [u8; constants::SCHNORR_PUBLIC_KEY_SIZE] { self.0.serialize() }
 }
 
-impl TweakedKeyPair {
-    /// Creates a new [`TweakedKeyPair`] from a [`KeyPair`]. No tweak is applied, consider
+impl TweakedKeypair {
+    /// Creates a new [`TweakedKeypair`] from a [`KeyPair`]. No tweak is applied, consider
     /// calling `tap_tweak` on an [`UntweakedKeyPair`] instead of using this constructor.
     ///
     /// This method is dangerous and can lead to loss of funds if used incorrectly.
     /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
     #[inline]
-    pub fn dangerous_assume_tweaked(pair: KeyPair) -> TweakedKeyPair { TweakedKeyPair(pair) }
+    pub fn dangerous_assume_tweaked(pair: KeyPair) -> TweakedKeypair { TweakedKeypair(pair) }
 
     /// Returns the underlying key pair.
     #[inline]
     pub fn to_inner(self) -> KeyPair { self.0 }
 
-    /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeyPair`].
+    /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeypair`].
     #[inline]
     pub fn public_parts(&self) -> (TweakedPublicKey, Parity) {
         let (xonly, parity) = self.0.x_only_public_key();
@@ -677,14 +687,14 @@ impl From<TweakedPublicKey> for XOnlyPublicKey {
     fn from(pair: TweakedPublicKey) -> Self { pair.0 }
 }
 
-impl From<TweakedKeyPair> for KeyPair {
+impl From<TweakedKeypair> for KeyPair {
     #[inline]
-    fn from(pair: TweakedKeyPair) -> Self { pair.0 }
+    fn from(pair: TweakedKeypair) -> Self { pair.0 }
 }
 
-impl From<TweakedKeyPair> for TweakedPublicKey {
+impl From<TweakedKeypair> for TweakedPublicKey {
     #[inline]
-    fn from(pair: TweakedKeyPair) -> Self { TweakedPublicKey::from_keypair(pair) }
+    fn from(pair: TweakedKeypair) -> Self { TweakedPublicKey::from_keypair(pair) }
 }
 /// A key-related error.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -14,7 +14,7 @@ use hex::FromHex;
 use internals::write_err;
 #[cfg(feature = "rand-std")]
 pub use secp256k1::rand;
-pub use secp256k1::{self, constants, KeyPair, Parity, Secp256k1, Verification, XOnlyPublicKey};
+pub use secp256k1::{self, constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::crypto::ecdsa;
 use crate::network::Network;
@@ -512,7 +512,7 @@ impl fmt::Display for TweakedPublicKey {
 pub type UntweakedKeyPair = UntweakedKeypair;
 
 /// Untweaked BIP-340 key pair
-pub type UntweakedKeypair = KeyPair;
+pub type UntweakedKeypair = Keypair;
 
 /// Tweaked BIP-340 key pair
 #[deprecated(since = "0.31.0", note = "use TweakedKeypair instead")]
@@ -524,10 +524,10 @@ pub type TweakedKeyPair = TweakedKeypair;
 /// # Examples
 /// ```
 /// # #[cfg(feature = "rand-std")] {
-/// # use bitcoin::key::{KeyPair, TweakedKeypair, TweakedPublicKey};
+/// # use bitcoin::key::{Keypair, TweakedKeypair, TweakedPublicKey};
 /// # use bitcoin::secp256k1::{rand, Secp256k1};
 /// # let secp = Secp256k1::new();
-/// # let keypair = TweakedKeypair::dangerous_assume_tweaked(KeyPair::new(&secp, &mut rand::thread_rng()));
+/// # let keypair = TweakedKeypair::dangerous_assume_tweaked(Keypair::new(&secp, &mut rand::thread_rng()));
 /// // There are various conversion methods available to get a tweaked pubkey from a tweaked keypair.
 /// let (_pk, _parity) = keypair.public_parts();
 /// let _pk  = TweakedPublicKey::from_keypair(keypair);
@@ -538,7 +538,7 @@ pub type TweakedKeyPair = TweakedKeypair;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct TweakedKeypair(KeyPair);
+pub struct TweakedKeypair(Keypair);
 
 /// A trait for tweaking BIP340 key types (x-only public keys and key pairs).
 pub trait TapTweak {
@@ -548,7 +548,7 @@ pub trait TapTweak {
     type TweakedKey;
 
     /// Tweaks an untweaked key with corresponding public key value and optional script tree merkle
-    /// root. For the [`KeyPair`] type this also tweaks the private key in the pair.
+    /// root. For the [`Keypair`] type this also tweaks the private key in the pair.
     ///
     /// This is done by using the equation Q = P + H(P|c)G, where
     ///  * Q is the tweaked public key
@@ -607,7 +607,7 @@ impl TapTweak for UntweakedKeypair {
     type TweakedAux = TweakedKeypair;
     type TweakedKey = TweakedKeypair;
 
-    /// Tweaks private and public keys within an untweaked [`KeyPair`] with corresponding public key
+    /// Tweaks private and public keys within an untweaked [`Keypair`] with corresponding public key
     /// value and optional script tree merkle root.
     ///
     /// This is done by tweaking private key within the pair using the equation q = p + H(P|c), where
@@ -662,17 +662,17 @@ impl TweakedPublicKey {
 }
 
 impl TweakedKeypair {
-    /// Creates a new [`TweakedKeypair`] from a [`KeyPair`]. No tweak is applied, consider
-    /// calling `tap_tweak` on an [`UntweakedKeyPair`] instead of using this constructor.
+    /// Creates a new [`TweakedKeypair`] from a [`Keypair`]. No tweak is applied, consider
+    /// calling `tap_tweak` on an [`UntweakedKeypair`] instead of using this constructor.
     ///
     /// This method is dangerous and can lead to loss of funds if used incorrectly.
     /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
     #[inline]
-    pub fn dangerous_assume_tweaked(pair: KeyPair) -> TweakedKeypair { TweakedKeypair(pair) }
+    pub fn dangerous_assume_tweaked(pair: Keypair) -> TweakedKeypair { TweakedKeypair(pair) }
 
     /// Returns the underlying key pair.
     #[inline]
-    pub fn to_inner(self) -> KeyPair { self.0 }
+    pub fn to_inner(self) -> Keypair { self.0 }
 
     /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeypair`].
     #[inline]
@@ -687,7 +687,7 @@ impl From<TweakedPublicKey> for XOnlyPublicKey {
     fn from(pair: TweakedPublicKey) -> Self { pair.0 }
 }
 
-impl From<TweakedKeypair> for KeyPair {
+impl From<TweakedKeypair> for Keypair {
     #[inline]
     fn from(pair: TweakedKeypair) -> Self { pair.0 }
 }
@@ -1076,7 +1076,7 @@ mod tests {
         use secp256k1::rand;
 
         let secp = Secp256k1::new();
-        let kp = KeyPair::new(&secp, &mut rand::thread_rng());
+        let kp = Keypair::new(&secp, &mut rand::thread_rng());
 
         let _ = PublicKey::new(kp);
         let _ = PublicKey::new_uncompressed(kp);

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1733,7 +1733,7 @@ mod tests {
             };
 
             // tests
-            let keypair = secp256k1::KeyPair::from_secret_key(secp, &internal_priv_key);
+            let keypair = secp256k1::Keypair::from_secret_key(secp, &internal_priv_key);
             let (internal_key, _parity) = XOnlyPublicKey::from_keypair(&keypair);
             let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
             let tweaked_keypair = keypair.add_xonly_tweak(secp, &tweak.to_scalar()).unwrap();
@@ -1753,7 +1753,7 @@ mod tests {
                 .unwrap();
 
             // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-            let msg = secp256k1::Message::from_slice(sighash.as_byte_array())
+            let msg = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
                 .expect("sighash is 32 bytes long");
             let key_spend_sig = secp.sign_schnorr_with_aux_rand(&msg, &tweaked_keypair, &[0u8; 32]);
 

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -8,7 +8,7 @@
 use core::fmt;
 
 use internals::write_err;
-pub use secp256k1::{self, constants, KeyPair, Parity, Secp256k1, Verification, XOnlyPublicKey};
+pub use secp256k1::{self, constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::prelude::*;
 use crate::sighash::{InvalidSighashTypeError, TapSighashType};

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -407,7 +407,8 @@ impl Psbt {
                 let sighash = cache.legacy_signature_hash(input_index, spk, hash_ty.to_u32())?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }
@@ -418,7 +419,8 @@ impl Psbt {
                     cache.legacy_signature_hash(input_index, script_code, hash_ty.to_u32())?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }
@@ -426,7 +428,8 @@ impl Psbt {
                 let sighash = cache.p2wpkh_signature_hash(input_index, spk, utxo.value, hash_ty)?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }
@@ -436,7 +439,8 @@ impl Psbt {
                     cache.p2wpkh_signature_hash(input_index, redeem_script, utxo.value, hash_ty)?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }
@@ -447,7 +451,8 @@ impl Psbt {
                     cache.p2wsh_signature_hash(input_index, witness_script, utxo.value, hash_ty)?;
                 // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
                 Ok((
-                    Message::from_slice(sighash.as_byte_array()).expect("sighash is 32 bytes long"),
+                    Message::from_digest_slice(sighash.as_byte_array())
+                        .expect("sighash is 32 bytes long"),
                     hash_ty,
                 ))
             }

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -131,7 +131,7 @@ mod message_signing {
             msg_hash: sha256d::Hash,
         ) -> Result<PublicKey, MessageSignatureError> {
             // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-            let msg = secp256k1::Message::from_slice(msg_hash.as_byte_array())
+            let msg = secp256k1::Message::from_digest_slice(msg_hash.as_byte_array())
                 .expect("sh256d hash is 32 bytes long");
 
             let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
@@ -231,7 +231,7 @@ mod tests {
         let message = "rust-bitcoin MessageSignature test";
         let msg_hash = super::signed_msg_hash(message);
         // TODO: After upgrade of secp change this to Message::from_digest(sighash.to_byte_array()).
-        let msg = secp256k1::Message::from_slice(msg_hash.as_byte_array())
+        let msg = secp256k1::Message::from_digest_slice(msg_hash.as_byte_array())
             .expect("sh256d hash is 32 bytes long");
 
         let privkey = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -22,8 +22,6 @@ if cargo --version | grep ${MSRV}; then
     # memcrh 2.6.0 uses edition 2021
     cargo update -p memchr --precise 2.5.0
 
-    cargo update -p bitcoin:0.30.1 --precise 0.30.0
-
     # Build MSRV with pinned versions.
     cargo check --all-features --all-targets
 fi

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { version = "0.30.0", features = [ "serde" ] }
+bitcoin = { version = "0.31.0", features = [ "serde" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -21,7 +21,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { version = "0.30.0", features = [ "serde" ] }
+bitcoin = { version = "0.31.0", features = [ "serde" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
Bump the version number.

Since we[ added the new changelog tool](https://github.com/rust-bitcoin/rust-bitcoin/pull/2050) I'm not totally sure what the release work flow is?

We do not currently have any releases at https://github.com/rust-bitcoin/rust-bitcoin/releases. Perhaps when we tag this commit on master when it merges (eg, `bitcoin-0.31.0`), the new release will auto-magically turn up there? 

My thoughts, to see if they are correct, we intend on keeping`CHANGELOG.md`, and is it just a matter of copying what the CI job creates after the release is tagged and patching the changelog file. I don't see quite how this works because then the changelog changes will not be in the tagged release patch?
