### PR TITLE
hashes: Improve crate ergonomics 

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -39,3 +39,7 @@ actual-core2 = { package = "core2", version = "0.3.2", default-features = false,
 [dev-dependencies]
 serde_test = "1.0"
 serde_json = "1.0"
+
+[[example]]
+name = "hash-a-file"
+required-features = ["std"]

--- a/hashes/examples/hash-a-file.rs
+++ b/hashes/examples/hash-a-file.rs
@@ -1,0 +1,22 @@
+//! Use `bitcoin_hashes` to sha256 hash the contents of a file.
+
+use std::io::{self, BufRead};
+
+use bitcoin_hashes::{sha256, Hash as _, HashEngine as _};
+
+const FILE: &str = "a mock text file \n a line of text \n and another one \n";
+
+fn main() {
+    // This would usually be BufReader::new(File::open(path)?);
+    let reader = io::Cursor::new(&FILE);
+
+    let mut engine = sha256::Hash::engine();
+
+    for line in reader.lines() {
+        let line = line.expect("line read failed");
+        engine.input(line.as_bytes());
+    }
+    let hash = sha256::Hash::from_engine(engine);
+
+    println!("\n\t{}", hash);
+}

--- a/hashes/examples/hash-a-file.rs
+++ b/hashes/examples/hash-a-file.rs
@@ -10,14 +10,13 @@ const FILE: &str = "a mock text file \n a line of text \n and another one \n";
 fn main() {
     // This would usually be BufReader::new(File::open(path)?);
     let reader = io::Cursor::new(&FILE);
-
-    let mut engine = sha256::Hash::engine();
+    let mut engine = sha256::engine();
 
     for line in reader.lines() {
         let line = line.expect("line read failed");
         engine.input(line.as_bytes());
     }
-    let hash = sha256::Hash::from_engine(engine);
+    let hash = engine.extract();
 
     println!("\n\t{}", hash);
 }

--- a/hashes/examples/hash-a-file.rs
+++ b/hashes/examples/hash-a-file.rs
@@ -2,7 +2,8 @@
 
 use std::io::{self, BufRead};
 
-use bitcoin_hashes::{sha256, Hash as _, HashEngine as _};
+use bitcoin_hashes::prelude::*;
+use bitcoin_hashes::sha256;
 
 const FILE: &str = "a mock text file \n a line of text \n and another one \n";
 

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -12,7 +12,8 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::str;
 
-use crate::{ripemd160, sha256, FromSliceError};
+use crate::prelude::*;
+use crate::{ripemd160, sha256};
 
 crate::internal_macros::hash_type! {
     160,
@@ -20,6 +21,31 @@ crate::internal_macros::hash_type! {
     "Output of the Bitcoin HASH160 hash function. (RIPEMD160(SHA256))",
     "crate::util::json_hex_string::len_20"
 }
+
+/// Creates a HASH160 hash engine.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{hash160, prelude::*};
+///
+/// // Hash bytes with an engine, `engine.input()` can be called in a loop.
+/// let mut engine = hash160::engine();
+/// engine.input(b"some bytes for the hash engine");
+/// let hash = engine.extract();
+/// ```
+pub fn engine() -> HashEngine { Hash::engine() }
+
+/// Hashes some `bytes`.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{hash160, prelude::*};
+/// let hash = hash160::hash(b"hash this byte string").to_string();
+/// assert_eq!(hash, "cf0f12e3599bb7a4037562a44d09870fc1f2799f");
+/// ```
+pub fn hash(bytes: &[u8]) -> Hash { Hash::hash(bytes) }
 
 type HashEngine = sha256::HashEngine;
 

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -11,58 +11,71 @@
 //!
 //! Hashing a single byte slice or a string:
 //!
-//! ```rust
-//! use bitcoin_hashes::sha256;
-//! use bitcoin_hashes::Hash;
+//! ```
+//! use bitcoin_hashes::{sha1, prelude::*};
 //!
 //! let bytes = [0u8; 5];
-//! let hash_of_bytes = sha256::Hash::hash(&bytes);
-//! let hash_of_string = sha256::Hash::hash("some string".as_bytes());
+//! let hash_of_bytes = sha1::hash(&bytes);
+//! let hash_of_string = sha1::hash("some string".as_bytes());
+//! ```
+//!
+//!
+//! Hashing multiple byte slices:
+//!
+//! ```no_run
+//! # #[cfg(feature = "std")] {
+//! use std::io::{self, BufRead};
+//! use bitcoin_hashes::{sha256, prelude::*};
+//!
+//! const FILE: &str = "path/to/file";
+//! let reader = io::Cursor::new(&FILE); // In real code, this could be a `File` or `TcpStream`.
+//! let mut engine = sha256::engine();
+//!
+//! for line in reader.lines() {
+//!     let line = line.expect("line read failed");
+//!     engine.input(line.as_bytes());
+//! }
+//! let hash = engine.extract();
+//! # }
 //! ```
 //!
 //!
 //! Hashing content from a reader:
 //!
-//! ```rust
-//! use bitcoin_hashes::sha256;
-//! use bitcoin_hashes::Hash;
-//!
-//! #[cfg(std)]
+//! ```
 //! # fn main() -> std::io::Result<()> {
-//! let mut reader: &[u8] = b"hello"; // in real code, this could be a `File` or `TcpStream`
-//! let mut engine = sha256::HashEngine::default();
-//! std::io::copy(&mut reader, &mut engine)?;
-//! let hash = sha256::Hash::from_engine(engine);
-//! # Ok(())
-//! # }
+//! # #[cfg(feature = "std")] {
+//! use bitcoin_hashes::{ripemd160, prelude::*};
 //!
-//! #[cfg(not(std))]
-//! # fn main() {}
+//! let mut reader: &[u8] = b"hello"; // In real code, this could be a `File` or `TcpStream`.
+//! let mut engine = ripemd160::engine();
+//! std::io::copy(&mut reader, &mut engine).expect("handle error");
+//! let hash = engine.extract();
+//! # Ok(()) }
+//! # #[cfg(not(feature = "std"))] { fn main()  {} }}
 //! ```
 //!
 //!
-//! Hashing content by [`std::io::Write`] on HashEngine:
+//! Hashing content using [`std::io::Write`]:
 //!
-//! ```rust
-//! use bitcoin_hashes::sha256;
-//! use bitcoin_hashes::Hash;
-//! use std::io::Write;
-//!
-//! #[cfg(std)]
+//! ```
 //! # fn main() -> std::io::Result<()> {
+//! # #[cfg(feature = "std")] {
+//! use std::io::Write;
+//! use bitcoin_hashes::{sha512, prelude::*};
+//!
 //! let mut part1: &[u8] = b"hello";
 //! let mut part2: &[u8] = b" ";
 //! let mut part3: &[u8] = b"world";
-//! let mut engine = sha256::HashEngine::default();
-//! engine.write_all(part1)?;
-//! engine.write_all(part2)?;
-//! engine.write_all(part3)?;
-//! let hash = sha256::Hash::from_engine(engine);
-//! # Ok(())
-//! # }
+//! let mut engine = sha512::HashEngine::default();
 //!
-//! #[cfg(not(std))]
-//! # fn main() {}
+//! engine.write_all(part1).expect("handle error");
+//! engine.write_all(part2).expect("handle error");
+//! engine.write_all(part3).expect("handle error");
+//!
+//! let hash = engine.extract();
+//! # Ok(()) }
+//! # #[cfg(not(feature = "std"))] { fn main()  {} }}
 //! ```
 
 // Coding conventions

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -106,6 +106,13 @@ pub mod _export {
     }
 }
 
+/// Re-export common traits/types.
+///
+/// Enables downstream users to import with: `use hashes::prelude::*`;
+pub mod prelude {
+    pub use crate::{FromSliceError, Hash as _, HashEngine as _};
+}
+
 #[cfg(feature = "schemars")]
 extern crate schemars;
 

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -142,6 +142,7 @@ use std::io;
 
 #[cfg(all(not(test), not(feature = "std"), feature = "core2"))]
 use core2::io;
+#[doc(inline)]
 pub use hmac::{Hmac, HmacEngine};
 
 /// A hashing engine which bytes can be serialized into.

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -8,7 +8,7 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};
 
