### PR TITLE
Do not enable "core2" feature from `hex-conservative`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -146,9 +146,6 @@ name = "hex-conservative"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
-dependencies = [
- "core2",
-]
 
 [[package]]
 name = "hex_lit"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -145,9 +145,6 @@ name = "hex-conservative"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
-dependencies = [
- "core2",
-]
 
 [[package]]
 name = "hex_lit"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -27,7 +27,7 @@ bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
 std = ["secp256k1/std", "hashes/std", "bech32/std", "internals/std", "hex/std"]
-no-std = ["core2", "hashes/alloc", "hashes/core2", "bech32/alloc", "secp256k1/alloc", "hex/alloc", "hex/core2"]
+no-std = ["core2", "hashes/alloc", "hashes/core2", "bech32/alloc", "secp256k1/alloc", "hex/alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -18,7 +18,7 @@ std = ["alloc", "hex/std"]
 alloc = ["hex/alloc"]
 serde-std = ["serde/std"]
 # If you want I/O you must enable either "std" or "core2".
-core2 = ["actual-core2", "hex/core2"]
+core2 = ["actual-core2"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
 


### PR DESCRIPTION
We do not require the `hex-conservative` "core2" feature to be enabled.

Remove the "core2" feature from the `hex` dependency and update the recent/minimal lock files to reflect this.