### PR TITLE
hashes: Check for changes to the public API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -166,3 +166,18 @@ jobs:
         env:
           DO_WASM: true
         run: cd hashes && ./contrib/test.sh
+
+  API:
+    name: Check for changes to the public API
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-public-api
+        run: cargo install --locked cargo-public-api
+      - name: Running API checker script
+        run: ./contrib/check-for-api-changes.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,11 @@ Use of `unsafe` code is prohibited unless there is a unanimous decision among
 library maintainers on the exclusion from this rule. In such cases there is a
 requirement to test unsafe code with sanitizers including Miri.
 
+### API changes
+
+All PRs that change the public API of `rust-bitcoin` must include a patch to the
+`api/` text files. For PRs that include API changes, add a separate patch to the PR
+that is the diff created by running `contrib/check-for-api-changes.sh`.
 
 ## Security
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,11 @@
+API text files
+==============
+
+Each file here lists the public API when built with some set of features
+enabled. To create these files run `contrib/check-for-api-changes.sh`:
+
+Requires `cargo-public-api`, install with:
+
+    `cargo +stable install cargo-public-api --locked`.
+
+ref: https://github.com/enselic/cargo-public-api

--- a/api/hashes/api-all-features.txt
+++ b/api/hashes/api-all-features.txt
@@ -1,0 +1,929 @@
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::FromSliceError> for bitcoin_hashes::FromSliceError
+impl core::cmp::PartialEq<bitcoin_hashes::hash160::Hash> for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::ripemd160::Hash> for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha1::Hash> for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256d::Hash> for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256::Hash> for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256::Midstate> for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq<bitcoin_hashes::sha512_256::Hash> for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha512::Hash> for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::siphash24::Hash> for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::hash160::Hash> for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::ripemd160::Hash> for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha1::Hash> for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256d::Hash> for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256::Hash> for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256::Midstate> for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd<bitcoin_hashes::sha512_256::Hash> for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha512::Hash> for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::siphash24::Hash> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
+impl core::error::Error for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Midstate
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::hash160::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::ripemd160::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha1::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256d::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256::Midstate
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512_256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::siphash24::Hash
+impl<'de, T: bitcoin_hashes::Hash + serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
+impl<'de, T: bitcoin_hashes::sha256t::Tag> serde::de::Deserialize<'de> for bitcoin_hashes::sha256t::Hash<T>
+impl hex_conservative::parse::FromHex for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::hash160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::ripemd160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha1::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256d::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512_256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::siphash24::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
+impl schemars::JsonSchema for bitcoin_hashes::hash160::Hash
+impl schemars::JsonSchema for bitcoin_hashes::ripemd160::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha1::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha256d::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha256::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha512_256::Hash
+impl schemars::JsonSchema for bitcoin_hashes::sha512::Hash
+impl schemars::JsonSchema for bitcoin_hashes::siphash24::Hash
+impl serde::ser::Serialize for bitcoin_hashes::hash160::Hash
+impl serde::ser::Serialize for bitcoin_hashes::ripemd160::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha1::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256d::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256::Midstate
+impl serde::ser::Serialize for bitcoin_hashes::sha512_256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha512::Hash
+impl serde::ser::Serialize for bitcoin_hashes::siphash24::Hash
+impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine
+impl std::io::Write for bitcoin_hashes::sha1::HashEngine
+impl std::io::Write for bitcoin_hashes::sha256::HashEngine
+impl std::io::Write for bitcoin_hashes::sha512::HashEngine
+impl std::io::Write for bitcoin_hashes::siphash24::HashEngine
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::borrow::Borrow<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<usize> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + schemars::JsonSchema> schemars::JsonSchema for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + serde::ser::Serialize> serde::ser::Serialize for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq<bitcoin_hashes::sha256t::Hash<T>> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd<bitcoin_hashes::sha256t::Hash<T>> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> schemars::JsonSchema for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> serde::ser::Serialize for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Eq + bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq<bitcoin_hashes::hmac::Hmac<T>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd<bitcoin_hashes::hmac::Hmac<T>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+#[non_exhaustive] pub struct bitcoin_hashes::FromSliceError
+pub bitcoin_hashes::hmac::HmacMidState::inner: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub bitcoin_hashes::hmac::HmacMidState::outer: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::Hash::LEN: usize
+pub const bitcoin_hashes::hash160::Hash::N: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::Hmac<T>::LEN: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::LEN: usize
+pub const bitcoin_hashes::ripemd160::Hash::N: usize
+pub const bitcoin_hashes::serde_macros::serde_details::SerdeHash::N: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::LEN: usize
+pub const bitcoin_hashes::sha1::Hash::N: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::Hash::LEN: usize
+pub const bitcoin_hashes::sha256d::Hash::N: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::LEN: usize
+pub const bitcoin_hashes::sha256::Hash::N: usize
+pub const bitcoin_hashes::sha256::Midstate::N: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::Hash<T>::LEN: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::N: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::LEN: usize
+pub const bitcoin_hashes::sha512_256::Hash::N: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::LEN: usize
+pub const bitcoin_hashes::sha512::Hash::N: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::LEN: usize
+pub const bitcoin_hashes::siphash24::Hash::N: usize
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub extern crate bitcoin_hashes::hex
+pub extern crate bitcoin_hashes::serde
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::FromSliceError::clone(&self) -> bitcoin_hashes::FromSliceError
+pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSliceError) -> bool
+pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::FromSliceError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hash160::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::hash160::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::hash160::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::hash160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::Hash>::Engine, oengine: <T as bitcoin_hashes::Hash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFrom<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeTo<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: usize) -> &u8
+pub fn bitcoin_hashes::hmac::Hmac<T>::is_referenceable() -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::hmac::Hmac<T>::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::hmac::Hmac<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::ripemd160::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::ripemd160::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::ripemd160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::deserialize<'de, D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha1::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha1::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::sha1::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha1::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256d::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256d::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::sha256d::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha256d::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::sha256::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Midstate, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Err> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin_hashes::sha256::Midstate::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Midstate::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256t::Hash<T>::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha256t::Hash<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512_256::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::sha512_256::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha512_256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::sha512::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::sha512::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::siphash24::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::default() -> Self
+pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::midstate(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::siphash24::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitcoin_hashes::siphash24::Hash::schema_name() -> alloc::string::String
+pub fn bitcoin_hashes::siphash24::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::borrow_slice_impl!
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::hex_fmt_impl!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::serde_macros::serde_details
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate(pub [u8; 32])
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::fmt::Debug + core::fmt::Display + core::fmt::LowerHex + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeFrom<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeTo<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::Range<usize>, Output = [u8]> + core::ops::index::Index<usize, Output = u8> + core::borrow::Borrow<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone + core::default::Default
+pub trait bitcoin_hashes::serde_macros::serde_details::SerdeHash where Self: core::marker::Sized + core::str::traits::FromStr + core::fmt::Display + core::ops::index::Index<usize, Output = u8> + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]>, <Self as core::str::traits::FromStr>::Err: core::fmt::Display
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::hash160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
+pub type bitcoin_hashes::Hash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::hmac::HmacEngine<T>::MidState = bitcoin_hashes::hmac::HmacMidState<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8]
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = u8
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::ripemd160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::HashEngine::MidState = bitcoin_hashes::sha256::Midstate
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::Midstate::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Midstate::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::HashEngine::MidState = bitcoin_hashes::siphash24::State
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T: bitcoin_hashes::sha256t::Tag>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)

