### PR TITLE
ci(fuzz): replace toolchain and runner

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,29 +11,29 @@ on:
 jobs:
   fuzz:
     if: ${{ !github.event.act }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         fuzz_target: [
-bitcoin_outpoint_string,
-bitcoin_deserialize_amount,
-bitcoin_deserialize_transaction,
-bitcoin_deser_net_msg,
-bitcoin_deserialize_address,
-bitcoin_script_bytes_to_asm_fmt,
-bitcoin_deserialize_prefilled_transaction,
-bitcoin_deserialize_witness,
-bitcoin_deserialize_psbt,
-bitcoin_deserialize_block,
-bitcoin_deserialize_script,
-hashes_json,
-hashes_cbor,
-hashes_sha256,
-hashes_ripemd160,
-hashes_sha512_256,
-hashes_sha512,
-hashes_sha1,
+          bitcoin_deser_net_msg,
+          bitcoin_deserialize_address,
+          bitcoin_deserialize_amount,
+          bitcoin_deserialize_block,
+          bitcoin_deserialize_prefilled_transaction,
+          bitcoin_deserialize_psbt,
+          bitcoin_deserialize_script,
+          bitcoin_deserialize_transaction,
+          bitcoin_deserialize_witness,
+          bitcoin_outpoint_string,
+          bitcoin_script_bytes_to_asm_fmt,
+          hashes_cbor,
+          hashes_json,
+          hashes_ripemd160,
+          hashes_sha1,
+          hashes_sha256,
+          hashes_sha512,
+          hashes_sha512_256,
         ]
     steps:
       - name: Install test dependencies
@@ -47,11 +47,9 @@ hashes_sha1,
             fuzz/target
             target
           key: cache-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.65.0"
-          override: true
-          profile: minimal
+          toolchain: '1.65.0'
       - name: fuzz
         run: |
           if [[ "${{ matrix.fuzz_target }}" =~ ^bitcoin ]]; then

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         fuzz_target: [
-          bitcoin_deser_net_msg,
           bitcoin_deserialize_address,
           bitcoin_deserialize_amount,
           bitcoin_deserialize_block,
@@ -25,6 +24,7 @@ jobs:
           bitcoin_deserialize_script,
           bitcoin_deserialize_transaction,
           bitcoin_deserialize_witness,
+          bitcoin_deser_net_msg,
           bitcoin_outpoint_string,
           bitcoin_script_bytes_to_asm_fmt,
           hashes_cbor,
@@ -32,8 +32,8 @@ jobs:
           hashes_ripemd160,
           hashes_sha1,
           hashes_sha256,
-          hashes_sha512,
           hashes_sha512_256,
+          hashes_sha512,
         ]
     steps:
       - name: Install test dependencies

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,73 +17,73 @@ serde_json = "1.0"
 serde_cbor = "0.9"
 
 [[bin]]
-name = "bitcoin_outpoint_string"
-path = "fuzz_targets/bitcoin/outpoint_string.rs"
-
-[[bin]]
-name = "bitcoin_deserialize_amount"
-path = "fuzz_targets/bitcoin/deserialize_amount.rs"
-
-[[bin]]
-name = "bitcoin_deserialize_transaction"
-path = "fuzz_targets/bitcoin/deserialize_transaction.rs"
-
-[[bin]]
 name = "bitcoin_deser_net_msg"
-path = "fuzz_targets/bitcoin/deser_net_msg.rs"
+path = "fuzz_targets//bitcoin/deser_net_msg.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_address"
-path = "fuzz_targets/bitcoin/deserialize_address.rs"
+path = "fuzz_targets//bitcoin/deserialize_address.rs"
 
 [[bin]]
-name = "bitcoin_script_bytes_to_asm_fmt"
-path = "fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs"
-
-[[bin]]
-name = "bitcoin_deserialize_prefilled_transaction"
-path = "fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs"
-
-[[bin]]
-name = "bitcoin_deserialize_witness"
-path = "fuzz_targets/bitcoin/deserialize_witness.rs"
-
-[[bin]]
-name = "bitcoin_deserialize_psbt"
-path = "fuzz_targets/bitcoin/deserialize_psbt.rs"
+name = "bitcoin_deserialize_amount"
+path = "fuzz_targets//bitcoin/deserialize_amount.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_block"
-path = "fuzz_targets/bitcoin/deserialize_block.rs"
+path = "fuzz_targets//bitcoin/deserialize_block.rs"
+
+[[bin]]
+name = "bitcoin_deserialize_prefilled_transaction"
+path = "fuzz_targets//bitcoin/deserialize_prefilled_transaction.rs"
+
+[[bin]]
+name = "bitcoin_deserialize_psbt"
+path = "fuzz_targets//bitcoin/deserialize_psbt.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_script"
-path = "fuzz_targets/bitcoin/deserialize_script.rs"
+path = "fuzz_targets//bitcoin/deserialize_script.rs"
 
 [[bin]]
-name = "hashes_json"
-path = "fuzz_targets/hashes/json.rs"
+name = "bitcoin_deserialize_transaction"
+path = "fuzz_targets//bitcoin/deserialize_transaction.rs"
+
+[[bin]]
+name = "bitcoin_deserialize_witness"
+path = "fuzz_targets//bitcoin/deserialize_witness.rs"
+
+[[bin]]
+name = "bitcoin_outpoint_string"
+path = "fuzz_targets//bitcoin/outpoint_string.rs"
+
+[[bin]]
+name = "bitcoin_script_bytes_to_asm_fmt"
+path = "fuzz_targets//bitcoin/script_bytes_to_asm_fmt.rs"
 
 [[bin]]
 name = "hashes_cbor"
-path = "fuzz_targets/hashes/cbor.rs"
+path = "fuzz_targets//hashes/cbor.rs"
 
 [[bin]]
-name = "hashes_sha256"
-path = "fuzz_targets/hashes/sha256.rs"
+name = "hashes_json"
+path = "fuzz_targets//hashes/json.rs"
 
 [[bin]]
 name = "hashes_ripemd160"
-path = "fuzz_targets/hashes/ripemd160.rs"
-
-[[bin]]
-name = "hashes_sha512_256"
-path = "fuzz_targets/hashes/sha512_256.rs"
-
-[[bin]]
-name = "hashes_sha512"
-path = "fuzz_targets/hashes/sha512.rs"
+path = "fuzz_targets//hashes/ripemd160.rs"
 
 [[bin]]
 name = "hashes_sha1"
-path = "fuzz_targets/hashes/sha1.rs"
+path = "fuzz_targets//hashes/sha1.rs"
+
+[[bin]]
+name = "hashes_sha256"
+path = "fuzz_targets//hashes/sha256.rs"
+
+[[bin]]
+name = "hashes_sha512"
+path = "fuzz_targets//hashes/sha512.rs"
+
+[[bin]]
+name = "hashes_sha512_256"
+path = "fuzz_targets//hashes/sha512_256.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,73 +17,73 @@ serde_json = "1.0"
 serde_cbor = "0.9"
 
 [[bin]]
-name = "bitcoin_deser_net_msg"
-path = "fuzz_targets//bitcoin/deser_net_msg.rs"
-
-[[bin]]
 name = "bitcoin_deserialize_address"
-path = "fuzz_targets//bitcoin/deserialize_address.rs"
+path = "fuzz_targets/bitcoin/deserialize_address.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_amount"
-path = "fuzz_targets//bitcoin/deserialize_amount.rs"
+path = "fuzz_targets/bitcoin/deserialize_amount.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_block"
-path = "fuzz_targets//bitcoin/deserialize_block.rs"
+path = "fuzz_targets/bitcoin/deserialize_block.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_prefilled_transaction"
-path = "fuzz_targets//bitcoin/deserialize_prefilled_transaction.rs"
+path = "fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_psbt"
-path = "fuzz_targets//bitcoin/deserialize_psbt.rs"
+path = "fuzz_targets/bitcoin/deserialize_psbt.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_script"
-path = "fuzz_targets//bitcoin/deserialize_script.rs"
+path = "fuzz_targets/bitcoin/deserialize_script.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_transaction"
-path = "fuzz_targets//bitcoin/deserialize_transaction.rs"
+path = "fuzz_targets/bitcoin/deserialize_transaction.rs"
 
 [[bin]]
 name = "bitcoin_deserialize_witness"
-path = "fuzz_targets//bitcoin/deserialize_witness.rs"
+path = "fuzz_targets/bitcoin/deserialize_witness.rs"
+
+[[bin]]
+name = "bitcoin_deser_net_msg"
+path = "fuzz_targets/bitcoin/deser_net_msg.rs"
 
 [[bin]]
 name = "bitcoin_outpoint_string"
-path = "fuzz_targets//bitcoin/outpoint_string.rs"
+path = "fuzz_targets/bitcoin/outpoint_string.rs"
 
 [[bin]]
 name = "bitcoin_script_bytes_to_asm_fmt"
-path = "fuzz_targets//bitcoin/script_bytes_to_asm_fmt.rs"
+path = "fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs"
 
 [[bin]]
 name = "hashes_cbor"
-path = "fuzz_targets//hashes/cbor.rs"
+path = "fuzz_targets/hashes/cbor.rs"
 
 [[bin]]
 name = "hashes_json"
-path = "fuzz_targets//hashes/json.rs"
+path = "fuzz_targets/hashes/json.rs"
 
 [[bin]]
 name = "hashes_ripemd160"
-path = "fuzz_targets//hashes/ripemd160.rs"
+path = "fuzz_targets/hashes/ripemd160.rs"
 
 [[bin]]
 name = "hashes_sha1"
-path = "fuzz_targets//hashes/sha1.rs"
+path = "fuzz_targets/hashes/sha1.rs"
 
 [[bin]]
 name = "hashes_sha256"
-path = "fuzz_targets//hashes/sha256.rs"
-
-[[bin]]
-name = "hashes_sha512"
-path = "fuzz_targets//hashes/sha512.rs"
+path = "fuzz_targets/hashes/sha256.rs"
 
 [[bin]]
 name = "hashes_sha512_256"
-path = "fuzz_targets//hashes/sha512_256.rs"
+path = "fuzz_targets/hashes/sha512_256.rs"
+
+[[bin]]
+name = "hashes_sha512"
+path = "fuzz_targets/hashes/sha512.rs"

--- a/fuzz/fuzz-util.sh
+++ b/fuzz/fuzz-util.sh
@@ -4,7 +4,7 @@ REPO_DIR=$(git rev-parse --show-toplevel)
 
 listTargetFiles() {
   pushd "$REPO_DIR/fuzz" > /dev/null || exit 1
-  find fuzz_targets/ -type f -name "*.rs"
+  find fuzz_targets/ -type f -name "*.rs" | sort
   popd > /dev/null || exit 1
 }
 
@@ -12,7 +12,8 @@ targetFileToName() {
   echo "$1" \
     | sed 's/^fuzz_targets\///' \
     | sed 's/\.rs$//' \
-    | sed 's/\//_/g'
+    | sed 's/\//_/g' \
+    | sed 's/^_//g'
 }
 
 targetFileToHFuzzInputArg() {


### PR DESCRIPTION
1. Changes the toolchain fom `actions-rs/toolchain` to `dtolnay/rust-toolchain`.
   Closes #2113.
1. Changes the CI runner from `ubuntu-20.04` to `ubuntu-latest`.
   Related #2114.
1. Updates the `fuzz/generate-files.sh` to match `.github/workflows/fuzz.yml`.
   Closes #2115.
