### PR TITLE
Improve the `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,6 +17,21 @@ lint:
 format:
   cargo +nightly fmt --all --check
 
+# Quick and dirty CI useful for pre-push checks.
+sane: lint
+  cargo test --quiet --workspace --all-targets --no-default-features > /dev/null || exit 1
+  cargo test --quiet --workspace --all-targets > /dev/null || exit 1
+  cargo test --quiet --workspace --all-targets --all-features > /dev/null || exit 1
+
+  # Docs tests (these don't run when testing from workspace root)
+  cargo test --quiet --manifest-path bitcoin/Cargo.toml --doc > /dev/null  || exit 1
+  cargo test --quiet --manifest-path hashes/Cargo.toml --doc > /dev/null  || exit 1
+  cargo test --quiet --manifest-path io/Cargo.toml --doc > /dev/null  || exit 1
+  cargo test --quiet --manifest-path units/Cargo.toml --doc > /dev/null  || exit 1
+
+  # Make an attempt to catch feature gate problems in doctests
+  cargo test --manifest-path bitcoin/Cargo.toml --doc --no-default-features > /dev/null || exit 1
+
 # Update the recent and minimal lock files.
 update-lock-files:
   contrib/update-lock-files.sh

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ check:
 
 # Lint everything.
 lint:
-  cargo clippy --workspace --all-targets --all-features -- --deny warnings
+  cargo +nightly clippy --workspace --all-targets --all-features -- --deny warnings
 
 # Check the formatting
 format:


### PR DESCRIPTION
Improve the `justfile` by doing:

- Update linter toolchain
- Add `just sane` to run a minimal set of checks/tests that can be used pre-push but is not as slow as using `DO_FEATURE_MATRIX=true contrib/test.sh`.