### PR TITLE
Add convenience constants to `Denomination`

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -59,6 +59,12 @@ pub enum Denomination {
 }
 
 impl Denomination {
+    /// Convenience alias for `Denomination::Bitcoin`.
+    pub const BTC: Self = Denomination::Bitcoin;
+
+    /// Convenience alias for `Denomination::Satoshi`.
+    pub const SAT: Self = Denomination::Satoshi;
+
     /// The number of decimal places more than a satoshi.
     fn precision(self) -> i8 {
         match self {


### PR DESCRIPTION
`Denomination::Bitcoin` and `Denomination::Satoshi` are often used, especially in test code so this change adds `BTC` and `SAT` - short, readable constants. Notably this doesn't add the other constants as that would lead to either unidiomatic names or confusing casing (MSAT meaning millisat not megasat) and they are not used that much anyway.