### PR TITLE
Add a new `sha256t::HashEngine` type

### DIFF
--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -1561,7 +1561,7 @@ mod test {
     use core::str::FromStr;
 
     use hashes::sha256t::Tag;
-    use hashes::{sha256, Hash, HashEngine};
+    use hashes::{sha256, sha256t, Hash, HashEngine};
     use hex::FromHex;
     use secp256k1::{VerifyOnly, XOnlyPublicKey};
 
@@ -1577,12 +1577,12 @@ mod test {
         serde_test::{assert_tokens, Token},
     };
 
-    fn tag_engine(tag_name: &str) -> sha256::HashEngine {
+    fn tag_engine(tag_name: &str) -> sha256t::HashEngine {
         let mut engine = sha256::Hash::engine();
         let tag_hash = sha256::Hash::hash(tag_name.as_bytes());
         engine.input(tag_hash.as_ref());
         engine.input(tag_hash.as_ref());
-        engine
+        sha256t::HashEngine::from_pretagged(engine)
     }
 
     #[test]

--- a/hashes/extended_tests/schemars/src/main.rs
+++ b/hashes/extended_tests/schemars/src/main.rs
@@ -123,10 +123,11 @@ mod tests {
         pub struct TestHashTag;
 
         impl sha256t::Tag for TestHashTag {
-            fn engine() -> sha256::HashEngine {
+            fn engine() -> sha256t::HashEngine {
                 // The TapRoot TapLeaf midstate.
                 let midstate = sha256::Midstate::from_byte_array(TEST_MIDSTATE);
-                sha256::HashEngine::from_midstate(midstate, 64)
+                let engine = sha256::HashEngine::from_midstate(midstate, 64);
+                sha256t::HashEngine::from_pretagged(engine)
             }
         }
 

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -148,6 +148,8 @@ impl<T: Hash> Hash for Hmac<T> {
     type Engine = HmacEngine<T>;
     type Bytes = T::Bytes;
 
+    fn engine() -> Self::Engine { Default::default() }
+
     fn from_engine(mut e: HmacEngine<T>) -> Hmac<T> {
         let ihash = T::from_engine(e.iengine);
         e.oengine.input(&ihash[..]);

--- a/hashes/src/impls.rs
+++ b/hashes/src/impls.rs
@@ -5,7 +5,7 @@
 //! Implementations of traits defined in `std` / `core2` and not in `core`.
 //!
 
-use crate::{hmac, io, ripemd160, sha1, sha256, sha512, siphash24, HashEngine};
+use crate::{hmac, io, ripemd160, sha1, sha256, sha256t, sha512, siphash24, HashEngine};
 
 impl io::Write for sha1::HashEngine {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
@@ -17,6 +17,15 @@ impl io::Write for sha1::HashEngine {
 }
 
 impl io::Write for sha256::HashEngine {
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.input(buf);
+        Ok(buf.len())
+    }
+}
+
+impl io::Write for sha256t::HashEngine {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -140,7 +140,7 @@ use core2::io;
 pub use hmac::{Hmac, HmacEngine};
 
 /// A hashing engine which bytes can be serialized into.
-pub trait HashEngine: Clone + Default {
+pub trait HashEngine: Clone {
     /// Byte array representing the internal state of the hash engine.
     type MidState;
 
@@ -186,7 +186,7 @@ pub trait Hash:
     type Bytes: hex::FromHex + Copy;
 
     /// Constructs a new engine.
-    fn engine() -> Self::Engine { Self::Engine::default() }
+    fn engine() -> Self::Engine;
 
     /// Produces a hash from the current state of a given engine.
     fn from_engine(e: Self::Engine) -> Self;


### PR DESCRIPTION
This is an alternate solution to the issue described in https://github.com/rust-bitcoin/rust-bitcoin/issues/1552

Patch 1 removes the `Default` trait bound on `Hash` which allows us to remove the footgun without having to add a tag to the `sha256::HashEngine`.

Resolves: #1552