-use crate::{FromSliceError, HashEngine as _};
+use crate::prelude::*;
 
 crate::internal_macros::hash_type! {
     160,
@@ -16,6 +16,31 @@ crate::internal_macros::hash_type! {
     "Output of the RIPEMD160 hash function.",
     "crate::util::json_hex_string::len_20"
 }
+
+/// Creates a RIPEMD160 hash engine.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{ripemd160, prelude::*};
+///
+/// // Hash bytes with an engine, `engine.input()` can be called in a loop.
+/// let mut engine = ripemd160::engine();
+/// engine.input(b"some bytes for the hash engine");
+/// let _hash = engine.extract();
+/// ```
+pub fn engine() -> HashEngine { Hash::engine() }
+
+/// Hashes some `bytes`.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{ripemd160, prelude::*};
+/// let hash = ripemd160::hash(b"hash this byte string").to_string();
+/// assert_eq!(hash, "6ff070a19bb860169c0b4074dc97f166735f521e");
+/// ```
+pub fn hash(bytes: &[u8]) -> Hash { Hash::hash(bytes) }
 
 #[cfg(not(hashes_fuzz))]
 fn from_engine(mut e: HashEngine) -> Hash {
@@ -52,6 +77,11 @@ pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],
     length: usize,
+}
+
+impl HashEngine {
+    /// Extracts a hash from the current state of this engine.
+    pub fn extract(self) -> Hash { from_engine(self) }
 }
 
 impl Default for HashEngine {

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -8,7 +8,7 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};
 
