### PR TITLE
Remove several unnecessary clippy attributes

### DIFF
--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -66,7 +66,6 @@ pub const LOCK_TIME_THRESHOLD: u32 = 500_000_000;
 ///     _ => panic!("handle invalid comparison error"),
 /// };
 /// ```
-#[allow(clippy::derive_ord_xor_partial_ord)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LockTime {
     /// A block height lock time value.

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -26,7 +26,6 @@ use crate::relative;
 ///
 /// * [BIP 68 Relative lock-time using consensus-enforced sequence numbers](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
 /// * [BIP 112 CHECKSEQUENCEVERIFY](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki)
-#[allow(clippy::derive_ord_xor_partial_ord)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1237,7 +1237,6 @@ impl<E> EncodeSigningDataResult<E> {
     ///     // use a hash value of "1", instead of computing the actual hash due to SIGHASH_SINGLE bug
     /// }
     /// ```
-    #[allow(clippy::wrong_self_convention)] // E is not Copy so we consume self.
     pub fn is_sighash_single_bug(self) -> Result<bool, E> {
         match self {
             EncodeSigningDataResult::SighashSingleBug => Ok(true),


### PR DESCRIPTION
Am I missing something and are they necessary in some other clippy configuration than the one I ran?

It's surprising really that clippy doesn't have a lint to notice unnecessary clippy exception attributes..