### PR TITLE
Add difficulty functions for individual networks

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -95,6 +95,26 @@ impl Header {
     /// how difficult it would be at the highest possible target (highest target == lowest difficulty).
     pub fn difficulty(&self, network: Network) -> u128 { self.target().difficulty(network) }
 
+    /// Computes the popular "difficulty" measure for mining on the mainnet network.
+    ///
+    /// See [`Self::difficulty`] for more information.
+    pub fn mainnet_difficulty(&self) -> u128 { self.difficulty(Network::Bitcoin) }
+
+    /// Computes the popular "difficulty" measure for mining on the testnet network.
+    ///
+    /// See [`Self::difficulty`] for more information.
+    pub fn testnet_difficulty(&self) -> u128 { self.difficulty(Network::Testnet) }
+
+    /// Computes the popular "difficulty" measure for mining on the regtest network.
+    ///
+    /// See [`Self::difficulty`] for more information.
+    pub fn regtest_difficulty(&self) -> u128 { self.difficulty(Network::Regtest) }
+
+    /// Computes the popular "difficulty" measure for mining on the signet network.
+    ///
+    /// See [`Self::difficulty`] for more information.
+    pub fn signet_difficulty(&self) -> u128 { self.difficulty(Network::Signet) }
+
     /// Computes the popular "difficulty" measure for mining and returns a float value of f64.
     pub fn difficulty_float(&self) -> f64 { self.target().difficulty_float() }
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -235,6 +235,26 @@ impl Target {
         d.saturating_to_u128()
     }
 
+    /// Computes the popular "difficulty" measure for mining on the mainnet network.
+    ///
+    /// See [`Self::difficulty`] for more information.
+    pub fn mainnet_difficulty(&self) -> u128 { self.difficulty(Network::Bitcoin) }
+
+    /// Computes the popular "difficulty" measure for mining on the testnet network.
+    ///
+    /// See [`Self::difficulty`] for more information.
+    pub fn testnet_difficulty(&self) -> u128 { self.difficulty(Network::Testnet) }
+
+    /// Computes the popular "difficulty" measure for mining on the regtest network.
+    ///
+    /// See [`Self::difficulty`] for more information.
+    pub fn regtest_difficulty(&self) -> u128 { self.difficulty(Network::Regtest) }
+
+    /// Computes the popular "difficulty" measure for mining on the signet network.
+    ///
+    /// See [`Self::difficulty`] for more information.
+    pub fn signet_difficulty(&self) -> u128 { self.difficulty(Network::Signet) }
+
     /// Computes the popular "difficulty" measure for mining and returns a float value of f64.
     ///
     /// See [`difficulty`] for details.


### PR DESCRIPTION
Add inherent methods on the `Target` and `Header` types for calculating difficulty for each of the individual networks.

Done in an effort to reduce the requirement for users to use the `Network` type.