### PR TITLE
ci: fuzz test YAML toolchain future-proof

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -49,7 +49,7 @@ hashes_sha1,
           key: cache-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.65.0
+          toolchain: "1.65.0"
           override: true
           profile: minimal
       - name: fuzz


### PR DESCRIPTION
To avoid YAML automatic parsing of inputs as floats, e.g. [`1.60` being parsed as `1.6`](https://github.com/rust-bitcoin/rust-bitcoin/pull/2109#issuecomment-1751392327), it is best to future-proof the `toolchain` input in CI fuzz testing as a string.