### PR TITLE
Build script sanity check

### DIFF
--- a/internals/build.rs
+++ b/internals/build.rs
@@ -24,9 +24,7 @@ fn main() {
         .parse::<u64>()
         .expect("invalid Rust minor version");
 
-    // print cfg for all interesting versions less than or equal to minor
-    // 55 adds `kind()` to `ParseIntError`
-    for version in &[55] {
+    for version in &[53, 55, 60] {
         if *version <= minor {
             println!("cargo:rustc-cfg=rust_v_1_{}", version);
         }

--- a/internals/build.rs
+++ b/internals/build.rs
@@ -25,9 +25,8 @@ fn main() {
         .expect("invalid Rust minor version");
 
     // print cfg for all interesting versions less than or equal to minor
-    // 46 adds `track_caller`
     // 55 adds `kind()` to `ParseIntError`
-    for version in &[46, 55] {
+    for version in &[55] {
         if *version <= minor {
             println!("cargo:rustc-cfg=rust_v_1_{}", version);
         }


### PR DESCRIPTION
Propose adding a sanity check so that the cfg versions in the source code are synchronized with the versions declared in `build.rs`.  If either the build.rs or the cfg attributes in the project source are out of sync, then panic before building.