### PR TITLE
Update bech32 dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -16,9 +16,9 @@ checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-alpha"
+version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cc1dec4c25e5a78c52802eda8e2adf0d2aca57ffc536326b75c0e531ea0a9b"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bincode"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -16,9 +16,9 @@ checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-alpha"
+version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cc1dec4c25e5a78c52802eda8e2adf0d2aca57ffc536326b75c0e531ea0a9b"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bincode"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -36,7 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 internals = { package = "bitcoin-internals", version = "0.2.0" }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
-bech32 = { version = "0.10.0-alpha", default-features = false }
+bech32 = { version = "0.10.0-beta", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
 hex_lit = "0.1.1"

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -103,7 +103,7 @@ pub enum ParseError {
     /// Base58 error.
     Base58(base58::Error),
     /// Bech32 segwit decoding error.
-    Bech32(bech32::primitives::decode::SegwitHrpstringError),
+    Bech32(bech32::segwit::DecodeError),
     /// A witness version conversion/parsing error.
     WitnessVersion(witness_version::TryFromError),
     /// A witness program error.
@@ -141,8 +141,8 @@ impl From<base58::Error> for ParseError {
     fn from(e: base58::Error) -> Self { Self::Base58(e) }
 }
 
-impl From<bech32::primitives::decode::SegwitHrpstringError> for ParseError {
-    fn from(e: bech32::primitives::decode::SegwitHrpstringError) -> Self { Self::Bech32(e) }
+impl From<bech32::segwit::DecodeError> for ParseError {
+    fn from(e: bech32::segwit::DecodeError) -> Self { Self::Bech32(e) }
 }
 
 impl From<witness_version::TryFromError> for ParseError {

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -264,9 +264,9 @@ impl<'a> fmt::Display for AddressEncoding<'a> {
                 let program = witness_program.program().as_bytes();
 
                 if fmt.alternate() {
-                    bech32::segwit::encode_to_fmt_unchecked_uppercase(fmt, hrp, version, program)
+                    bech32::segwit::encode_upper_to_fmt_unchecked(fmt, hrp, version, program)
                 } else {
-                    bech32::segwit::encode_to_fmt_unchecked(fmt, hrp, version, program)
+                    bech32::segwit::encode_lower_to_fmt_unchecked(fmt, hrp, version, program)
                 }
             }
         }


### PR DESCRIPTION
Update the `bech32` dependency to use the newly release beta version.

The main fix here is silent, a bug fix in `bech32` that was being hit by our fuzzing suite.