### PR TITLE
Remove code deprecated since `v0.31.0`

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -519,14 +519,6 @@ impl Amount {
     /// Gets the number of satoshis in this [`Amount`].
     pub fn to_sat(self) -> u64 { self.0 }
 
-    /// The maximum value of an [Amount].
-    #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
-    pub const fn max_value() -> Amount { Amount(u64::max_value()) }
-
-    /// The minimum value of an [Amount].
-    #[deprecated(since = "0.31.0", note = "Use Self::MIN instead")]
-    pub const fn min_value() -> Amount { Amount(u64::min_value()) }
-
     /// Convert from a value expressing bitcoins to an [Amount].
     pub fn from_btc(btc: f64) -> Result<Amount, ParseAmountError> {
         Amount::from_float_in(btc, Denomination::Bitcoin)
@@ -895,14 +887,6 @@ impl SignedAmount {
 
     /// Gets the number of satoshis in this [`SignedAmount`].
     pub fn to_sat(self) -> i64 { self.0 }
-
-    /// The maximum value of an [SignedAmount].
-    #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
-    pub const fn max_value() -> SignedAmount { SignedAmount(i64::max_value()) }
-
-    /// The minimum value of an [SignedAmount].
-    #[deprecated(since = "0.31.0", note = "Use Self::MIN instead")]
-    pub const fn min_value() -> SignedAmount { SignedAmount(i64::min_value()) }
 
     /// Convert from a value expressing bitcoins to an [SignedAmount].
     pub fn from_btc(btc: f64) -> Result<SignedAmount, ParseAmountError> {

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -328,10 +328,6 @@ impl Block {
         size
     }
 
-    /// Returns the stripped size of the block.
-    #[deprecated(since = "0.31.0", note = "use Block::base_size() instead")]
-    pub fn strippedsize(&self) -> usize { self.base_size() }
-
     /// Returns the coinbase transaction, if one is present.
     pub fn coinbase(&self) -> Option<&Transaction> { self.txdata.first() }
 

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -31,14 +31,6 @@ pub const DIFFCHANGE_INTERVAL: u32 = 2016;
 /// How much time on average should occur between diffchanges.
 pub const DIFFCHANGE_TIMESPAN: u32 = 14 * 24 * 3600;
 
-#[deprecated(since = "0.31.0", note = "Use Weight::MAX_BLOCK instead")]
-/// The maximum allowed weight for a block, see BIP 141 (network rule).
-pub const MAX_BLOCK_WEIGHT: u32 = 4_000_000;
-
-#[deprecated(since = "0.31.0", note = "Use Weight::MIN_TRANSACTION instead")]
-/// The minimum transaction weight for a valid serialized transaction.
-pub const MIN_TRANSACTION_WEIGHT: u32 = 4 * 60;
-
 /// The factor that non-witness serialization data is multiplied by during weight calculation.
 pub const WITNESS_SCALE_FACTOR: usize = 4;
 /// The maximum allowed number of signature check operations in a block.

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -407,18 +407,6 @@ impl Height {
     /// The maximum absolute block height.
     pub const MAX: Self = Height(LOCK_TIME_THRESHOLD - 1);
 
-    /// The minimum absolute block height (0), the genesis block.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MIN`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MIN instead")]
-    pub const fn min_value() -> Self { Self::MIN }
-
-    /// The maximum absolute block height.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MAX`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
-    pub const fn max_value() -> Self { Self::MAX }
-
     /// Constructs a new block height.
     ///
     /// # Errors
@@ -488,18 +476,6 @@ impl Time {
 
     /// The maximum absolute block time (Sun Feb 07 2106 06:28:15 GMT+0000).
     pub const MAX: Self = Time(u32::max_value());
-
-    /// The minimum absolute block time.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MIN`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MIN instead")]
-    pub const fn min_value() -> Self { Self::MIN }
-
-    /// The maximum absolute block time.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MAX`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
-    pub const fn max_value() -> Self { Self::MAX }
 
     /// Constructs a new block time.
     ///

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -206,18 +206,6 @@ impl Height {
     /// The maximum relative block height.
     pub const MAX: Self = Height(u16::max_value());
 
-    /// The minimum relative block height (0), can be included in any block.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MIN`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MIN instead")]
-    pub const fn min_value() -> Self { Self::MIN }
-
-    /// The maximum relative block height.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Height::MAX`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
-    pub const fn max_value() -> Self { Self::MAX }
-
     /// Returns the inner `u16` value.
     #[inline]
     pub fn value(self) -> u16 { self.0 }
@@ -251,18 +239,6 @@ impl Time {
 
     /// The maximum relative block time (33,554,432 seconds or approx 388 days).
     pub const MAX: Self = Time(u16::max_value());
-
-    /// The minimum relative block time.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MIN`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MIN instead")]
-    pub const fn min_value() -> Self { Self::MIN }
-
-    /// The maximum relative block time.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Time::MAX`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
-    pub const fn max_value() -> Self { Self::MAX }
 
     /// Create a [`Time`] using time intervals where each interval is equivalent to 512 seconds.
     ///

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -149,25 +149,7 @@ impl Script {
     /// Computes the P2WSH output corresponding to this witnessScript (aka the "witness redeem
     /// script").
     #[inline]
-    #[deprecated(since = "0.31.0", note = "use to_p2wsh instead")]
-    pub fn to_v0_p2wsh(&self) -> ScriptBuf { self.to_p2wsh() }
-
-    /// Computes the P2WSH output corresponding to this witnessScript (aka the "witness redeem
-    /// script").
-    #[inline]
     pub fn to_p2wsh(&self) -> ScriptBuf { ScriptBuf::new_p2wsh(&self.wscript_hash()) }
-
-    /// Computes P2TR output with a given internal key and a single script spending path equal to
-    /// the current script, assuming that the script is a Tapscript.
-    #[inline]
-    #[deprecated(since = "0.31.0", note = "use to_p2tr instead")]
-    pub fn to_v1_p2tr<C: Verification>(
-        &self,
-        secp: &Secp256k1<C>,
-        internal_key: UntweakedPublicKey,
-    ) -> ScriptBuf {
-        self.to_p2tr(secp, internal_key)
-    }
 
     /// Computes P2TR output with a given internal key and a single script spending path equal to
     /// the current script, assuming that the script is a Tapscript.
@@ -331,21 +313,11 @@ impl Script {
 
     /// Checks whether a script pubkey is a P2WSH output.
     #[inline]
-    #[deprecated(since = "0.31.0", note = "use is_p2wsh instead")]
-    pub fn is_v0_p2wsh(&self) -> bool { self.is_p2wsh() }
-
-    /// Checks whether a script pubkey is a P2WSH output.
-    #[inline]
     pub fn is_p2wsh(&self) -> bool {
         self.0.len() == 34
             && self.witness_version() == Some(WitnessVersion::V0)
             && self.0[1] == OP_PUSHBYTES_32.to_u8()
     }
-
-    /// Checks whether a script pubkey is a P2WPKH output.
-    #[inline]
-    #[deprecated(since = "0.31.0", note = "use is_p2wpkh instead")]
-    pub fn is_v0_p2wpkh(&self) -> bool { self.is_p2wpkh() }
 
     /// Checks whether a script pubkey is a P2WPKH output.
     #[inline]
@@ -362,11 +334,6 @@ impl Script {
             None
         }
     }
-
-    /// Checks whether a script pubkey is a P2TR output.
-    #[inline]
-    #[deprecated(since = "0.31.0", note = "use is_p2tr instead")]
-    pub fn is_v1_p2tr(&self) -> bool { self.is_p2tr() }
 
     /// Checks whether a script pubkey is a P2TR output.
     #[inline]

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -99,34 +99,15 @@ impl ScriptBuf {
     }
 
     /// Generates P2WPKH-type of scriptPubkey.
-    #[deprecated(since = "0.31.0", note = "use new_p2wpkh instead")]
-    pub fn new_v0_p2wpkh(pubkey_hash: &WPubkeyHash) -> Self { Self::new_p2wpkh(pubkey_hash) }
-
-    /// Generates P2WPKH-type of scriptPubkey.
     pub fn new_p2wpkh(pubkey_hash: &WPubkeyHash) -> Self {
         // pubkey hash is 20 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
         ScriptBuf::new_witness_program_unchecked(WitnessVersion::V0, pubkey_hash)
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
-    #[deprecated(since = "0.31.0", note = "use new_p2wsh instead")]
-    pub fn new_v0_p2wsh(script_hash: &WScriptHash) -> Self { Self::new_p2wsh(script_hash) }
-
-    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
     pub fn new_p2wsh(script_hash: &WScriptHash) -> Self {
         // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
         ScriptBuf::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
-    }
-
-    /// Generates P2TR for script spending path using an internal public key and some optional
-    /// script tree merkle root.
-    #[deprecated(since = "0.31.0", note = "use new_p2tr instead")]
-    pub fn new_v1_p2tr<C: Verification>(
-        secp: &Secp256k1<C>,
-        internal_key: UntweakedPublicKey,
-        merkle_root: Option<TapNodeHash>,
-    ) -> Self {
-        Self::new_p2tr(secp, internal_key, merkle_root)
     }
 
     /// Generates P2TR for script spending path using an internal public key and some optional
@@ -139,12 +120,6 @@ impl ScriptBuf {
         let (output_key, _) = internal_key.tap_tweak(secp, merkle_root);
         // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
         ScriptBuf::new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
-    }
-
-    /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].
-    #[deprecated(since = "0.31.0", note = "use new_p2tr_tweaked instead")]
-    pub fn new_v1_p2tr_tweaked(output_key: TweakedPublicKey) -> Self {
-        Self::new_p2tr_tweaked(output_key)
     }
 
     /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -329,12 +329,6 @@ impl Sequence {
     /// BIP-68 relative lock time type flag mask.
     const LOCK_TYPE_MASK: u32 = 0x00400000;
 
-    /// The maximum allowable sequence number.
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Sequence::MAX`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
-    pub const fn max_value() -> Self { Self::MAX }
-
     /// Returns `true` if the sequence number enables absolute lock-time ([`Transaction::lock_time`]).
     #[inline]
     pub fn enables_absolute_lock_time(&self) -> bool { *self != Sequence::MAX }
@@ -789,10 +783,6 @@ impl Transaction {
         self.weight().to_vbytes_ceil() as usize
     }
 
-    /// Returns the size of this transaction excluding the witness data.
-    #[deprecated(since = "0.31.0", note = "Use Transaction::base_size() instead")]
-    pub fn strippedsize(&self) -> usize { self.base_size() }
-
     /// Checks if this is a coinbase transaction.
     ///
     /// The first transaction in the block distributes the mining reward and is called the coinbase
@@ -803,10 +793,6 @@ impl Transaction {
     pub fn is_coinbase(&self) -> bool {
         self.input.len() == 1 && self.input[0].previous_output.is_null()
     }
-
-    /// Checks if this is a coinbase transaction.
-    #[deprecated(since = "0.31.0", note = "use is_coinbase instead")]
-    pub fn is_coin_base(&self) -> bool { self.is_coinbase() }
 
     /// Returns `true` if the transaction itself opted in to be BIP-125-replaceable (RBF).
     ///

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -385,11 +385,6 @@ impl_int_encodable!(i64, read_i64, emit_i64);
 
 #[allow(clippy::len_without_is_empty)] // VarInt has on concept of 'is_empty'.
 impl VarInt {
-    /// Gets the length of this VarInt when encoded.
-    #[inline]
-    #[deprecated(since = "0.31.0", note = "use size instead")]
-    pub const fn len(&self) -> usize { self.size() }
-
     /// Returns the number of bytes this varint contributes to a transaction size.
     ///
     /// Returns 1 for 0..=0xFC, 3 for 0xFD..=(2^16-1), 5 for 0x10000..=(2^32-1), and 9 otherwise.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -507,17 +507,7 @@ impl fmt::Display for TweakedPublicKey {
 }
 
 /// Untweaked BIP-340 key pair
-#[deprecated(since = "0.31.0", note = "use UntweakedKeypair instead")]
-#[allow(deprecated)]
-pub type UntweakedKeyPair = UntweakedKeypair;
-
-/// Untweaked BIP-340 key pair
 pub type UntweakedKeypair = Keypair;
-
-/// Tweaked BIP-340 key pair
-#[deprecated(since = "0.31.0", note = "use TweakedKeypair instead")]
-#[allow(deprecated)]
-pub type TweakedKeyPair = TweakedKeypair;
 
 /// Tweaked BIP-340 key pair
 ///

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -856,20 +856,6 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
 
     /// Encodes the BIP143 signing data for any flag type into a given object implementing a
     /// [`std::io::Write`] trait.
-    #[deprecated(since = "0.31.0", note = "use segwit_v0_encode_signing_data_to instead")]
-    pub fn segwit_encode_signing_data_to<Write: io::Write>(
-        &mut self,
-        writer: Write,
-        input_index: usize,
-        script_code: &Script,
-        value: Amount,
-        sighash_type: EcdsaSighashType,
-    ) -> Result<(), Error> {
-        self.segwit_v0_encode_signing_data_to(writer, input_index, script_code, value, sighash_type)
-    }
-
-    /// Encodes the BIP143 signing data for any flag type into a given object implementing a
-    /// [`std::io::Write`] trait.
     ///
     /// `script_code` is dependent on the type of the spend transaction. For p2wpkh use
     /// [`Script::p2wpkh_script_code`], for p2wsh just pass in the witness script. (Also see
@@ -931,26 +917,6 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         self.tx.borrow().lock_time.consensus_encode(&mut writer)?;
         sighash_type.to_u32().consensus_encode(&mut writer)?;
         Ok(())
-    }
-
-    /// Computes the BIP143 sighash for any flag type.
-    #[deprecated(since = "0.31.0", note = "use (p2wpkh|p2wsh)_signature_hash instead")]
-    pub fn segwit_signature_hash(
-        &mut self,
-        input_index: usize,
-        script_code: &Script,
-        value: Amount,
-        sighash_type: EcdsaSighashType,
-    ) -> Result<SegwitV0Sighash, Error> {
-        let mut enc = SegwitV0Sighash::engine();
-        self.segwit_v0_encode_signing_data_to(
-            &mut enc,
-            input_index,
-            script_code,
-            value,
-            sighash_type,
-        )?;
-        Ok(SegwitV0Sighash::from_engine(enc))
     }
 
     /// Computes the BIP143 sighash to spend a p2wpkh transaction for any flag type.
@@ -1235,7 +1201,7 @@ impl<R: BorrowMut<Transaction>> SighashCache<R> {
     /// let mut sig_hasher = SighashCache::new(&mut tx_to_sign);
     /// for inp in 0..input_count {
     ///     let prevout_script = Script::new();
-    ///     let _sighash = sig_hasher.segwit_signature_hash(inp, prevout_script, Amount::ONE_SAT, EcdsaSighashType::All);
+    ///     let _sighash = sig_hasher.p2wpkh_signature_hash(inp, prevout_script, Amount::ONE_SAT, EcdsaSighashType::All);
     ///     // ... sign the sighash
     ///     sig_hasher.witness_mut(inp).unwrap().push(&Vec::new());
     /// }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -137,12 +137,6 @@ impl Target {
     // https://github.com/bitcoin/bitcoin/blob/8105bce5b384c72cf08b25b7c5343622754e7337/src/kernel/chainparams.cpp#L348
     pub const MAX_ATTAINABLE_SIGNET: Self = Target(U256(0x0377_ae00 << 80, 0));
 
-    /// The maximum possible target (see [`Target::MAX`]).
-    ///
-    /// This is provided for consistency with Rust 1.41.1, newer code should use [`Target::MAX`].
-    #[deprecated(since = "0.31.0", note = "Use Self::MAX instead")]
-    pub const fn max_value() -> Self { Target::MAX }
-
     /// Computes the [`Target`] value from a compact representation.
     ///
     /// ref: <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -291,10 +291,6 @@ impl TaprootSpendInfo {
         info
     }
 
-    /// Returns the internal script map.
-    #[deprecated(since = "0.31.0", note = "use Self::script_map instead")]
-    pub fn as_script_map(&self) -> &ScriptMerkleProofMap { self.script_map() }
-
     /// Constructs a [`ControlBlock`] for particular script with the given version.
     ///
     /// # Returns


### PR DESCRIPTION
We only deprecate for a single release.

Remove all code deprecated since `v0.31.0`.