-use crate::{FromSliceError, HashEngine as _};
+use crate::prelude::*;
 
 crate::internal_macros::hash_type! {
     160,
@@ -16,6 +16,31 @@ crate::internal_macros::hash_type! {
     "Output of the SHA1 hash function.",
     "crate::util::json_hex_string::len_20"
 }
+
+/// Creates a SHA1 hash engine.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha1, prelude::*};
+///
+/// // Hash bytes with an engine, `engine.input()` can be called in a loop.
+/// let mut engine = sha1::engine();
+/// engine.input(b"some bytes for the hash engine");
+/// let _hash = engine.extract();
+/// ```
+pub fn engine() -> HashEngine { Hash::engine() }
+
+/// Hashes some `bytes`.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha1, prelude::*};
+/// let hash = sha1::hash(b"hash this byte string").to_string();
+/// assert_eq!(hash, "af12d71a1227018e1ccdcb8e2d96853268a6e69d");
+/// ```
+pub fn hash(bytes: &[u8]) -> Hash { Hash::hash(bytes) }
 
 fn from_engine(mut e: HashEngine) -> Hash {
     // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
@@ -44,6 +69,11 @@ pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],
     length: usize,
+}
+
+impl HashEngine {
+    /// Extracts a hash from the current state of this engine.
+    pub fn extract(self) -> Hash { from_engine(self) }
 }
 
 impl Default for HashEngine {

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -12,7 +12,8 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};
 
