### PR TITLE
fix nightly clippy issues

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -668,14 +668,14 @@ mod test {
         let bytes = out;
 
         {
-            let query = vec![hex!("abcdef"), hex!("eeeeee")];
+            let query = [hex!("abcdef"), hex!("eeeeee")];
             let reader = GcsFilterReader::new(0, 0, M, P);
             assert!(reader
                 .match_any(&mut bytes.as_slice(), &mut query.iter().map(|v| v.as_slice()))
                 .unwrap());
         }
         {
-            let query = vec![hex!("abcdef"), hex!("123456")];
+            let query = [hex!("abcdef"), hex!("123456")];
             let reader = GcsFilterReader::new(0, 0, M, P);
             assert!(!reader
                 .match_any(&mut bytes.as_slice(), &mut query.iter().map(|v| v.as_slice()))

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -40,6 +40,7 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::uninhabited_references)] // falsely claims that 100% safe code is UB
 #![allow(clippy::manual_range_contains)] // more readable than clippy's format
+#![allow(clippy::unconditional_recursion)] // broken; see https://github.com/rust-lang/rust-clippy/issues/12133
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]


### PR DESCRIPTION
I don't mind making these PRs, but I think we should start pinning our nightlies, and using a script to update the pin every week (or day, or whatever). When our CI breaks due to tooling changes, it means that our release branches will have permanently broken CI jobs, which I'd like to avoid in the future.

If the automatic pin update failed, we'd close it and manually create one that fixed the nw issues.