### PR TITLE
Backport address conversion functions

### DIFF
--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -639,6 +639,19 @@ impl NetworkValidation for NetworkUnchecked {
     const IS_CHECKED: bool = false;
 }
 
+/// The inner representation of an address, without the network validation tag.
+///
+/// An `Address` is composed of a payload and a network. This struct represents the inner
+/// representation of an address without the network validation tag, which is used to ensure that
+/// addresses are used only on the appropriate network.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct AddressInner {
+    /// The type of the address.
+    pub payload: Payload,
+    /// The network on which this address is usable.
+    pub network: Network,
+}
+
 /// A Bitcoin address.
 ///
 /// ### Parsing addresses
@@ -727,17 +740,15 @@ impl NetworkValidation for NetworkUnchecked {
 /// * [BIP341 - Taproot: SegWit version 1 spending rules](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)
 /// * [BIP350 - Bech32m format for v1+ witness addresses](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Address<V = NetworkChecked>
+///
+/// The `#[repr(transparent)]` attribute is used to guarantee that the layout of the
+/// `Address` struct is the same as the layout of the `AddressInner` struct. This attribute is
+/// an implementation detail and users should not rely on it in their code.
+///
+#[repr(transparent)]
+pub struct Address<V = NetworkChecked>(AddressInner, PhantomData<V>)
 where
-    V: NetworkValidation,
-{
-    /// The type of the address.
-    pub payload: Payload,
-    /// The network on which this address is usable.
-    pub network: Network,
-    /// Marker of the status of network validation.
-    _validation: PhantomData<V>,
-}
+    V: NetworkValidation;
 
 #[cfg(feature = "serde")]
 struct DisplayUnchecked<'a>(&'a Address<NetworkUnchecked>);
