### PR TITLE
just: Reduce docs commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,11 +23,8 @@ sane: lint
   cargo test --quiet --workspace --all-targets > /dev/null || exit 1
   cargo test --quiet --workspace --all-targets --all-features > /dev/null || exit 1
 
-  # Docs tests (these don't run when testing from workspace root)
-  cargo test --quiet --manifest-path bitcoin/Cargo.toml --doc > /dev/null  || exit 1
-  cargo test --quiet --manifest-path hashes/Cargo.toml --doc > /dev/null  || exit 1
-  cargo test --quiet --manifest-path io/Cargo.toml --doc > /dev/null  || exit 1
-  cargo test --quiet --manifest-path units/Cargo.toml --doc > /dev/null  || exit 1
+  # doctests don't get run from workspace root with `cargo test`.
+  cargo test --quiet --workspace --doc || exit 1
 
   # Make an attempt to catch feature gate problems in doctests
   cargo test --manifest-path bitcoin/Cargo.toml --doc --no-default-features > /dev/null || exit 1


### PR DESCRIPTION
`cargo --doc` works from the workspace root, no need to run the docs builds individually.

## More context

`cargo test` does not run docs tests if run from the workspace root as it does when run in a crate directory.