### PR TITLE
Add functions for network validation

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -55,7 +55,7 @@ use crate::taproot::TapNodeHash;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    error::{Error, ParseError, UnknownAddressTypeError, UnknownHrpError},
+    error::{Error, ParseError, UnknownAddressTypeError, UnknownHrpError, NetworkValidationError},
 };
 
 /// The different types of addresses.
@@ -667,11 +667,11 @@ impl Address<NetworkUnchecked> {
     /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
     /// on [`Address`].
     #[inline]
-    pub fn require_network(self, required: Network) -> Result<Address, Error> {
+    pub fn require_network(self, required: Network) -> Result<Address, NetworkValidationError> {
         if self.is_valid_for_network(required) {
             Ok(self.assume_checked())
         } else {
-            Err(Error::NetworkValidation { required, address: self })
+            Err(NetworkValidationError { required, address: self })
         }
     }
 


### PR DESCRIPTION
This error variant is returned from exactly one function `require_network`, which currently returns the general `address::Error` even though it has a single error path.
    
Pull `NetworkValidation` out into a new `NetworkValidationError` type.
