### PR TITLE
Introduce usage of TBD instead of NEXT-RELEASE

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -12,9 +12,9 @@ main () {
 
             # Check if there is any mention of NEXT_RELEASE which means the
             # next version number should be filled in.
-            if grep -qr NEXT.RELEASE ./$crate; then
+            if grep -qr "since = \"TBD" ./$crate; then
                 echo Version number needs to be filled in following places:
-                grep -r NEXT.RELEASE ./$crate
+                grep -r "since = \"TBD" ./$crate
                 exit 1
             fi
 


### PR DESCRIPTION
There is an ecosystem-wide solution to our custom usage of `NEXT-RELEASE` in deprecation attributes - use

   `#[decprecated(since = "TBD", note = "use bar instead")]`

Lets use it.