### PR TITLE
Add github action for llvm-cov coverage

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage for tests
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --ignore-filename-regex fuzz --all-features --workspace --lcov --output-path lcov.info
       - name: Upload report to coveralls
         uses: coverallsapp/github-action@v2        

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,0 +1,24 @@
+on:
+  - push
+  - pull_request
+
+name: Code coverage with llvm-cov
+
+jobs:
+  Coveralls:
+    name: Code coverage - stable toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v4
+      - name: Checkout Toolchain
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage for tests
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload report to coveralls
+        uses: coverallsapp/github-action@v2        


### PR DESCRIPTION
There has been discussion around generating coverage reports for tests. See #1853  and #2353.

This PR adds an action using llvm-cov and coveralls.

The action generates lcov coverage report using llvm-cov and uploads the generated report to coveralls. You can see sample reports for my fork here: https://coveralls.io/github/pool2win/rust-bitcoin

I am using the [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) wrapper around llvm-cov.

I also use the coveralls official github action to push the coverage report to coveralls. It removes the need to deal with repository secrets etc, making the action easy to run for all contributors on their forks.

We can move this action later to rust.yml if we need to.

   