### PR TITLE
Use hex-conservative to display pubkey

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -220,12 +220,8 @@ pub struct SortKey(ArrayVec<u8, 65>);
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // TODO: fast hex encoding
         self.with_serialized(|bytes| {
-            for ch in bytes {
-                write!(f, "{:02x}", ch)?;
-            }
-            Ok(())
+            fmt::Display::fmt(&bytes.as_hex(), f)
         })
     }
 }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -832,7 +832,6 @@ impl crate::serde::Serialize for U256 {
         }
 
         if serializer.is_human_readable() {
-            // TODO: fast hex encoding.
             serializer.collect_str(&DisplayHex(*self))
         } else {
             let bytes = self.to_be_bytes();


### PR DESCRIPTION
We introduced `hex-conservative` ages ago, use it to display the `PublicKey`.