### PR TITLE
units: Enable parsing Amount from `u64::MAX`

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1710,10 +1710,17 @@ mod tests {
         assert_eq!(f(42.123456781, D::Bitcoin), Err(ParseAmountError::TooPrecise));
         assert_eq!(sf(-184467440738.0, D::Bitcoin), Err(ParseAmountError::TooBig));
         assert_eq!(f(18446744073709551617.0, D::Satoshi), Err(ParseAmountError::TooBig));
+
+        // Amount can be grater than the max SignedAmount.
         assert!(f(SignedAmount::MAX.to_float_in(D::Satoshi) + 1.0, D::Satoshi).is_ok());
 
         assert_eq!(
             f(Amount::MAX.to_float_in(D::Satoshi) + 1.0, D::Satoshi),
+            Err(ParseAmountError::TooBig)
+        );
+
+        assert_eq!(
+            sf(SignedAmount::MAX.to_float_in(D::Satoshi) + 1.0, D::Satoshi),
             Err(ParseAmountError::TooBig)
         );
 

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1782,6 +1782,7 @@ mod tests {
         // make sure satoshi > i64::MAX is checked.
         let amount = Amount::from_sat(i64::MAX as u64);
         assert_eq!(Amount::from_str_in(&amount.to_string_in(sat), sat), Ok(amount));
+        assert!(SignedAmount::from_str_in(&(amount + Amount(1)).to_string_in(sat), sat).is_err());
         assert!(Amount::from_str_in(&(amount + Amount(1)).to_string_in(sat), sat).is_ok());
 
         assert_eq!(p("12.000", Denomination::MilliSatoshi), Err(E::TooPrecise));

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -611,9 +611,6 @@ impl Amount {
         if negative {
             return Err(ParseAmountError::Negative);
         }
-        if satoshi > i64::MAX as u64 {
-            return Err(ParseAmountError::TooBig);
-        }
         Ok(Amount::from_sat(satoshi))
     }
 
@@ -1714,10 +1711,8 @@ mod tests {
         assert_eq!(f(42.123456781, D::Bitcoin), Err(ParseAmountError::TooPrecise));
         assert_eq!(sf(-184467440738.0, D::Bitcoin), Err(ParseAmountError::TooBig));
         assert_eq!(f(18446744073709551617.0, D::Satoshi), Err(ParseAmountError::TooBig));
-        assert_eq!(
-            f(SignedAmount::MAX.to_float_in(D::Satoshi) + 1.0, D::Satoshi),
-            Err(ParseAmountError::TooBig)
-        );
+        assert!(f(SignedAmount::MAX.to_float_in(D::Satoshi) + 1.0, D::Satoshi).is_ok());
+
         assert_eq!(
             f(Amount::MAX.to_float_in(D::Satoshi) + 1.0, D::Satoshi),
             Err(ParseAmountError::TooBig)
@@ -1781,10 +1776,7 @@ mod tests {
         // make sure satoshi > i64::MAX is checked.
         let amount = Amount::from_sat(i64::MAX as u64);
         assert_eq!(Amount::from_str_in(&amount.to_string_in(sat), sat), Ok(amount));
-        assert_eq!(
-            Amount::from_str_in(&(amount + Amount(1)).to_string_in(sat), sat),
-            Err(E::TooBig)
-        );
+        assert!(Amount::from_str_in(&(amount + Amount(1)).to_string_in(sat), sat).is_ok());
 
         assert_eq!(p("12.000", Denomination::MilliSatoshi), Err(E::TooPrecise));
         // exactly 50 chars.
@@ -2115,10 +2107,7 @@ mod tests {
             ua_str(&ua_sat(1_000_000_000_000).to_string_in(D::MilliBitcoin), D::MilliBitcoin),
             Ok(ua_sat(1_000_000_000_000))
         );
-        assert_eq!(
-            ua_str(&ua_sat(u64::MAX).to_string_in(D::MilliBitcoin), D::MilliBitcoin),
-            Err(ParseAmountError::TooBig)
-        );
+        assert!(ua_str(&ua_sat(u64::MAX).to_string_in(D::MilliBitcoin), D::MilliBitcoin).is_ok());
 
         assert_eq!(
             sa_str(&sa_sat(-1).to_string_in(D::MicroBitcoin), D::MicroBitcoin),

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1707,7 +1707,6 @@ mod tests {
         assert_eq!(f(-100.0, D::MilliSatoshi), Err(ParseAmountError::Negative));
         assert_eq!(f(11.22, D::Satoshi), Err(ParseAmountError::TooPrecise));
         assert_eq!(sf(-100.0, D::MilliSatoshi), Err(ParseAmountError::TooPrecise));
-        assert_eq!(sf(-100.0, D::MilliSatoshi), Err(ParseAmountError::TooPrecise));
         assert_eq!(f(42.123456781, D::Bitcoin), Err(ParseAmountError::TooPrecise));
         assert_eq!(sf(-184467440738.0, D::Bitcoin), Err(ParseAmountError::TooBig));
         assert_eq!(f(18446744073709551617.0, D::Satoshi), Err(ParseAmountError::TooBig));


### PR DESCRIPTION
Our `Amount` type uses an internal `u64` and we maintain no invariants on the inner value. Therefore we should be able to parse `u64::MAX`.

Fix the parsing code by removing the explicit, incorrect check and fix unit tests to mirror this behaviour.

Fix: #2297