### PR TITLE
Add `params` method to `Network`

### DIFF
--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -50,7 +50,7 @@ pub struct Params {
 
 impl Params {
     /// Creates parameters set for the given network.
-    pub fn new(network: Network) -> Self {
+    pub const fn new(network: Network) -> Self {
         match network {
             Network::Bitcoin => Params {
                 network: Network::Bitcoin,

--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -116,3 +116,27 @@ impl Params {
         self.pow_target_timespan / self.pow_target_spacing
     }
 }
+
+impl From<Network> for Params {
+    fn from(value: Network) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&Network> for Params {
+    fn from(value: &Network) -> Self {
+        Self::new(*value)
+    }
+}
+
+impl From<Network> for &'static Params {
+    fn from(value: Network) -> Self {
+        value.params()
+    }
+}
+
+impl From<&Network> for &'static Params {
+    fn from(value: &Network) -> Self {
+        value.params()
+    }
+}

--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -27,6 +27,7 @@ use internals::write_err;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::consensus::Params;
 use crate::constants::ChainHash;
 use crate::p2p::Magic;
 use crate::prelude::{String, ToOwned};
@@ -143,6 +144,17 @@ impl Network {
     /// ```
     pub fn from_chain_hash(chain_hash: ChainHash) -> Option<Network> {
         Network::try_from(chain_hash).ok()
+    }
+
+    /// Returns the associated network parameters.
+    pub const fn params(self) -> &'static Params {
+        const PARAMS: [Params; 4] = [
+            Params::new(Network::Bitcoin),
+            Params::new(Network::Testnet),
+            Params::new(Network::Signet),
+            Params::new(Network::Regtest),
+        ];
+        &PARAMS[self as usize]
     }
 }
 


### PR DESCRIPTION
Writing `network.params()` is less annoying than `Params::network()`, so this adds it. Making it return a static could also improve performance.

Didn't do `Params` -> `Network` conversions because of #2173 