### PR TITLE
Use full path in all macro usage of Result

### DIFF
--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -67,10 +67,10 @@ macro_rules! all_opcodes {
         pub static OP_NOP3: Opcode = OP_CSV;
 
         impl fmt::Display for Opcode {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                  match *self {
                    $(
-                        $op => fmt::Display::fmt(stringify!($op), f),
+                        $op => core::fmt::Display::fmt(stringify!($op), f),
                     )+
                 }
             }
@@ -484,7 +484,7 @@ macro_rules! ordinary_opcode {
         }
 
         impl fmt::Display for Ordinary {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
                 match *self {
                    $(Ordinary::$op => { f.pad(stringify!($op)) }),*
                 }

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -107,7 +107,7 @@ macro_rules! impl_tryfrom_str_from_int_infallible {
         impl core::convert::TryFrom<$from> for $to {
             type Error = $crate::error::ParseIntError;
 
-            fn try_from(s: $from) -> Result<Self, Self::Error> {
+            fn try_from(s: $from) -> core::result::Result<Self, Self::Error> {
                 $crate::parse::int::<$inner, $from>(s).map($to::$fn)
             }
         }
@@ -127,7 +127,7 @@ macro_rules! impl_parse_str_from_int_infallible {
         impl core::str::FromStr for $to {
             type Err = $crate::error::ParseIntError;
 
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
+            fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
                 $crate::parse::int::<$inner, &str>(s).map($to::$fn)
             }
         }
@@ -144,7 +144,7 @@ macro_rules! impl_tryfrom_str_from_int_fallible {
         impl core::convert::TryFrom<$from> for $to {
             type Error = $err;
 
-            fn try_from(s: $from) -> Result<Self, Self::Error> {
+            fn try_from(s: $from) -> core::result::Result<Self, Self::Error> {
                 let u = $crate::parse::int::<$inner, $from>(s)?;
                 $to::$fn(u)
             }
@@ -165,7 +165,7 @@ macro_rules! impl_parse_str_from_int_fallible {
         impl core::str::FromStr for $to {
             type Err = $err;
 
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
+            fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
                 let u = $crate::parse::int::<$inner, &str>(s)?;
                 $to::$fn(u)
             }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -44,17 +44,17 @@ macro_rules! do_impl {
 
         impl fmt::Display for $ty {
             #[inline]
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result { fmt::Display::fmt(&self.0, f) }
         }
 
         impl fmt::LowerHex for $ty {
             #[inline]
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
         }
 
         impl fmt::UpperHex for $ty {
             #[inline]
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
         }
     };
 }
@@ -810,7 +810,7 @@ impl fmt::Debug for U256 {
 macro_rules! impl_hex {
     ($hex:ident, $case:expr) => {
         impl $hex for U256 {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
                 hex::fmt_hex_exact!(f, 32, &self.to_be_bytes(), $case)
             }
         }

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -309,7 +309,7 @@ pub mod hex_bytes {
 macro_rules! serde_string_serialize_impl {
     ($name:ty, $expecting:literal) => {
         impl $crate::serde::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
             where
                 S: $crate::serde::Serializer,
             {
@@ -322,21 +322,21 @@ macro_rules! serde_string_serialize_impl {
 macro_rules! serde_string_deserialize_impl {
     ($name:ty, $expecting:literal) => {
         impl<'de> $crate::serde::Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<$name, D::Error>
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
-                use core::fmt::{self, Formatter};
+                use core::fmt::Formatter;
 
                 struct Visitor;
                 impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
                     type Value = $name;
 
-                    fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                    fn expecting(&self, f: &mut Formatter) -> core::fmt::Result {
                         f.write_str($expecting)
                     }
 
-                    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                    fn visit_str<E>(self, v: &str) -> core::result::Result<Self::Value, E>
                     where
                         E: $crate::serde::de::Error,
                     {
@@ -363,23 +363,23 @@ pub(crate) use {serde_string_deserialize_impl, serde_string_impl, serde_string_s
 macro_rules! serde_struct_human_string_impl {
     ($name:ident, $expecting:literal, $($fe:ident),*) => (
         impl<'de> $crate::serde::Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<$name, D::Error>
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
                 if deserializer.is_human_readable() {
-                    use core::fmt::{self, Formatter};
+                    use core::fmt::Formatter;
                     use core::str::FromStr;
 
                     struct Visitor;
                     impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
                         type Value = $name;
 
-                        fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                        fn expecting(&self, f: &mut Formatter) -> core::fmt::Result {
                             f.write_str($expecting)
                         }
 
-                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                        fn visit_str<E>(self, v: &str) -> core::result::Result<Self::Value, E>
                         where
                             E: $crate::serde::de::Error,
                         {
@@ -390,7 +390,7 @@ macro_rules! serde_struct_human_string_impl {
 
                     deserializer.deserialize_str(Visitor)
                 } else {
-                    use core::fmt::{self, Formatter};
+                    use core::fmt::Formatter;
                     use $crate::serde::de::IgnoredAny;
 
                     #[allow(non_camel_case_types)]
@@ -400,11 +400,11 @@ macro_rules! serde_struct_human_string_impl {
                     impl<'de> $crate::serde::de::Visitor<'de> for EnumVisitor {
                         type Value = Enum;
 
-                        fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                        fn expecting(&self, f: &mut Formatter) -> core::fmt::Result {
                             f.write_str("a field name")
                         }
 
-                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                        fn visit_str<E>(self, v: &str) -> core::result::Result<Self::Value, E>
                         where
                             E: $crate::serde::de::Error,
                         {
@@ -418,7 +418,7 @@ macro_rules! serde_struct_human_string_impl {
                     }
 
                     impl<'de> $crate::serde::Deserialize<'de> for Enum {
-                        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                        fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
                         where
                             D: $crate::serde::de::Deserializer<'de>,
                         {
@@ -431,11 +431,11 @@ macro_rules! serde_struct_human_string_impl {
                     impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
                         type Value = $name;
 
-                        fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                        fn expecting(&self, f: &mut Formatter) -> core::fmt::Result {
                             f.write_str("a struct")
                         }
 
-                        fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+                        fn visit_seq<V>(self, mut seq: V) -> core::result::Result<Self::Value, V::Error>
                         where
                             V: $crate::serde::de::SeqAccess<'de>,
                         {
@@ -457,7 +457,7 @@ macro_rules! serde_struct_human_string_impl {
                             Ok(ret)
                         }
 
-                        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                        fn visit_map<A>(self, mut map: A) -> core::result::Result<Self::Value, A::Error>
                         where
                             A: $crate::serde::de::MapAccess<'de>,
                         {
@@ -503,7 +503,7 @@ macro_rules! serde_struct_human_string_impl {
         }
 
         impl $crate::serde::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
             where
                 S: $crate::serde::Serializer,
             {

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -241,7 +241,7 @@ macro_rules! hash_newtype {
             }
 
             #[inline]
-            fn from_slice(sl: &[u8]) -> Result<$newtype, $crate::FromSliceError> {
+            fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<$newtype, $crate::FromSliceError> {
                 Ok($newtype(<$hash as $crate::Hash>::from_slice(sl)?))
             }
 

--- a/internals/src/parse.rs
+++ b/internals/src/parse.rs
@@ -9,7 +9,7 @@ macro_rules! impl_try_from_stringly {
         impl core::convert::TryFrom<$from> for $to {
             type Error = $error;
 
-            fn try_from(s: $from) -> Result<Self, Self::Error> {
+            fn try_from(s: $from) -> core::result::Result<Self, Self::Error> {
                 $func(AsRef::<str>::as_ref(s)).map_err(|source| <$error>::new(s, source))
             }
         }
@@ -36,7 +36,7 @@ macro_rules! impl_parse {
         impl core::str::FromStr for $type {
             type Err = $error;
 
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
+            fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
                 $func(s).map_err(|source| <$error>::new(s, source))
             }
         }
@@ -64,7 +64,7 @@ macro_rules! impl_parse_and_serde {
         // We don't use `serde_string_impl` because we want to avoid allocating input.
         #[cfg(feature = "serde")]
         impl<'de> $crate::serde::Deserialize<'de> for $type {
-            fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<$name, D::Error>
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
@@ -75,11 +75,11 @@ macro_rules! impl_parse_and_serde {
                 impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
                     type Value = $name;
 
-                    fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                    fn expecting(&self, f: &mut Formatter) -> core::fmt::Result {
                         f.write_str($descr)
                     }
 
-                    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                    fn visit_str<E>(self, s: &str) -> core::result::Result<Self::Value, E>
                     where
                         E: $crate::serde::de::Error,
                     {
@@ -96,7 +96,7 @@ macro_rules! impl_parse_and_serde {
 
         #[cfg(feature = "serde")]
         impl $crate::serde::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
             where
                 S: $crate::serde::Serializer,
             {


### PR DESCRIPTION
Follow-up to https://github.com/rust-bitcoin/rust-bitcoin/pull/2355

Couldn't think of a clever way to do this , so just grepped for all instances of `macro_rules` and added the full path for the imports. Wasn't sure if it was necessary for `fmt::Result`, but went ahead and added the full path for consistency.

Tested locally and confirmed this fixes the issue I was seeing.