### PR TITLE
Remove bech32 from the public API

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -59,9 +59,6 @@ extern crate alloc;
 /// Encodes and decodes base64 as bytes or utf8.
 pub extern crate base64;
 
-/// Encodes and decodes the Bech32 forrmat.
-pub extern crate bech32;
-
 /// Rust implementation of cryptographic hash function algorithms.
 pub extern crate hashes;
 


### PR DESCRIPTION
The only place that `bech32` appears in the pubic API is as a pub extern crate re-export. This is totally unnecessary since no other `bech32` functions or types appear in the public API.

Removing `bech32` from the public API allows us to stabilize `rust-bitcoin` without waiting for `bech32` to stabalize - WIN.