### PR TITLE
Derive `Copy` for `WitnessProgram`

### DIFF
--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -29,7 +29,7 @@ pub const MAX_SIZE: usize = 40;
 /// The segregated witness program is technically only the program bytes _excluding_ the witness
 /// version, however we maintain length invariants on the `program` that are governed by the version
 /// number, therefore we carry the version number around along with the program bytes.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WitnessProgram {
     /// The segwit version associated with this witness program.
     version: WitnessVersion,


### PR DESCRIPTION
Recently we started using our custom `ArrayVec` for the `program` field of `WitnessProgram`, this means we can now derive `Copy`.

Fix: #2313