### PR TITLE
Re-export everything from consensus::encode

### DIFF
--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -16,7 +16,7 @@ pub mod validation;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    encode::{deserialize, deserialize_partial, serialize, Decodable, Encodable, ReadExt, WriteExt},
+    encode::{deserialize, deserialize_partial, serialize, serialize_hex, Decodable, Encodable, ReadExt, WriteExt, CheckedData, MAX_VEC_SIZE, Error},
     params::Params,
 };
 


### PR DESCRIPTION
Most of the types and functions from `consensus::encode` are re-exported in `consensus` but not all of them, there is no obvious reason for not re-exporting all types and functions.