### PR TITLE
Implement `CompressedPublicKey`

### DIFF
--- a/bitcoin/embedded/src/main.rs
+++ b/bitcoin/embedded/src/main.rs
@@ -43,8 +43,8 @@ fn main() -> ! {
     let secp = Secp256k1::preallocated_new(&mut buf_ful).unwrap();
 
     // Derive address
-    let pubkey = pk.public_key(&secp);
-    let address = Address::p2wpkh(&pubkey, Network::Bitcoin).unwrap();
+    let pubkey = pk.public_key(&secp).try_into().unwrap();
+    let address = Address::p2wpkh(&pubkey, Network::Bitcoin);
     hprintln!("Address: {}", address).unwrap();
 
     assert_eq!(address.to_string(), "bc1qpx9t9pzzl4qsydmhyt6ctrxxjd4ep549np9993".to_string());

--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -8,7 +8,7 @@ use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::PublicKey;
+use bitcoin::CompressedPublicKey;
 
 fn main() {
     // This example derives root xprv from a 32-byte seed,
@@ -53,6 +53,6 @@ fn main() {
     // manually creating indexes this time
     let zero = ChildNumber::from_normal_idx(0).unwrap();
     let public_key = xpub.derive_pub(&secp, &[zero, zero]).unwrap().public_key;
-    let address = Address::p2wpkh(&PublicKey::new(public_key), network).unwrap();
+    let address = Address::p2wpkh(&CompressedPublicKey(public_key), network);
     println!("First receiving address: {}", address);
 }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -19,7 +19,7 @@ use secp256k1::{self, Secp256k1, XOnlyPublicKey};
 use serde;
 
 use crate::base58;
-use crate::crypto::key::{self, Keypair, PrivateKey, PublicKey};
+use crate::crypto::key::{self, Keypair, PrivateKey, CompressedPublicKey};
 use crate::internal_macros::impl_bytes_newtype;
 use crate::network::Network;
 use crate::prelude::*;
@@ -708,7 +708,7 @@ impl Xpub {
     }
 
     /// Constructs ECDSA compressed public key matching internal public key representation.
-    pub fn to_pub(self) -> PublicKey { PublicKey { compressed: true, inner: self.public_key } }
+    pub fn to_pub(self) -> CompressedPublicKey { CompressedPublicKey(self.public_key) }
 
     /// Constructs BIP340 x-only public key for BIP-340 signatures and Taproot use matching
     /// the internal public key representation.

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -14,7 +14,7 @@ use secp256k1::{Secp256k1, Verification};
 
 use crate::blockdata::script::witness_version::WitnessVersion;
 use crate::blockdata::script::{PushBytes, PushBytesBuf, PushBytesErrorReport, Script};
-use crate::crypto::key::{self, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
+use crate::crypto::key::{CompressedPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
 use crate::taproot::TapNodeHash;
 
 /// The segregated witness program.
@@ -67,10 +67,9 @@ impl WitnessProgram {
     }
 
     /// Creates a [`WitnessProgram`] from `pk` for a P2WPKH output.
-    pub fn p2wpkh(pk: &PublicKey) -> Result<Self, key::UncompressedPubkeyError> {
-        let hash = pk.wpubkey_hash()?;
-        let program = WitnessProgram::new_p2wpkh(hash.to_byte_array());
-        Ok(program)
+    pub fn p2wpkh(pk: &CompressedPublicKey) -> Self {
+        let hash = pk.wpubkey_hash();
+        WitnessProgram::new_p2wpkh(hash.to_byte_array())
     }
 
     /// Creates a [`WitnessProgram`] from `script` for a P2WSH output.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -261,6 +261,129 @@ impl From<&PublicKey> for PubkeyHash {
     fn from(key: &PublicKey) -> PubkeyHash { key.pubkey_hash() }
 }
 
+/// An always-compressed Bitcoin ECDSA public key
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CompressedPublicKey(pub secp256k1::PublicKey);
+
+impl CompressedPublicKey {
+    /// Returns bitcoin 160-bit hash of the public key
+    pub fn pubkey_hash(&self) -> PubkeyHash { PubkeyHash::hash(&self.to_bytes()) }
+
+    /// Returns bitcoin 160-bit hash of the public key for witness program
+    pub fn wpubkey_hash(&self) -> WPubkeyHash {
+        WPubkeyHash::from_byte_array(hash160::Hash::hash(&self.to_bytes()).to_byte_array())
+    }
+
+    /// Write the public key into a writer
+    pub fn write_into<W: io::Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_all(&self.to_bytes())
+    }
+
+    /// Read the public key from a reader
+    ///
+    /// This internally reads the first byte before reading the rest, so
+    /// use of a `BufReader` is recommended.
+    pub fn read_from<R: io::Read + ?Sized>(reader: &mut R) -> Result<Self, io::Error> {
+        let mut bytes = [0; 33];
+
+        reader.read_exact(&mut bytes)?;
+        Self::from_slice(&bytes).map_err(|e| {
+            // Need a static string for no-std io
+            #[cfg(feature = "std")]
+            let reason = e;
+            #[cfg(not(feature = "std"))]
+            let reason = "secp256k1 error";
+            io::Error::new(io::ErrorKind::InvalidData, reason)
+        })
+    }
+
+    /// Serializes the public key.
+    ///
+    /// As the type name suggests, the key is serialzied in compressed format.
+    ///
+    /// Note that this can be used as a sort key to get BIP67-compliant sorting.
+    /// That's why this type doesn't have the `to_sort_key` method - it would duplicate this one.
+    pub fn to_bytes(&self) -> [u8; 33] {
+        self.0.serialize()
+    }
+
+    /// Deserialize a public key from a slice
+    pub fn from_slice(data: &[u8]) -> Result<Self, secp256k1::Error> {
+        secp256k1::PublicKey::from_slice(data).map(CompressedPublicKey)
+    }
+
+    /// Computes the public key as supposed to be used with this secret
+    pub fn from_private_key<C: secp256k1::Signing>(
+        secp: &Secp256k1<C>,
+        sk: &PrivateKey,
+    ) -> Result<Self, UncompressedPubkeyError> {
+        sk.public_key(secp).try_into()
+    }
+
+    /// Checks that `sig` is a valid ECDSA signature for `msg` using this public key.
+    pub fn verify<C: secp256k1::Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        msg: &secp256k1::Message,
+        sig: &ecdsa::Signature,
+    ) -> Result<(), Error> {
+        Ok(secp.verify_ecdsa(msg, &sig.sig, &self.0)?)
+    }
+}
+
+impl fmt::Display for CompressedPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.to_bytes().as_hex(), f)
+    }
+}
+
+impl FromStr for CompressedPublicKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        CompressedPublicKey::from_slice(&<[u8; 33]>::from_hex(s)?).map_err(Into::into)
+    }
+}
+
+impl TryFrom<PublicKey> for CompressedPublicKey {
+    type Error = UncompressedPubkeyError;
+
+    fn try_from(value: PublicKey) -> Result<Self, Self::Error> {
+        if value.compressed {
+            Ok(CompressedPublicKey(value.inner))
+        } else {
+            Err(UncompressedPubkeyError)
+        }
+    }
+}
+
+impl From<CompressedPublicKey> for PublicKey {
+    fn from(value: CompressedPublicKey) -> Self {
+        PublicKey::new(value.0)
+    }
+}
+
+impl From<CompressedPublicKey> for XOnlyPublicKey {
+    fn from(pk: CompressedPublicKey) -> Self { pk.0.into() }
+}
+
+impl From<CompressedPublicKey> for PubkeyHash {
+    fn from(key: CompressedPublicKey) -> Self { key.pubkey_hash() }
+}
+
+impl From<&CompressedPublicKey> for PubkeyHash {
+    fn from(key: &CompressedPublicKey) -> Self { key.pubkey_hash() }
+}
+
+impl From<CompressedPublicKey> for WPubkeyHash {
+    fn from(key: CompressedPublicKey) -> Self { key.wpubkey_hash() }
+}
+
+impl From<&CompressedPublicKey> for WPubkeyHash {
+    fn from(key: &CompressedPublicKey) -> Self { key.wpubkey_hash() }
+}
+
+
 /// A Bitcoin ECDSA private key
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PrivateKey {
@@ -484,6 +607,71 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for CompressedPublicKey {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if s.is_human_readable() {
+            s.collect_str(self)
+        } else {
+            s.serialize_bytes(&self.to_bytes())
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for CompressedPublicKey {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        if d.is_human_readable() {
+            struct HexVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for HexVisitor {
+                type Value = CompressedPublicKey;
+
+                fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    formatter.write_str("a 66 digits long ASCII hex string")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    if let Ok(hex) = core::str::from_utf8(v) {
+                        CompressedPublicKey::from_str(hex).map_err(E::custom)
+                    } else {
+                        Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
+                    }
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    CompressedPublicKey::from_str(v).map_err(E::custom)
+                }
+            }
+            d.deserialize_str(HexVisitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = CompressedPublicKey;
+
+                fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    formatter.write_str("a bytestring")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    CompressedPublicKey::from_slice(v).map_err(E::custom)
+                }
+            }
+
+            d.deserialize_bytes(BytesVisitor)
+        }
+    }
+}
 /// Untweaked BIP-340 X-coord-only public key
 pub type UntweakedPublicKey = XOnlyPublicKey;
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -130,7 +130,7 @@ pub use crate::{
     blockdata::witness::{self, Witness},
     consensus::encode::VarInt,
     crypto::ecdsa,
-    crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey},
+    crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, CompressedPublicKey, WPubkeyHash, XOnlyPublicKey},
     crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},
     merkle_tree::MerkleBlock,
     network::Network,

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -238,22 +238,25 @@ mod tests {
 
         assert_eq!(signature.to_base64(), signature.to_string());
         let signature2 = super::MessageSignature::from_str(&signature.to_string()).unwrap();
-        let pubkey = signature2.recover_pubkey(&secp, msg_hash).unwrap();
-        assert!(pubkey.compressed);
-        assert_eq!(pubkey.inner, secp256k1::PublicKey::from_secret_key(&secp, &privkey));
+        let pubkey = signature2.recover_pubkey(&secp, msg_hash)
+            .unwrap()
+            .try_into()
+            .expect("compressed was set to true");
 
-        let p2pkh = Address::p2pkh(pubkey, Network::Bitcoin);
-        assert_eq!(signature2.is_signed_by_address(&secp, &p2pkh, msg_hash), Ok(true));
-        let p2wpkh = Address::p2wpkh(&pubkey, Network::Bitcoin).unwrap();
+        let p2wpkh = Address::p2wpkh(&pubkey, Network::Bitcoin);
         assert_eq!(
             signature2.is_signed_by_address(&secp, &p2wpkh, msg_hash),
             Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2wpkh))
         );
-        let p2shwpkh = Address::p2shwpkh(&pubkey, Network::Bitcoin).unwrap();
+        let p2shwpkh = Address::p2shwpkh(&pubkey, Network::Bitcoin);
         assert_eq!(
             signature2.is_signed_by_address(&secp, &p2shwpkh, msg_hash),
             Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2sh))
         );
+        let p2pkh = Address::p2pkh(pubkey, Network::Bitcoin);
+        assert_eq!(signature2.is_signed_by_address(&secp, &p2pkh, msg_hash), Ok(true));
+
+        assert_eq!(pubkey.0, secp256k1::PublicKey::from_secret_key(&secp, &privkey));
     }
 
     #[test]


### PR DESCRIPTION
P2WPKH requires keys to be compressed which introduces error handling even in cases when it's statically known that a key is compressed. To avoid it, this change introduces `CompressedPublicKey` which is similar to `PublicKey` except it's statically known to be compressed.

This also changes relevant code to use `CompressedPublicKey` instead of `PublicKey`.