### PR TITLE
Remove Push enum

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -589,22 +589,12 @@ impl Script {
     /// Iterates the script to find the last pushdata.
     ///
     /// Returns `None` if the instruction is an opcode or if the script is empty.
-    pub(crate) fn last_pushdata(&self) -> Option<Push> {
+    pub(crate) fn last_pushdata(&self) -> Option<&PushBytes> {
         match self.instructions().last() {
             // Handles op codes up to (but excluding) OP_PUSHNUM_NEG.
-            Some(Ok(Instruction::PushBytes(bytes))) => Some(Push::Data(bytes)),
+            Some(Ok(Instruction::PushBytes(bytes))) => Some(bytes),
             // OP_16 (0x60) and lower are considered "pushes" by Bitcoin Core (excl. OP_RESERVED).
-            // By here we know that op is between OP_PUSHNUM_NEG AND OP_PUSHNUM_16 inclusive.
-            Some(Ok(Instruction::Op(op))) if op.to_u8() <= 0x60 => {
-                if op == OP_PUSHNUM_NEG1 {
-                    Some(Push::Num(-1))
-                } else if op == OP_RESERVED {
-                    Some(Push::Reserved)
-                } else {
-                    let num = (op.to_u8() - 0x50) as i8; // cast ok, num is [1, 16].
-                    Some(Push::Num(num))
-                }
-            }
+            // However we are only interested in the pushdata so we can ignore them.
             _ => None,
         }
     }
@@ -620,19 +610,6 @@ impl Script {
         let inner = unsafe { Box::from_raw(rw) };
         ScriptBuf(Vec::from(inner))
     }
-}
-
-/// Data pushed by "push" opcodes.
-///
-/// "push" opcodes are defined by Bitcoin Core as OP_PUSHBYTES_, OP_PUSHDATA, OP_PUSHNUM_, and
-/// OP_RESERVED i.e., everything less than OP_PUSHNUM_16 (0x60) . (TODO: Add link to core code).
-pub(crate) enum Push<'a> {
-    /// All the OP_PUSHBYTES_ and OP_PUSHDATA_ opcodes.
-    Data(&'a PushBytes),
-    /// All the OP_PUSHNUM_ opcodes (-1, 1, 2, .., 16)
-    Num(i8),
-    /// OP_RESERVED
-    Reserved,
 }
 
 /// Iterator over bytes of a script

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -28,7 +28,6 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::parse::impl_parse_str_from_int_infallible;
 use crate::prelude::*;
-use crate::script::Push;
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::string::FromHexStr;
@@ -909,7 +908,7 @@ impl Transaction {
         fn count_sigops(prevout: &TxOut, input: &TxIn) -> usize {
             let mut count: usize = 0;
             if prevout.script_pubkey.is_p2sh() {
-                if let Some(Push::Data(redeem)) = input.script_sig.last_pushdata() {
+                if let Some(redeem) = input.script_sig.last_pushdata() {
                     count =
                         count.saturating_add(Script::from_bytes(redeem.as_bytes()).count_sigops());
                 }
@@ -955,7 +954,7 @@ impl Transaction {
             } else if prevout.script_pubkey.is_p2sh() && script_sig.is_push_only() {
                 // If prevout is P2SH and scriptSig is push only
                 // then we wrap the last push (redeemScript) in a Script
-                if let Some(Push::Data(push_bytes)) = script_sig.last_pushdata() {
+                if let Some(push_bytes) = script_sig.last_pushdata() {
                     Script::from_bytes(push_bytes.as_bytes())
                 } else {
                     return 0;


### PR DESCRIPTION
The `Push` enum is only ever used to get access to one of its variants. Since it is a private type we can remove it entirely and just return `PushBytes` from the `last_pushdata` function.

Needs careful review but I believe the function name is still correctly descriptive.

This was discovered by of a new nightly clippy warning.