### PR TITLE
CI: Run sanity cargo commands with --locked

### DIFF
--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -27,8 +27,8 @@ fi
 export CARGO_TERM_VERBOSE=true
 
 # Defaults / sanity checks
-cargo build
-cargo test
+cargo build --locked
+cargo test --locked
 
 if [ "$DO_LINT" = true ]
 then

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -24,8 +24,8 @@ fi
 export CARGO_TERM_VERBOSE=true
 
 # Defaults / sanity checks
-cargo build
-cargo test
+cargo build --locked
+cargo test --locked
 
 if [ "$DO_LINT" = true ]
 then

--- a/internals/contrib/test.sh
+++ b/internals/contrib/test.sh
@@ -17,8 +17,8 @@ fi
 export CARGO_TERM_VERBOSE=true
 
 # Defaults / sanity checks
-cargo --locked build
-cargo --locked test
+cargo build --locked
+cargo test --locked
 
 if [ "$DO_LINT" = true ]
 then

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -17,8 +17,8 @@ fi
 export CARGO_TERM_VERBOSE=true
 
 # Defaults / sanity checks
-cargo build
-cargo test
+cargo build --locked
+cargo test --locked
 
 if [ "$DO_LINT" = true ]
 then


### PR DESCRIPTION
In order to catch issues with the recent and minimal lock files we should be running `cargo` with `--locked` all the time, otherwise `cargo` will update the lock files - defeating the purpose of having them.

EDIT: Converting to draft because I did https://github.com/rust-bitcoin/rust-bitcoin/pull/2328 while investigating CI failse.