### PR TITLE
ci: automated nightly rustfmt scheduled/manual PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - name: Running test script
         env:
-          DO_FMT: true
+          DO_FMT: false
           DO_BENCH: true
           AS_DEPENDENCY: false
           DO_NO_STD: true

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,26 @@
+name: Nightly rustfmt
+on:
+  schedule:
+    - cron: "0 0 * * 0" # runs weekly on Sunday at 00:00
+  workflow_dispatch: # allows manual triggering
+jobs:
+  format:
+    name: Nightly rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - name: Run Nightly rustfmt
+        run: cargo +nightly fmt
+      - name: Get the current date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: Automated nightly rustfmt (${{ env.date }})
+          body: |
+           Automated nightly `rustfmt` changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+          commit-message: ${{ env.date }} automated rustfmt nightly 
+          labels: rustfmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,12 +195,6 @@ any of the following conditions:
 
 Library reflects Bitcoin Core approach whenever possible.
 
-### Formatting
-
-The repository currently uses `rustfmt` (WIP, some directories are excluded). We use nightly
-features so to run the formatter use `cargo +nightly fmt`. (Remember that your editor may be
-configured to fmt with a stable toolchain, this will result in many unwanted changes.)
-
 ### Naming conventions
 
 Naming of data structures/enums and their fields/variants must follow names used


### PR DESCRIPTION
## Summary

- Removes nightly `rustfmt` checks from CI and `CONTRIBUTING.md`. Superseds #2127
- Adds automated nightly `rustfmt` PR creations manual and every Sunday 00:00 UTC. Closes #2128. Closes #1712.

## Details

The new `.github/workflows/rustfmt.yml` action does the following:

1. Checkouts the repo
1. Install the nightly Rust toolchain with `rustfmt` component
1. Run `cargo +nightly fmt` which format all the codebase with the nightly Rust toolchain writing the changes
1. Add the current date in `YYYY-MM-DD` format as an GH action ENV var
1. If changes are detected, create a PR with the following details:
    - Title: Automated nightly rustfmt (`DATE`)
    - Body: Automated nightly `rustfmt` changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
    - Commit message: `DATE` automated rustfmt nightly
    - label: `rustfmt`

I did a test run (with `workflow_dispatch` and some minor changes to trigger the PR) in my fork.
Check how the PR looks in https://github.com/realeinherjar/rust-bitcoin/pull/5
Of course, all of these things can be changed.
They are all suggestions...

## Security Disclaimer

We are only introducing a new action, which is quite battle-checked, [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) with ~2k stars and proper maintained.