--- a/api/hashes/api-alloc.txt
+++ b/api/hashes/api-alloc.txt
@@ -1,0 +1,788 @@
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::FromSliceError> for bitcoin_hashes::FromSliceError
+impl core::cmp::PartialEq<bitcoin_hashes::hash160::Hash> for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::ripemd160::Hash> for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha1::Hash> for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256d::Hash> for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256::Hash> for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256::Midstate> for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq<bitcoin_hashes::sha512_256::Hash> for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha512::Hash> for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::siphash24::Hash> for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::hash160::Hash> for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::ripemd160::Hash> for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha1::Hash> for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256d::Hash> for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256::Hash> for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256::Midstate> for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd<bitcoin_hashes::sha512_256::Hash> for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha512::Hash> for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::siphash24::Hash> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Midstate
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl hex_conservative::parse::FromHex for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::hash160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::ripemd160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha1::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256d::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512_256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::siphash24::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::borrow::Borrow<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<usize> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq<bitcoin_hashes::sha256t::Hash<T>> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd<bitcoin_hashes::sha256t::Hash<T>> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Eq + bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq<bitcoin_hashes::hmac::Hmac<T>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd<bitcoin_hashes::hmac::Hmac<T>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+#[non_exhaustive] pub struct bitcoin_hashes::FromSliceError
+pub bitcoin_hashes::hmac::HmacMidState::inner: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub bitcoin_hashes::hmac::HmacMidState::outer: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::Hash::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::Hmac<T>::LEN: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::LEN: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::LEN: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::Hash::LEN: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::LEN: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::Hash<T>::LEN: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::LEN: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::LEN: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::LEN: usize
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub extern crate bitcoin_hashes::hex
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::FromSliceError::clone(&self) -> bitcoin_hashes::FromSliceError
+pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSliceError) -> bool
+pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::Hash>::Engine, oengine: <T as bitcoin_hashes::Hash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFrom<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeTo<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: usize) -> &u8
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Err> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin_hashes::sha256::Midstate::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::default() -> Self
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::midstate(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::borrow_slice_impl!
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::hex_fmt_impl!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate(pub [u8; 32])
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::fmt::Debug + core::fmt::Display + core::fmt::LowerHex + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeFrom<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeTo<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::Range<usize>, Output = [u8]> + core::ops::index::Index<usize, Output = u8> + core::borrow::Borrow<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone + core::default::Default
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::hash160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
+pub type bitcoin_hashes::Hash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::hmac::HmacEngine<T>::MidState = bitcoin_hashes::hmac::HmacMidState<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8]
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = u8
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::ripemd160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::HashEngine::MidState = bitcoin_hashes::sha256::Midstate
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::Midstate::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Midstate::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::HashEngine::MidState = bitcoin_hashes::siphash24::State
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T: bitcoin_hashes::sha256t::Tag>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)

