### PR TITLE
Add Script ASM interpreter as ScriptBuf::parse_asm

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,6 +26,7 @@ jobs:
           bitcoin_deserialize_witness,
           bitcoin_deser_net_msg,
           bitcoin_outpoint_string,
+          bitcoin_script_asm_roundtrip,
           bitcoin_script_bytes_to_asm_fmt,
           hashes_cbor,
           hashes_json,

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -33,7 +33,7 @@ use crate::prelude::*;
 /// </details>
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Opcode {
-    code: u8,
+    pub(crate) code: u8,
 }
 
 pub use self::all::*;

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -9,7 +9,7 @@
 #![allow(non_camel_case_types)]
 
 use core::convert::From;
-use core::fmt;
+use core::{fmt, str};
 
 use internals::debug_from_display;
 #[cfg(feature = "serde")]
@@ -73,6 +73,19 @@ macro_rules! all_opcodes {
                         $op => fmt::Display::fmt(stringify!($op), f),
                     )+
                 }
+            }
+        }
+
+        impl str::FromStr for Opcode {
+            type Err = ();
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                $(
+                    // NB all opcodes begin with OP_
+                    if s == stringify!($op) || s == &stringify!($op)[3..] {
+                        return Ok($op);
+                    }
+                )+
+                Err(())
             }
         }
     }

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -36,7 +36,7 @@ pub struct Opcode {
     code: u8,
 }
 
-use self::all::*;
+pub use self::all::*;
 
 macro_rules! all_opcodes {
     ($($op:ident => $val:expr, $doc:expr);*) => {

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -54,6 +54,7 @@ use core::borrow::{Borrow, BorrowMut};
 use core::cmp::Ordering;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
+use core::str::FromStr;
 
 use hashes::{hash160, sha256};
 #[cfg(feature = "serde")]
@@ -675,6 +676,140 @@ pub(super) fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Re
         }
     }
     Ok(())
