### PR TITLE
bitcoin: Tracking PR for release `v0.31.0` 

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.31.0-rc2"
+version = "0.31.0"
 dependencies = [
  "base64",
  "bech32",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.31.0-rc2"
+version = "0.31.0"
 dependencies = [
  "base64",
  "bech32",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.31.0-rc2"
+version = "0.31.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { version = "0.31.0-rc2", features = [ "serde" ] }
+bitcoin = { version = "0.31.0", features = [ "serde" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -21,7 +21,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { version = "0.31.0-rc2", features = [ "serde" ] }
+bitcoin = { version = "0.31.0", features = [ "serde" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
In preparation for release of v0.31.0 bump the version number.

The changelog is already up to date because we have done two RC releases.
