### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,6 @@ jobs:
           DO_COV: true
           AS_DEPENDENCY: false
           DO_FEATURE_MATRIX: true
-          DO_SCHEMARS_TESTS: true # Currently only used in hashes crate.
         run: ./contrib/test.sh
 
   Beta:
@@ -221,3 +220,18 @@ jobs:
         env:
           DO_WASM: true
         run: cd hashes && ./contrib/test.sh
+
+  Schemars:
+    name: Schemars - stable toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v4
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Running test script
+        env:
+          DO_SCHEMARS_TESTS: true # Currently only used in hashes crate.
+        run: ./contrib/test.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,23 @@ jobs:
           DO_LINT: true
         run: ./contrib/test.sh
 
+  Dups:
+    name: Duplicate dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v4
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Running test script
+        env:
+          DO_DUP_DEPS: true
+        run: ./contrib/test.sh
+
   Docsrs:
     name: Docsrs build - nightly toolchain
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,21 @@ jobs:
           DO_DOCS: true
         run: ./contrib/test.sh
 
+  Bench:
+    name: Bench - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v4
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Running test script
+        env:
+          DO_BENCH: true
+        run: ./contrib/test.sh
+
   Stable:
     name: Test - stable toolchain
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Running WASM build
         env:
           DO_WASM: true
-        run: cd hashes && ./contrib/test.sh
+        run: ./contrib/test.sh
 
   Schemars:
     name: Schemars - stable toolchain

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -194,7 +194,7 @@ jobs:
         run: cd hashes/embedded && cargo run --target thumbv7m-none-eabi --features=alloc
 
   ASAN:
-    name: Address sanitizer     # hashes crate only.
+    name: Address sanitizer
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
@@ -206,7 +206,7 @@ jobs:
       - name: Running address sanitizer
         env:
           DO_ASAN: true
-        run: cd hashes && ./contrib/test.sh
+        run: ./contrib/test.sh
 
   WASM:
     name: WebAssembly Build # hashes crate only.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,53 @@ on:
 name: Continuous integration
 
 jobs:
+  Lint:
+    name: Lint - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v4
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Running test script
+        env:
+          DO_LINT: true
+        run: ./contrib/test.sh
+
+  Docsrs:
+    name: Docsrs build - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v4
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Running test script
+        env:
+          DO_DOCSRS: true
+        run: ./contrib/test.sh
+
+  Docs:
+    name: Docs build - stable toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v4
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Running test script
+        env:
+          DO_DOCS: true
+        run: ./contrib/test.sh
+
   Stable:
     name: Test - stable toolchain
     runs-on: ubuntu-latest
@@ -23,7 +70,6 @@ jobs:
         env:
           DO_COV: true
           AS_DEPENDENCY: false
-          DO_DOCS: true
           DO_FEATURE_MATRIX: true
           DO_SCHEMARS_TESTS: true # Currently only used in hashes crate.
         run: ./contrib/test.sh
@@ -53,15 +99,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Checkout Toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - name: Install clippy
-        run: rustup component add clippy
       - name: Running test script
         env:
-          DO_LINT: true
           DO_FMT: false
           DO_BENCH: true
           AS_DEPENDENCY: false
-          DO_DOCSRS: true
         run: ./contrib/test.sh
 
   MSRV:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ on:
       - 'test-ci/**'
   pull_request:
 
-name: Continuous integration
+name: CI
 
 jobs:
   Lint:

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -23,9 +23,6 @@ if cargo --version | grep beta; then
     STABLE=false
 fi
 
-# Make all cargo invocations verbose
-export CARGO_TERM_VERBOSE=true
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -32,14 +32,6 @@ cargo test
 
 if [ "$DO_LINT" = true ]
 then
