### PR TITLE
Use `unsigned_abs` instead of manual code

### DIFF
--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -135,7 +135,7 @@ pub fn write_scriptint(out: &mut [u8; 8], n: i64) -> usize {
 
     let neg = n < 0;
 
-    let mut abs = if neg { -n } else { n } as usize;
+    let mut abs = n.unsigned_abs();
     while abs > 0xFF {
         out[len] = (abs & 0xFF) as u8;
         len += 1;


### PR DESCRIPTION
The code originally used `if` and incorrectly casted the value into `usize` rather than `u64`. This change replaces the whole thing with `unsigned_abs`.

Closes #1247