### PR TITLE
Make crate level attributes uniform

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -29,18 +29,20 @@
 //!                            happen the implementations diverge one day.
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
 // Experimental features we need.
-#![cfg_attr(bench, feature(test))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-// Coding conventions
+#![cfg_attr(bench, feature(test))]
+
+// Coding conventions.
 #![warn(missing_docs)]
+
 // Instead of littering the codebase for non-fuzzing code just globally allow.
 #![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
-// Exclude clippy lints we don't think are valuable
+
+// Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
-#![allow(clippy::uninhabited_references)] // falsely claims that 100% safe code is UB
-#![allow(clippy::manual_range_contains)] // more readable than clippy's format
-#![allow(clippy::unconditional_recursion)] // broken; see https://github.com/rust-lang/rust-clippy/issues/12133
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -65,21 +65,21 @@
 //! # fn main() {}
 //! ```
 
-// Coding conventions
-#![warn(missing_docs)]
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(bench, feature(test))]
-// In general, rust is absolutely horrid at supporting users doing things like,
-// for example, compiling Rust code for real environments. Disable useless lints
-// that don't do anything but annoy us and cant actually ever be resolved.
-#![allow(bare_trait_objects)]
-#![allow(ellipsis_inclusive_range_patterns)]
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+
+// Coding conventions.
+#![warn(missing_docs)]
+
 // Instead of littering the codebase for non-fuzzing code just globally allow.
 #![cfg_attr(hashes_fuzz, allow(dead_code, unused_imports))]
-// Exclude clippy lints we don't think are valuable
+
+// Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -7,12 +7,16 @@
 //!
 
 #![no_std]
+
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-// Coding conventions
+
+// Coding conventions.
 #![warn(missing_docs)]
-// Exclude clippy lints we don't think are valuable
+
+// Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
 alloc = []
 
 [package.metadata.docs.rs]

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -20,7 +20,7 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 
-#[cfg(any(feature = "alloc", feature = "std"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod error;
@@ -316,6 +316,9 @@ pub fn sink() -> Sink { Sink }
 mod tests {
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{string::ToString, vec};
+
     #[test]
     fn buf_read_fill_and_consume_slice() {
         let data = [0_u8, 1, 2];
@@ -339,7 +342,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "alloc", feature = "std"))]
+    #[cfg(feature = "alloc")]
     fn read_to_limit_greater_than_total_length() {
         let s = "16-byte-string!!".to_string();
         let mut reader = Cursor::new(&s);
@@ -352,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "alloc", feature = "std"))]
+    #[cfg(feature = "alloc")]
     fn read_to_limit_less_than_total_length() {
         let s = "16-byte-string!!".to_string();
         let mut reader = Cursor::new(&s);

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -9,8 +9,16 @@
 //! `std::io`'s traits without unnecessary complexity.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+// Coding conventions.
+// #![warn(missing_docs)]
+
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 extern crate alloc;

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -6,10 +6,13 @@
 
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-// Coding conventions
+
+// Coding conventions.
 #![warn(missing_docs)]
-// Exclude clippy lints we don't think are valuable
+
+// Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 
 #![no_std]
 


### PR DESCRIPTION
Make the trait level attributes uniform across all released crates in the repo. Excludes things that are obviously not needed, eg, bench stuff if there is not bench code.

- Remove `uninhabited_references` - this is allow by default now.
- Remove `unconditional_recursion` and mark the single false positive we have with an `allow`.

Note, this does not add `missing_docs` to the `io` crate. There is an open PR at the moment to add that along with the required docs.