### PR TITLE
Refactor weight mod

### DIFF
--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     fn kilo_weight_constructor() {
-        assert_eq!(Weight(1_000), Weight::from_kwu(1).expect("expected weight unit"));
+        assert_eq!(Weight(1_000), Weight::from_kwu(1).unwrap());
     }
 
     #[test]
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn from_vb() {
-        let weight = Weight::from_vb(1).expect("expected weight unit");
+        let weight = Weight::from_vb(1).unwrap();
         assert_eq!(Weight(4), weight);
 
         let weight = Weight::from_vb(u64::MAX);
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn checked_add() {
-        let result = Weight(1).checked_add(Weight(1)).expect("expected weight unit");
+        let result = Weight(1).checked_add(Weight(1)).unwrap();
         assert_eq!(Weight(2), result);
 
         let result = Weight::MAX.checked_add(Weight(1));
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn checked_sub() {
-        let result = Weight(1).checked_sub(Weight(1)).expect("expected weight unit");
+        let result = Weight(1).checked_sub(Weight(1)).unwrap();
         assert_eq!(Weight::ZERO, result);
 
         let result = Weight::MIN.checked_sub(Weight(1));
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn checked_mul() {
-        let result = Weight(2).checked_mul(2).expect("expected weight unit");
+        let result = Weight(2).checked_mul(2).unwrap();
         assert_eq!(Weight(4), result);
 
         let result = Weight::MAX.checked_mul(2);
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn checked_div() {
-        let result = Weight(2).checked_div(2).expect("expected weight unit");
+        let result = Weight(2).checked_div(2).unwrap();
         assert_eq!(Weight(1), result);
 
         let result = Weight(2).checked_div(0);
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn scale_by_witness_factor() {
-        let result = Weight(1).scale_by_witness_factor().expect("expected weight unit");
+        let result = Weight(1).scale_by_witness_factor().unwrap();
         assert_eq!(Weight(4), result);
 
         let result = Weight::MAX.scale_by_witness_factor();

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -158,11 +158,11 @@ mod tests {
 
     #[test]
     fn from_vb() {
-        let vb = Weight::from_vb(1).expect("expected weight unit");
-        assert_eq!(Weight(4), vb);
+        let weight = Weight::from_vb(1).expect("expected weight unit");
+        assert_eq!(Weight(4), weight);
 
-        let vb = Weight::from_vb(u64::MAX);
-        assert_eq!(None, vb);
+        let weight = Weight::from_vb(u64::MAX);
+        assert_eq!(None, weight);
     }
 
     #[test]
@@ -173,8 +173,8 @@ mod tests {
 
     #[test]
     fn from_vb_unchecked() {
-        let vb = Weight::from_vb_unchecked(1);
-        assert_eq!(Weight(4), vb);
+        let weight = Weight::from_vb_unchecked(1);
+        assert_eq!(Weight(4), weight);
     }
 
     #[test]

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -135,6 +135,82 @@ impl fmt::Display for Weight {
     }
 }
 
+impl From<Weight> for u64 {
+    fn from(value: Weight) -> Self { value.to_wu() }
+}
+
+impl Add for Weight {
+    type Output = Weight;
+
+    fn add(self, rhs: Weight) -> Self::Output { Weight(self.0 + rhs.0) }
+}
+
+impl AddAssign for Weight {
+    fn add_assign(&mut self, rhs: Self) { self.0 += rhs.0 }
+}
+
+impl Sub for Weight {
+    type Output = Weight;
+
+    fn sub(self, rhs: Weight) -> Self::Output { Weight(self.0 - rhs.0) }
+}
+
+impl SubAssign for Weight {
+    fn sub_assign(&mut self, rhs: Self) { self.0 -= rhs.0 }
+}
+
+impl Mul<u64> for Weight {
+    type Output = Weight;
+
+    fn mul(self, rhs: u64) -> Self::Output { Weight(self.0 * rhs) }
+}
+
+impl Mul<Weight> for u64 {
+    type Output = Weight;
+
+    fn mul(self, rhs: Weight) -> Self::Output { Weight(self * rhs.0) }
+}
+
+impl MulAssign<u64> for Weight {
+    fn mul_assign(&mut self, rhs: u64) { self.0 *= rhs }
+}
+
+impl Div<u64> for Weight {
+    type Output = Weight;
+
+    fn div(self, rhs: u64) -> Self::Output { Weight(self.0 / rhs) }
+}
+
+impl Div<Weight> for Weight {
+    type Output = u64;
+
+    fn div(self, rhs: Weight) -> Self::Output { self.to_wu() / rhs.to_wu() }
+}
+
+impl DivAssign<u64> for Weight {
+    fn div_assign(&mut self, rhs: u64) { self.0 /= rhs }
+}
+
+impl core::iter::Sum for Weight {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = Self>,
+    {
+        Weight(iter.map(Weight::to_wu).sum())
+    }
+}
+
+impl<'a> core::iter::Sum<&'a Weight> for Weight {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Weight>,
+    {
+        iter.cloned().sum()
+    }
+}
+
+crate::parse::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -254,79 +330,3 @@ mod tests {
         assert_eq!(None, result);
     }
 }
-
-impl From<Weight> for u64 {
-    fn from(value: Weight) -> Self { value.to_wu() }
-}
-
-impl Add for Weight {
-    type Output = Weight;
-
-    fn add(self, rhs: Weight) -> Self::Output { Weight(self.0 + rhs.0) }
-}
-
-impl AddAssign for Weight {
-    fn add_assign(&mut self, rhs: Self) { self.0 += rhs.0 }
-}
-
-impl Sub for Weight {
-    type Output = Weight;
-
-    fn sub(self, rhs: Weight) -> Self::Output { Weight(self.0 - rhs.0) }
-}
-
-impl SubAssign for Weight {
-    fn sub_assign(&mut self, rhs: Self) { self.0 -= rhs.0 }
-}
-
-impl Mul<u64> for Weight {
-    type Output = Weight;
-
-    fn mul(self, rhs: u64) -> Self::Output { Weight(self.0 * rhs) }
-}
-
-impl Mul<Weight> for u64 {
-    type Output = Weight;
-
-    fn mul(self, rhs: Weight) -> Self::Output { Weight(self * rhs.0) }
-}
-
-impl MulAssign<u64> for Weight {
-    fn mul_assign(&mut self, rhs: u64) { self.0 *= rhs }
-}
-
-impl Div<u64> for Weight {
-    type Output = Weight;
-
-    fn div(self, rhs: u64) -> Self::Output { Weight(self.0 / rhs) }
-}
-
-impl Div<Weight> for Weight {
-    type Output = u64;
-
-    fn div(self, rhs: Weight) -> Self::Output { self.to_wu() / rhs.to_wu() }
-}
-
-impl DivAssign<u64> for Weight {
-    fn div_assign(&mut self, rhs: u64) { self.0 /= rhs }
-}
-
-impl core::iter::Sum for Weight {
-    fn sum<I>(iter: I) -> Self
-    where
-        I: Iterator<Item = Self>,
-    {
-        Weight(iter.map(Weight::to_wu).sum())
-    }
-}
-
-impl<'a> core::iter::Sum<&'a Weight> for Weight {
-    fn sum<I>(iter: I) -> Self
-    where
-        I: Iterator<Item = &'a Weight>,
-    {
-        iter.cloned().sum()
-    }
-}
-
-crate::parse::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -227,9 +227,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn kilo_weight_constructor_panic() {
-        Weight::from_kwu(u64::MAX).expect("expected weight unit");
+    fn kilo_weight_constructor_overflow() {
+        assert!(Weight::from_kwu(u64::MAX).is_none())
     }
 
     #[test]


### PR DESCRIPTION
Just a few trivial fixes:

- type implementations are under the tests and not grouped together.
- assignment statements in the test have confusing variable names.
- expect message wording is wrong.  It should be the reason the behavior is expected to succeed ref: https://doc.rust-lang.org/std/option/enum.Option.html#recommended-message-style
- doc message says overflow when it should say underflow for subtraction