### PR TITLE
Use full path in all macro usage of Result

### DIFF
--- a/bitcoin/src/psbt/macros.rs
+++ b/bitcoin/src/psbt/macros.rs
@@ -19,7 +19,7 @@ macro_rules! impl_psbt_de_serialize {
 macro_rules! impl_psbt_deserialize {
     ($thing:ty) => {
         impl $crate::psbt::serialize::Deserialize for $thing {
-            fn deserialize(bytes: &[u8]) -> Result<Self, $crate::psbt::Error> {
+            fn deserialize(bytes: &[u8]) -> core::result::Result<Self, $crate::psbt::Error> {
                 $crate::consensus::deserialize(&bytes[..]).map_err(|e| $crate::psbt::Error::from(e))
             }
         }
@@ -45,7 +45,7 @@ macro_rules! impl_psbtmap_serialize {
 macro_rules! impl_psbtmap_deserialize {
     ($thing:ty) => {
         impl $crate::psbt::serialize::Deserialize for $thing {
-            fn deserialize(bytes: &[u8]) -> Result<Self, $crate::psbt::Error> {
+            fn deserialize(bytes: &[u8]) -> core::result::Result<Self, $crate::psbt::Error> {
                 let mut decoder = bytes;
                 Self::decode(&mut decoder)
             }
@@ -58,7 +58,7 @@ macro_rules! impl_psbtmap_decoding {
         impl $thing {
             pub(crate) fn decode<R: $crate::io::BufRead + ?Sized>(
                 r: &mut R,
-            ) -> Result<Self, $crate::psbt::Error> {
+            ) -> core::result::Result<Self, $crate::psbt::Error> {
                 let mut rv: Self = core::default::Default::default();
 
                 loop {
@@ -148,7 +148,7 @@ macro_rules! impl_psbt_hash_de_serialize {
 macro_rules! impl_psbt_hash_deserialize {
     ($hash_type:ty) => {
         impl $crate::psbt::serialize::Deserialize for $hash_type {
-            fn deserialize(bytes: &[u8]) -> Result<Self, $crate::psbt::Error> {
+            fn deserialize(bytes: &[u8]) -> core::result::Result<Self, $crate::psbt::Error> {
                 <$hash_type>::from_slice(&bytes[..]).map_err(|e| $crate::psbt::Error::from(e))
             }
         }

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -104,7 +104,7 @@ macro_rules! hash_trait_impls {
 
         impl<$($gen: $gent),*> str::FromStr for Hash<$($gen),*> {
             type Err = $crate::hex::HexToArrayError;
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
+            fn from_str(s: &str) -> $crate::_export::_core::result::Result<Self, Self::Err> {
                 use $crate::hex::{FromHex, HexToBytesIter};
                 use $crate::Hash;
 
@@ -151,7 +151,7 @@ macro_rules! hash_trait_impls {
                 from_engine(e)
             }
 
-            fn from_slice(sl: &[u8]) -> Result<Hash<$($gen),*>, FromSliceError> {
+            fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<Hash<$($gen),*>, FromSliceError> {
                 if sl.len() != $bits / 8 {
                     Err(FromSliceError{expected: Self::LEN, got: sl.len()})
                 } else {

--- a/hashes/src/serde_macros.rs
+++ b/hashes/src/serde_macros.rs
@@ -25,7 +25,7 @@ pub mod serde_details {
             formatter.write_str("an ASCII hex string")
         }
 
-        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        fn visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E>
         where
             E: de::Error,
         {
@@ -36,7 +36,7 @@ pub mod serde_details {
             }
         }
 
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        fn visit_str<E>(self, v: &str) -> core::result::Result<Self::Value, E>
         where
             E: de::Error,
         {
@@ -57,7 +57,7 @@ pub mod serde_details {
             formatter.write_str("a bytestring")
         }
 
-        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        fn visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E>
         where
             E: de::Error,
         {
@@ -82,10 +82,10 @@ pub mod serde_details {
         const N: usize;
 
         /// Helper function to turn a deserialized slice into the correct hash type.
-        fn from_slice_delegated(sl: &[u8]) -> Result<Self, FromSliceError>;
+        fn from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, FromSliceError>;
 
         /// Do serde serialization.
-        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        fn serialize<S: Serializer>(&self, s: S) -> core::result::Result<S::Ok, S::Error> {
             if s.is_human_readable() {
                 s.collect_str(self)
             } else {
@@ -94,7 +94,7 @@ pub mod serde_details {
         }
 
         /// Do serde deserialization.
-        fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        fn deserialize<'de, D: Deserializer<'de>>(d: D) -> core::result::Result<Self, D::Error> {
             if d.is_human_readable() {
                 d.deserialize_str(HexVisitor::<Self>(PhantomData))
             } else {
@@ -112,7 +112,7 @@ macro_rules! serde_impl(
     ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => (
         impl<$($gen: $gent),*> $crate::serde_macros::serde_details::SerdeHash for $t<$($gen),*> {
             const N : usize = $len;
-            fn from_slice_delegated(sl: &[u8]) -> Result<Self, $crate::FromSliceError> {
+            fn from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, $crate::FromSliceError> {
                 #[allow(unused_imports)]
                 use $crate::Hash as _;
                 $t::from_slice(sl)
@@ -120,13 +120,13 @@ macro_rules! serde_impl(
         }
 
         impl<$($gen: $gent),*> $crate::serde::Serialize for $t<$($gen),*> {
-            fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> core::result::Result<S::Ok, S::Error> {
                 $crate::serde_macros::serde_details::SerdeHash::serialize(self, s)
             }
         }
 
         impl<'de $(, $gen: $gent)*> $crate::serde::Deserialize<'de> for $t<$($gen),*> {
-            fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> Result<$t<$($gen),*>, D::Error> {
+            fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> core::result::Result<$t<$($gen),*>, D::Error> {
                 $crate::serde_macros::serde_details::SerdeHash::deserialize(d)
             }
         }

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -42,7 +42,7 @@ macro_rules! impl_array_newtype {
         impl<'a> core::convert::TryFrom<&'a [$ty]> for $thing {
             type Error = core::array::TryFromSliceError;
 
-            fn try_from(data: &'a [$ty]) -> Result<Self, Self::Error> {
+            fn try_from(data: &'a [$ty]) -> core::result::Result<Self, Self::Error> {
                 use core::convert::TryInto;
 
                 Ok($thing(data.try_into()?))
@@ -99,7 +99,7 @@ macro_rules! impl_array_newtype {
 macro_rules! debug_from_display {
     ($thing:ident) => {
         impl core::fmt::Debug for $thing {
-            fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
                 core::fmt::Display::fmt(self, f)
             }
         }


### PR DESCRIPTION
Apparently when someone uses a custom `Result` type and then uses some of these macros, they can get type conflict errors.

(Thanks josibake for finding this using the `sha256t_hash_newtype` macro.)