### PR TITLE
Remove `Cursor` usage in `PublicKey` unit test

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1096,16 +1096,15 @@ mod tests {
             k.write_into(&mut v).expect("writing into vec");
         }
 
+        let mut reader = v.as_slice();
         let mut dec_keys = vec![];
-        let mut cursor = io::Cursor::new(&v);
         for _ in 0..N_KEYS {
-            dec_keys.push(PublicKey::read_from(&mut cursor).expect("reading from vec"));
+            dec_keys.push(PublicKey::read_from(&mut reader).expect("reading from vec"));
         }
-
         assert_eq!(keys, dec_keys);
+        assert!(PublicKey::read_from(&mut reader).is_err());
 
         // sanity checks
-        assert!(PublicKey::read_from(&mut cursor).is_err());
         assert!(PublicKey::read_from(&mut io::Cursor::new(&[])).is_err());
         assert!(PublicKey::read_from(&mut io::Cursor::new(&[0; 33][..])).is_err());
         assert!(PublicKey::read_from(&mut io::Cursor::new(&[2; 32][..])).is_err());

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1105,11 +1105,12 @@ mod tests {
         assert!(PublicKey::read_from(&mut reader).is_err());
 
         // sanity checks
-        assert!(PublicKey::read_from(&mut io::Cursor::new(&[])).is_err());
-        assert!(PublicKey::read_from(&mut io::Cursor::new(&[0; 33][..])).is_err());
-        assert!(PublicKey::read_from(&mut io::Cursor::new(&[2; 32][..])).is_err());
-        assert!(PublicKey::read_from(&mut io::Cursor::new(&[0; 65][..])).is_err());
-        assert!(PublicKey::read_from(&mut io::Cursor::new(&[4; 64][..])).is_err());
+        let mut empty: &[u8] = &[];
+        assert!(PublicKey::read_from(&mut empty).is_err());
+        assert!(PublicKey::read_from(&mut &[0; 33][..]).is_err());
+        assert!(PublicKey::read_from(&mut &[2; 32][..]).is_err());
+        assert!(PublicKey::read_from(&mut &[0; 65][..]).is_err());
+        assert!(PublicKey::read_from(&mut &[4; 64][..]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
We do not need to use `Cursor` in these tests, remove the usage.

PR touches test code only.