### PR TITLE
Deprecate `Script::is_provably_unspendable`

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -353,7 +353,11 @@ impl Script {
         }
     }
 
-    /// Checks whether a script can be proven to have no satisfying input.
+    /// Checks whether a script is trivially known to have no satisfying input.
+    ///
+    /// This method has potentially confusing semantics and an unclear purpose, so it's going to be
+    /// removed. Use `is_op_return` if you want `OP_RETURN` semantics.
+    #[deprecated(since = "TBD", note = "The method is not very useful, you might want `is_op_return`")]
     #[inline]
     pub fn is_provably_unspendable(&self) -> bool {
         use crate::blockdata::opcodes::Class::{IllegalOp, ReturnOp};


### PR DESCRIPTION
This method is not really that useful because it checked an arbitrary condition. There already exists `OP_RETURN` semantics and the method didn't cover all possible ways the script may be invalid.

This deprecates the method and documents why.

Closes #2191 