### PR TITLE
Remove DO_COV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Running test script
         env:
-          DO_COV: true
           AS_DEPENDENCY: false
           DO_DOCS: true
           DO_FEATURE_MATRIX: true

--- a/bitcoin/contrib/test.sh
+++ b/bitcoin/contrib/test.sh
@@ -4,11 +4,6 @@ set -ex
 
 FEATURES="std rand-std rand serde secp-recovery bitcoinconsensus-std base64 bitcoinconsensus"
 
-if [ "$DO_COV" = true ]
-then
-    export RUSTFLAGS="-C link-dead-code"
-fi
-
 cargo --version
 rustc --version
 


### PR DESCRIPTION
We have test coverage by way of `coveralls` now. Remove the old stale `DO_COV` stuff.

Fix: #1853