### PR TITLE
Remove the "no-std" feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,6 @@ jobs:
           DO_COV: true
           DO_LINT: true
           AS_DEPENDENCY: false
-          DO_NO_STD: true
           DO_DOCS: true
           DO_FEATURE_MATRIX: true
           DO_SCHEMARS_TESTS: true # Currently only used in hashes crate.
@@ -43,7 +42,6 @@ jobs:
       - name: Running test script
         env:
           AS_DEPENDENCY: false
-          DO_NO_STD: true
         run: ./contrib/test.sh
 
   Nightly:
@@ -61,7 +59,6 @@ jobs:
           DO_FMT: false
           DO_BENCH: true
           AS_DEPENDENCY: false
-          DO_NO_STD: true
           DO_DOCSRS: true
         run: ./contrib/test.sh
 
@@ -80,7 +77,6 @@ jobs:
       - name: Running test script
         env:
           DO_FEATURE_MATRIX: true
-          DO_NO_STD: true
         run: ./contrib/test.sh
 
   Arch32bit:

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
 - Bump MSRV to Rust 1.56.1
+- Remove "no-std" feature
 
 # 0.31.1 - 2023-10-18
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = [ "std", "secp-recovery" ]
+std = ["bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "secp256k1/std"]
 rand-std = ["secp256k1/rand-std", "std"]
 rand = ["secp256k1/rand"]
 serde = ["actual-serde", "hashes/serde", "secp256k1/serde", "internals/serde"]
@@ -22,26 +23,18 @@ secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
 
-# At least one of std, no-std must be enabled.
-#
-# The no-std feature doesn't disable std - you need to turn off the std feature for that by disabling default.
-# Instead no-std enables additional features required for this crate to be usable without std.
-# As a result, both can be enabled without conflict.
-std = ["bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "secp256k1/std"]
-no-std = ["bech32/alloc", "hashes/alloc", "hashes/io", "hex/alloc", "io/alloc", "secp256k1/alloc"]
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-bech32 = { version = "0.10.0-beta", default-features = false }
-hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false }
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
+bech32 = { version = "0.10.0-beta", default-features = false, features = ["alloc"] }
+hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc", "io"] }
+hex = { package = "hex-conservative", version = "0.1.1", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
 internals = { package = "bitcoin-internals", version = "0.2.0" }
-io = { package = "bitcoin-io", version = "0.1", default-features = false }
-secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes"] }
+io = { package = "bitcoin-io", version = "0.1", default-features = false, features = ["alloc"] }
+secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes", "alloc"] }
 
 base64 = { version = "0.21.3", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -27,21 +27,21 @@ bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
 # The no-std feature doesn't disable std - you need to turn off the std feature for that by disabling default.
 # Instead no-std enables additional features required for this crate to be usable without std.
 # As a result, both can be enabled without conflict.
-std = ["secp256k1/std", "io/std", "hashes/std", "bech32/std", "internals/std", "hex/std"]
-no-std = ["hashes/alloc", "hashes/io", "io/alloc", "bech32/alloc", "secp256k1/alloc", "hex/alloc"]
+std = ["bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "secp256k1/std"]
+no-std = ["bech32/alloc", "hashes/alloc", "hashes/io", "hex/alloc", "io/alloc", "secp256k1/alloc"]
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.2.0" }
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 bech32 = { version = "0.10.0-beta", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false }
-secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes"] }
-io = { package = "bitcoin-io", version = "0.1", default-features = false }
+hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 hex_lit = "0.1.1"
+internals = { package = "bitcoin-internals", version = "0.2.0" }
+io = { package = "bitcoin-io", version = "0.1", default-features = false }
+secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes"] }
 
 base64 = { version = "0.21.3", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="base64 bitcoinconsensus serde rand secp-recovery"
+FEATURES="std rand-std rand serde secp-recovery bitcoinconsensus-std base64 bitcoinconsensus"
 
 if [ "$DO_COV" = true ]
 then
@@ -22,6 +22,13 @@ fi
 if cargo --version | grep beta; then
     STABLE=false
 fi
+
+# Make all cargo invocations verbose
+export CARGO_TERM_VERBOSE=true
+
+# Defaults / sanity checks
+cargo build
+cargo test
 
 if [ "$DO_LINT" = true ]
 then
@@ -53,20 +60,25 @@ then
     fi
 fi
 
-echo "********* Testing std *************"
-# Test without any features other than std first
-cargo test --locked --verbose --no-default-features --features="std"
+if [ "$DO_FEATURE_MATRIX" = true ]; then
+    cargo build --locked --no-default-features
+    cargo test --locked --no-default-features
 
-echo "********* Testing default *************"
-# Then test with the default features
-cargo test --verbose
-
-# Test each feature
-for feature in ${FEATURES}
-do
-    echo "********* Testing $feature *************"
-    cargo test --locked --verbose --features="$feature"
-done
+    # All features
+    cargo build --locked --no-default-features --features="$FEATURES"
+    cargo test --locked --no-default-features --features="$FEATURES"
+    # Single features
+    for feature in ${FEATURES}
+    do
+        cargo build --locked --no-default-features --features="$feature"
+        cargo test --locked --no-default-features --features="$feature"
+		# All combos of two features
+		for featuretwo in ${FEATURES}; do
+			cargo build --locked --no-default-features --features="$feature $featuretwo"
+			cargo test --locked --no-default-features --features="$feature $featuretwo"
+		done
+    done
+fi
 
 cargo run --locked --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
 cargo run --locked --no-default-features --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -61,37 +61,15 @@ echo "********* Testing default *************"
 # Then test with the default features
 cargo test --verbose
 
-if [ "$DO_NO_STD" = true ]
-then
-    echo "********* Testing no-std build *************"
-    # Build no_std, to make sure that cfg(test) doesn't hide any issues
-    cargo build --locked --verbose --features="no-std" --no-default-features
-
-    # Build std + no_std, to make sure they are not incompatible
-    cargo build --locked --verbose --features="no-std"
-
-    # Test no_std
-    cargo test --locked --verbose --features="no-std" --no-default-features
-
-    # Build all features
-    cargo build --locked --verbose --features="no-std $FEATURES" --no-default-features
-
-    # Build specific features
-    for feature in ${FEATURES}
-    do
-        cargo build --locked --verbose --features="no-std $feature" --no-default-features
-    done
-
-    cargo run --locked --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
-    cargo run --locked --no-default-features --features no-std --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
-fi
-
 # Test each feature
 for feature in ${FEATURES}
 do
     echo "********* Testing $feature *************"
     cargo test --locked --verbose --features="$feature"
 done
+
+cargo run --locked --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+cargo run --locked --no-default-features --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
 
 cargo run --locked --example ecdsa-psbt --features=bitcoinconsensus
 cargo run --locked --example sign-tx-segwit-v0 --features=rand-std -- -D warnings

--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -15,7 +15,7 @@ cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 alloc-cortex-m = "0.4.1"
-bitcoin = { path="../", default-features = false, features = ["no-std", "secp-lowmemory"] }
+bitcoin = { path="../", default-features = false, features = ["secp-lowmemory"] }
 
 [[bin]]
 name = "embedded"

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -22,8 +22,6 @@
 //! * `serde` - (dependency), implements `serde`-based serialization and
 //!                 deserialization.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
-//! * `no-std` - enables additional features required for this crate to be usable
-//!              without std. Does **not** disable `std`.
 //! * `bitcoinconsensus-std` - enables `std` in `bitcoinconsensus` and communicates it
 //!                            to this crate so it knows how to implement
 //!                            `std::error::Error`. At this time there's a hack to
@@ -40,9 +38,6 @@
 #![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
 // Exclude clippy lints we don't think are valuable
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
-
-#[cfg(not(any(feature = "std", feature = "no-std")))]
-compile_error!("at least one of the `std` or `no-std` features must be enabled");
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]


### PR DESCRIPTION
Now we have the `io` crate we can remove the "no-std" feature.

Do a few cleanups to the `bitcoin` manifest, then remove the "no-std" feature - BOOM!

