### PR TITLE
Add `From<u32>` impl for Sequence

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -488,6 +488,10 @@ impl Default for Sequence {
     fn default() -> Self { Sequence::MAX }
 }
 
+impl From<u32> for Sequence {
+    fn from(n: u32) -> Self { Self(n) }
+}
+
 impl From<Sequence> for u32 {
     fn from(sequence: Sequence) -> u32 { sequence.0 }
 }


### PR DESCRIPTION
The `Sequence` type wraps a `u32` and its public. There is no reason not to implement `From` for it.

Fix: #1302