### PR TITLE
use arrayvec to represent witness programs internally

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -39,6 +39,7 @@
 // Exclude clippy lints we don't think are valuable
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::uninhabited_references)] // falsely claims that 100% safe code is UB
+#![allow(clippy::manual_range_contains)] // more readable than clippy's format
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -2087,7 +2087,7 @@ mod tests {
         psbt.inputs[0].bip32_derivation = map;
 
         // Second input is unspendable by us e.g., from another wallet that supports future upgrades.
-        let unknown_prog = WitnessProgram::new(WitnessVersion::V4, vec![0xaa; 34]).unwrap();
+        let unknown_prog = WitnessProgram::new(WitnessVersion::V4, &[0xaa; 34]).unwrap();
         let txout_unknown_future = TxOut {
             value: Amount::from_sat(10),
             script_pubkey: ScriptBuf::new_witness_program(&unknown_prog),


### PR DESCRIPTION
Fixes https://github.com/rust-bitcoin/rust-bitcoin/issues/2261

Introduces a new constructor, `WitnessProgram::from_bytes`, which creates a witness program by copying the program content from a byte slice.