### PR TITLE
Remove mention of core2

### DIFF
--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -195,7 +195,6 @@ where
     }
 }
 
-// core2 doesn't have read_to_end
 pub(crate) fn read_to_end<D: Read + ?Sized>(d: &mut D) -> Result<Vec<u8>, io::Error> {
     let mut result = vec![];
     let mut buf = [0u8; 64];


### PR DESCRIPTION
We no longer depend on `core2`, remove stale code comment mention of the crate.

Fix: #2034