### PR TITLE
Tracking PR for release `v0.31.0-rc1`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.30.0"
+version = "0.31.0-rc1"
 dependencies = [
  "base64",
  "bech32",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.30.0"
+version = "0.31.0-rc1"
 dependencies = [
  "base64",
  "bech32",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.30.0"
+version = "0.31.0-rc1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -22,8 +22,6 @@ if cargo --version | grep ${MSRV}; then
     # byteorder 1.5.0 uses edition 2021
     cargo update -p byteorder --precise 1.4.3
 
-    cargo update -p bitcoin:0.30.1 --precise 0.30.0
-
     # Build MSRV with pinned versions.
     cargo check --all-features --all-targets
 fi

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { version = "0.30.0", features = [ "serde" ] }
+bitcoin = { version = "0.31.0-rc1", features = [ "serde" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -21,7 +21,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { version = "0.30.0", features = [ "serde" ] }
+bitcoin = { version = "0.31.0-rc1", features = [ "serde" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
Lets go!

As discussed in #2099 we are going to do RC releases for this release. This PR is for the first one, as such it does not include changelog entries, we are going to try out using the new github action to create those. 