+}
+
+/// The different kinds of [AsmParseError] that can occur.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AsmParseErrorKind {
+    /// ASM ended unexpectedly.
+    UnexpectedEOF,
+    /// We were not able to interpret the instruction.
+    UnknownInstruction,
+    /// Invalid hexadecimal bytes.
+    InvalidHex,
+    /// Byte push exceeding the maximum size.
+    PushExceedsMaxSize,
+    /// ASM contains a byte push with non-minimal size prefix.
+    ///
+    /// This is not necessarily invalid, but we can't construct such pushes.
+    NonMinimalBytePush,
+}
+
+/// Error from parsing Script ASM.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseAsmError {
+    /// The index of the instruction causing the error.
+    ///
+    /// This index is counted from 0 and incremented after
+    /// every chunk of whitespace.
+    pub index: usize,
+
+    /// The kind of error that occurred.
+    pub kind: AsmParseErrorKind,
+}
+
+/// Try to parse raw hex bytes and push them into the buffer.
+fn try_parse_raw_hex(hex: &str, buf: &mut Vec<u8>) -> bool {
+    buf.clear();
+    let iter = match hex::HexToBytesIter::new(hex) {
+        Ok(i) => i,
+        Err(_) => return false,
+    };
+    for item in iter {
+        let item = match item {
+            Ok(i) => i,
+            Err(_) => return false,
+        };
+        buf.push(item);
+    }
+    true
+}
+
+/// Parse a Script in ASM format.
+pub(super) fn parse_asm(asm: &str) -> Result<ScriptBuf, ParseAsmError> {
+    use std::convert::TryFrom;
+
+    fn err(index: usize, kind: AsmParseErrorKind) -> ParseAsmError {
+        ParseAsmError { index, kind }
+    }
+
+    let mut buf = Vec::with_capacity(65);
+    let mut builder = Builder::new();
+    let mut words = asm.split_whitespace().enumerate();
+    while let Some((idx, mut word)) = words.next() {
+        // We have this special case in our formatter.
+        if word == "OP_0" {
+            builder = builder.push_opcode(OP_PUSHBYTES_0);
+            continue;
+        }
+
+        if let Ok(op) = Opcode::from_str(word) {
+            // check for push opcodes
+            if op.code <= OP_PUSHDATA4.code {
+                let (_, push) = words.next().ok_or(err(idx+1, AsmParseErrorKind::UnexpectedEOF))?;
+                if !try_parse_raw_hex(push, &mut buf) {
+                    return Err(err(idx+1, AsmParseErrorKind::InvalidHex));
+                }
+
+                // NB our API doesn't actually allow us to make byte pushes with
+                // non-minimal length prefix, so we can only check and error if
+                // the user wants a non-minimal push
+                let expected_push_op = match buf.len() {
+                    n if n < opcodes::OP_PUSHDATA1.code as usize => {
+                        Opcode::from(n as u8)
+                    }
+                    n if n < 0x100 => {
+                        opcodes::OP_PUSHDATA1
+                    }
+                    n if n < 0x10000 => {
+                        opcodes::OP_PUSHDATA2
+                    }
+                    n if n < 0x100000000 => {
+                        opcodes::OP_PUSHDATA4
+                    }
+                    _ => return Err(err(idx+1, AsmParseErrorKind::PushExceedsMaxSize)),
+                };
+                if op != expected_push_op {
+                    return Err(err(idx, AsmParseErrorKind::NonMinimalBytePush));
+                }
+
+                let push = <&PushBytes>::try_from(&buf[..])
+                    .map_err(|_| err(idx+1, AsmParseErrorKind::PushExceedsMaxSize))?;
+                builder = builder.push_slice(push);
+            } else {
+                builder = builder.push_opcode(op);
+            }
+            continue;
+        }
+
+        // Not an opcode, try to interpret as number or push.
+
+        if word.starts_with('<') && word.ends_with('>') {
+            word = &word[1..word.len()-1];
+        }
+
+        // Try a number.
+        if let Ok(i) = i64::from_str(&word) {
+            builder = builder.push_int(i);
+            continue;
+        }
+
+        // Finally, try hex in various forms.
+        if word.starts_with("0x") {
+            word = &word[2..];
+        }
+
+        if try_parse_raw_hex(word, &mut buf) {
+            let push = <&PushBytes>::try_from(&buf[..])
+                .map_err(|_| err(idx, AsmParseErrorKind::PushExceedsMaxSize))?;
+            builder = builder.push_slice(push);
+        } else {
+            return Err(err(idx, AsmParseErrorKind::UnknownInstruction));
+        }
+    }
+
+    Ok(builder.into_script())
 }
 
 /// Ways that a script might fail. Not everything is split up as

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -10,7 +10,8 @@ use crate::blockdata::opcodes::{self, Opcode};
 use crate::blockdata::script::witness_program::WitnessProgram;
 use crate::blockdata::script::witness_version::WitnessVersion;
 use crate::blockdata::script::{
-    opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash,
+    opcode_to_verify, parse_asm, Builder, Instruction, ParseAsmError, PushBytes, Script,
+    ScriptHash, WScriptHash,
 };
 use crate::key::{
     PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
@@ -193,6 +194,15 @@ impl ScriptBuf {
     ///
     /// This method doesn't (re)allocate.
     pub fn from_bytes(bytes: Vec<u8>) -> Self { ScriptBuf(bytes) }
+
+    /// Parse a Script in ASM format.
+    ///
+    /// NOTE: Receiving an [Ok] result from this function **ONLY** means that
+    /// our script interpreter could interpret the script, but it gives **no
+    /// guarantees** on the validity of the resulting script.
+    pub fn parse_asm(asm: &str) -> Result<Self, ParseAsmError> {
+        parse_asm(asm)
+    }
 
     /// Converts the script into a byte vector.
     ///

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -213,20 +213,20 @@ impl ScriptBuf {
     fn push_slice_no_opt(&mut self, data: &PushBytes) {
         // Start with a PUSH opcode
         match data.len() as u64 {
-            n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {
+            n if n < opcodes::OP_PUSHDATA1.to_u8() as u64 => {
                 self.0.push(n as u8);
             }
             n if n < 0x100 => {
-                self.0.push(opcodes::Ordinary::OP_PUSHDATA1.to_u8());
+                self.0.push(opcodes::OP_PUSHDATA1.to_u8());
                 self.0.push(n as u8);
             }
             n if n < 0x10000 => {
-                self.0.push(opcodes::Ordinary::OP_PUSHDATA2.to_u8());
+                self.0.push(opcodes::OP_PUSHDATA2.to_u8());
                 self.0.push((n % 0x100) as u8);
                 self.0.push((n / 0x100) as u8);
             }
             n if n < 0x100000000 => {
-                self.0.push(opcodes::Ordinary::OP_PUSHDATA4.to_u8());
+                self.0.push(opcodes::OP_PUSHDATA4.to_u8());
                 self.0.push((n % 0x100) as u8);
                 self.0.push(((n / 0x100) % 0x100) as u8);
                 self.0.push(((n / 0x10000) % 0x100) as u8);

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -9,6 +9,7 @@ use super::*;
 use crate::blockdata::opcodes;
 use crate::consensus::encode::{deserialize, serialize};
 use crate::crypto::key::{PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey};
+use crate::hex::DisplayHex;
 
 #[test]
 #[rustfmt::skip]
@@ -435,21 +436,34 @@ fn script_json_serialize() {
     assert_eq!(original, des);
 }
 
+fn script_asm_pair(script_hex: &str, asm: &str) {
+    let script = ScriptBuf::from_hex(script_hex).unwrap();
+    assert_eq!(script.to_asm_string(), asm, "asm from script fail: {} <> {}", script_hex, asm);
+
+    let parsed = ScriptBuf::parse_asm(asm).expect(&format!("asm err for '{}'", asm));
+    assert_eq!(script, parsed, "parse roundtrip fail: {}: {} <> {}", asm, script_hex, parsed)
+}
+
 #[test]
 fn script_asm() {
-    assert_eq!(
-        ScriptBuf::from_hex("6363636363686868686800").unwrap().to_asm_string(),
+    script_asm_pair(
+        "6363636363686868686800",
         "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
     );
-    assert_eq!(
-        ScriptBuf::from_hex("6363636363686868686800").unwrap().to_asm_string(),
+    script_asm_pair(
+        "6363636363686868686800",
         "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
     );
-    assert_eq!(ScriptBuf::from_hex("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").unwrap().to_asm_string(),
-               "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG");
+    script_asm_pair(
+        "2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac",
+        "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG",
+    );
     // Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to test PUSHDATA1
-    assert_eq!(ScriptBuf::from_hex("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").unwrap().to_asm_string(),
-               "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae");
+    script_asm_pair(
+        "0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae",
+        "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae",
+    );
+
     // Various weird scripts found in transaction 6d7ed9914625c73c0288694a6819196a27ef6c08f98e1270d975a8e65a3dc09a
     // which triggerred overflow bugs on 32-bit machines in script formatting in the past.
     assert_eq!(
@@ -474,6 +488,14 @@ fn script_asm() {
         ScriptBuf::from_hex("4effffffff01").unwrap().to_asm_string(),
         "OP_PUSHDATA4 <push past end>"
     );
+
+    // Parsing tests
+    fn asm_to_hex(asm: &str) -> String {
+        ScriptBuf::parse_asm(asm).expect(&format!("asm: {}", asm)).to_bytes().as_hex().to_string()
+    }
+    assert_eq!(asm_to_hex("<0x01>"), "0101");
+    assert_eq!(asm_to_hex("0x01"), "0101");
+    assert_eq!(asm_to_hex("<01>"), "51");
 }
 
 #[test]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -57,6 +57,10 @@ name = "bitcoin_outpoint_string"
 path = "fuzz_targets/bitcoin/outpoint_string.rs"
 
 [[bin]]
+name = "bitcoin_script_asm_roundtrip"
+path = "fuzz_targets/bitcoin/script_asm_roundtrip.rs"
+
+[[bin]]
 name = "bitcoin_script_bytes_to_asm_fmt"
 path = "fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs"
 

--- a/fuzz/fuzz_targets/bitcoin/script_asm_roundtrip.rs
+++ b/fuzz/fuzz_targets/bitcoin/script_asm_roundtrip.rs
@@ -1,0 +1,45 @@
+use std::fmt;
+
+use honggfuzz::fuzz;
+
+fn do_test(data: &[u8]) {
+    let asm = bitcoin::Script::from_bytes(data).to_asm_string();
+    let parsed = bitcoin::ScriptBuf::parse_asm(&asm).unwrap();
+    assert_eq!(parsed.as_bytes(), data);
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(all(test, fuzzing))]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("00000", &mut a);
+        super::do_test(&a);
+    }
+}
+


### PR DESCRIPTION
Currently in draft, I have tested this only against the current existing unit tests for scripts, I'm trying to get the fuzz target that I added working so that I can fuzz this for any script.

I added some more flexibility for how to parse pushes and integers, I will try to go over to some alternative projects like ScriptWiz IDE, btcdeb, Core and @dgpv 's bsst to get some alternative formats to see if that works.

Planning to include this in hal.