### PR TITLE
policy: Add section on standard set of derives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,6 +335,27 @@ sure, feel free to ask. If we determine panicking is more practical it must be d
 panics that could theoretically occur because of bugs in our code must not be documented.
 
 
+#### Derives
+
+We try to use standard set of derives if it makes sense:
+
+```
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum Foo {
+    Bar,
+    Baz,
+}
+```
+
+For types that do should not form a total or partial order, or that technically do but it does not
+make sense to compare them, we use the `Ordered` trait from the
+[`ordered`](https://crates.io/crates/ordered) crate. See `absolute::LockTime` for an example.
+
+For error types you likely want to use `#[derive(Debug, Clone, PartialEq, Eq)]`.
+
+See [Errors](#errors) section.
+
+
 #### Attributes
 
 - `#[track_caller]`: Used on functions that panic on invalid arguments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,6 @@ changes to this document in a pull request.
   * [Peer review](#peer-review)
   * [Repository maintainers](#repository-maintainers)
 - [Coding conventions](#coding-conventions)
-  * [Formatting](#formatting)
-  * [MSRV](#msrv)
   * [Naming conventions](#naming-conventions)
   * [Upgrading dependencies](#upgrading-dependencies)
   * [Unsafe code](#unsafe-code)


### PR DESCRIPTION
We can have a standard set of derives to make it easier for new devs to work out what to use and also to help us move towards a uniform set in preparation for crate stabilization.

This is not me imposing my view but rather a place for the discussion to happen, could have been a discussions topic also? Using "open" instead of "draft" to aid visibility. Probably requires more than the usual amount of acks.