### PR TITLE
Improve the `io` crate

### DIFF
--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -9,7 +9,8 @@ description = "Simple I/O traits for no-std (and std) environments"
 categories = ["no-std"]
 keywords = [ "io", "no-std" ]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.1"
 exclude = ["tests", "contrib"]
 
 [features]

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -26,8 +26,6 @@ mod macros;
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use self::error::{Error, ErrorKind};
 
-/// Standard I/O stream definitions which are API-equivalent to `std`'s `io` module. See
-/// [`std::io`] for more info.
 use core::convert::TryInto;
 
 pub type Result<T> = core::result::Result<T, Error>;

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -24,6 +24,7 @@ mod error;
 mod macros;
 
 use core::convert::TryInto;
+use core::cmp;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use self::error::{Error, ErrorKind};
@@ -59,7 +60,7 @@ pub struct Take<'a, R: Read + ?Sized> {
 impl<'a, R: Read + ?Sized> Read for Take<'a, R> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let len = core::cmp::min(buf.len(), self.remaining.try_into().unwrap_or(buf.len()));
+        let len = cmp::min(buf.len(), self.remaining.try_into().unwrap_or(buf.len()));
         let read = self.reader.read(&mut buf[..len])?;
         self.remaining -= read.try_into().unwrap_or(self.remaining);
         Ok(read)
@@ -78,7 +79,7 @@ impl<R: std::io::Read> Read for R {
 impl Read for &[u8] {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let cnt = core::cmp::min(self.len(), buf.len());
+        let cnt = cmp::min(self.len(), buf.len());
         buf[..cnt].copy_from_slice(&self[..cnt]);
         *self = &self[cnt..];
         Ok(cnt)

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -199,4 +199,5 @@ impl std::io::Write for Sink {
 }
 
 /// Returns a sink to which all writes succeed. See [`std::io::sink`] for more info.
+#[inline]
 pub fn sink() -> Sink { Sink }

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -23,10 +23,10 @@ extern crate alloc;
 mod error;
 mod macros;
 
+use core::convert::TryInto;
+
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use self::error::{Error, ErrorKind};
-
-use core::convert::TryInto;
 
 pub type Result<T> = core::result::Result<T, Error>;
 


### PR DESCRIPTION
In preparation for adding the `BufRead` trait do a few improvements, the first ones are all trivial, the last sets the MSRV to Rust 1.56.1