### PR TITLE
Use KnowHrp instead of Network

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -3,12 +3,12 @@ extern crate bitcoin;
 use std::str::FromStr;
 use std::{env, process};
 
-use bitcoin::address::Address;
+use bitcoin::address::{Address, KnownHrp};
 use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::{CompressedPublicKey, Network, NetworkKind};
+use bitcoin::{CompressedPublicKey, NetworkKind};
 
 fn main() {
     // This example derives root xprv from a 32-byte seed,
@@ -50,6 +50,6 @@ fn main() {
     // manually creating indexes this time
     let zero = ChildNumber::from_normal_idx(0).unwrap();
     let public_key = xpub.derive_pub(&secp, &[zero, zero]).unwrap().public_key;
-    let address = Address::p2wpkh(&CompressedPublicKey(public_key), Network::Bitcoin);
+    let address = Address::p2wpkh(&CompressedPublicKey(public_key), KnownHrp::Mainnet);
     println!("First receiving address: {}", address);
 }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -116,7 +116,7 @@ pub mod taproot;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use crate::{
-    address::{Address, AddressType},
+    address::{Address, AddressType, KnownHrp},
     amount::{Amount, Denomination, SignedAmount},
     bip158::{FilterHash, FilterHeader},
     bip32::XKeyIdentifier,

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1436,7 +1436,7 @@ mod test {
 
     use super::*;
     use crate::sighash::{TapSighash, TapSighashTag};
-    use crate::{Address, Network};
+    use crate::{Address, KnownHrp};
     extern crate serde_json;
 
     #[cfg(feature = "serde")]
@@ -1828,7 +1828,7 @@ mod test {
 
             let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
             let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
-            let addr = Address::p2tr(secp, internal_key, merkle_root, Network::Bitcoin);
+            let addr = Address::p2tr(secp, internal_key, merkle_root, KnownHrp::Mainnet);
             let spk = addr.script_pubkey();
 
             assert_eq!(expected_output_key, output_key.to_inner());


### PR DESCRIPTION
We have a bunch of functions that take `Network` when what they really want is something that can be converted to a `KnownHrp`.

Make `KnownHrp` public and accept `impl Into<KnownHrp>`.