### PR TITLE
Remove TODOs

### DIFF
--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -12,8 +12,6 @@ use hex_lit::hex;
 
 //run with: cargo run --example sighash
 
-//TODO add P2TR examples, ideally for both key-path and script-path spending
-
 /// Computes segwit sighash for a transaction input that spends a p2wpkh output with "witness_v0_keyhash" scriptPubKey.type
 ///
 /// # Arguments

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -534,7 +534,6 @@ mod tests {
         );
         assert_eq!(real_decode.header.difficulty(network), 1);
         assert_eq!(real_decode.header.difficulty_float(), 1.0);
-        // [test] TODO: check the transaction data
 
         assert_eq!(real_decode.total_size(), some_block.len());
         assert_eq!(real_decode.base_size(), some_block.len());
@@ -577,7 +576,6 @@ mod tests {
         );
         assert_eq!(real_decode.header.difficulty(network), 2456598);
         assert_eq!(real_decode.header.difficulty_float(), 2456598.4399242126);
-        // [test] TODO: check the transaction data
 
         assert_eq!(real_decode.total_size(), segwit_block.len());
         assert_eq!(real_decode.base_size(), 4283);

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -1017,7 +1017,6 @@ mod tests {
     #[test]
     fn serialize_vector_test() {
         assert_eq!(serialize(&vec![1u8, 2, 3]), vec![3u8, 1, 2, 3]);
-        // TODO: test vectors of more interesting objects
     }
 
     #[test]

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -66,7 +66,7 @@ pub mod hex {
         }
     }
 
-    // TODO measure various sizes and determine the best value
+    // We just guessed at a reasonably sane value.
     const HEX_BUF_SIZE: usize = 512;
 
     /// Hex byte encoder.

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -562,7 +562,6 @@ mod test {
 
     #[test]
     fn full_round_ser_der_raw_network_message_test() {
-        // TODO: Impl Rand traits here to easily generate random values.
         let version_msg: VersionMessage = deserialize(&hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff0000000000000100000000000000fd87d87eeb4364f22cf54dca59412db7208d47d920cffce83ee8102f5361746f7368693a302e392e39392f2c9f040001")).unwrap();
         let tx: Transaction = deserialize(&hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000")).unwrap();
         let block: Block = deserialize(&include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw")[..]).unwrap();

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -189,9 +189,6 @@ pub enum NetworkMessage {
     SendHeaders,
     /// `getaddr`
     GetAddr,
-    // TODO: checkorder,
-    // TODO: submitorder,
-    // TODO: reply,
     /// `ping`
     Ping(u64),
     /// `pong`

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -97,7 +97,6 @@ pub struct Input {
     /// The finalized, fully-constructed scriptWitness with signatures and any
     /// other scripts necessary for this input to pass validation.
     pub final_script_witness: Option<Witness>,
-    /// TODO: Proof of reserves commitment
     /// RIPEMD160 hash to preimage map.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_byte_values"))]
     pub ripemd160_preimages: BTreeMap<ripemd160::Hash, Vec<u8>>,

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -321,7 +321,6 @@ impl Serialize for (Vec<TapLeafHash>, KeySource) {
     fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(32 * self.0.len() + key_source_len(&self.1));
         self.0.consensus_encode(&mut buf).expect("Vecs don't error allocation");
-        // TODO: Add support for writing into a writer for key-source
         buf.extend(self.1.serialize());
         buf
     }

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -29,7 +29,6 @@ extern crate core;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
-// TODO: Make amount module less dependent on an allocator.
 #[cfg(feature = "alloc")]
 pub mod amount;
 


### PR DESCRIPTION
Done while working on #2368.  There are 5 left. Do we want to leave the MSRV ones in there?

```bash
bitcoin/src/blockdata/weight.rs:66:                 // TODO replace with panic!() when MSRV = 1.57+
bitcoin/src/consensus/serde.rs:101:    // TODO: statically prove impossible cases
bitcoin/src/pow.rs:445:            // TODO: Use `carrying_mul` when stabilized: https://github.com/rust-lang/rust/issues/85532
units/src/amount.rs:595:        // TODO replace whith unwrap() when available in const context.
units/src/amount.rs:599:                // TODO replace with panic!() when MSRV = 1.57+
```