### PR TITLE
Move `sha512_256` code

### DIFF
--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -13,6 +13,19 @@ use core::str;
 
 use crate::{sha512, FromSliceError};
 
+crate::internal_macros::hash_type! {
+    256,
+    false,
+    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>. ",
+    "crate::util::json_hex_string::len_32"
+}
+
+fn from_engine(e: HashEngine) -> Hash {
+    let mut ret = [0; 32];
+    ret.copy_from_slice(&sha512::from_engine(e.0)[..32]);
+    Hash(ret)
+}
+
 /// Engine to compute SHA512/256 hash function.
 ///
 /// SHA512/256 is a hash function that uses the sha512 alogrithm but it truncates
@@ -39,19 +52,6 @@ impl crate::HashEngine for HashEngine {
     fn n_bytes_hashed(&self) -> usize { self.0.n_bytes_hashed() }
 
     fn input(&mut self, inp: &[u8]) { self.0.input(inp); }
-}
-
-crate::internal_macros::hash_type! {
-    256,
-    false,
-    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 alogrithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>. ",
-    "crate::util::json_hex_string::len_32"
-}
-
-fn from_engine(e: HashEngine) -> Hash {
-    let mut ret = [0; 32];
-    ret.copy_from_slice(&sha512::from_engine(e.0)[..32]);
-    Hash(ret)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Make the `sha512_256` module use similar code layout to the other hash modules by putting the call to `hash_type` at the top followed by the `from_engine` function.

Code move only, no other changes.
