### PR TITLE
Add to unchecked version of to_unsigned

### DIFF
--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -1067,9 +1067,17 @@ impl SignedAmount {
         if self.is_negative() {
             Err(ParseAmountError::Negative)
         } else {
-            Ok(Amount::from_sat(self.to_sat() as u64))
+            Ok(self.unchecked_to_unsigned())
         }
     }
+
+    /// Converts to an [Amount].
+    ///
+    /// Unlike [`SignedAmount::to_unsigned`], this method will panic instead of error.
+    pub fn unchecked_to_unsigned(self) -> Amount {
+        Amount::from_sat(self.to_sat() as u64)
+    }
+
 }
 
 impl default::Default for SignedAmount {


### PR DESCRIPTION
Adds an unchecked version of `to_unsigned`.  Useful in situations where the invariant can be safety converted to an unsigned amount.

For example:
```
let value: Amount = Amount::ZERO;
if effective_value.is_positive() {
    value += effective_value.unchecked_to_unsigned();
}
```

Convenience function to avoid writing:
```
let value: Amount = Amount::ZERO;
if effective_value.is_positive() {
    value += Amount::from_sat(effective_value.to_sat() as u64);
}
```