### PR TITLE
Improve private function `use_segwit_serialization`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -985,10 +985,8 @@ impl Transaction {
 
     /// Returns whether or not to serialize transaction as specified in BIP-144.
     fn uses_segwit_serialization(&self) -> bool {
-        for input in &self.input {
-            if !input.witness.is_empty() {
-                return true;
-            }
+        if self.input.iter().any(|input| !input.witness.is_empty()) {
+            return true;
         }
         // To avoid serialization ambiguity, no inputs means we use BIP141 serialization (see
         // `Transaction` docs for full explanation).


### PR DESCRIPTION
- Patch 1: Improve the name.
- Patch 2: Use `any` instead of manual loop.