--- a/api/hashes/api-default-features.txt
+++ b/api/hashes/api-default-features.txt
@@ -1,0 +1,808 @@
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::FromSliceError> for bitcoin_hashes::FromSliceError
+impl core::cmp::PartialEq<bitcoin_hashes::hash160::Hash> for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::ripemd160::Hash> for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha1::Hash> for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256d::Hash> for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256::Hash> for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256::Midstate> for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq<bitcoin_hashes::sha512_256::Hash> for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha512::Hash> for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::siphash24::Hash> for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::hash160::Hash> for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::ripemd160::Hash> for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha1::Hash> for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256d::Hash> for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256::Hash> for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256::Midstate> for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd<bitcoin_hashes::sha512_256::Hash> for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha512::Hash> for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::siphash24::Hash> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
+impl core::error::Error for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Midstate
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl hex_conservative::parse::FromHex for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::hash160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::ripemd160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha1::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256d::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512_256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::siphash24::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
+impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine
+impl std::io::Write for bitcoin_hashes::sha1::HashEngine
+impl std::io::Write for bitcoin_hashes::sha256::HashEngine
+impl std::io::Write for bitcoin_hashes::sha512::HashEngine
+impl std::io::Write for bitcoin_hashes::siphash24::HashEngine
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::borrow::Borrow<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<usize> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq<bitcoin_hashes::sha256t::Hash<T>> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd<bitcoin_hashes::sha256t::Hash<T>> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Eq + bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq<bitcoin_hashes::hmac::Hmac<T>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd<bitcoin_hashes::hmac::Hmac<T>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+#[non_exhaustive] pub struct bitcoin_hashes::FromSliceError
+pub bitcoin_hashes::hmac::HmacMidState::inner: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub bitcoin_hashes::hmac::HmacMidState::outer: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::Hash::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::Hmac<T>::LEN: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::LEN: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::LEN: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::Hash::LEN: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::LEN: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::Hash<T>::LEN: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::LEN: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::LEN: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::LEN: usize
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub extern crate bitcoin_hashes::hex
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::FromSliceError::clone(&self) -> bitcoin_hashes::FromSliceError
+pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSliceError) -> bool
+pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::FromSliceError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::Hash>::Engine, oengine: <T as bitcoin_hashes::Hash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFrom<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeTo<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: usize) -> &u8
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Err> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin_hashes::sha256::Midstate::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::default() -> Self
+pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::midstate(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::borrow_slice_impl!
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::hex_fmt_impl!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate(pub [u8; 32])
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::fmt::Debug + core::fmt::Display + core::fmt::LowerHex + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeFrom<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeTo<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::Range<usize>, Output = [u8]> + core::ops::index::Index<usize, Output = u8> + core::borrow::Borrow<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone + core::default::Default
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::hash160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
+pub type bitcoin_hashes::Hash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::hmac::HmacEngine<T>::MidState = bitcoin_hashes::hmac::HmacMidState<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8]
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = u8
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::ripemd160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::HashEngine::MidState = bitcoin_hashes::sha256::Midstate
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::Midstate::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Midstate::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::HashEngine::MidState = bitcoin_hashes::siphash24::State
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T: bitcoin_hashes::sha256t::Tag>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)

