### PR TITLE
Add clippy exceptions for needless_question_mark lint

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -38,6 +38,8 @@
 #![warn(missing_docs)]
 // Instead of littering the codebase for non-fuzzing code just globally allow.
 #![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
+// Exclude clippy lints we don't think are valuable
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 
 #[cfg(not(any(feature = "std", feature = "no-std")))]
 compile_error!("at least one of the `std` or `no-std` features must be enabled");

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -78,6 +78,8 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 // Instead of littering the codebase for non-fuzzing code just globally allow.
 #![cfg_attr(hashes_fuzz, allow(dead_code, unused_imports))]
+// Exclude clippy lints we don't think are valuable
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 
 #[cfg(all(not(test), not(feature = "std"), feature = "core2"))]
 extern crate actual_core2 as core2;

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -11,6 +11,8 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions
 #![warn(missing_docs)]
+// Exclude clippy lints we don't think are valuable
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
This lint forces you to write semantically different code that is in most cases inferior, just to save you 5 characters.

The reason why the code is inferior is because it doesn't do error conversion so it would break when either of the two function signatures changes while in the original code using the `?` operator, nothing would break if the inner error can be converted into the outer error.