### PR TITLE
Create uniform build script

### DIFF
--- a/internals/build.rs
+++ b/internals/build.rs
@@ -1,3 +1,5 @@
+const MSRV_MINOR: u64 = 48;
+
 fn main() {
     let rustc = std::env::var_os("RUSTC");
     let rustc = rustc.as_ref().map(std::path::Path::new).unwrap_or_else(|| "rustc".as_ref());
@@ -25,11 +27,7 @@ fn main() {
         .expect("invalid Rust minor version");
 
     // print cfg for all interesting versions less than or equal to minor
-    // 46 adds `track_caller`
-    // 55 adds `kind()` to `ParseIntError`
-    for version in &[46, 55] {
-        if *version <= minor {
-            println!("cargo:rustc-cfg=rust_v_1_{}", version);
-        }
+    for version in MSRV_MINOR..=minor {
+        println!("cargo:rustc-cfg=rust_v_1_{}", version);
     }
 }


### PR DESCRIPTION
Previously, each unique compiler cfg attribute that appeared in the codebase was hard coded and emitted to stdout at compile time.  This meant keeping the file up to date as different compiler cfg attributes changed.  It's inconsequential to emit a compiler version that's not used, so this change just emits all possibilities to reduce the maintenance burden of the build script.

Note that there is a bit of diff noise in one of the `build.rs` since I simply did a copy of one to the other to make them uniform.