--- a/api/hashes/api-no-features.txt
+++ b/api/hashes/api-no-features.txt
@@ -1,0 +1,788 @@
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::FromSliceError> for bitcoin_hashes::FromSliceError
+impl core::cmp::PartialEq<bitcoin_hashes::hash160::Hash> for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::ripemd160::Hash> for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha1::Hash> for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256d::Hash> for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256::Hash> for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha256::Midstate> for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq<bitcoin_hashes::sha512_256::Hash> for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::sha512::Hash> for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq<bitcoin_hashes::siphash24::Hash> for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::hash160::Hash> for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::ripemd160::Hash> for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha1::Hash> for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256d::Hash> for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256::Hash> for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha256::Midstate> for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd<bitcoin_hashes::sha512_256::Hash> for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::sha512::Hash> for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd<bitcoin_hashes::siphash24::Hash> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Midstate
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Midstate
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl hex_conservative::parse::FromHex for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::hash160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::ripemd160::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha1::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256d::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Midstate
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512_256::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::siphash24::Hash
+impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::borrow::Borrow<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::ops::index::Index<usize> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq<bitcoin_hashes::sha256t::Hash<T>> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd<bitcoin_hashes::sha256t::Hash<T>> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Eq + bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq<bitcoin_hashes::hmac::Hmac<T>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd<bitcoin_hashes::hmac::Hmac<T>> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+#[non_exhaustive] pub struct bitcoin_hashes::FromSliceError
+pub bitcoin_hashes::hmac::HmacMidState::inner: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub bitcoin_hashes::hmac::HmacMidState::outer: <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::Hash::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::Hmac<T>::LEN: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::LEN: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::LEN: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::Hash::LEN: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::LEN: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::Hash<T>::LEN: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::LEN: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::LEN: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::LEN: usize
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub extern crate bitcoin_hashes::hex
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::FromSliceError::clone(&self) -> bitcoin_hashes::FromSliceError
+pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSliceError) -> bool
+pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::Hash>::Engine, oengine: <T as bitcoin_hashes::Hash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFrom<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeFull) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::RangeTo<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: usize) -> &u8
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Err> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::parse::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn bitcoin_hashes::sha256::Midstate::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::default() -> Self
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::midstate(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> usize
+pub fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::borrow_slice_impl!
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::hex_fmt_impl!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate(pub [u8; 32])
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::fmt::Debug + core::fmt::Display + core::fmt::LowerHex + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeFrom<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::RangeTo<usize>, Output = [u8]> + core::ops::index::Index<core::ops::range::Range<usize>, Output = [u8]> + core::ops::index::Index<usize, Output = u8> + core::borrow::Borrow<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone + core::default::Default
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::hash160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
+pub type bitcoin_hashes::Hash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::hmac::HmacEngine<T>::MidState = bitcoin_hashes::hmac::HmacMidState<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8]
+pub type bitcoin_hashes::hmac::Hmac<T>::Output = u8
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::ripemd160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::HashEngine::MidState = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::HashEngine::MidState = bitcoin_hashes::sha256::Midstate
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256::Midstate::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256::Midstate::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::HashEngine::MidState = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::HashEngine::MidState = bitcoin_hashes::siphash24::State
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::parse::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T: bitcoin_hashes::sha256t::Tag>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Checks the public API of crates, exits with non-zero if there are currently
+# changes to the public API not already committed to in the various api/*.txt
+# files.
+
+set -e
+
+export RUSTDOCFLAGS='-A rustdoc::broken-intra-doc-links'
+REPO_DIR=$(git rev-parse --show-toplevel)
+API_DIR="$REPO_DIR/api"
+CMD="cargo +nightly public-api --simplified"
+
+# cargo public-api uses nightly so the toolchain must be available.
+if ! cargo +nightly --version > /dev/null; then
+    echo "script requires a nightly toolchain to be installed (possibly >= nightly-2023-05-24)" >&2
+    exit 1
+fi
+
+pushd "$REPO_DIR/hashes" > /dev/null
+$CMD --no-default-features | sort --unique > "$API_DIR/hashes/api-no-features.txt"
+$CMD | sort --unique > "$API_DIR/hashes/api-default-features.txt"
+$CMD --no-default-features --features=alloc | sort --unique > "$API_DIR/hashes/api-alloc.txt"
+$CMD --all-features | sort --unique > "$API_DIR/hashes/api-all-features.txt"
+popd > /dev/null
+
+pushd "$REPO_DIR" > /dev/null
+if [[ $(git status --porcelain api) ]]; then
+    echo "You have introduced changes to the public API, commit the changes to api/ currently in your working directory" >&2
+else
+    echo "No changes to the current public API"
+fi
+popd > /dev/null

--- a/justfile
+++ b/justfile
@@ -20,3 +20,7 @@ format:
 # Update the recent and minimal lock files.
 update-lock-files:
   contrib/update-lock-files.sh
+
+# Check for API changes
+check-api:
+ contrib/check-for-api-changes.sh


### PR DESCRIPTION
This is #1880 but only for the `hashes` crate.

Since we are making a push to get `hashes` stabalized as a stepping stone to stabalizing `bitcoin` lets start checking the public API of `hashes`. This will help us prove the value of the checking script in a repo that is more high volume than `bech32` but in a way that doesn't choke the whole repo in case it has teething problems. 

See #1875 for more context.