### PR TITLE
Rename `PublicKey` to `LegacyPublicKey`

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -8,12 +8,12 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "rand-std")] {
-//! use bitcoin::{Address, PublicKey, Network};
+//! use bitcoin::{Address, LegacyPublicKey, Network};
 //! use bitcoin::secp256k1::{rand, Secp256k1};
 //!
 //! // Generate random key pair.
 //! let s = Secp256k1::new();
-//! let public_key = PublicKey::new(s.generate_keypair(&mut rand::thread_rng()).1);
+//! let public_key = LegacyPublicKey::new(s.generate_keypair(&mut rand::thread_rng()).1);
 //!
 //! // Generate pay-to-pubkey-hash address.
 //! let address = Address::p2pkh(&public_key, Network::Bitcoin);
@@ -45,7 +45,7 @@ use crate::blockdata::constants::{
 use crate::blockdata::script::witness_program::WitnessProgram;
 use crate::blockdata::script::witness_version::WitnessVersion;
 use crate::blockdata::script::{self, PushBytesBuf, Script, ScriptBuf, ScriptHash};
-use crate::crypto::key::{PubkeyHash, PublicKey, CompressedPublicKey, TweakedPublicKey, UntweakedPublicKey};
+use crate::crypto::key::{PubkeyHash, LegacyPublicKey, CompressedPublicKey, TweakedPublicKey, UntweakedPublicKey};
 use crate::network::Network;
 use crate::prelude::*;
 use crate::taproot::TapNodeHash;
@@ -627,7 +627,7 @@ impl Address {
     /// This is determined by directly comparing the address payload with either the
     /// hash of the given public key or the segwit redeem hash generated from the
     /// given key. For taproot addresses, the supplied key is assumed to be tweaked
-    pub fn is_related_to_pubkey(&self, pubkey: &PublicKey) -> bool {
+    pub fn is_related_to_pubkey(&self, pubkey: &LegacyPublicKey) -> bool {
         let pubkey_hash = pubkey.pubkey_hash();
         let payload = self.payload_as_bytes();
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
@@ -838,7 +838,7 @@ mod tests {
     use secp256k1::XOnlyPublicKey;
 
     use super::*;
-    use crate::crypto::key::PublicKey;
+    use crate::crypto::key::LegacyPublicKey;
     use crate::network::Network::{Bitcoin, Testnet};
 
     fn roundtrips(addr: &Address, network: Network) {
@@ -881,12 +881,12 @@ mod tests {
 
     #[test]
     fn test_p2pkh_from_key() {
-        let key = "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183".parse::<PublicKey>().unwrap();
+        let key = "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183".parse::<LegacyPublicKey>().unwrap();
         let addr = Address::p2pkh(key, Bitcoin);
         assert_eq!(&addr.to_string(), "1QJVDzdqb1VpbDK7uDeyVXy9mR27CJiyhY");
 
         let key = "03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f"
-            .parse::<PublicKey>()
+            .parse::<LegacyPublicKey>()
             .unwrap();
         let addr = Address::p2pkh(key, Testnet);
         assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
@@ -1163,12 +1163,12 @@ mod tests {
             .expect("mainnet");
 
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = LegacyPublicKey::from_str(pubkey_string).expect("pubkey");
 
         let result = address.is_related_to_pubkey(&pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
+        let unused_pubkey = LegacyPublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
@@ -1184,12 +1184,12 @@ mod tests {
             .expect("mainnet");
 
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = LegacyPublicKey::from_str(pubkey_string).expect("pubkey");
 
         let result = address.is_related_to_pubkey(&pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
+        let unused_pubkey = LegacyPublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
@@ -1205,12 +1205,12 @@ mod tests {
             .expect("mainnet");
 
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = LegacyPublicKey::from_str(pubkey_string).expect("pubkey");
 
         let result = address.is_related_to_pubkey(&pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
+        let unused_pubkey = LegacyPublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
@@ -1226,12 +1226,12 @@ mod tests {
             .expect("testnet");
 
         let pubkey_string = "04e96e22004e3db93530de27ccddfdf1463975d2138ac018fc3e7ba1a2e5e0aad8e424d0b55e2436eb1d0dcd5cb2b8bcc6d53412c22f358de57803a6a655fbbd04";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = LegacyPublicKey::from_str(pubkey_string).expect("pubkey");
 
         let result = address.is_related_to_pubkey(&pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
+        let unused_pubkey = LegacyPublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
@@ -1241,7 +1241,7 @@ mod tests {
     #[test]
     fn test_is_related_to_pubkey_p2tr() {
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = LegacyPublicKey::from_str(pubkey_string).expect("pubkey");
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
         let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(xonly_pubkey);
         let address = Address::p2tr_tweaked(tweaked_pubkey, Network::Bitcoin);
@@ -1257,7 +1257,7 @@ mod tests {
         let result = address.is_related_to_pubkey(&pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
+        let unused_pubkey = LegacyPublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
@@ -1267,7 +1267,7 @@ mod tests {
     #[test]
     fn test_is_related_to_xonly_pubkey() {
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = LegacyPublicKey::from_str(pubkey_string).expect("pubkey");
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
         let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(xonly_pubkey);
         let address = Address::p2tr_tweaked(tweaked_pubkey, Network::Bitcoin);

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -19,7 +19,7 @@ use crate::blockdata::script::{
     ScriptHash, WScriptHash,
 };
 use crate::consensus::Encodable;
-use crate::key::{PublicKey, UntweakedPublicKey};
+use crate::key::{LegacyPublicKey, UntweakedPublicKey};
 use crate::policy::DUST_RELAY_TX_FEE;
 use crate::prelude::*;
 use crate::taproot::{LeafVersion, TapLeafHash, TapNodeHash};
@@ -223,8 +223,8 @@ impl Script {
     /// This happens when the public key is invalid (e.g. the point not being on the curve).
     /// In this situation the script is unspendable.
     #[inline]
-    pub fn p2pk_public_key(&self) -> Option<PublicKey> {
-        PublicKey::from_slice(self.p2pk_pubkey_bytes()?).ok()
+    pub fn p2pk_public_key(&self) -> Option<LegacyPublicKey> {
+        LegacyPublicKey::from_slice(self.p2pk_pubkey_bytes()?).ok()
     }
 
     /// Returns the bytes of the (possibly invalid) public key if this script is P2PK.

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -10,7 +10,7 @@ use crate::blockdata::opcodes::all::*;
 use crate::blockdata::opcodes::{self, Opcode};
 use crate::blockdata::script::{opcode_to_verify, write_scriptint, PushBytes, Script, ScriptBuf};
 use crate::blockdata::transaction::Sequence;
-use crate::key::PublicKey;
+use crate::key::LegacyPublicKey;
 use crate::prelude::*;
 
 /// An Object which can be used to construct a script piece by piece.
@@ -64,7 +64,7 @@ impl Builder {
     }
 
     /// Adds instructions to push a public key onto the stack.
-    pub fn push_key(self, key: &PublicKey) -> Builder {
+    pub fn push_key(self, key: &LegacyPublicKey) -> Builder {
         if key.compressed {
             self.push_slice(key.inner.serialize())
         } else {

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -13,7 +13,7 @@ use crate::blockdata::script::{
     opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash,
 };
 use crate::key::{
-    PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
+    PubkeyHash, LegacyPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
 };
 use crate::prelude::*;
 use crate::taproot::TapNodeHash;
@@ -74,7 +74,7 @@ impl ScriptBuf {
     pub fn builder() -> Builder { Builder::new() }
 
     /// Generates P2PK-type of scriptPubkey.
-    pub fn new_p2pk(pubkey: &PublicKey) -> Self {
+    pub fn new_p2pk(pubkey: &LegacyPublicKey) -> Self {
         Builder::new().push_key(pubkey).push_opcode(OP_CHECKSIG).into_script()
     }
 

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -9,7 +9,7 @@ use super::*;
 use crate::FeeRate;
 use crate::blockdata::opcodes;
 use crate::consensus::encode::{deserialize, serialize};
-use crate::crypto::key::{PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey};
+use crate::crypto::key::{PubkeyHash, LegacyPublicKey, WPubkeyHash, XOnlyPublicKey};
 
 #[test]
 #[rustfmt::skip]
@@ -37,10 +37,10 @@ fn script() {
 
     // keys
     const KEYSTR1: &str = "21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";
-    let key = PublicKey::from_str(&KEYSTR1[2..]).unwrap();
+    let key = LegacyPublicKey::from_str(&KEYSTR1[2..]).unwrap();
     script = script.push_key(&key); comp.extend_from_slice(&hex!(KEYSTR1)); assert_eq!(script.as_bytes(), &comp[..]);
     const KEYSTR2: &str = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
-    let key = PublicKey::from_str(&KEYSTR2[2..]).unwrap();
+    let key = LegacyPublicKey::from_str(&KEYSTR2[2..]).unwrap();
     script = script.push_key(&key); comp.extend_from_slice(&hex!(KEYSTR2)); assert_eq!(script.as_bytes(), &comp[..]);
 
     // opcodes
@@ -51,7 +51,7 @@ fn script() {
 #[test]
 fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = LegacyPublicKey::from_str(key_str).unwrap();
     let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
     assert_eq!(actual.to_vec(), key.to_bytes());
@@ -60,7 +60,7 @@ fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
 #[test]
 fn p2pk_pubkey_bytes_no_checksig_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = LegacyPublicKey::from_str(key_str).unwrap();
     let no_checksig = Script::builder().push_key(&key).into_script();
     assert_eq!(no_checksig.p2pk_pubkey_bytes(), None);
 }
@@ -81,7 +81,7 @@ fn p2pk_pubkey_bytes_no_key_returns_none() {
 #[test]
 fn p2pk_pubkey_bytes_different_op_code_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = LegacyPublicKey::from_str(key_str).unwrap();
     let different_op_code = Script::builder().push_key(&key).push_opcode(OP_NOP).into_script();
     assert!(different_op_code.p2pk_pubkey_bytes().is_none());
 }
@@ -106,7 +106,7 @@ fn p2pk_pubkey_bytes_invalid_key_returns_some() {
 #[test]
 fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
     let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
-    let key = PublicKey::from_str(compressed_key_str).unwrap();
+    let key = LegacyPublicKey::from_str(compressed_key_str).unwrap();
     let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
     assert_eq!(actual.to_vec(), key.to_bytes());
@@ -115,7 +115,7 @@ fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
 #[test]
 fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = LegacyPublicKey::from_str(key_str).unwrap();
     let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_public_key().unwrap();
     assert_eq!(actual, key);
@@ -124,7 +124,7 @@ fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
 #[test]
 fn p2pk_public_key_no_checksig_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = LegacyPublicKey::from_str(key_str).unwrap();
     let no_checksig = Script::builder().push_key(&key).into_script();
     assert_eq!(no_checksig.p2pk_public_key(), None);
 }
@@ -144,7 +144,7 @@ fn p2pk_public_key_no_key_returns_none() {
 #[test]
 fn p2pk_public_key_different_op_code_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = LegacyPublicKey::from_str(key_str).unwrap();
     let different_op_code = Script::builder().push_key(&key).push_opcode(OP_NOP).into_script();
     assert!(different_op_code.p2pk_public_key().is_none());
 }
@@ -168,7 +168,7 @@ fn p2pk_public_key_invalid_key_returns_none() {
 #[test]
 fn p2pk_public_key_compressed_key_returns_some() {
     let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
-    let key = PublicKey::from_str(compressed_key_str).unwrap();
+    let key = LegacyPublicKey::from_str(compressed_key_str).unwrap();
     let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_public_key().unwrap();
     assert_eq!(actual, key);
@@ -201,7 +201,7 @@ fn script_builder() {
 #[test]
 fn script_generators() {
     let pubkey =
-        PublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e")
+        LegacyPublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e")
             .unwrap();
     assert!(ScriptBuf::new_p2pk(&pubkey).is_p2pk());
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -126,7 +126,7 @@ pub use crate::{
     blockdata::witness::{self, Witness},
     consensus::encode::VarInt,
     crypto::ecdsa,
-    crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, CompressedPublicKey, WPubkeyHash, XOnlyPublicKey},
+    crypto::key::{self, PrivateKey, PubkeyHash, LegacyPublicKey, CompressedPublicKey, WPubkeyHash, XOnlyPublicKey},
     crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},
     merkle_tree::MerkleBlock,
     network::Network,
@@ -135,6 +135,9 @@ pub use crate::{
     sighash::{EcdsaSighashType, TapSighashType},
     taproot::{TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash, TapTweakHash, TapTweakTag},
 };
+
+#[allow(deprecated)] 
+pub use crate::key::PublicKey;
 
 #[rustfmt::skip]
 mod prelude {

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -10,7 +10,7 @@ use crate::bip32::KeySource;
 use crate::blockdata::script::ScriptBuf;
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::blockdata::witness::Witness;
-use crate::crypto::key::PublicKey;
+use crate::crypto::key::LegacyPublicKey;
 use crate::crypto::{ecdsa, taproot};
 use crate::prelude::*;
 use crate::psbt::map::Map;
@@ -79,7 +79,7 @@ pub struct Input {
     pub witness_utxo: Option<TxOut>,
     /// A map from public keys to their corresponding signature as would be
     /// pushed to the stack from a scriptSig or witness for a non-taproot inputs.
-    pub partial_sigs: BTreeMap<PublicKey, ecdsa::Signature>,
+    pub partial_sigs: BTreeMap<LegacyPublicKey, ecdsa::Signature>,
     /// The sighash type to be used for this input. Signatures for this input
     /// must use the sighash type.
     pub sighash_type: Option<PsbtSighashType>,
@@ -257,7 +257,7 @@ impl Input {
             }
             PSBT_IN_PARTIAL_SIG => {
                 impl_psbt_insert_pair! {
-                    self.partial_sigs <= <raw_key: PublicKey>|<raw_value: ecdsa::Signature>
+                    self.partial_sigs <= <raw_key: LegacyPublicKey>|<raw_value: ecdsa::Signature>
                 }
             }
             PSBT_IN_SIGHASH_TYPE => {

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -15,7 +15,7 @@ use crate::blockdata::script::ScriptBuf;
 use crate::blockdata::transaction::{Transaction, TxOut};
 use crate::blockdata::witness::Witness;
 use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
-use crate::crypto::key::PublicKey;
+use crate::crypto::key::LegacyPublicKey;
 use crate::crypto::{ecdsa, taproot};
 use crate::prelude::*;
 use crate::psbt::{Error, Psbt};
@@ -129,7 +129,7 @@ impl Deserialize for ScriptBuf {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> { Ok(Self::from(bytes.to_vec())) }
 }
 
-impl Serialize for PublicKey {
+impl Serialize for LegacyPublicKey {
     fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         self.write_into(&mut buf).expect("vecs don't error");
@@ -137,9 +137,9 @@ impl Serialize for PublicKey {
     }
 }
 
-impl Deserialize for PublicKey {
+impl Deserialize for LegacyPublicKey {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        PublicKey::from_slice(bytes).map_err(Error::InvalidPublicKey)
+        LegacyPublicKey::from_slice(bytes).map_err(Error::InvalidPublicKey)
     }
 }
 

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -28,7 +28,7 @@ mod message_signing {
     use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 
     use crate::address::{Address, AddressType};
-    use crate::crypto::key::PublicKey;
+    use crate::crypto::key::LegacyPublicKey;
 
     /// An error used for dealing with Bitcoin Signed Messages.
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,10 +133,10 @@ mod message_signing {
             &self,
             secp_ctx: &secp256k1::Secp256k1<C>,
             msg_hash: sha256d::Hash,
-        ) -> Result<PublicKey, MessageSignatureError> {
+        ) -> Result<LegacyPublicKey, MessageSignatureError> {
             let msg = secp256k1::Message::from_digest(msg_hash.to_byte_array());
             let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
-            Ok(PublicKey { inner: pubkey, compressed: self.compressed })
+            Ok(LegacyPublicKey { inner: pubkey, compressed: self.compressed })
         }
 
         /// Verify that the signature signs the message and was signed by the given address.
@@ -265,7 +265,7 @@ mod tests {
         use base64::prelude::{Engine as _, BASE64_STANDARD};
         use secp256k1;
 
-        use crate::crypto::key::PublicKey;
+        use crate::crypto::key::LegacyPublicKey;
         use crate::{Address, Network};
 
         let secp = secp256k1::Secp256k1::new();
@@ -280,7 +280,7 @@ mod tests {
             super::MessageSignature::from_base64(signature_base64).expect("message signature");
 
         let pubkey =
-            PublicKey::from_slice(&BASE64_STANDARD.decode(pubkey_base64).expect("base64 string"))
+            LegacyPublicKey::from_slice(&BASE64_STANDARD.decode(pubkey_base64).expect("base64 string"))
                 .expect("pubkey slice");
 
         let p2pkh = Address::p2pkh(pubkey, Network::Bitcoin);

--- a/bitcoin/tests/psbt.rs
+++ b/bitcoin/tests/psbt.rs
@@ -13,7 +13,7 @@ use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::script::PushBytes;
 use bitcoin::secp256k1::{self, Secp256k1};
 use bitcoin::{
-    absolute, Amount, Denomination, Network, OutPoint, PrivateKey, PublicKey, ScriptBuf, Sequence,
+    absolute, Amount, Denomination, Network, OutPoint, PrivateKey, LegacyPublicKey, ScriptBuf, Sequence,
     Transaction, TxIn, TxOut, Witness,
 };
 
@@ -279,7 +279,7 @@ fn bip32_derivation(
         let pk = pk_path[i].0;
         let path = pk_path[i].1;
 
-        let pk = PublicKey::from_str(pk).unwrap();
+        let pk = LegacyPublicKey::from_str(pk).unwrap();
         let path = path.into_derivation_path().unwrap();
 
         tree.insert(pk.inner, (fingerprint, path));
@@ -310,7 +310,7 @@ fn update_psbt_with_sighash_all(mut psbt: Psbt) -> Psbt {
 fn parse_and_verify_keys(
     ext_priv: &Xpriv,
     sk_path: &[(&str, &str)],
-) -> BTreeMap<PublicKey, PrivateKey> {
+) -> BTreeMap<LegacyPublicKey, PrivateKey> {
     let secp = &Secp256k1::new();
 
     let mut key_map = BTreeMap::new();
@@ -330,7 +330,7 @@ fn parse_and_verify_keys(
 
 /// Does the first signing according to the BIP, returns the signed PSBT. Verifies against BIP 174 test vector.
 #[track_caller]
-fn signer_one_sign(psbt: Psbt, key_map: BTreeMap<bitcoin::PublicKey, PrivateKey>) -> Psbt {
+fn signer_one_sign(psbt: Psbt, key_map: BTreeMap<bitcoin::LegacyPublicKey, PrivateKey>) -> Psbt {
     let expected_psbt_hex = include_str!("data/sign_1_psbt_hex");
     let expected_psbt: Psbt = hex_psbt(expected_psbt_hex);
 
@@ -342,7 +342,7 @@ fn signer_one_sign(psbt: Psbt, key_map: BTreeMap<bitcoin::PublicKey, PrivateKey>
 
 /// Does the second signing according to the BIP, returns the signed PSBT. Verifies against BIP 174 test vector.
 #[track_caller]
-fn signer_two_sign(psbt: Psbt, key_map: BTreeMap<bitcoin::PublicKey, PrivateKey>) -> Psbt {
+fn signer_two_sign(psbt: Psbt, key_map: BTreeMap<bitcoin::LegacyPublicKey, PrivateKey>) -> Psbt {
     let expected_psbt_hex = include_str!("data/sign_2_psbt_hex");
     let expected_psbt: Psbt = hex_psbt(expected_psbt_hex);
 
@@ -411,7 +411,7 @@ fn combine_lexicographically() {
 }
 
 /// Signs `psbt` with `keys` if required.
-fn sign(mut psbt: Psbt, keys: BTreeMap<bitcoin::PublicKey, PrivateKey>) -> Psbt {
+fn sign(mut psbt: Psbt, keys: BTreeMap<bitcoin::LegacyPublicKey, PrivateKey>) -> Psbt {
     let secp = Secp256k1::new();
     psbt.sign(&keys, &secp).unwrap();
     psbt

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -38,7 +38,7 @@ use bitcoin::psbt::{Input, Output, Psbt, PsbtSighashType};
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapTree, TaprootBuilder};
 use bitcoin::{
-    ecdsa, transaction, Address, Amount, Block, Network, OutPoint, PrivateKey, PublicKey,
+    ecdsa, transaction, Address, Amount, Block, Network, OutPoint, PrivateKey, LegacyPublicKey,
     ScriptBuf, Sequence, Target, Transaction, TxIn, TxOut, Txid, Work,
 };
 
@@ -144,7 +144,7 @@ fn serde_regression_witness() {
 #[test]
 fn serde_regression_address() {
     let s = include_str!("data/serde/public_key_hex");
-    let pk = PublicKey::from_str(s.trim()).unwrap();
+    let pk = LegacyPublicKey::from_str(s.trim()).unwrap();
     let addr = Address::p2pkh(pk, Network::Bitcoin);
 
     let got = serialize(&addr).unwrap();
@@ -212,7 +212,7 @@ fn serde_regression_private_key() {
 #[test]
 fn serde_regression_public_key() {
     let s = include_str!("data/serde/public_key_hex");
-    let pk = PublicKey::from_str(s.trim()).unwrap();
+    let pk = LegacyPublicKey::from_str(s.trim()).unwrap();
     let got = serialize(&pk).unwrap();
     let want = include_bytes!("data/serde/public_key_bincode") as &[_];
     assert_eq!(got, want)


### PR DESCRIPTION
We would like to shorten the name `CompressedPublicKey` into `PublicKey` since legacy things are second-class in this library. However doing this directly would make upgrading the library very painful, maybe even error-prone. To aid with this we first just rename `PublicKey` and leave a deprecated type alias in its place.

In case it helps anyone (maybe during rebases), this change was produced by renaming the type, modifying the rest of the file in vim with `:'<,'>s/\([^a-z:]\)PublicKey/\1LegacyPublicKey/g`, then running:

```shell
sed -i -e 's/\(use.*[^a-z0-9]\)\(PublicKey[^A-Z]\)/\1Legacy\2/' -e 's/key::PublicKey/key::LegacyPublicKey/g' -e 's/bitcoin::PublicKey/bitcoin::LegacyPublicKey/' -e 's/\([^a-z0-9:]\)\(PublicKey\)/\1Legacy\2/g' bitcoin/tests/serde.rs bitcoin/src/blockdata/script/tests.rs bitcoin/src/sign_message.rs bitcoin/src/psbt/map/input.rs bitcoin/src/address/mod.rs bitcoin/src/address/mod.rs bitcoin/src/blockdata/script/builder.rs bitcoin/src/blockdata/script/borrowed.rs bitcoin/src/blockdata/script/owned.rs bitcoin/src/psbt/mod.rs bitcoin/src/psbt/serialize.rs bitcoin/tests/psbt.rs
```

(Yes, I should setup RA. :))