### PR TITLE
Remove NEXT_RELEASE from release script comment

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -10,7 +10,7 @@ main () {
         if release_changes $crate; then
             echo "$crate has changes implying this is a release PR, checking if we can publish ..."
 
-            # Check if there is any mention of NEXT_RELEASE which means the
+            # Check if there is any mention of TBD which means the
             # next version number should be filled in.
             if grep -qr "since = \"TBD" ./$crate; then
                 echo Version number needs to be filled in following places:


### PR DESCRIPTION
Recently we remove the usage of `NEXT_RELEASE` in favour of `TBD` but I missed the code comment.