### PR TITLE
Make `consensus::encode` private

### DIFF
--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -387,7 +387,7 @@ the case and how we broke both `rust-miniscript` and BDK.
 - Refactor `CommandString`.
 - Refactor `Reject` message.
 - Rename `RejectReason` enum variants.
-- Refactor `encode::Error`.
+- Refactor `consensus::Error`.
 - Implement `Default` for `TxIn`.
 - Implement `std::hash::Hash` for `Inventory`.
 - Implement `Copy` for `InvType` enum.
@@ -423,7 +423,7 @@ the case and how we broke both `rust-miniscript` and BDK.
     * Now supports segwit addresses with version >0.
     * Add `Address::from_script` constructor.
     * Add `Address::address_type` inspector.
-    * Parsing now returns an `address::Error` instead of `encode::Error`.
+    * Parsing now returns an `address::Error` instead of `consensus::Error`.
     * Removed `bitcoin_bech32` dependency for bech32 payloads.
 * bip143: Rename `witness_script` to `script_code`
 * Rename `BlockHeader::spv_validate` to `validate_pow`

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -34,13 +34,12 @@ use std::fmt;
 use std::str::FromStr;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
-use bitcoin::consensus::encode;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::{self, Input, Psbt, PsbtSighashType};
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};
 use bitcoin::{
-    transaction, Address, Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction,
-    TxIn, TxOut, Witness,
+    consensus, transaction, Address, Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence,
+    Transaction, TxIn, TxOut, Witness,
 };
 
 type Result<T> = std::result::Result<T, Error>;
@@ -85,7 +84,7 @@ fn main() -> Result<()> {
     let tx = finalized.extract_tx_unchecked_fee_rate();
     tx.verify(|_| Some(previous_output())).expect("failed to verify transaction");
 
-    let hex = encode::serialize_hex(&tx);
+    let hex = consensus::serialize_hex(&tx);
     println!("You should now be able to broadcast the following transaction: \n\n{}", hex);
 
     Ok(())

--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -5,7 +5,7 @@ use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpStream};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, process};
 
