### PR TITLE
Fix a small typo in 'contrib/test.sh'

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -17,7 +17,7 @@ if cargo --version | grep ${MSRV}; then
     cargo update -p schemars --precise 0.8.12
     # schemars_derive 0.8.13 uses edition 2021
     cargo update -p schemars_derive --precise 0.8.12
-    # memcrh 2.6.0 uses edition 2021
+    # memchr 2.6.0 uses edition 2021
     cargo update -p memchr --precise 2.5.0
     # byteorder 1.5.0 uses edition 2021
     cargo update -p byteorder --precise 1.4.3


### PR DESCRIPTION
`memcrh` -> `memchr`