@@ -766,6 +777,11 @@ impl serde::Serialize for Address<NetworkUnchecked> {
 /// Methods on [`Address`] that can be called on both `Address<NetworkChecked>` and
 /// `Address<NetworkUnchecked>`.
 impl<V: NetworkValidation> Address<V> {
+    /// Returns a reference to the address as if it was unchecked.
+    pub fn as_unchecked(&self) -> &Address<NetworkUnchecked> {
+        unsafe { &*(self as *const Address<V> as *const Address<NetworkUnchecked>) }
+    }
+
     /// Gets the address type of the address.
     ///
     /// This method is publicly available as [`address_type`](Address<NetworkChecked>::address_type)
@@ -775,7 +791,7 @@ impl<V: NetworkValidation> Address<V> {
     /// # Returns
     /// None if unknown, non-standard or related to the future witness version.
     fn address_type_internal(&self) -> Option<AddressType> {
-        match self.payload {
+        match self.0.payload {
             Payload::PubkeyHash(_) => Some(AddressType::P2pkh),
             Payload::ScriptHash(_) => Some(AddressType::P2sh),
             Payload::WitnessProgram(ref prog) => {
@@ -797,21 +813,21 @@ impl<V: NetworkValidation> Address<V> {
 
     /// Format the address for the usage by `Debug` and `Display` implementations.
     fn fmt_internal(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let p2pkh_prefix = match self.network {
+        let p2pkh_prefix = match self.0.network {
             Network::Bitcoin => PUBKEY_ADDRESS_PREFIX_MAIN,
             Network::Testnet | Network::Signet | Network::Regtest => PUBKEY_ADDRESS_PREFIX_TEST,
         };
-        let p2sh_prefix = match self.network {
+        let p2sh_prefix = match self.0.network {
             Network::Bitcoin => SCRIPT_ADDRESS_PREFIX_MAIN,
             Network::Testnet | Network::Signet | Network::Regtest => SCRIPT_ADDRESS_PREFIX_TEST,
         };
-        let bech32_hrp = match self.network {
+        let bech32_hrp = match self.0.network {
             Network::Bitcoin => "bc",
             Network::Testnet | Network::Signet => "tb",
             Network::Regtest => "bcrt",
         };
         let encoding =
-            AddressEncoding { payload: &self.payload, p2pkh_prefix, p2sh_prefix, bech32_hrp };
+            AddressEncoding { payload: &self.0.payload, p2pkh_prefix, p2sh_prefix, bech32_hrp };
 
         use fmt::Display;
 
@@ -822,12 +838,15 @@ impl<V: NetworkValidation> Address<V> {
     /// marker type of the address.
     #[inline]
     pub fn new(network: Network, payload: Payload) -> Address<V> {
-        Address { network, payload, _validation: PhantomData }
+        Address(AddressInner { network, payload }, PhantomData)
     }
 }
 
 /// Methods and functions that can be called only on `Address<NetworkChecked>`.
 impl Address {
+    /// Gets the network associated with this address.
+    pub fn network(&self) -> Network { self.0.network }
+
     /// Creates a pay to (compressed) public key hash address from a public key.
     ///
     /// This is the preferred non-witness type address.
@@ -929,7 +948,7 @@ impl Address {
     }
 
     /// Generates a script pubkey spending to this address.
-    pub fn script_pubkey(&self) -> ScriptBuf { self.payload.script_pubkey() }
+    pub fn script_pubkey(&self) -> ScriptBuf { self.0.payload.script_pubkey() }
 
     /// Creates a URI string *bitcoin:address* optimized to be encoded in QR codes.
     ///
@@ -959,7 +978,7 @@ impl Address {
     /// # assert_eq!(writer, ADDRESS);
     /// ```
     pub fn to_qr_uri(&self) -> String {
-        let schema = match self.payload {
+        let schema = match self.0.payload {
             Payload::WitnessProgram { .. } => "BITCOIN",
             _ => "bitcoin",
         };
@@ -973,7 +992,7 @@ impl Address {
     /// given key. For taproot addresses, the supplied key is assumed to be tweaked
     pub fn is_related_to_pubkey(&self, pubkey: &PublicKey) -> bool {
         let pubkey_hash = pubkey.pubkey_hash();
-        let payload = self.payload.inner_prog_as_bytes();
+        let payload = self.0.payload.inner_prog_as_bytes();
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
 
         (*pubkey_hash.as_byte_array() == *payload)
@@ -986,19 +1005,26 @@ impl Address {
     /// This will only work for Taproot addresses. The Public Key is
     /// assumed to have already been tweaked.
     pub fn is_related_to_xonly_pubkey(&self, xonly_pubkey: &XOnlyPublicKey) -> bool {
-        let payload = self.payload.inner_prog_as_bytes();
+        let payload = self.0.payload.inner_prog_as_bytes();
         payload == xonly_pubkey.serialize()
     }
 
     /// Returns true if the address creates a particular script
     /// This function doesn't make any allocations.
     pub fn matches_script_pubkey(&self, script_pubkey: &Script) -> bool {
-        self.payload.matches_script_pubkey(script_pubkey)
+        self.0.payload.matches_script_pubkey(script_pubkey)
     }
 }
 
 /// Methods that can be called only on `Address<NetworkUnchecked>`.
 impl Address<NetworkUnchecked> {
+    /// Returns a reference to the checked address.
+    ///
+    /// This function is dangerous in case the address is not a valid checked address.
+    pub fn assume_checked_ref(&self) -> &Address {
+        unsafe { &*(self as *const Address<NetworkUnchecked> as *const Address) }
+    }
+
     /// Parsed addresses do not always have *one* network. The problem is that legacy testnet,
     /// regtest and signet addresse use the same prefix instead of multiple different ones. When
     /// parsing, such addresses are always assumed to be testnet addresses (the same is true for
@@ -1026,7 +1052,7 @@ impl Address<NetworkUnchecked> {
             _ => false,
         };
 
-        match (self.network, network) {
+        match (self.0.network, network) {
             (a, b) if a == b => true,
             (Network::Bitcoin, _) | (_, Network::Bitcoin) => false,
             (Network::Regtest, _) | (_, Network::Regtest) if !is_legacy => false,
@@ -1043,7 +1069,7 @@ impl Address<NetworkUnchecked> {
         if self.is_valid_for_network(required) {
             Ok(self.assume_checked())
         } else {
-            Err(Error::NetworkValidation { found: self.network, required, address: self })
+            Err(Error::NetworkValidation { found: self.0.network, required, address: self })
         }
     }
 
@@ -1054,7 +1080,7 @@ impl Address<NetworkUnchecked> {
     /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
     /// on [`Address`].
     #[inline]
-    pub fn assume_checked(self) -> Address { Address::new(self.network, self.payload) }
+    pub fn assume_checked(self) -> Address { Address::new(self.0.network, self.0.payload) }
 }
 
 impl From<Address> for script::ScriptBuf {
@@ -1191,7 +1217,7 @@ mod tests {
             addr,
         );
         assert_eq!(
-            Address::from_script(&addr.script_pubkey(), addr.network).as_ref(),
+            Address::from_script(&addr.script_pubkey(), addr.0.network).as_ref(),
             Ok(addr),
             "script round-trip failed for {}",
             addr,

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -154,7 +154,7 @@ mod message_signing {
             match address.address_type() {
                 Some(AddressType::P2pkh) => {
                     let pubkey = self.recover_pubkey(secp_ctx, msg_hash)?;
-                    Ok(*address == Address::p2pkh(&pubkey, address.network))
+                    Ok(*address == Address::p2pkh(&pubkey, address.network()))
                 }
                 Some(address_type) =>
                     Err(MessageSignatureError::UnsupportedAddressType(address_type)),


### PR DESCRIPTION
Backport the address conversion functions from PR #1765. This is not a stragiht cherry-pick because the `address` module has changed substantially.
    
In order to be able to grab the two required conversion functions we need to also create the `AddressInner` type so that we are guaranteed the same layout when casting in unsafe code.
    
The `network` field is accessed once outside the `address` module so add a getter method for it but use `.0` inside the `address` module.

The two functions we are backporting are:
    
- `assume_checked_ref`
- `as_unchecked`
 


Fix: #2299