### PR TITLE
Use nightly toolchain in pre-commit hook

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -46,4 +46,4 @@ fi
 git diff-index --check --cached $against -- || exit 1
 
 # Check that code lints cleanly.
-cargo clippy --all-features -- -D warnings || exit 1
+cargo +nightly clippy --all-features -- -D warnings || exit 1


### PR DESCRIPTION
We use the nightly toolchain to run `clippy` now, update the git pre-commit hook to mirror this.