-use crate::{hex, sha256d, FromSliceError, HashEngine as _};
+use crate::prelude::*;
+use crate::{hex, sha256d};
 
 crate::internal_macros::hash_type! {
     256,
@@ -20,6 +21,31 @@ crate::internal_macros::hash_type! {
     "Output of the SHA256 hash function.",
     "crate::util::json_hex_string::len_32"
 }
+
+/// Creates a SHA256 hash engine.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha256, prelude::*};
+///
+/// // Hash bytes with an engine, `engine.input()` can be called in a loop.
+/// let mut engine = sha256::engine();
+/// engine.input(b"some bytes for the hash engine");
+/// let _hash = engine.extract();
+/// ```
+pub fn engine() -> HashEngine { Hash::engine() }
+
+/// Hashes some `bytes`.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha256, prelude::*};
+/// let hash = sha256::hash(b"hash this byte string").to_string();
+/// assert_eq!(hash, "0d5f977936baa4e27c8a5b910ba30ef200c5b97c81460e681f2811e226899d73");
+/// ```
+pub fn hash(bytes: &[u8]) -> Hash { Hash::hash(bytes) }
 
 #[cfg(not(hashes_fuzz))]
 fn from_engine(mut e: HashEngine) -> Hash {
@@ -60,6 +86,11 @@ pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 8],
     length: usize,
+}
+
+impl HashEngine {
+    /// Extracts a hash from the current state of this engine.
+    pub fn extract(self) -> Hash { from_engine(self) }
 }
 
 impl Default for HashEngine {

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -7,7 +7,8 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::str;
 
-use crate::{sha256, FromSliceError};
+use crate::prelude::*;
+use crate::sha256;
 
 crate::internal_macros::hash_type! {
     256,
@@ -17,6 +18,31 @@ crate::internal_macros::hash_type! {
 }
 
 type HashEngine = sha256::HashEngine;
+
+/// Creates a SHA256d hash engine.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha256d, prelude::*};
+///
+/// // Hash bytes with an engine, `engine.input()` can be called in a loop.
+/// let mut engine = sha256d::engine();
+/// engine.input(b"some bytes for the hash engine");
+/// let _hash = engine.extract();
+/// ```
+pub fn engine() -> HashEngine { Hash::engine() }
+
+/// Hashes some `bytes`.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha256d, prelude::*};
+/// let hash = sha256d::hash(b"hash this byte string").to_string();
+/// assert_eq!(hash, "f543037d673edeef100f08023204165d0eadec58dc407a3cf06e549fb21c00c2");
+/// ```
+pub fn hash(bytes: &[u8]) -> Hash { Hash::hash(bytes) }
 
 fn from_engine(e: sha256::HashEngine) -> Hash {
     use crate::Hash as _;

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -8,7 +8,7 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};
 
-use crate::{FromSliceError, HashEngine as _};
+use crate::prelude::*;
 
 crate::internal_macros::hash_trait_impls!(512, false);
 
@@ -31,6 +31,31 @@ impl Hash {
 
     fn internal_engine() -> HashEngine { Default::default() }
 }
+
+/// Creates a SHA512 hash engine.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha512, prelude::*};
+///
+/// // Hash bytes with an engine, `engine.input()` can be called in a loop.
+/// let mut engine = sha512::engine();
+/// engine.input(b"some bytes for the hash engine");
+/// let _hash = engine.extract();
+/// ```
+pub fn engine() -> HashEngine { Hash::engine() }
+
+/// Hashes some `bytes`.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha512, prelude::*};
+/// let hash = sha512::hash(b"hash this byte string").to_string();
+/// assert_eq!(hash, "ef5dfe5df933b10e1faac13c2d73a311b3eccdec3425599c9c71ebedcaf73de9f173887d5d5aae7c00abfc933e7ab83c44c15c66f8a887c07ce418aa70e70f38");
+/// ```
+pub fn hash(bytes: &[u8]) -> Hash { Hash::hash(bytes) }
 
 #[cfg(not(hashes_fuzz))]
 pub(crate) fn from_engine(mut e: HashEngine) -> Hash {
@@ -66,6 +91,11 @@ pub struct HashEngine {
     h: [u64; 8],
     length: usize,
     buffer: [u8; BLOCK_SIZE],
+}
+
+impl HashEngine {
+    /// Extracts a hash from the current state of this engine.
+    pub fn extract(self) -> Hash { from_engine(self) }
 }
 
 impl Default for HashEngine {

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -14,6 +14,52 @@ crate::internal_macros::hash_trait_impls!(512, false);
 
 pub(crate) const BLOCK_SIZE: usize = 128;
 
+/// Output of the SHA512 hash function.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
+pub struct Hash(
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(schema_with = "crate::util::json_hex_string::len_64")
+    )]
+    [u8; 64],
+);
+
+impl Hash {
+    fn internal_new(arr: [u8; 64]) -> Self { Hash(arr) }
+
+    fn internal_engine() -> HashEngine { Default::default() }
+}
+
+#[cfg(not(hashes_fuzz))]
+pub(crate) fn from_engine(mut e: HashEngine) -> Hash {
+    // pad buffer with a single 1-bit then all 0s, until there are exactly 16 bytes remaining
+    let data_len = e.length as u64;
+
+    let zeroes = [0; BLOCK_SIZE - 16];
+    e.input(&[0x80]);
+    if e.length % BLOCK_SIZE > zeroes.len() {
+        e.input(&zeroes);
+    }
+    let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
+    e.input(&zeroes[..pad_length]);
+    debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
+
+    e.input(&[0; 8]);
+    e.input(&(8 * data_len).to_be_bytes());
+    debug_assert_eq!(e.length % BLOCK_SIZE, 0);
+
+    Hash(e.midstate())
+}
+
+#[cfg(hashes_fuzz)]
+pub(crate) fn from_engine(e: HashEngine) -> Hash {
+    let mut hash = e.midstate();
+    hash[0] ^= 0xff; // Make this distinct from SHA-256
+    Hash(hash)
+}
+
 /// Engine to compute SHA512 hash function.
 #[derive(Clone)]
 pub struct HashEngine {
@@ -75,52 +121,6 @@ impl crate::HashEngine for HashEngine {
     fn n_bytes_hashed(&self) -> usize { self.length }
 
     engine_input_impl!();
-}
-
-/// Output of the SHA512 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[repr(transparent)]
-pub struct Hash(
-    #[cfg_attr(
-        feature = "schemars",
-        schemars(schema_with = "crate::util::json_hex_string::len_64")
-    )]
-    [u8; 64],
-);
-
-impl Hash {
-    fn internal_new(arr: [u8; 64]) -> Self { Hash(arr) }
-
-    fn internal_engine() -> HashEngine { Default::default() }
-}
-
-#[cfg(not(hashes_fuzz))]
-pub(crate) fn from_engine(mut e: HashEngine) -> Hash {
-    // pad buffer with a single 1-bit then all 0s, until there are exactly 16 bytes remaining
-    let data_len = e.length as u64;
-
-    let zeroes = [0; BLOCK_SIZE - 16];
-    e.input(&[0x80]);
-    if e.length % BLOCK_SIZE > zeroes.len() {
-        e.input(&zeroes);
-    }
-    let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
-    e.input(&zeroes[..pad_length]);
-    debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
-
-    e.input(&[0; 8]);
-    e.input(&(8 * data_len).to_be_bytes());
-    debug_assert_eq!(e.length % BLOCK_SIZE, 0);
-
-    Hash(e.midstate())
-}
-
-#[cfg(hashes_fuzz)]
-pub(crate) fn from_engine(e: HashEngine) -> Hash {
-    let mut hash = e.midstate();
-    hash[0] ^= 0xff; // Make this distinct from SHA-256
-    Hash(hash)
 }
 
 #[allow(non_snake_case)]

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -13,6 +13,19 @@ use core::str;
 
 use crate::{sha512, FromSliceError};
 
+crate::internal_macros::hash_type! {
+    256,
+    false,
+    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>. ",
+    "crate::util::json_hex_string::len_32"
+}
+
+fn from_engine(e: HashEngine) -> Hash {
+    let mut ret = [0; 32];
+    ret.copy_from_slice(&sha512::from_engine(e.0)[..32]);
+    Hash(ret)
+}
+
 /// Engine to compute SHA512/256 hash function.
 ///
 /// SHA512/256 is a hash function that uses the sha512 alogrithm but it truncates
@@ -39,19 +52,6 @@ impl crate::HashEngine for HashEngine {
     fn n_bytes_hashed(&self) -> usize { self.0.n_bytes_hashed() }
 
     fn input(&mut self, inp: &[u8]) { self.0.input(inp); }
-}
-
-crate::internal_macros::hash_type! {
-    256,
-    false,
-    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>. ",
-    "crate::util::json_hex_string::len_32"
-}
-
-fn from_engine(e: HashEngine) -> Hash {
-    let mut ret = [0; 32];
-    ret.copy_from_slice(&sha512::from_engine(e.0)[..32]);
-    Hash(ret)
 }
 
 #[cfg(test)]

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -11,7 +11,8 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::str;
 
-use crate::{sha512, FromSliceError};
+use crate::prelude::*;
+use crate::sha512;
 
 crate::internal_macros::hash_type! {
     256,
@@ -19,6 +20,31 @@ crate::internal_macros::hash_type! {
     "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>. ",
     "crate::util::json_hex_string::len_32"
 }
+
+/// Creates a SHA512_256 hash engine.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha512_256, prelude::*};
+///
+/// // Hash bytes with an engine, `engine.input()` can be called in a loop.
+/// let mut engine = sha512_256::engine();
+/// engine.input(b"some bytes for the hash engine");
+/// let _hash = engine.extract();
+/// ```
+pub fn engine() -> HashEngine { Hash::engine() }
+
+/// Hashes some `bytes`.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{sha512_256, prelude::*};
+/// let hash = sha512_256::hash(b"hash this byte string").to_string();
+/// assert_eq!(hash, "f345af7e31cf0f2dffb5510f7bf2d606c64926ec3ae7a93b53897c31dfbcb895");
+/// ```
+pub fn hash(bytes: &[u8]) -> Hash { Hash::hash(bytes) }
 
 fn from_engine(e: HashEngine) -> Hash {
     let mut ret = [0; 32];
@@ -34,6 +60,11 @@ fn from_engine(e: HashEngine) -> Hash {
 /// <https://eprint.iacr.org/2010/548.pdf>.
 #[derive(Clone)]
 pub struct HashEngine(sha512::HashEngine);
+
+impl HashEngine {
+    /// Extracts a hash from the current state of this engine.
+    pub fn extract(self) -> Hash { from_engine(self) }
+}
 
 impl Default for HashEngine {
     #[rustfmt::skip]

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -7,7 +7,7 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, mem, ptr, str};
 
-use crate::{FromSliceError, Hash as _, HashEngine as _};
+use crate::prelude::*;
 
 crate::internal_macros::hash_type! {
     64,
@@ -15,6 +15,31 @@ crate::internal_macros::hash_type! {
     "Output of the SipHash24 hash function.",
     "crate::util::json_hex_string::len_8"
 }
+
+/// Creates a SIPHASH24 hash engine.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{siphash24, prelude::*};
+///
+/// // Hash bytes with an engine, `engine.input()` can be called in a loop.
+/// let mut engine = siphash24::engine();
+/// engine.input(b"some bytes for the hash engine");
+/// let _hash = engine.extract();
+/// ```
+pub fn engine() -> HashEngine { Hash::engine() }
+
+/// Hashes some `bytes`.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin_hashes::{siphash24, prelude::*};
+/// let hash = siphash24::hash(b"hash this byte string").to_string();
+/// assert_eq!(hash, "a959da88f2a364c1");
+/// ```
+pub fn hash(bytes: &[u8]) -> Hash { Hash::hash(bytes) }
 
 #[cfg(not(hashes_fuzz))]
 fn from_engine(e: HashEngine) -> Hash { Hash::from_u64(Hash::from_engine_to_u64(e)) }
@@ -112,6 +137,9 @@ impl HashEngine {
 
     /// Retrieves the keys of this engine.
     pub fn keys(&self) -> (u64, u64) { (self.k0, self.k1) }
+
+    /// Extracts a hash from the current state of this engine.
+    pub fn extract(self) -> Hash { from_engine(self) }
 
     #[inline]
     fn c_rounds(state: &mut State) {


### PR DESCRIPTION
Make an effort to improve the ergonomics and docs of the `hashes` crate.

Add stand alone functions to each of the hash types (excl. `Hmac`) as well as an `HashEngine::extract` method to enable the following:

```rust
use bitcoin_hashes::prelude::*;

fn foo() {
    let mut engine = sha1::engine();
    engine.input(b"some stuff");
    let hash = engine.extract();
    ...
}
``` 

(PR includes the prelude thing and a bunch of rustdocs improvements. Can split the changes out if required.)