### PR TITLE
Backport #1820 and bump minor version 0.30.2

### DIFF
--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.2 - 2023-11-16
+
+- Expose valid (min, max) difficulty transition thresholds [#1820](Expose valid (min, max) difficulty transition thresholds)
+
 # 0.30.1 - 2023-07-16
 
 - Fix compilation when [`RUSTFLAGS=--cfg=bench` is set](https://github.com/rust-bitcoin/rust-bitcoin/pull/1943)

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.30.1"
+version = "0.30.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -235,6 +235,20 @@ impl Target {
     /// [`difficulty`]: Target::difficulty
     #[cfg_attr(all(test, mutate), mutate)]
     pub fn difficulty_float(&self) -> f64 { TARGET_MAX_F64 / self.0.to_f64() }
+
+    /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs.
+    ///
+    /// The difficulty can only decrease or increase by a factor of 4 max on each difficulty
+    /// adjustment period.
+    pub fn min_difficulty_transition_threshold(&self) -> Self { Self(self.0 >> 2) }
+
+    /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs.
+    ///
+    /// The difficulty can only decrease or increase by a factor of 4 max on each difficulty
+    /// adjustment period.
+    pub fn max_difficulty_transition_threshold(&self) -> Self { Self(self.0 << 2) }
 }
 do_impl!(Target);
 


### PR DESCRIPTION
Patch one backports #1820, I believe this is all that is needed for LDK to be able to upgrade to `rust-bitcoin v0.30`.

Context:

- https://github.com/rust-bitcoin/rust-bitcoin/pull/1820
- https://github.com/lightningdevkit/rust-lightning/issues/2124

Patch 2 adds a changelog entry and bumps the minor version.