### PR TITLE
Add functionality to serialize signatures to a writer

### DIFF
--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -8,6 +8,7 @@
 use core::fmt;
 
 use internals::write_err;
+use io::Write;
 
 use crate::prelude::*;
 use crate::sighash::{InvalidSighashTypeError, TapSighashType};
@@ -47,7 +48,6 @@ impl Signature {
     ///
     /// Note: this allocates on the heap, prefer [`serialize`](Self::serialize) if vec is not needed.
     pub fn to_vec(self) -> Vec<u8> {
-        // TODO: add support to serialize to a writer to SerializedSig
         let mut ser_sig = self.signature.as_ref().to_vec();
         if self.sighash_type == TapSighashType::Default {
             // default sighash type, don't add extra sighash byte
@@ -55,6 +55,13 @@ impl Signature {
             ser_sig.push(self.sighash_type as u8);
         }
         ser_sig
+    }
+
+    /// Serializes the signature to `writer`.
+    #[inline]
+    pub fn serialize_to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        let sig = self.serialize();
+        sig.write_to(writer)
     }
 
     /// Serializes the signature (without heap allocation)

--- a/bitcoin/src/taproot/serialized_signature.rs
+++ b/bitcoin/src/taproot/serialized_signature.rs
@@ -10,6 +10,7 @@ use core::convert::TryFrom;
 use core::{fmt, ops};
 
 pub use into_iter::IntoIter;
+use io::Write;
 
 use super::{SigFromSliceError, Signature};
 
@@ -166,6 +167,12 @@ impl SerializedSignature {
     /// (this serializes it)
     #[inline]
     pub fn from_signature(sig: &Signature) -> SerializedSignature { sig.serialize() }
+
+    /// Writes this serialized signature to a `writer`.
+    #[inline]
+    pub fn write_to<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_all(self)
+    }
 }
 
 /// Separate mod to prevent outside code from accidentally breaking invariants.


### PR DESCRIPTION
Serializing the ecdsa and taproot `Signature` straight to a writer is a useful thing to be able to do.

Add `to_writer` to both `SerializedSignature`s and also to the `Signature`s (calling through to `SerializedSignature`).

Remove TODO comments from code.