### PR TITLE
Fully encapsulate bitcoinconsensus

### DIFF
--- a/bitcoin/src/consensus/validation.rs
+++ b/bitcoin/src/consensus/validation.rs
@@ -51,13 +51,13 @@ pub fn verify_script_with_flags<F: Into<u32>>(
     spending_tx: &[u8],
     flags: F,
 ) -> Result<(), BitcoinconsensusError> {
-    Ok(bitcoinconsensus::verify_with_flags(
+    bitcoinconsensus::verify_with_flags(
         script.as_bytes(),
         amount.to_sat(),
         spending_tx,
         index,
         flags.into(),
-    )?)
+    ).map_err(BitcoinconsensusError)
 }
 
 /// Verifies that this transaction is able to spend its inputs.
@@ -196,10 +196,6 @@ impl std::error::Error for BitcoinconsensusError {
 #[cfg(all(feature = "std", not(feature = "bitcoinconsensus-std")))]
 impl std::error::Error for BitcoinconsensusError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
-
-impl From<bitcoinconsensus::Error> for BitcoinconsensusError {
-    fn from(e: bitcoinconsensus::Error) -> Self { Self(e) }
 }
 
 /// An error during transaction validation.

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -59,9 +59,9 @@ pub extern crate base64;
 /// Encodes and decodes the Bech32 forrmat.
 pub extern crate bech32;
 
-#[cfg(feature = "bitcoinconsensus")]
 /// Bitcoin's libbitcoinconsensus with Rust binding.
-pub extern crate bitcoinconsensus;
+#[cfg(feature = "bitcoinconsensus")]
+extern crate bitcoinconsensus;
 
 /// Rust implementation of cryptographic hash function algorithems.
 pub extern crate hashes;


### PR DESCRIPTION
The `bitcoinconsensus` crate is not fully under our control because it exposes code from Core, so we cannot guarantee its stability across versions. To make our semver compliance easier we can fully encapsulate the `bitcoinconsensus` crate so it does not appear in our public API.

### Please note that with this applied:

- The `bitcoinconsenus` crate is no longer exported at the crate root
- No `bitcoinconsensus` types appear in our public API