-use bitcoin::consensus::{encode, Decodable};
+use bitcoin::consensus::{self, Decodable};
 use bitcoin::p2p::{self, address, message, message_network};
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::rand::Rng;
@@ -33,7 +33,7 @@ fn main() {
 
     if let Ok(mut stream) = TcpStream::connect(address) {
         // Send the message
-        let _ = stream.write_all(encode::serialize(&first_message).as_slice());
+        let _ = stream.write_all(consensus::serialize(&first_message).as_slice());
         println!("Sent version message");
 
         // Setup StreamReader
@@ -51,7 +51,7 @@ fn main() {
                         message::NetworkMessage::Verack,
                     );
 
-                    let _ = stream.write_all(encode::serialize(&second_message).as_slice());
+                    let _ = stream.write_all(consensus::serialize(&second_message).as_slice());
                     println!("Sent verack message");
                 }
                 message::NetworkMessage::Verack => {

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -79,7 +79,6 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
-use bitcoin::consensus::encode;
 use bitcoin::hashes::Hash;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
@@ -88,8 +87,8 @@ use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::{self, SighashCache, TapSighash, TapSighashType};
 use bitcoin::taproot::{self, LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::{
-    absolute, script, transaction, Address, Amount, Network, OutPoint, ScriptBuf, Transaction,
-    TxIn, TxOut, Witness,
+    absolute, consensus, script, transaction, Address, Amount, Network, OutPoint, ScriptBuf,
+    Transaction, TxIn, TxOut, Witness,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -112,7 +111,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|x| x.checked_sub(ABSOLUTE_FEES_IN_SATS))
         .ok_or("Fees more than input amount!")?;
 
-    let tx_hex_string = encode::serialize_hex(&generate_bip86_key_spend_tx(
+    let tx_hex_string = consensus::serialize_hex(&generate_bip86_key_spend_tx(
         &secp,
         // The master extended private key from the descriptor in step 4
         Xpriv::from_str(BENEFACTOR_XPRIV_STR)?,
@@ -144,7 +143,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             absolute::LockTime::from_height(1000).unwrap(),
             UTXO_2,
         )?;
-        let tx_hex = encode::serialize_hex(&tx);
+        let tx_hex = consensus::serialize_hex(&tx);
 
         println!("Inheritance funding tx hex:\n\n{}", tx_hex);
         // You can now broadcast the transaction hex:
@@ -158,7 +157,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             absolute::LockTime::from_height(1000).unwrap(),
             to_address,
         )?;
-        let spending_tx_hex = encode::serialize_hex(&spending_tx);
+        let spending_tx_hex = consensus::serialize_hex(&spending_tx);
         println!("\nInheritance spending tx hex:\n\n{}", spending_tx_hex);
         // If you try to broadcast now, the transaction will be rejected as it is timelocked.
         // First mine 900 blocks so we're sure we are over the 1000 block locktime:
@@ -182,7 +181,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             absolute::LockTime::from_height(2000).unwrap(),
             UTXO_3,
         )?;
-        let tx_hex = encode::serialize_hex(&tx);
+        let tx_hex = consensus::serialize_hex(&tx);
 
         println!("Inheritance funding tx hex:\n\n{}", tx_hex);
         // You can now broadcast the transaction hex:
@@ -197,7 +196,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // by the timelock so we can spend it immediately. We set up a new output similar to the first with
         // a locktime that is 'locktime_delta' blocks greater.
         let (tx, _) = benefactor.refresh_tx(1000)?;
-        let tx_hex = encode::serialize_hex(&tx);
+        let tx_hex = consensus::serialize_hex(&tx);
 
         println!("\nRefreshed inheritance tx hex:\n\n{}\n", tx_hex);
 

--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -11,9 +11,9 @@ use core::fmt::{self, Write};
 use core::str::FromStr;
 use core::{default, ops};
 
-use crate::consensus::encode::{self, Decodable, Encodable};
-use crate::io;
+use crate::consensus::{Decodable, Encodable};
 use crate::prelude::*;
+use crate::{consensus, io};
 
 /// A set of denominations in which amounts can be expressed.
 ///
@@ -690,7 +690,7 @@ impl Amount {
 
 impl Decodable for Amount {
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Ok(Amount(Decodable::consensus_decode(r)?))
     }
 }

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -13,7 +13,7 @@ use std::error;
 use hashes::{sha256, siphash24, Hash};
 use internals::impl_array_newtype;
 
-use crate::consensus::encode::{self, Decodable, Encodable, VarInt};
+use crate::consensus::{self, Decodable, Encodable, VarInt};
 use crate::internal_macros::{impl_bytes_newtype, impl_consensus_encoding};
 use crate::prelude::*;
 use crate::{block, io, Block, BlockHash, Transaction};
@@ -80,10 +80,11 @@ impl Encodable for PrefilledTransaction {
 
 impl Decodable for PrefilledTransaction {
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         let idx = VarInt::consensus_decode(r)?.0;
-        let idx = u16::try_from(idx)
-            .map_err(|_| encode::Error::ParseFailed("BIP152 prefilled tx index out of bounds"))?;
+        let idx = u16::try_from(idx).map_err(|_| {
+            consensus::Error::ParseFailed("BIP152 prefilled tx index out of bounds")
+        })?;
         let tx = Transaction::consensus_decode(r)?;
         Ok(PrefilledTransaction { idx, tx })
     }
@@ -136,7 +137,7 @@ impl Encodable for ShortId {
 
 impl Decodable for ShortId {
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<ShortId, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<ShortId, consensus::Error> {
         Ok(ShortId(Decodable::consensus_decode(r)?))
     }
 }
@@ -272,7 +273,7 @@ impl Encodable for BlockTransactionsRequest {
 }
 
 impl Decodable for BlockTransactionsRequest {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Ok(BlockTransactionsRequest {
             block_hash: BlockHash::consensus_decode(r)?,
             indexes: {
@@ -284,11 +285,11 @@ impl Decodable for BlockTransactionsRequest {
                 // transactions that would be allowed in a vector.
                 let byte_size = (nb_indexes)
                     .checked_mul(mem::size_of::<Transaction>())
-                    .ok_or(encode::Error::ParseFailed("Invalid length"))?;
-                if byte_size > encode::MAX_VEC_SIZE {
-                    return Err(encode::Error::OversizedVectorAllocation {
+                    .ok_or(consensus::Error::ParseFailed("Invalid length"))?;
+                if byte_size > consensus::MAX_VEC_SIZE {
+                    return Err(consensus::Error::OversizedVectorAllocation {
                         requested: byte_size,
-                        max: encode::MAX_VEC_SIZE,
+                        max: consensus::MAX_VEC_SIZE,
                     });
                 }
 
@@ -298,12 +299,12 @@ impl Decodable for BlockTransactionsRequest {
                     let differential: VarInt = Decodable::consensus_decode(r)?;
                     last_index = match last_index.checked_add(differential.0) {
                         Some(i) => i,
-                        None => return Err(encode::Error::ParseFailed("block index overflow")),
+                        None => return Err(consensus::Error::ParseFailed("block index overflow")),
                     };
                     indexes.push(last_index);
                     last_index = match last_index.checked_add(1) {
                         Some(i) => i,
-                        None => return Err(encode::Error::ParseFailed("block index overflow")),
+                        None => return Err(consensus::Error::ParseFailed("block index overflow")),
                     };
                 }
                 indexes
@@ -375,7 +376,7 @@ mod test {
     use super::*;
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::transaction;
-    use crate::consensus::encode::{deserialize, serialize};
+    use crate::consensus::{deserialize, serialize};
     use crate::hash_types::TxMerkleNode;
     use crate::{
         Amount, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -48,8 +48,7 @@ use internals::write_err;
 use crate::blockdata::block::Block;
 use crate::blockdata::script::Script;
 use crate::blockdata::transaction::OutPoint;
-use crate::consensus::encode::VarInt;
-use crate::consensus::{Decodable, Encodable};
+use crate::consensus::{Decodable, Encodable, VarInt};
 use crate::hash_types::{BlockHash, FilterHash, FilterHeader};
 use crate::io;
 use crate::prelude::*;
@@ -556,7 +555,7 @@ mod test {
     use serde_json::Value;
 
     use super::*;
-    use crate::consensus::encode::deserialize;
+    use crate::consensus::deserialize;
     use crate::hash_types::BlockHash;
     use crate::ScriptBuf;
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -15,12 +15,12 @@ use hashes::{Hash, HashEngine};
 use super::Weight;
 use crate::blockdata::script;
 use crate::blockdata::transaction::Transaction;
-use crate::consensus::{encode, Decodable, Encodable};
+use crate::consensus::{Decodable, Encodable};
 use crate::hash_types::{TxMerkleNode, WitnessCommitment, WitnessMerkleNode, Wtxid};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::pow::{CompactTarget, Target, Work};
 use crate::prelude::*;
-use crate::{io, merkle_tree, Network, VarInt};
+use crate::{consensus, io, merkle_tree, Network, VarInt};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -191,7 +191,7 @@ impl Encodable for Version {
 }
 
 impl Decodable for Version {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Decodable::consensus_decode(r).map(Version)
     }
 }
@@ -466,7 +466,7 @@ mod tests {
     use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::*;
-    use crate::consensus::encode::{deserialize, serialize};
+    use crate::consensus::{deserialize, serialize};
 
     #[test]
     fn test_coinbase_and_bip34() {

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -191,7 +191,7 @@ mod test {
     use super::*;
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::transaction;
-    use crate::consensus::encode::serialize;
+    use crate::consensus::serialize;
     use crate::network::Network;
 
     #[test]

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -15,7 +15,7 @@ use mutagen::mutate;
 
 #[cfg(doc)]
 use crate::absolute;
-use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::{self, Decodable, Encodable};
 use crate::error::ParseIntError;
 use crate::io::{self, Read, Write};
 use crate::parse::{impl_parse_str_from_int_fallible, impl_parse_str_from_int_infallible};
@@ -345,7 +345,7 @@ impl Encodable for LockTime {
 
 impl Decodable for LockTime {
     #[inline]
-    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         u32::consensus_decode(r).map(LockTime::from_consensus)
     }
 }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -71,7 +71,7 @@ use serde;
 
 use crate::blockdata::opcodes::all::*;
 use crate::blockdata::opcodes::{self, Opcode};
-use crate::consensus::{encode, Decodable, Encodable};
+use crate::consensus::{self, Decodable, Encodable};
 use crate::prelude::*;
 use crate::{io, OutPoint};
 
@@ -579,7 +579,7 @@ impl<'de> serde::Deserialize<'de> for ScriptBuf {
 impl Encodable for Script {
     #[inline]
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        crate::consensus::encode::consensus_encode_with_size(&self.0, w)
+        consensus::consensus_encode_with_size(&self.0, w)
     }
 }
 
@@ -594,7 +594,7 @@ impl Decodable for ScriptBuf {
     #[inline]
     fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, consensus::Error> {
         Ok(ScriptBuf(Decodable::consensus_decode_from_finite_reader(r)?))
     }
 }

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -7,7 +7,7 @@ use hex_lit::hex;
 
 use super::*;
 use crate::blockdata::opcodes;
-use crate::consensus::encode::{deserialize, serialize};
+use crate::consensus::{deserialize, serialize};
 use crate::crypto::key::{PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey};
 
 #[test]

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -23,7 +23,7 @@ use crate::blockdata::locktime::absolute::{self, Height, Time};
 use crate::blockdata::locktime::relative;
 use crate::blockdata::script::{Script, ScriptBuf};
 use crate::blockdata::witness::Witness;
-use crate::consensus::{encode, Decodable, Encodable};
+use crate::consensus::{Decodable, Encodable};
 use crate::hash_types::{Txid, Wtxid};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::parse::impl_parse_str_from_int_infallible;
@@ -32,7 +32,7 @@ use crate::script::Push;
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::string::FromHexStr;
-use crate::{io, Amount, VarInt};
+use crate::{consensus, io, Amount, VarInt};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[cfg(feature = "bitcoinconsensus")]
@@ -1002,7 +1002,7 @@ impl Encodable for Version {
 }
 
 impl Decodable for Version {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Decodable::consensus_decode(r).map(Version)
     }
 }
@@ -1016,7 +1016,7 @@ impl Encodable for OutPoint {
     }
 }
 impl Decodable for OutPoint {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Ok(OutPoint {
             txid: Decodable::consensus_decode(r)?,
             vout: Decodable::consensus_decode(r)?,
@@ -1037,7 +1037,7 @@ impl Decodable for TxIn {
     #[inline]
     fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, consensus::Error> {
         Ok(TxIn {
             previous_output: Decodable::consensus_decode_from_finite_reader(r)?,
             script_sig: Decodable::consensus_decode_from_finite_reader(r)?,
@@ -1054,7 +1054,7 @@ impl Encodable for Sequence {
 }
 
 impl Decodable for Sequence {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Decodable::consensus_decode(r).map(Sequence)
     }
 }
@@ -1086,7 +1086,7 @@ impl Encodable for Transaction {
 impl Decodable for Transaction {
     fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, consensus::Error> {
         let version = Version::consensus_decode_from_finite_reader(r)?;
         let input = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
         // segwit
@@ -1101,7 +1101,9 @@ impl Decodable for Transaction {
                         txin.witness = Decodable::consensus_decode_from_finite_reader(r)?;
                     }
                     if !input.is_empty() && input.iter().all(|input| input.witness.is_empty()) {
-                        Err(encode::Error::ParseFailed("witness flag set but no witnesses present"))
+                        Err(consensus::Error::ParseFailed(
+                            "witness flag set but no witnesses present",
+                        ))
                     } else {
                         Ok(Transaction {
                             version,
@@ -1112,7 +1114,7 @@ impl Decodable for Transaction {
                     }
                 }
                 // We don't support anything else
-                x => Err(encode::Error::UnsupportedSegwitFlag(x)),
+                x => Err(consensus::Error::UnsupportedSegwitFlag(x)),
             }
         // non-segwit
         } else {
@@ -1452,7 +1454,7 @@ mod tests {
     use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::script::ScriptBuf;
-    use crate::consensus::encode::{deserialize, serialize};
+    use crate::consensus::{deserialize, serialize};
     use crate::sighash::EcdsaSighashType;
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -9,8 +9,7 @@ use core::convert::TryInto;
 use core::fmt;
 use core::ops::Index;
 
-use crate::consensus::encode::{Error, MAX_VEC_SIZE};
-use crate::consensus::{Decodable, Encodable, WriteExt};
+use crate::consensus::{Decodable, Encodable, Error, WriteExt, MAX_VEC_SIZE};
 use crate::crypto::ecdsa;
 use crate::io::{self, Read, Write};
 use crate::prelude::*;

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -6,7 +6,7 @@
 //! conform to Bitcoin consensus.
 //!
 
-pub mod encode;
+mod encode;
 mod params;
 #[cfg(feature = "serde")]
 pub mod serde;
@@ -16,10 +16,11 @@ pub mod validation;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    encode::{deserialize, deserialize_partial, serialize, Decodable, Encodable, ReadExt, WriteExt},
+    encode::{deserialize, deserialize_partial, serialize, serialize_hex, Decodable, Encodable, Error, ReadExt, WriteExt, VarInt, CheckedData, MAX_VEC_SIZE},
     params::Params,
 };
 
+pub(crate) use self::encode::consensus_encode_with_size;
 #[cfg(feature = "bitcoinconsensus")]
 #[doc(inline)]
 pub use self::validation::{

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -7,7 +7,7 @@
 //!
 
 pub mod encode;
-pub mod params;
+mod params;
 #[cfg(feature = "serde")]
 pub mod serde;
 #[cfg(feature = "bitcoinconsensus")]

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -371,23 +371,23 @@ enum DecodeError<E> {
 
 // not a trait impl because we panic on some variants
 fn consensus_error_into_serde<E: serde::de::Error>(error: ConsensusError) -> E {
+    use crate::consensus::encode::Error::*;
     match error {
-        ConsensusError::Io(error) => panic!("unexpected IO error {:?}", error),
-        ConsensusError::OversizedVectorAllocation { requested, max } => E::custom(format_args!(
+        Io(error) => panic!("unexpected IO error {:?}", error),
+        OversizedVectorAllocation { requested, max } => E::custom(format_args!(
             "the requested allocation of {} items exceeds maximum of {}",
             requested, max
         )),
-        ConsensusError::InvalidChecksum { expected, actual } => E::invalid_value(
+        InvalidChecksum { expected, actual } => E::invalid_value(
             Unexpected::Bytes(&actual),
             &DisplayExpected(format_args!(
                 "checksum {:02x}{:02x}{:02x}{:02x}",
                 expected[0], expected[1], expected[2], expected[3]
             )),
         ),
-        ConsensusError::NonMinimalVarInt =>
-            E::custom(format_args!("compact size was not encoded minimally")),
-        ConsensusError::ParseFailed(msg) => E::custom(msg),
-        ConsensusError::UnsupportedSegwitFlag(flag) =>
+        NonMinimalVarInt => E::custom(format_args!("compact size was not encoded minimally")),
+        ParseFailed(msg) => E::custom(msg),
+        UnsupportedSegwitFlag(flag) =>
             E::invalid_value(Unexpected::Unsigned(flag.into()), &"segwit version 1 flag"),
     }
 }

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -16,7 +16,7 @@ use serde::de::{SeqAccess, Unexpected, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserializer, Serializer};
 
-use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::{self, Decodable, Encodable};
 use crate::io;
 
 /// Hex-encoding strategy
@@ -364,13 +364,13 @@ impl<D: fmt::Display> serde::de::Expected for DisplayExpected<D> {
 
 enum DecodeError<E> {
     TooManyBytes,
-    Consensus(encode::Error),
+    Consensus(consensus::Error),
     Other(E),
 }
 
 // not a trait impl because we panic on some variants
-fn consensus_error_into_serde<E: serde::de::Error>(error: encode::Error) -> E {
-    use crate::consensus::encode::Error::*;
+fn consensus_error_into_serde<E: serde::de::Error>(error: consensus::Error) -> E {
+    use crate::consensus::Error::*;
     match error {
         Io(error) => panic!("unexpected IO error {:?}", error),
         OversizedVectorAllocation { requested, max } => E::custom(format_args!(
@@ -433,9 +433,9 @@ impl<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> IterReader<E, I> {
             },
             (Ok(value), None) => Ok(value),
             (Ok(_), Some(error)) => panic!("{} silently ate the error: {:?}", core::any::type_name::<T>(), error),
-            (Err(encode::Error::Io(io_error)), Some(de_error)) if io_error.kind() == io::ErrorKind::Other && io_error.get_ref().is_none() => Err(DecodeError::Other(de_error)),
+            (Err(consensus::Error::Io(io_error)), Some(de_error)) if io_error.kind() == io::ErrorKind::Other && io_error.get_ref().is_none() => Err(DecodeError::Other(de_error)),
             (Err(consensus_error), None) => Err(DecodeError::Consensus(consensus_error)),
-            (Err(encode::Error::Io(io_error)), de_error) => panic!("Unexpected IO error {:?} returned from {}::consensus_decode(), deserialization error: {:?}", io_error, core::any::type_name::<T>(), de_error),
+            (Err(consensus::Error::Io(io_error)), de_error) => panic!("Unexpected IO error {:?} returned from {}::consensus_decode(), deserialization error: {:?}", io_error, core::any::type_name::<T>(), de_error),
             (Err(consensus_error), Some(de_error)) => panic!("{} should've returned `Other` IO error because of deserialization error {:?} but it returned consensus error {:?} instead", core::any::type_name::<T>(), de_error, consensus_error),
         }
     }

--- a/bitcoin/src/consensus/validation.rs
+++ b/bitcoin/src/consensus/validation.rs
@@ -11,9 +11,7 @@ use internals::write_err;
 use crate::amount::Amount;
 use crate::blockdata::script::Script;
 use crate::blockdata::transaction::{OutPoint, Transaction, TxOut};
-#[cfg(doc)]
 use crate::consensus;
-use crate::consensus::encode;
 
 /// Verifies spend of an input script.
 ///
@@ -87,7 +85,7 @@ where
     S: FnMut(&OutPoint) -> Option<TxOut>,
     F: Into<u32>,
 {
-    let serialized_tx = encode::serialize(tx);
+    let serialized_tx = consensus::serialize(tx);
     let flags: u32 = flags.into();
     for (idx, input) in tx.input.iter().enumerate() {
         if let Some(output) = spent(&input.previous_output) {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -18,7 +18,7 @@ use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
 use internals::write_err;
 
 use crate::blockdata::witness::Witness;
-use crate::consensus::{encode, Encodable};
+use crate::consensus::{self, Encodable};
 use crate::prelude::*;
 use crate::taproot::{LeafVersion, TapLeafHash, TAPROOT_ANNEX_PREFIX};
 use crate::{io, Amount, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut};
@@ -1231,7 +1231,7 @@ impl<'a> Annex<'a> {
 
 impl<'a> Encodable for Annex<'a> {
     fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        encode::consensus_encode_with_size(self.0, w)
+        consensus::consensus_encode_with_size(self.0, w)
     }
 }
 

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -18,7 +18,7 @@ macro_rules! impl_hashencode {
         }
 
         impl $crate::consensus::Decodable for $hashtype {
-            fn consensus_decode<R: $crate::io::Read + ?Sized>(r: &mut R) -> Result<Self, $crate::consensus::encode::Error> {
+            fn consensus_decode<R: $crate::io::Read + ?Sized>(r: &mut R) -> Result<Self, $crate::consensus::Error> {
                 use $crate::hashes::Hash;
                 Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode(r)?))
             }

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -24,7 +24,7 @@ macro_rules! impl_consensus_encoding {
             #[inline]
             fn consensus_decode_from_finite_reader<R: $crate::io::Read + ?Sized>(
                 r: &mut R,
-            ) -> Result<$thing, $crate::consensus::encode::Error> {
+            ) -> Result<$thing, $crate::consensus::Error> {
                 Ok($thing {
                     $($field: $crate::consensus::Decodable::consensus_decode_from_finite_reader(r)?),+
                 })
@@ -33,8 +33,8 @@ macro_rules! impl_consensus_encoding {
             #[inline]
             fn consensus_decode<R: $crate::io::Read + ?Sized>(
                 r: &mut R,
-            ) -> Result<$thing, $crate::consensus::encode::Error> {
-                let mut r = r.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
+            ) -> Result<$thing, $crate::consensus::Error> {
+                let mut r = r.take($crate::consensus::MAX_VEC_SIZE as u64);
                 Ok($thing {
                     $($field: $crate::consensus::Decodable::consensus_decode(&mut r)?),+
                 })

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -132,7 +132,7 @@ pub use crate::{
     blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut},
     blockdata::weight::Weight,
     blockdata::witness::{self, Witness},
-    consensus::encode::VarInt,
+    consensus::VarInt,
     crypto::ecdsa,
     crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey},
     crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -20,7 +20,7 @@ use core::iter;
 
 use hashes::Hash;
 
-use crate::consensus::encode::Encodable;
+use crate::consensus::Encodable;
 use crate::io;
 use crate::prelude::*;
 
@@ -116,7 +116,7 @@ mod tests {
 
     use super::*;
     use crate::blockdata::block::Block;
-    use crate::consensus::encode::deserialize;
+    use crate::consensus::deserialize;
 
     #[test]
     fn both_merkle_root_functions_return_the_same_result() {

--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -10,7 +10,7 @@
 //!
 //! ```rust
 //! use bitcoin::Network;
-//! use bitcoin::consensus::encode::serialize;
+//! use bitcoin::consensus::serialize;
 //!
 //! let network = Network::Bitcoin;
 //! let bytes = serialize(&network.magic());
@@ -286,7 +286,7 @@ impl TryFrom<ChainHash> for Network {
 #[cfg(test)]
 mod tests {
     use super::Network;
-    use crate::consensus::encode::{deserialize, serialize};
+    use crate::consensus::{deserialize, serialize};
     use crate::p2p::ServiceFlags;
 
     #[test]

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -9,7 +9,7 @@
 use core::{fmt, iter};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
 
-use crate::consensus::encode::{self, Decodable, Encodable, ReadExt, VarInt, WriteExt};
+use crate::consensus::{self, Decodable, Encodable, ReadExt, VarInt, WriteExt};
 use crate::io;
 use crate::p2p::ServiceFlags;
 use crate::prelude::*;
@@ -74,7 +74,7 @@ impl Encodable for Address {
 
 impl Decodable for Address {
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Ok(Address {
             services: Decodable::consensus_decode(r)?,
             address: read_be_address(r)?,
@@ -84,7 +84,7 @@ impl Decodable for Address {
 }
 
 /// Read a big-endian address from reader.
-fn read_be_address<R: io::Read + ?Sized>(r: &mut R) -> Result<[u16; 8], encode::Error> {
+fn read_be_address<R: io::Read + ?Sized>(r: &mut R) -> Result<[u16; 8], consensus::Error> {
     let mut address = [0u16; 8];
     let mut buf = [0u8; 2];
 
@@ -166,32 +166,32 @@ impl Encodable for AddrV2 {
 }
 
 impl Decodable for AddrV2 {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         let network_id = u8::consensus_decode(r)?;
         let len = VarInt::consensus_decode(r)?.0;
         if len > 512 {
-            return Err(encode::Error::ParseFailed("IP must be <= 512 bytes"));
+            return Err(consensus::Error::ParseFailed("IP must be <= 512 bytes"));
         }
         Ok(match network_id {
             1 => {
                 if len != 4 {
-                    return Err(encode::Error::ParseFailed("Invalid IPv4 address"));
+                    return Err(consensus::Error::ParseFailed("Invalid IPv4 address"));
                 }
                 let addr: [u8; 4] = Decodable::consensus_decode(r)?;
                 AddrV2::Ipv4(Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]))
             }
             2 => {
                 if len != 16 {
-                    return Err(encode::Error::ParseFailed("Invalid IPv6 address"));
+                    return Err(consensus::Error::ParseFailed("Invalid IPv6 address"));
                 }
                 let addr: [u16; 8] = read_be_address(r)?;
                 if addr[0..3] == ONION {
-                    return Err(encode::Error::ParseFailed(
+                    return Err(consensus::Error::ParseFailed(
                         "OnionCat address sent with IPv6 network id",
                     ));
                 }
                 if addr[0..6] == [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xFFFF] {
-                    return Err(encode::Error::ParseFailed(
+                    return Err(consensus::Error::ParseFailed(
                         "IPV4 wrapped address sent with IPv6 network id",
                     ));
                 }
@@ -201,33 +201,33 @@ impl Decodable for AddrV2 {
             }
             3 => {
                 if len != 10 {
-                    return Err(encode::Error::ParseFailed("Invalid TorV2 address"));
+                    return Err(consensus::Error::ParseFailed("Invalid TorV2 address"));
                 }
                 let id = Decodable::consensus_decode(r)?;
                 AddrV2::TorV2(id)
             }
             4 => {
                 if len != 32 {
-                    return Err(encode::Error::ParseFailed("Invalid TorV3 address"));
+                    return Err(consensus::Error::ParseFailed("Invalid TorV3 address"));
                 }
                 let pubkey = Decodable::consensus_decode(r)?;
                 AddrV2::TorV3(pubkey)
             }
             5 => {
                 if len != 32 {
-                    return Err(encode::Error::ParseFailed("Invalid I2P address"));
+                    return Err(consensus::Error::ParseFailed("Invalid I2P address"));
                 }
                 let hash = Decodable::consensus_decode(r)?;
                 AddrV2::I2p(hash)
             }
             6 => {
                 if len != 16 {
-                    return Err(encode::Error::ParseFailed("Invalid CJDNS address"));
+                    return Err(consensus::Error::ParseFailed("Invalid CJDNS address"));
                 }
                 let addr: [u16; 8] = read_be_address(r)?;
                 // check the first byte for the CJDNS marker
                 if addr[0] != u16::from_be_bytes([0xFC, 0x00]) {
-                    return Err(encode::Error::ParseFailed("Invalid CJDNS address"));
+                    return Err(consensus::Error::ParseFailed("Invalid CJDNS address"));
                 }
                 AddrV2::Cjdns(Ipv6Addr::new(
                     addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7],
@@ -284,7 +284,7 @@ impl Encodable for AddrV2Message {
 }
 
 impl Decodable for AddrV2Message {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Ok(AddrV2Message {
             time: Decodable::consensus_decode(r)?,
             services: ServiceFlags::from(VarInt::consensus_decode(r)?.0),
@@ -309,7 +309,7 @@ mod test {
     use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::{AddrV2, AddrV2Message, Address};
-    use crate::consensus::encode::{deserialize, serialize};
+    use crate::consensus::{deserialize, serialize};
     use crate::p2p::ServiceFlags;
 
     #[test]

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -12,7 +12,7 @@ use core::{fmt, iter};
 use hashes::{sha256d, Hash};
 
 use crate::blockdata::{block, transaction};
-use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, VarInt};
+use crate::consensus::{self, CheckedData, Decodable, Encodable, VarInt};
 use crate::io;
 use crate::merkle_tree::MerkleBlock;
 use crate::p2p::address::{AddrV2Message, Address};
@@ -111,7 +111,7 @@ impl Encodable for CommandString {
 
 impl Decodable for CommandString {
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         let rawbytes: [u8; 12] = Decodable::consensus_decode(r)?;
         let rv = iter::FromIterator::from_iter(rawbytes.iter().filter_map(|&u| {
             if u > 0 {
@@ -410,7 +410,7 @@ impl Decodable for HeaderDeserializationWrapper {
     #[inline]
     fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, consensus::Error> {
         let len = VarInt::consensus_decode(r)?.0;
         // should be above usual number of items to avoid
         // allocation
@@ -418,7 +418,7 @@ impl Decodable for HeaderDeserializationWrapper {
         for _ in 0..len {
             ret.push(Decodable::consensus_decode(r)?);
             if u8::consensus_decode(r)? != 0u8 {
-                return Err(encode::Error::ParseFailed(
+                return Err(consensus::Error::ParseFailed(
                     "Headers message should not contain transactions",
                 ));
             }
@@ -427,7 +427,7 @@ impl Decodable for HeaderDeserializationWrapper {
     }
 
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
     }
 }
@@ -435,7 +435,7 @@ impl Decodable for HeaderDeserializationWrapper {
 impl Decodable for RawNetworkMessage {
     fn consensus_decode_from_finite_reader<R: io::Read + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, consensus::Error> {
         let magic = Decodable::consensus_decode_from_finite_reader(r)?;
         let cmd = CommandString::consensus_decode_from_finite_reader(r)?;
         let checked_data = CheckedData::consensus_decode_from_finite_reader(r)?;
@@ -532,7 +532,7 @@ impl Decodable for RawNetworkMessage {
     }
 
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
     }
 }
@@ -551,7 +551,7 @@ mod test {
     use crate::blockdata::block::{self, Block};
     use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::Transaction;
-    use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
+    use crate::consensus::{deserialize, deserialize_partial, serialize};
     use crate::network::Network;
     use crate::p2p::address::{AddrV2, AddrV2Message, Address};
     use crate::p2p::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -8,7 +8,7 @@
 
 use hashes::{sha256d, Hash as _};
 
-use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::{self, Decodable, Encodable};
 use crate::hash_types::{BlockHash, Txid, Wtxid};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::prelude::*;
@@ -81,7 +81,7 @@ impl Encodable for Inventory {
 
 impl Decodable for Inventory {
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         let inv_type: u32 = Decodable::consensus_decode(r)?;
         Ok(match inv_type {
             0 => Inventory::Error,
@@ -148,7 +148,7 @@ mod tests {
     use hex::test_hex_unwrap as hex;
 
     use super::{GetBlocksMessage, GetHeadersMessage, Vec};
-    use crate::consensus::encode::{deserialize, serialize};
+    use crate::consensus::{deserialize, serialize};
 
     #[test]
     fn getblocks_message_test() {

--- a/bitcoin/src/p2p/message_bloom.rs
+++ b/bitcoin/src/p2p/message_bloom.rs
@@ -5,7 +5,7 @@
 //! This module describes BIP37 Connection Bloom filtering network messages.
 //!
 
-use crate::consensus::{encode, Decodable, Encodable, ReadExt};
+use crate::consensus::{self, Decodable, Encodable, ReadExt};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::io;
 
@@ -47,12 +47,12 @@ impl Encodable for BloomFlags {
 }
 
 impl Decodable for BloomFlags {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Ok(match r.read_u8()? {
             0 => BloomFlags::None,
             1 => BloomFlags::All,
             2 => BloomFlags::PubkeyOnly,
-            _ => return Err(encode::Error::ParseFailed("unknown bloom flag")),
+            _ => return Err(consensus::Error::ParseFailed("unknown bloom flag")),
         })
     }
 }

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -8,7 +8,7 @@
 
 use hashes::sha256d;
 
-use crate::consensus::{encode, Decodable, Encodable, ReadExt};
+use crate::consensus::{self, Decodable, Encodable, ReadExt};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::p2p::address::Address;
 use crate::p2p::ServiceFlags;
@@ -109,7 +109,7 @@ impl Encodable for RejectReason {
 }
 
 impl Decodable for RejectReason {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Ok(match r.read_u8()? {
             0x01 => RejectReason::Malformed,
             0x10 => RejectReason::Invalid,
@@ -119,7 +119,7 @@ impl Decodable for RejectReason {
             0x41 => RejectReason::Dust,
             0x42 => RejectReason::Fee,
             0x43 => RejectReason::Checkpoint,
-            _ => return Err(encode::Error::ParseFailed("unknown reject code")),
+            _ => return Err(consensus::Error::ParseFailed("unknown reject code")),
         })
     }
 }
@@ -145,7 +145,7 @@ mod tests {
     use hex::test_hex_unwrap as hex;
 
     use super::{Reject, RejectReason, VersionMessage};
-    use crate::consensus::encode::{deserialize, serialize};
+    use crate::consensus::{deserialize, serialize};
     use crate::p2p::ServiceFlags;
 
     #[test]

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -27,7 +27,7 @@ use core::{fmt, ops};
 use hex::FromHex;
 use internals::{debug_from_display, write_err};
 
-use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::{self, Decodable, Encodable};
 use crate::prelude::{Borrow, BorrowMut, String, ToOwned};
 use crate::{io, Network};
 
@@ -198,7 +198,7 @@ impl Encodable for ServiceFlags {
 
 impl Decodable for ServiceFlags {
     #[inline]
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         Ok(ServiceFlags(Decodable::consensus_decode(r)?))
     }
 }
@@ -290,7 +290,7 @@ impl Encodable for Magic {
 }
 
 impl Decodable for Magic {
-    fn consensus_decode<R: io::Read + ?Sized>(reader: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(reader: &mut R) -> Result<Self, consensus::Error> {
         Ok(Magic(Decodable::consensus_decode(reader)?))
     }
 }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -12,9 +12,9 @@ use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
 
-use crate::consensus::encode::{self, Decodable, Encodable};
 #[cfg(doc)]
 use crate::consensus::Params;
+use crate::consensus::{self, Decodable, Encodable};
 use crate::hash_types::BlockHash;
 use crate::io::{self, Read, Write};
 use crate::prelude::String;
@@ -301,7 +301,7 @@ impl Encodable for CompactTarget {
 
 impl Decodable for CompactTarget {
     #[inline]
-    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         u32::consensus_decode(r).map(CompactTarget)
     }
 }

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -6,10 +6,9 @@ use internals::write_err;
 
 use crate::bip32::Xpub;
 use crate::blockdata::transaction::Transaction;
-use crate::consensus::encode;
 use crate::prelude::*;
 use crate::psbt::raw;
-use crate::{hashes, io};
+use crate::{consensus, hashes, io};
 
 /// Enum for marking psbt hash error.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -71,7 +70,7 @@ pub enum Error {
     /// global extended public key has inconsistent key sources
     CombineInconsistentKeySources(Box<Xpub>),
     /// Serialization error in bitcoin consensus-encoded structures
-    ConsensusEncoding(encode::Error),
+    ConsensusEncoding(consensus::Error),
     /// Negative fee
     NegativeFee,
     /// Integer overflow in fee calculation
@@ -206,8 +205,8 @@ impl From<hashes::FromSliceError> for Error {
     fn from(e: hashes::FromSliceError) -> Error { Error::InvalidHash(e) }
 }
 
-impl From<encode::Error> for Error {
-    fn from(e: encode::Error) -> Self { Error::ConsensusEncoding(e) }
+impl From<consensus::Error> for Error {
+    fn from(e: consensus::Error) -> Self { Error::ConsensusEncoding(e) }
 }
 
 impl From<io::Error> for Error {

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -4,8 +4,7 @@ use core::convert::TryFrom;
 
 use crate::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
 use crate::blockdata::transaction::Transaction;
-use crate::consensus::encode::MAX_VEC_SIZE;
-use crate::consensus::{encode, Decodable};
+use crate::consensus::{self, Decodable, MAX_VEC_SIZE};
 use crate::io::{self, Cursor, Read};
 use crate::prelude::*;
 use crate::psbt::map::Map;
@@ -30,10 +29,10 @@ impl Map for Psbt {
                 // Manually serialized to ensure 0-input txs are serialized
                 // without witnesses.
                 let mut ret = Vec::new();
-                ret.extend(encode::serialize(&self.unsigned_tx.version));
-                ret.extend(encode::serialize(&self.unsigned_tx.input));
-                ret.extend(encode::serialize(&self.unsigned_tx.output));
-                ret.extend(encode::serialize(&self.unsigned_tx.lock_time));
+                ret.extend(consensus::serialize(&self.unsigned_tx.version));
+                ret.extend(consensus::serialize(&self.unsigned_tx.input));
+                ret.extend(consensus::serialize(&self.unsigned_tx.output));
+                ret.extend(consensus::serialize(&self.unsigned_tx.lock_time));
                 ret
             },
         });

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -10,7 +10,7 @@ use core::convert::TryFrom;
 use core::fmt;
 
 use super::serialize::{Deserialize, Serialize};
-use crate::consensus::encode::{
+use crate::consensus::{
     self, deserialize, serialize, Decodable, Encodable, ReadExt, VarInt, WriteExt, MAX_VEC_SIZE,
 };
 use crate::io;
@@ -84,7 +84,7 @@ impl Key {
         let key_byte_size: u64 = byte_size - 1;
 
         if key_byte_size > MAX_VEC_SIZE as u64 {
-            return Err(encode::Error::OversizedVectorAllocation {
+            return Err(consensus::Error::OversizedVectorAllocation {
                 requested: key_byte_size as usize,
                 max: MAX_VEC_SIZE,
             }
@@ -159,7 +159,7 @@ impl<Subtype> Decodable for ProprietaryKey<Subtype>
 where
     Subtype: Copy + From<u8> + Into<u8>,
 {
-    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         let prefix = Vec::<u8>::consensus_decode(r)?;
         let subtype = Subtype::from(r.read_u8()?);
         let key = read_to_end(r)?;

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -16,7 +16,7 @@ use crate::bip32::{ChildNumber, Fingerprint, KeySource};
 use crate::blockdata::script::ScriptBuf;
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::blockdata::witness::Witness;
-use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
+use crate::consensus::{self, deserialize_partial, serialize, Decodable, Encodable};
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
 use crate::prelude::*;
@@ -233,7 +233,7 @@ impl Serialize for PsbtSighashType {
 
 impl Deserialize for PsbtSighashType {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        let raw: u32 = encode::deserialize(bytes)?;
+        let raw: u32 = consensus::deserialize(bytes)?;
         Ok(PsbtSighashType { inner: raw })
     }
 }

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -8,7 +8,7 @@
 
 use hashes::{sha256d, Hash, HashEngine};
 
-use crate::consensus::{encode, Encodable};
+use crate::consensus::{self, Encodable};
 
 #[rustfmt::skip]
 #[doc(inline)]
@@ -200,7 +200,7 @@ mod message_signing {
 pub fn signed_msg_hash(msg: &str) -> sha256d::Hash {
     let mut engine = sha256d::Hash::engine();
     engine.input(BITCOIN_SIGNED_MSG_PREFIX);
-    let msg_len = encode::VarInt::from(msg.len());
+    let msg_len = consensus::VarInt::from(msg.len());
     msg_len.consensus_encode(&mut engine).expect("engines don't error");
     engine.input(msg.as_bytes());
     sha256d::Hash::from_engine(engine)

--- a/bitcoin/tests/psbt.rs
+++ b/bitcoin/tests/psbt.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use bitcoin::bip32::{Fingerprint, IntoDerivationPath, KeySource, Xpriv, Xpub};
 use bitcoin::blockdata::opcodes::OP_0;
 use bitcoin::blockdata::{script, transaction};
-use bitcoin::consensus::encode::{deserialize, serialize_hex};
+use bitcoin::consensus::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::script::PushBytes;

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -30,7 +30,7 @@ use bincode::serialize;
 use bitcoin::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
 use bitcoin::blockdata::locktime::{absolute, relative};
 use bitcoin::blockdata::witness::Witness;
-use bitcoin::consensus::encode::deserialize;
+use bitcoin::consensus::deserialize;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use bitcoin::hex::FromHex;
 use bitcoin::psbt::raw::{self, Key, Pair, ProprietaryKey};

--- a/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
@@ -2,7 +2,7 @@ use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
     let _: Result<bitcoin::p2p::message::RawNetworkMessage, _> =
-        bitcoin::consensus::encode::deserialize(data);
+        bitcoin::consensus::deserialize(data);
 }
 
 fn main() {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
@@ -2,7 +2,7 @@ use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
     let _: Result<bitcoin::blockdata::block::Block, _> =
-        bitcoin::consensus::encode::deserialize(data);
+        bitcoin::consensus::deserialize(data);
 }
 
 fn main() {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs
@@ -3,12 +3,12 @@ use honggfuzz::fuzz;
 fn do_test(data: &[u8]) {
     // We already fuzz Transactions in `./deserialize_transaction.rs`.
     let tx_result: Result<bitcoin::bip152::PrefilledTransaction, _> =
-        bitcoin::consensus::encode::deserialize(data);
+        bitcoin::consensus::deserialize(data);
 
     match tx_result {
         Err(_) => {}
         Ok(tx) => {
-            let ser = bitcoin::consensus::encode::serialize(&tx);
+            let ser = bitcoin::consensus::serialize(&tx);
             assert_eq!(&ser[..], data);
         }
     }

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -1,11 +1,11 @@
 use bitcoin::address::Address;
 use bitcoin::blockdata::script;
-use bitcoin::consensus::encode;
+use bitcoin::consensus;
 use bitcoin::Network;
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
-    let s: Result<script::ScriptBuf, _> = encode::deserialize(data);
+    let s: Result<script::ScriptBuf, _> = consensus::deserialize(data);
     if let Ok(script) = s {
         let _: Result<Vec<script::Instruction>, script::Error> = script.instructions().collect();
 
@@ -35,7 +35,7 @@ fn do_test(data: &[u8]) {
             }
         }
         assert_eq!(b.into_script(), script);
-        assert_eq!(data, &encode::serialize(&script)[..]);
+        assert_eq!(data, &consensus::serialize(&script)[..]);
 
         // Check if valid address and if that address roundtrips.
         if let Ok(addr) = Address::from_script(&script, Network::Bitcoin) {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
@@ -2,18 +2,18 @@ use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
     let tx_result: Result<bitcoin::blockdata::transaction::Transaction, _> =
-        bitcoin::consensus::encode::deserialize(data);
+        bitcoin::consensus::deserialize(data);
     match tx_result {
         Err(_) => {}
         Ok(mut tx) => {
-            let ser = bitcoin::consensus::encode::serialize(&tx);
+            let ser = bitcoin::consensus::serialize(&tx);
             assert_eq!(&ser[..], data);
             let len = ser.len();
             let calculated_weight = tx.weight().to_wu() as usize;
             for input in &mut tx.input {
                 input.witness = bitcoin::blockdata::witness::Witness::default();
             }
-            let no_witness_len = bitcoin::consensus::encode::serialize(&tx).len();
+            let no_witness_len = bitcoin::consensus::serialize(&tx).len();
             // For 0-input transactions, `no_witness_len` will be incorrect because
             // we serialize as segwit even after "stripping the witnesses". We need
             // to drop two bytes (i.e. eight weight). Similarly, calculated_weight is

--- a/fuzz/fuzz_targets/bitcoin/outpoint_string.rs
+++ b/fuzz/fuzz_targets/bitcoin/outpoint_string.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use bitcoin::blockdata::transaction::OutPoint;
-use bitcoin::consensus::encode;
+use bitcoin::consensus;
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
@@ -27,9 +27,9 @@ fn do_test(data: &[u8]) {
         }
         Err(_) => {
             // If we can't deserialize as a string, try consensus deserializing
-            let res: Result<OutPoint, _> = encode::deserialize(data);
+            let res: Result<OutPoint, _> = consensus::deserialize(data);
             if let Ok(deser) = res {
-                let ser = encode::serialize(&deser);
+                let ser = consensus::serialize(&deser);
                 assert_eq!(ser, data);
                 let string = deser.to_string();
                 match OutPoint::from_str(&string) {

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -15,7 +15,6 @@
 
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -24,10 +23,10 @@ extern crate alloc;
 /// Standard I/O stream definitions which are API-equivalent to `std`'s `io` module. See
 /// [`std::io`] for more info.
 pub mod io {
-    use core::convert::TryInto;
-    use core::fmt::{Debug, Display, Formatter};
     #[cfg(any(feature = "alloc", feature = "std"))]
     use alloc::boxed::Box;
+    use core::convert::TryInto;
+    use core::fmt::{Debug, Display, Formatter};
 
     #[cfg(all(feature = "alloc", not(feature = "std")))]
     mod sealed {
@@ -38,14 +37,10 @@ pub mod io {
             fn into(self) -> Box<dyn Debug + Send + Sync + 'static>;
         }
         impl IntoBoxDynDebug for &str {
-            fn into(self) -> Box<dyn Debug + Send + Sync + 'static> {
-                Box::new(String::from(self))
-            }
+            fn into(self) -> Box<dyn Debug + Send + Sync + 'static> { Box::new(String::from(self)) }
         }
         impl IntoBoxDynDebug for String {
-            fn into(self) -> Box<dyn Debug + Send + Sync + 'static> {
-                Box::new(self)
-            }
+            fn into(self) -> Box<dyn Debug + Send + Sync + 'static> { Box::new(self) }
         }
     }
 
@@ -71,9 +66,7 @@ pub mod io {
             Self { kind, error: Some(error.into()) }
         }
 
-        pub fn kind(&self) -> ErrorKind {
-            self.kind
-        }
+        pub fn kind(&self) -> ErrorKind { self.kind }
     }
 
     impl From<ErrorKind> for Error {
@@ -219,9 +212,7 @@ pub mod io {
             Ok(())
         }
         #[inline]
-        fn take(&mut self, limit: u64) -> Take<Self> {
-            Take { reader: self, remaining: limit }
-        }
+        fn take(&mut self, limit: u64) -> Take<Self> { Take { reader: self, remaining: limit } }
     }
 
     pub struct Take<'a, R: Read + ?Sized> {
@@ -263,17 +254,11 @@ pub mod io {
     }
     impl<T: AsRef<[u8]>> Cursor<T> {
         #[inline]
-        pub fn new(inner: T) -> Self {
-            Cursor { inner, pos: 0 }
-        }
+        pub fn new(inner: T) -> Self { Cursor { inner, pos: 0 } }
         #[inline]
-        pub fn position(&self) -> u64 {
-            self.pos
-        }
+        pub fn position(&self) -> u64 { self.pos }
         #[inline]
-        pub fn into_inner(self) -> T {
-            self.inner
-        }
+        pub fn into_inner(self) -> T { self.inner }
     }
     impl<T: AsRef<[u8]>> Read for Cursor<T> {
         #[inline]
@@ -282,7 +267,9 @@ pub mod io {
             let start_pos = self.pos.try_into().unwrap_or(inner.len());
             let read = core::cmp::min(inner.len().saturating_sub(start_pos), buf.len());
             buf[..read].copy_from_slice(&inner[start_pos..start_pos + read]);
-            self.pos = self.pos.saturating_add(read.try_into().unwrap_or(u64::max_value() /* unreachable */));
+            self.pos = self
+                .pos
+                .saturating_add(read.try_into().unwrap_or(u64::max_value() /* unreachable */));
             Ok(read)
         }
     }
@@ -313,9 +300,7 @@ pub mod io {
             Ok(<W as std::io::Write>::write(self, buf)?)
         }
         #[inline]
-        fn flush(&mut self) -> Result<()> {
-            Ok(<W as std::io::Write>::flush(self)?)
-        }
+        fn flush(&mut self) -> Result<()> { Ok(<W as std::io::Write>::flush(self)?) }
     }
 
     #[cfg(all(feature = "alloc", not(feature = "std")))]
@@ -347,9 +332,7 @@ pub mod io {
     #[cfg(not(feature = "std"))]
     impl Write for Sink {
         #[inline]
-        fn write(&mut self, buf: &[u8]) -> Result<usize> {
-            Ok(buf.len())
-        }
+        fn write(&mut self, buf: &[u8]) -> Result<usize> { Ok(buf.len()) }
         #[inline]
         fn write_all(&mut self, _: &[u8]) -> Result<()> { Ok(()) }
         #[inline]
@@ -358,9 +341,7 @@ pub mod io {
     #[cfg(feature = "std")]
     impl std::io::Write for Sink {
         #[inline]
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            Ok(buf.len())
-        }
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> { Ok(buf.len()) }
         #[inline]
         fn write_all(&mut self, _: &[u8]) -> std::io::Result<()> { Ok(()) }
         #[inline]
@@ -398,7 +379,6 @@ macro_rules! impl_write {
         }
     }
 }
-
 
 #[macro_export]
 /// Because we cannot provide a blanket implementation of [`std::io::Write`] for all implementers


### PR DESCRIPTION
Requires a few preparatory patches, all trivial enough. Last patch is massive but the diff is easy to flick through, its manly path renames.

This is an alternative to #1891 that achieves the same public API changes without the internal code changes, which can then be done later if we still want them. 