### PR TITLE
Add consts to Params for individual networks

### DIFF
--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -49,65 +49,80 @@ pub struct Params {
 }
 
 impl Params {
-    /// Creates parameters set for the given network.
+    /// The mainnet parameters (alias for `Params::MAINNET`).
+    pub const BITCOIN: Params = Params::MAINNET;
+
+    /// The mainnet parameters.
+    pub const MAINNET: Params = Params {
+        network: Network::Bitcoin,
+        bip16_time: 1333238400,                 // Apr 1 2012
+        bip34_height: 227931, // 000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8
+        bip65_height: 388381, // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
+        bip66_height: 363725, // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        rule_change_activation_threshold: 1916, // 95%
+        miner_confirmation_window: 2016,
+        pow_limit: Target::MAX_ATTAINABLE_MAINNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: false,
+        no_pow_retargeting: false,
+    };
+
+    /// The testnet parameters.
+    pub const TESTNET: Params = Params {
+        network: Network::Testnet,
+        bip16_time: 1333238400,                 // Apr 1 2012
+        bip34_height: 21111, // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
+        bip65_height: 581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+        bip66_height: 330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        rule_change_activation_threshold: 1512, // 75%
+        miner_confirmation_window: 2016,
+        pow_limit: Target::MAX_ATTAINABLE_TESTNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: true,
+        no_pow_retargeting: false,
+    };
+
+    /// The signet parameters.
+    pub const SIGNET: Params = Params {
+        network: Network::Signet,
+        bip16_time: 1333238400, // Apr 1 2012
+        bip34_height: 1,
+        bip65_height: 1,
+        bip66_height: 1,
+        rule_change_activation_threshold: 1916, // 95%
+        miner_confirmation_window: 2016,
+        pow_limit: Target::MAX_ATTAINABLE_SIGNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: false,
+        no_pow_retargeting: false,
+    };
+
+    /// The regtest parameters.
+    pub const REGTEST: Params = Params {
+        network: Network::Regtest,
+        bip16_time: 1333238400,  // Apr 1 2012
+        bip34_height: 100000000, // not activated on regtest
+        bip65_height: 1351,
+        bip66_height: 1251,                    // used only in rpc tests
+        rule_change_activation_threshold: 108, // 75%
+        miner_confirmation_window: 144,
+        pow_limit: Target::MAX_ATTAINABLE_REGTEST,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: true,
+        no_pow_retargeting: true,
+    };
+
+    /// Creates parameters set for the given network.    /// Creates parameters set for the given network.
     pub const fn new(network: Network) -> Self {
         match network {
-            Network::Bitcoin => Params {
-                network: Network::Bitcoin,
-                bip16_time: 1333238400,                 // Apr 1 2012
-                bip34_height: 227931, // 000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8
-                bip65_height: 388381, // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
-                bip66_height: 363725, // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
-                rule_change_activation_threshold: 1916, // 95%
-                miner_confirmation_window: 2016,
-                pow_limit: Target::MAX_ATTAINABLE_MAINNET,
-                pow_target_spacing: 10 * 60,            // 10 minutes.
-                pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
-                allow_min_difficulty_blocks: false,
-                no_pow_retargeting: false,
-            },
-            Network::Testnet => Params {
-                network: Network::Testnet,
-                bip16_time: 1333238400,                 // Apr 1 2012
-                bip34_height: 21111, // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
-                bip65_height: 581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
-                bip66_height: 330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
-                rule_change_activation_threshold: 1512, // 75%
-                miner_confirmation_window: 2016,
-                pow_limit: Target::MAX_ATTAINABLE_TESTNET,
-                pow_target_spacing: 10 * 60,            // 10 minutes.
-                pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
-                allow_min_difficulty_blocks: true,
-                no_pow_retargeting: false,
-            },
-            Network::Signet => Params {
-                network: Network::Signet,
-                bip16_time: 1333238400, // Apr 1 2012
-                bip34_height: 1,
-                bip65_height: 1,
-                bip66_height: 1,
-                rule_change_activation_threshold: 1916, // 95%
-                miner_confirmation_window: 2016,
-                pow_limit: Target::MAX_ATTAINABLE_SIGNET,
-                pow_target_spacing: 10 * 60,            // 10 minutes.
-                pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
-                allow_min_difficulty_blocks: false,
-                no_pow_retargeting: false,
-            },
-            Network::Regtest => Params {
-                network: Network::Regtest,
-                bip16_time: 1333238400,  // Apr 1 2012
-                bip34_height: 100000000, // not activated on regtest
-                bip65_height: 1351,
-                bip66_height: 1251,                    // used only in rpc tests
-                rule_change_activation_threshold: 108, // 75%
-                miner_confirmation_window: 144,
-                pow_limit: Target::MAX_ATTAINABLE_REGTEST,
-                pow_target_spacing: 10 * 60,            // 10 minutes.
-                pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
-                allow_min_difficulty_blocks: true,
-                no_pow_retargeting: true,
-            },
+            Network::Bitcoin => Params::MAINNET,
+            Network::Testnet => Params::TESTNET,
+            Network::Signet => Params::SIGNET,
+            Network::Regtest => Params::REGTEST,
         }
     }
 
@@ -120,6 +135,7 @@ impl Params {
 impl From<Network> for Params {
     fn from(value: Network) -> Self { Self::new(value) }
 }
+
 
 impl From<&Network> for Params {
     fn from(value: &Network) -> Self { Self::new(*value) }


### PR DESCRIPTION
Add consts to the `Params` type for the individual networks.
