### PR TITLE
Provide `Amount` & co in no-alloc

### DIFF
--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -29,10 +29,8 @@ extern crate core;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
-#[cfg(feature = "alloc")]
 pub mod amount;
 
-#[cfg(feature = "alloc")]
 #[doc(inline)]
 pub use self::amount::{Amount, ParseAmountError, SignedAmount};
 

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -4,13 +4,14 @@
 //!
 //! This library provides basic types used by the Rust Bitcoin ecosystem.
 
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions
 #![warn(missing_docs)]
 // Exclude clippy lints we don't think are valuable
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+
+#![no_std]
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]
@@ -19,11 +20,11 @@ compile_error!(
     know if you want 16-bit support. Note that we do NOT guarantee that we will implement it!"
 );
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
-extern crate core;
+#[cfg(feature = "std")]
+extern crate std;
 
 /// A generic serialization/deserialization framework.
 #[cfg(feature = "serde")]
@@ -33,12 +34,3 @@ pub mod amount;
 
 #[doc(inline)]
 pub use self::amount::{Amount, ParseAmountError, SignedAmount};
-
-#[rustfmt::skip]
-mod prelude {
-    #[cfg(all(feature = "alloc", not(feature = "std"), not(test)))]
-    pub use alloc::string::{String, ToString};
-
-    #[cfg(any(feature = "std", test))]
-    pub use std::string::{String, ToString};
-}


### PR DESCRIPTION
Using the crate without allocation was previously disabled making the
crate empty without the feature. This chage makes it more fine-grained:
it only disables string and float conversions which use allocator. We
could later provide float conversions by using a sufficiently-long
`ArrayString`.

Note that this is API-breaking because we disallow calling the methods of the sealed `SerdeAmount` trait. However I think it should've been obvious that the thing is internal and calling them is not a great idea. (BTW I only learned this trick recently).

Closes #2389 