### PR TITLE
Improve lock time errors

### DIFF
--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -19,14 +19,14 @@ use crate::prelude::*;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ParseIntError {
-    input: String,
+    pub(crate) input: String,
     // for displaying - see Display impl with nice error message below
     bits: u8,
     // We could represent this as a single bit but it wouldn't actually derease the cost of moving
     // the struct because String contains pointers so there will be padding of bits at least
     // pointer_size - 1 bytes: min 1B in practice.
     is_signed: bool,
-    source: core::num::ParseIntError,
+    pub(crate) source: core::num::ParseIntError,
 }
 
 impl ParseIntError {
@@ -136,41 +136,33 @@ macro_rules! impl_parse_str_from_int_infallible {
 }
 pub(crate) use impl_parse_str_from_int_infallible;
 
-/// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using fallible
-/// conversion function `fn`.
-macro_rules! impl_tryfrom_str_from_int_fallible {
-    ($($from:ty, $to:ident, $inner:ident, $fn:ident, $err:ident);*) => {
+macro_rules! impl_tryfrom_str {
+    ($($from:ty, $to:ty, $err:ty, $inner_fn:expr);*) => {
         $(
-        impl core::convert::TryFrom<$from> for $to {
-            type Error = $err;
+            impl core::convert::TryFrom<$from> for $to {
+                type Error = $err;
 
-            fn try_from(s: $from) -> core::result::Result<Self, Self::Error> {
-                let u = $crate::parse::int::<$inner, $from>(s)?;
-                $to::$fn(u)
+                fn try_from(s: $from) -> core::result::Result<Self, Self::Error> {
+                    $inner_fn(s)
+                }
             }
-        }
         )*
     }
 }
-pub(crate) use impl_tryfrom_str_from_int_fallible;
+pub(crate) use impl_tryfrom_str;
 
-/// Implements `FromStr` and `TryFrom<{&str, String, Box<str>}> for $to` using `parse::int`, mapping
-/// the output using fallible conversion function `fn`.
-///
-/// The `Error` type is `ParseIntError`
-macro_rules! impl_parse_str_from_int_fallible {
-    ($to:ident, $inner:ident, $fn:ident, $err:ident) => {
-        $crate::parse::impl_tryfrom_str_from_int_fallible!(&str, $to, $inner, $fn, $err; String, $to, $inner, $fn, $err; Box<str>, $to, $inner, $fn, $err);
+/// Implements standard parsing traits for `$type` by calling into `$inner_fn`.
+macro_rules! impl_parse_str {
+    ($to:ty, $err:ty, $inner_fn:expr) => {
+        $crate::parse::impl_tryfrom_str!(&str, $to, $err, $inner_fn; String, $to, $err, $inner_fn; Box<str>, $to, $err, $inner_fn);
 
         impl core::str::FromStr for $to {
             type Err = $err;
 
             fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-                let u = $crate::parse::int::<$inner, &str>(s)?;
-                $to::$fn(u)
+                $inner_fn(s)
             }
         }
-
     }
 }
-pub(crate) use impl_parse_str_from_int_fallible;
+pub(crate) use impl_parse_str;


### PR DESCRIPTION
The errors returned from various lock time functions had several issues. Among the obvious - `Error` being returned from all operations even when some of its variants were unreachable, there were subtle issues around error messages:

* `ParseIntError` didn't contain information whether the parsed object is `Height` or `Time`.
* Logically overflow and out-of-bounds should be the same thing but produced different error messages.
* Mentioning integers is too technical for a user, talking about upper and lower bound is easier to understand.
* When minus sign is present `std` reports it as invalid digit which is less helpful than saying negative numbers are not allowed.

It is also possible that `ParseIntError` will need to be removed from public API during crate smashing or stabilization, so avoiding it may be better.

This commit significantly refactors the errors. It adds separate types for parsing `Height` and `Time`. Notice that we don't compose them from `ParseIntError` and `ConversionError` - that's not helpful because they carry information that wouldn't be used when displaying which is wasteful. Keeping errors small can be important.

It's also worth noting that exposing the inner representation could cause confusion since the same thing: out of bounds can be represented as an overflow or as a conversion error. So for now we conservatively hide the details and even pretend there's no `source` in case of overflow. This can be expanded in the future if needed.

The returned errors are now minimal. `LockTime` parsing errors are currentlly unchanged.

I can add `LockTime` changes in the same commit or separate within this PR if you want. Just wanted to push something for review before I go to sleep.