### PR TITLE
Remove `non_exhaustive` from `Network`

### DIFF
--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -36,7 +36,6 @@ use crate::prelude::{String, ToOwned};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[non_exhaustive]
 pub enum Network {
     /// Mainnet Bitcoin.
     Bitcoin,


### PR DESCRIPTION
Recently we added the `non_exhaustive` attribute to `Network` in an attempt to make the type forward compatible. This has proven to be an annoyance to downstream users because there is no obvious recourse for the unknown variant and matching on `Network` is common.

Note that if/when a new network is added by Core it is a big deal so we can and should bump our version when we add support for it.

Remove `#[non_exhaustive]` from the `Network` type.

Fix: #2225