### PR TITLE
Add the implementation of `Display` for `transaction::Version`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1030,6 +1030,12 @@ impl Decodable for Version {
     }
 }
 
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
 impl_consensus_encoding!(TxOut, value, script_pubkey);
 
 impl Encodable for OutPoint {


### PR DESCRIPTION
Adds the implementation of `Display` trait for `transaction::Version`

fixes #2308 

This is unrelated to the issue but can anyone suggest some good issues that needs to be fixed. I am also taking a look but I am confused as to which I would be able to solve. I am here to learn more.
Thank you.