-    cargo clippy --locked --all-features --all-targets -- -D warnings
-    cargo clippy --locked --example bip32 -- -D warnings
-    cargo clippy --locked --example handshake --features=rand-std -- -D warnings
-    cargo clippy --locked --example ecdsa-psbt --features=bitcoinconsensus -- -D warnings
-    cargo clippy --locked --example sign-tx-segwit-v0 --features=rand-std -- -D warnings
-    cargo clippy --locked --example sign-tx-taproot --features=rand-std -- -D warnings
-    cargo clippy --locked --example taproot-psbt --features=rand-std,bitcoinconsensus -- -D warnings
-
     # We should not have any duplicate dependencies. This catches mistakes made upgrading dependencies
     # in one crate and not in another (e.g. upgrade bitcoin_hashes in bitcoin but not in secp).
     duplicate_dependencies=$(

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -80,16 +80,6 @@ cargo run --locked --example sign-tx-segwit-v0 --features=rand-std -- -D warning
 cargo run --locked --example sign-tx-taproot --features=rand-std -- -D warnings
 cargo run --locked --example taproot-psbt --features=rand-std,bitcoinconsensus
 
-# Run formatter if told to.
-if [ "$DO_FMT" = true ]; then
-    if [ "$NIGHTLY" = false ]; then
-        echo "DO_FMT requires a nightly toolchain (consider using RUSTUP_TOOLCHAIN)"
-        exit 1
-    fi
-    rustup component add rustfmt
-    cargo fmt --check
-fi
-
 # Bench if told to, only works with non-stable toolchain (nightly, beta).
 if [ "$DO_BENCH" = true ]
 then

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -3,18 +3,19 @@
 set -ex
 
 FEATURES="std rand-std rand serde secp-recovery bitcoinconsensus-std base64 bitcoinconsensus"
+CARGO="cargo --locked"
 
 if [ "$DO_COV" = true ]
 then
     export RUSTFLAGS="-C link-dead-code"
 fi
 
-cargo --version
+$CARGO --version
 rustc --version
 
 # Defaults / sanity checks
-cargo build
-cargo test
+$CARGO build
+$CARGO test
 
 if [ "$DO_LINT" = true ]
 then
@@ -39,29 +40,29 @@ then
 fi
 
 if [ "$DO_FEATURE_MATRIX" = true ]; then
-    cargo build --locked --no-default-features
-    cargo test --locked --no-default-features
+    $CARGO build --no-default-features
+    $CARGO test --no-default-features
 
     # All features
-    cargo build --locked --no-default-features --features="$FEATURES"
-    cargo test --locked --no-default-features --features="$FEATURES"
+    $CARGO build --no-default-features --features="$FEATURES"
+    $CARGO test --no-default-features --features="$FEATURES"
     # Single features
     for feature in ${FEATURES}
     do
-        cargo build --locked --no-default-features --features="$feature"
-        cargo test --locked --no-default-features --features="$feature"
+        $CARGO build --no-default-features --features="$feature"
+        $CARGO test --no-default-features --features="$feature"
 		# All combos of two features
 		for featuretwo in ${FEATURES}; do
-			cargo build --locked --no-default-features --features="$feature $featuretwo"
-			cargo test --locked --no-default-features --features="$feature $featuretwo"
+			$CARGO build --no-default-features --features="$feature $featuretwo"
+			$CARGO test --no-default-features --features="$feature $featuretwo"
 		done
     done
 fi
 
-cargo run --locked --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
-cargo run --locked --no-default-features --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+$CARGO run --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
+$CARGO run --no-default-features --example bip32 7934c09359b234e076b9fa5a1abfd38e3dc2a9939745b7cc3c22a48d831d14bd
 
-cargo run --locked --example ecdsa-psbt --features=bitcoinconsensus
-cargo run --locked --example sign-tx-segwit-v0 --features=rand-std -- -D warnings
-cargo run --locked --example sign-tx-taproot --features=rand-std -- -D warnings
-cargo run --locked --example taproot-psbt --features=rand-std,bitcoinconsensus
+$CARGO run --example ecdsa-psbt --features=bitcoinconsensus
+$CARGO run --example sign-tx-segwit-v0 --features=rand-std -- -D warnings
+$CARGO run --example sign-tx-taproot --features=rand-std -- -D warnings
+$CARGO run --example taproot-psbt --features=rand-std,bitcoinconsensus

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -65,15 +65,3 @@ cargo run --locked --example ecdsa-psbt --features=bitcoinconsensus
 cargo run --locked --example sign-tx-segwit-v0 --features=rand-std -- -D warnings
 cargo run --locked --example sign-tx-taproot --features=rand-std -- -D warnings
 cargo run --locked --example taproot-psbt --features=rand-std,bitcoinconsensus
-
-# Use as dependency if told to
-if [ "$AS_DEPENDENCY" = true ]
-then
-    cargo new dep_test 2> /dev/null # Mute warning about workspace, fixed below.
-    cd dep_test
-    echo 'bitcoin = { path = "..", features = ["serde"] }\n\n' >> Cargo.toml
-    # Adding an empty workspace section excludes this crate from the rust-bitcoin workspace.
-    echo '[workspace]\n\n' >> Cargo.toml
-
-    cargo test --verbose
-fi

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -77,20 +77,6 @@ cargo run --locked --example sign-tx-segwit-v0 --features=rand-std -- -D warning
 cargo run --locked --example sign-tx-taproot --features=rand-std -- -D warnings
 cargo run --locked --example taproot-psbt --features=rand-std,bitcoinconsensus
 
-# Bench if told to, only works with non-stable toolchain (nightly, beta).
-if [ "$DO_BENCH" = true ]
-then
-    if [ "$STABLE" = true ]; then
-        if [ -n "$RUSTUP_TOOLCHAIN" ]; then
-            echo "RUSTUP_TOOLCHAIN is set to a stable toolchain but DO_BENCH requires a non-stable (beta, nightly) toolchain"
-        else
-            echo "DO_BENCH requires a non-stable (beta, nightly) toolchain"
-        fi
-        exit 1
-    fi
-    RUSTFLAGS='--cfg=bench' cargo bench
-fi
-
 # Use as dependency if told to
 if [ "$AS_DEPENDENCY" = true ]
 then

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -17,28 +17,6 @@ rustc --version
 $CARGO build
 $CARGO test
 
-if [ "$DO_LINT" = true ]
-then
-    # We should not have any duplicate dependencies. This catches mistakes made upgrading dependencies
-    # in one crate and not in another (e.g. upgrade bitcoin_hashes in bitcoin but not in secp).
-    duplicate_dependencies=$(
-        # Only show the actual duplicated deps, not their reverse tree, then
-        # whitelist the 'syn' crate which is duplicated but it's not our fault.
-        #
-        # Whitelist `bitcoin_hashes` while we release it and until secp v0.28.0 comes out.
-        cargo tree  --target=all --all-features --duplicates \
-            | grep '^[0-9A-Za-z]' \
-            | grep -v 'syn' \
-            | grep -v 'bitcoin_hashes' \
-            | wc -l
-                          )
-    if [ "$duplicate_dependencies" -ne 0 ]; then
-        echo "Dependency tree is broken, contains duplicates"
-        cargo tree  --target=all --all-features --duplicates
-        exit 1
-    fi
-fi
-
 if [ "$DO_FEATURE_MATRIX" = true ]; then
     $CARGO build --no-default-features
     $CARGO test --no-default-features

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -12,17 +12,6 @@ fi
 cargo --version
 rustc --version
 
-# Some tests require certain toolchain types.
-NIGHTLY=false
-STABLE=true
-if cargo --version | grep nightly; then
-    STABLE=false
-    NIGHTLY=true
-fi
-if cargo --version | grep beta; then
-    STABLE=false
-fi
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -80,17 +80,6 @@ cargo run --locked --example sign-tx-segwit-v0 --features=rand-std -- -D warning
 cargo run --locked --example sign-tx-taproot --features=rand-std -- -D warnings
 cargo run --locked --example taproot-psbt --features=rand-std,bitcoinconsensus
 
-# Build the docs if told to (this only works with the nightly toolchain)
-if [ "$DO_DOCSRS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
-fi
-
-# Build the docs with a stable toolchain, in unison with the DO_DOCSRS command
-# above this checks that we feature guarded docs imports correctly.
-if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
-fi
-
 # Run formatter if told to.
 if [ "$DO_FMT" = true ]; then
     if [ "$NIGHTLY" = false ]; then

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,30 +2,40 @@
 
 set -ex
 
-CRATES="bitcoin hashes units internals fuzz"
-DEPS="recent minimal"
+main() {
+    run_per_crate_test_scripts
+}
 
-for dep in $DEPS
-do
-    cp "Cargo-$dep.lock" Cargo.lock
-    for crate in ${CRATES}
+run_per_crate_test_scripts() {
+    local crates="bitcoin hashes units internals fuzz"
+    local deps="recent minimal"
+
+    for dep in ${deps}
     do
-        (
-            cd "$crate"
-            ./contrib/test.sh
-        )
-    done
-    if [ "$dep" = recent ];
-    then
-        # We always test committed dependencies but we want to warn if they could've been updated
-        cargo update
-        if diff Cargo-recent.lock Cargo.lock;
+        cp "Cargo-$dep.lock" Cargo.lock
+        for crate in ${crates}
+        do
+            (
+                cd "$crate"
+                ./contrib/test.sh
+            )
+        done
+        if [ "$dep" = recent ];
         then
-            echo Dependencies are up to date
-        else
-            echo "::warning file=Cargo-recent.lock::Dependencies could be updated"
+            # We always test committed dependencies but we want to warn if they could've been updated
+            cargo update
+            if diff Cargo-recent.lock Cargo.lock;
+            then
+                echo Dependencies are up to date
+            else
+                echo "::warning file=Cargo-recent.lock::Dependencies could be updated"
+            fi
         fi
-    fi
-done
+    done
+}
 
+#
+# Main script
+#
+main "$@"
 exit 0

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -8,16 +8,19 @@ main() {
     if [ "$DO_LINT" = true ];
     then
         lint
+        exit 0
     fi
 
     if [ "$DO_DOCSRS" = true ];
     then
         build_docs_with_nightly_toolchain
+        exit 0
     fi
 
     if [ "$DO_DOCS" = true ];
     then
         build_docs_with_stable_toolchain
+        exit 0
     fi
 
     run_per_crate_test_scripts

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -26,6 +26,12 @@ main() {
         exit 0
     fi
 
+    if [ "$DO_BENCH" = true ];
+    then
+        bench
+        exit 0
+    fi
+
     run_per_crate_test_scripts
 }
 
@@ -95,6 +101,11 @@ build_docs_with_stable_toolchain() {
         RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
         popd > /dev/null || exit 1
     done
+}
+
+# Bench only works with a non-stable toolchain (nightly, beta).
+bench() {
+    RUSTFLAGS='--cfg=bench' cargo bench
 }
 
 #

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -38,6 +38,12 @@ main() {
         exit 0
     fi
 
+    if [ "$DO_SCHEMARS_TESTS" = true ];
+    then
+        do_schemars_test
+        exit 0
+    fi
+
     run_per_crate_test_scripts
 }
 
@@ -131,6 +137,13 @@ use_bitcoin_as_a_dependency() {
 
     cargo test --verbose
 }
+
+do_schemars_test() {
+    pushd "$REPO_DIR/hashes/extended_tests/schemars" > /dev/null
+    cargo test
+    popd > /dev/null
+}
+
 #
 # Main script
 #

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -137,15 +137,19 @@ bench() {
 use_bitcoin_as_a_dependency() {
     cargo new dep_test 2> /dev/null # Mute warning about workspace, fixed below.
     cd dep_test
-    printf 'bitcoin = { path = "../bitcoin", features = ["serde"] }\n\n' >> Cargo.toml
-    # Adding an empty workspace section excludes this crate from the rust-bitcoin workspace.
-    printf '[workspace]\n\n' >> Cargo.toml
 
-    # We have to patch all the local crates same as we do in main workspace.
-    printf '[patch.crates-io.bitcoin_hashes]\npath = "../hashes"\n\n' >> Cargo.toml
-    printf '[patch.crates-io.bitcoin-internals]\npath = "../internals"\n\n' >> Cargo.toml
-    printf '[patch.crates-io.bitcoin-io]\npath = "../io"\n\n' >> Cargo.toml
-    printf '[patch.crates-io.bitcoin-units]\npath = "../units"\n\n' >> Cargo.toml
+    {
+        printf 'bitcoin = { path = "../bitcoin", features = ["serde"] }\n\n'
+
+        # Adding an empty workspace section excludes this crate from the rust-bitcoin workspace.
+        printf '[workspace]\n\n'
+
+        # We have to patch all the local crates same as we do in main workspace.
+        printf '[patch.crates-io.bitcoin_hashes]\npath = "../hashes"\n\n'
+        printf '[patch.crates-io.bitcoin-internals]\npath = "../internals"\n\n'
+        printf '[patch.crates-io.bitcoin-io]\npath = "../io"\n\n'
+        printf '[patch.crates-io.bitcoin-units]\npath = "../units"\n\n'
+    } >> Cargo.toml
 
     cargo test --verbose
 }

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -3,6 +3,11 @@
 set -ex
 
 main() {
+    if [ "$DO_LINT" = true ];
+    then
+        lint
+    fi
+
     run_per_crate_test_scripts
 }
 
@@ -32,6 +37,20 @@ run_per_crate_test_scripts() {
             fi
         fi
     done
+}
+
+lint() {
+    # Run clippy on the whole workspace - this does not lint any code in `examples/` directories.
+    cargo +nightly clippy --workspace
+
+    # Run clippy against all the examples - this should be an exhaustive list of examples.
+    # Verify with `fd .rs | grep examples/`
+    cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example bip32 -- -D warnings
+    cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example handshake --features=rand-std -- -D warnings
+    cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example ecdsa-psbt --features=bitcoinconsensus -- -D warnings
+    cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example sign-tx-segwit-v0 --features=rand-std -- -D warnings
+    cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example sign-tx-taproot --features=rand-std -- -D warnings
+    cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example taproot-psbt --features=rand-std,bitcoinconsensus -- -D warnings
 }
 
 #

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+# Make all cargo invocations verbose.
+export CARGO_TERM_VERBOSE=true
+
 REPO_DIR=$(git rev-parse --show-toplevel)
 
 main() {

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,10 +2,22 @@
 
 set -ex
 
+REPO_DIR=$(git rev-parse --show-toplevel)
+
 main() {
     if [ "$DO_LINT" = true ];
     then
         lint
+    fi
+
+    if [ "$DO_DOCSRS" = true ];
+    then
+        build_docs_with_nightly_toolchain
+    fi
+
+    if [ "$DO_DOCS" = true ];
+    then
+        build_docs_with_stable_toolchain
     fi
 
     run_per_crate_test_scripts
@@ -51,6 +63,32 @@ lint() {
     cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example sign-tx-segwit-v0 --features=rand-std -- -D warnings
     cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example sign-tx-taproot --features=rand-std -- -D warnings
     cargo +nightly clippy --manifest-path bitcoin/Cargo.toml --example taproot-psbt --features=rand-std,bitcoinconsensus -- -D warnings
+}
+
+# Build the docs with a nightly toolchain, in unison with the function
+# below this checks that we feature guarded docs imports correctly.
+build_docs_with_nightly_toolchain() {
+    local crates="bitcoin hashes units"
+
+    for crate in ${crates}
+    do
+        pushd "$REPO_DIR/$crate" > /dev/null || exit 1
+        RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
+        popd > /dev/null || exit 1
+    done
+}
+
+# Build the docs with a stable toolchain, in unison with the function
+# above this checks that we feature guarded docs imports correctly.
+build_docs_with_stable_toolchain() {
+    local crates="bitcoin hashes units"
+
+    for crate in ${crates}
+    do
+        pushd "$REPO_DIR/$crate" > /dev/null || exit 1
+        RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
+        popd > /dev/null || exit 1
+    done
 }
 
 #

--- a/fuzz/contrib/test.sh
+++ b/fuzz/contrib/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fuzz/contrib/test.sh
+++ b/fuzz/contrib/test.sh
@@ -10,16 +10,6 @@ rustc --version
 # Make all cargo invocations verbose
 export CARGO_TERM_VERBOSE=true
 
-# Pin dependencies as required if we are using MSRV toolchain.
-if cargo --version | grep "1\.41"; then
-    # 1.0.157 uses syn 2.0 which requires edition 2021
-    cargo update -p serde --precise 1.0.156
-    # 1.0.108 uses `matches!` macro so does not work with Rust 1.41.1, bad `syn` no biscuit.
-    cargo update -p syn --precise 1.0.107
-    # Half 1.8 uses edition 2021 features
-    cargo update -p half --precise 1.7.1
-fi
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/fuzz/contrib/test.sh
+++ b/fuzz/contrib/test.sh
@@ -7,9 +7,6 @@ FEATURES=""
 cargo --version
 rustc --version
 
-# Make all cargo invocations verbose
-export CARGO_TERM_VERBOSE=true
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/fuzz/contrib/test.sh
+++ b/fuzz/contrib/test.sh
@@ -10,17 +10,3 @@ rustc --version
 # Defaults / sanity checks
 cargo build
 cargo test
-
-# Address Sanitizer
-if [ "$DO_ASAN" = true ]; then
-    cargo clean
-    CC='clang -fsanitize=address -fno-omit-frame-pointer'                                        \
-    RUSTFLAGS='-Zsanitizer=address -Clinker=clang -Cforce-frame-pointers=yes'                    \
-    ASAN_OPTIONS='detect_leaks=1 detect_invalid_pointer_pairs=1 detect_stack_use_after_return=1' \
-    cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
-    cargo clean
-    CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
-    RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
-    cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
-fi
-

--- a/fuzz/contrib/test.sh
+++ b/fuzz/contrib/test.sh
@@ -20,11 +20,6 @@ if cargo --version | grep "1\.41"; then
     cargo update -p half --precise 1.7.1
 fi
 
-if [ "$DO_LINT" = true ]
-then
-    cargo clippy --all-features --all-targets -- -D warnings
-fi
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -13,13 +13,6 @@ if cargo --version | grep nightly >/dev/null; then
     NIGHTLY=true
 fi
 
-# Pin dependencies as required if we are using MSRV toolchain.
-if cargo --version | grep "1\.48"; then
-    # 1.0.157 uses syn 2.0 which requires edition 2021
-    cargo update -p serde_json --precise 1.0.99
-    cargo update -p serde --precise 1.0.156
-fi
-
 # Make all cargo invocations verbose
 export CARGO_TERM_VERBOSE=true
 

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -45,16 +45,3 @@ if [ "$DO_WASM" = true ]; then
     CC=clang-9 wasm-pack build &&
     CC=clang-9 wasm-pack test --node;
 fi
-
-# Address Sanitizer
-if [ "$DO_ASAN" = true ]; then
-    cargo clean
-    CC='clang -fsanitize=address -fno-omit-frame-pointer'                                        \
-    RUSTFLAGS='-Zsanitizer=address -Clinker=clang -Cforce-frame-pointers=yes'                    \
-    ASAN_OPTIONS='detect_leaks=1 detect_invalid_pointer_pairs=1 detect_stack_use_after_return=1' \
-    cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
-    cargo clean
-    CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
-    RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
-    cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
-fi

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -3,33 +3,34 @@
 set -ex
 
 FEATURES="serde serde-std std io alloc"
+CARGO="cargo --locked"
 
-cargo --version
+$CARGO --version
 rustc --version
 
 # Defaults / sanity checks
-cargo build
-cargo test
+$CARGO build
+$CARGO test
 
 if [ "$DO_FEATURE_MATRIX" = true ]; then
-    cargo build --locked --no-default-features
-    cargo test --locked --no-default-features
+    $CARGO build --no-default-features
+    $CARGO test --no-default-features
 
     # All features
-    cargo build --locked --no-default-features --features="$FEATURES"
-    cargo test --locked --no-default-features --features="$FEATURES"
+    $CARGO build --no-default-features --features="$FEATURES"
+    $CARGO test --no-default-features --features="$FEATURES"
     # Single features
     for feature in ${FEATURES}
     do
-        cargo build --locked --no-default-features --features="$feature"
-        cargo test --locked --no-default-features --features="$feature"
+        $CARGO build --no-default-features --features="$feature"
+        $CARGO test --no-default-features --features="$feature"
 		# All combos of two features
 		for featuretwo in ${FEATURES}; do
-			cargo build --locked --no-default-features --features="$feature $featuretwo"
-			cargo test --locked --no-default-features --features="$feature $featuretwo"
+			$CARGO build --no-default-features --features="$feature $featuretwo"
+			$CARGO test --no-default-features --features="$feature $featuretwo"
 		done
     done
 
     # Other combos
-    cargo test --locked --no-default-features --features="std,schemars"
+    $CARGO test --no-default-features --features="std,schemars"
 fi

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -13,9 +13,6 @@ if cargo --version | grep nightly >/dev/null; then
     NIGHTLY=true
 fi
 
-# Make all cargo invocations verbose
-export CARGO_TERM_VERBOSE=true
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -36,12 +36,6 @@ fi
 
 REPO_DIR=$(git rev-parse --show-toplevel)
 
-if [ "$DO_SCHEMARS_TESTS" = true ]; then
-    pushd "$REPO_DIR/hashes/extended_tests/schemars" > /dev/null
-    cargo test
-    popd > /dev/null
-fi
-
 # Webassembly stuff
 if [ "$DO_WASM" = true ]; then
     clang --version &&

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -70,19 +70,3 @@ if [ "$DO_ASAN" = true ]; then
     RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
     cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
 fi
-
-# Bench if told to, only works with non-stable toolchain (nightly, beta).
-if [ "$DO_BENCH" = true ]
-then
-    if [ "$NIGHTLY" = false ]
-    then
-        if [ -n "$RUSTUP_TOOLCHAIN" ]
-        then
-            echo "RUSTUP_TOOLCHAIN is set to a non-nightly toolchain but DO_BENCH requires a nightly toolchain"
-        else
-            echo "DO_BENCH requires a nightly toolchain"
-        fi
-        exit 1
-    fi
-    RUSTFLAGS='--cfg=bench' cargo bench
-fi

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -74,16 +74,6 @@ if [ "$DO_ASAN" = true ]; then
     cargo test --lib --no-default-features --features="$FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
 fi
 
-# Run formatter if told to.
-if [ "$DO_FMT" = true ]; then
-    if [ "$NIGHTLY" = false ]; then
-        echo "DO_FMT requires a nightly toolchain (consider using RUSTUP_TOOLCHAIN)"
-        exit 1
-    fi
-    rustup component add rustfmt
-    cargo fmt --check
-fi
-
 # Bench if told to, only works with non-stable toolchain (nightly, beta).
 if [ "$DO_BENCH" = true ]
 then

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -27,11 +27,6 @@ export CARGO_TERM_VERBOSE=true
 cargo build
 cargo test
 
-if [ "$DO_LINT" = true ]
-then
-    cargo clippy --locked --all-features --all-targets -- -D warnings
-fi
-
 if [ "$DO_FEATURE_MATRIX" = true ]; then
     cargo build --locked --no-default-features
     cargo test --locked --no-default-features

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -7,12 +7,6 @@ FEATURES="serde serde-std std io alloc"
 cargo --version
 rustc --version
 
-# Work out if we are using a nightly toolchain.
-NIGHTLY=false
-if cargo --version | grep nightly >/dev/null; then
-    NIGHTLY=true
-fi
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -33,15 +33,3 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     # Other combos
     cargo test --locked --no-default-features --features="std,schemars"
 fi
-
-REPO_DIR=$(git rev-parse --show-toplevel)
-
-# Webassembly stuff
-if [ "$DO_WASM" = true ]; then
-    clang --version &&
-    CARGO_TARGET_DIR=wasm cargo install --force wasm-pack &&
-    printf '\n[target.wasm32-unknown-unknown.dev-dependencies]\nwasm-bindgen-test = "0.3"\n' >> Cargo.toml &&
-    printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml &&
-    CC=clang-9 wasm-pack build &&
-    CC=clang-9 wasm-pack test --node;
-fi

--- a/hashes/contrib/test.sh
+++ b/hashes/contrib/test.sh
@@ -58,17 +58,6 @@ if [ "$DO_SCHEMARS_TESTS" = true ]; then
     popd > /dev/null
 fi
 
-# Build the docs if told to (this only works with the nightly toolchain)
-if [ "$DO_DOCSRS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
-fi
-
-# Build the docs with a stable toolchain, in unison with the DO_DOCSRS command
-# above this checks that we feature guarded docs imports correctly.
-if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
-fi
-
 # Webassembly stuff
 if [ "$DO_WASM" = true ]; then
     clang --version &&

--- a/internals/contrib/test.sh
+++ b/internals/contrib/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 

--- a/internals/contrib/test.sh
+++ b/internals/contrib/test.sh
@@ -13,9 +13,6 @@ if cargo --version | grep nightly >/dev/null; then
     NIGHTLY=true
 fi
 
-# Make all cargo invocations verbose
-export CARGO_TERM_VERBOSE=true
-
 # Defaults / sanity checks
 cargo --locked build
 cargo --locked test

--- a/internals/contrib/test.sh
+++ b/internals/contrib/test.sh
@@ -20,11 +20,6 @@ export CARGO_TERM_VERBOSE=true
 cargo --locked build
 cargo --locked test
 
-if [ "$DO_LINT" = true ]
-then
-    cargo clippy --locked --all-features --all-targets -- -D warnings
-fi
-
 if [ "$DO_FEATURE_MATRIX" = true ]; then
     # No features
     cargo build --locked --no-default-features

--- a/internals/contrib/test.sh
+++ b/internals/contrib/test.sh
@@ -7,12 +7,6 @@ FEATURES="std alloc"
 cargo --version
 rustc --version
 
-# Work out if we are using a nightly toolchain.
-NIGHTLY=false
-if cargo --version | grep nightly >/dev/null; then
-    NIGHTLY=true
-fi
-
 # Defaults / sanity checks
 cargo --locked build
 cargo --locked test

--- a/internals/contrib/test.sh
+++ b/internals/contrib/test.sh
@@ -37,17 +37,6 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     done
 fi
 
-# Build the docs if told to (this only works with the nightly toolchain)
-if [ "$DO_DOCSRS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
-fi
-
-# Build the docs with a stable toolchain, in unison with the DO_DOCSRS command
-# above this checks that we feature guarded docs imports correctly.
-if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="-D warnings" cargo +stable doc --locked --all-features
-fi
-
 # Run formatter if told to.
 if [ "$DO_FMT" = true ]; then
     if [ "$NIGHTLY" = false ]; then

--- a/internals/contrib/test.sh
+++ b/internals/contrib/test.sh
@@ -36,13 +36,3 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
         cargo test --locked --no-default-features --features="$feature"
     done
 fi
-
-# Run formatter if told to.
-if [ "$DO_FMT" = true ]; then
-    if [ "$NIGHTLY" = false ]; then
-        echo "DO_FMT requires a nightly toolchain (consider using RUSTUP_TOOLCHAIN)"
-        exit 1
-    fi
-    rustup component add rustfmt
-    cargo fmt --check
-fi

--- a/internals/contrib/test.sh
+++ b/internals/contrib/test.sh
@@ -3,27 +3,28 @@
 set -ex
 
 FEATURES="std alloc"
+CARGO="cargo --locked"
 
-cargo --version
+$CARGO --version
 rustc --version
 
 # Defaults / sanity checks
-cargo --locked build
-cargo --locked test
+$CARGO build
+$CARGO test
 
 if [ "$DO_FEATURE_MATRIX" = true ]; then
     # No features
-    cargo build --locked --no-default-features
-    cargo test --locked --no-default-features
+    $CARGO build --no-default-features
+    $CARGO test --no-default-features
 
     # All features
-    cargo build --locked --no-default-features --features="$FEATURES"
-    cargo test --locked --no-default-features --features="$FEATURES"
+    $CARGO build --no-default-features --features="$FEATURES"
+    $CARGO test --no-default-features --features="$FEATURES"
 
     # Single features
     for feature in ${FEATURES}
     do
-        cargo build --locked --no-default-features --features="$feature"
-        cargo test --locked --no-default-features --features="$feature"
+        $CARGO build --no-default-features --features="$feature"
+        $CARGO test --no-default-features --features="$feature"
     done
 fi

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -20,11 +20,6 @@ export CARGO_TERM_VERBOSE=true
 cargo build
 cargo test
 
-if [ "$DO_LINT" = true ]
-then
-    cargo clippy --locked --all-features --all-targets -- -D warnings
-fi
-
 if [ "$DO_FEATURE_MATRIX" = true ]; then
     # No features
     cargo build --locked --no-default-features

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="std alloc serde"
+# FEATURES="std alloc serde"
 CARGO="cargo --locked"
 
 $CARGO --version

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -13,9 +13,6 @@ if cargo --version | grep nightly >/dev/null; then
     NIGHTLY=true
 fi
 
-# Make all cargo invocations verbose
-export CARGO_TERM_VERBOSE=true
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -36,17 +36,6 @@ fi
 
 REPO_DIR=$(git rev-parse --show-toplevel)
 
-# Build the docs if told to (this only works with the nightly toolchain)
-if [ "$DO_DOCSRS" = true ]; then
-    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
-fi
-
-# Build the docs with a stable toolchain, in unison with the DO_DOCSRS command
-# above this checks that we feature guarded docs imports correctly.
-if [ "$DO_DOCS" = true ]; then
-    RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
-fi
-
 # Run formatter if told to.
 if [ "$DO_FMT" = true ]; then
     if [ "$NIGHTLY" = false ]; then

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -30,19 +30,3 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     cargo build --locked --no-default-features --all-features
     cargo test --locked --no-default-features --all-features
 fi
-
-# Bench if told to, only works with non-stable toolchain (nightly, beta).
-if [ "$DO_BENCH" = true ]
-then
-    if [ "$NIGHTLY" = false ]
-    then
-        if [ -n "$RUSTUP_TOOLCHAIN" ]
-        then
-            echo "RUSTUP_TOOLCHAIN is set to a non-nightly toolchain but DO_BENCH requires a nightly toolchain"
-        else
-            echo "DO_BENCH requires a nightly toolchain"
-        fi
-        exit 1
-    fi
-    RUSTFLAGS='--cfg=bench' cargo bench
-fi

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -34,18 +34,6 @@ if [ "$DO_FEATURE_MATRIX" = true ]; then
     cargo test --locked --no-default-features --all-features
 fi
 
-REPO_DIR=$(git rev-parse --show-toplevel)
-
-# Run formatter if told to.
-if [ "$DO_FMT" = true ]; then
-    if [ "$NIGHTLY" = false ]; then
-        echo "DO_FMT requires a nightly toolchain (consider using RUSTUP_TOOLCHAIN)"
-        exit 1
-    fi
-    rustup component add rustfmt
-    cargo fmt --check
-fi
-
 # Bench if told to, only works with non-stable toolchain (nightly, beta).
 if [ "$DO_BENCH" = true ]
 then

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -7,12 +7,6 @@ FEATURES="std alloc serde"
 cargo --version
 rustc --version
 
-# Work out if we are using a nightly toolchain.
-NIGHTLY=false
-if cargo --version | grep nightly >/dev/null; then
-    NIGHTLY=true
-fi
-
 # Defaults / sanity checks
 cargo build
 cargo test

--- a/units/contrib/test.sh
+++ b/units/contrib/test.sh
@@ -3,24 +3,25 @@
 set -ex
 
 FEATURES="std alloc serde"
+CARGO="cargo --locked"
 
-cargo --version
+$CARGO --version
 rustc --version
 
 # Defaults / sanity checks
-cargo build
-cargo test
+$CARGO build
+$CARGO test
 
 if [ "$DO_FEATURE_MATRIX" = true ]; then
     # No features
-    cargo build --locked --no-default-features
-    cargo test --locked --no-default-features
+    $CARGO build --no-default-features
+    $CARGO test --no-default-features
 
     # Default features (this is std and alloc)
-    cargo build --locked
-    cargo test --locked
+    $CARGO build --locked
+    $CARGO test --locked
 
     # All features
-    cargo build --locked --no-default-features --all-features
-    cargo test --locked --no-default-features --all-features
+    $CARGO build --no-default-features --all-features
+    $CARGO test --no-default-features --all-features
 fi


### PR DESCRIPTION
This is now an epic re-work of the CI scripts. The aims are:

- Make it obvious what shell script code is running in which github actions job.
- Make the actions quicker to run and quicker to fail.
- Make it obvious when a CI job is red what failed without having to scroll through so much log file noise.
- Make it more clear what is happening to the lock file when the CI script runs.
- Reduce duplicate shell code.
- Make the whole CI setup more maintainable.
- You get the picture :)


I've made the changes really small and said _why_ in each commit log - I did this, more than usual, so as to help catch either bugs in the change set or bugs that currently exist in the CI scripts but we didn't notice them.