### PR TITLE
Fix kani test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,3 +163,14 @@ jobs:
         env:
           DO_WASM: true
         run: cd hashes && ./contrib/test.sh
+
+  Kani:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Checkout your code.'
+        uses: actions/checkout@v4
+
+      - name: 'Kani build proofs'
+        uses: model-checking/kani-github-action@v1.1
+        with:
+          args: '--only-codegen'

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1755,7 +1755,10 @@ mod verification {
             if n1 >= 0 {
                 Ok(Amount::from_sat(n1.try_into().unwrap()))
             } else {
-                Err(ParseAmountError::Negative)
+                Err(OutOfRangeError {
+                    is_signed: true,
+                    is_greater_than_max: false
+                })
             },
         );
     }


### PR DESCRIPTION
Recently (in #2379) we patched the `ParseAmountError` but we don't check kani code on every pull request so we broke it.

Fix kani test to use the new `OutOfRangeError`.

EDIT: Attempt, as a separate patch, to add a job that runs on each PR to build the kani test code.

Close: #2424

