### PR TITLE
Enforce `$source: std::error::Error` in `write_err`

### DIFF
--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -15,7 +15,7 @@ use core::borrow::{Borrow, BorrowMut};
 use core::{fmt, str};
 
 use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
-use internals::write_err;
+use internals::{write_err, write_err_unchecked_source};
 use io::Write;
 
 use crate::blockdata::witness::Witness;
@@ -1410,7 +1410,7 @@ impl<E: fmt::Display> fmt::Display for SigningDataError<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Io(error) => write_err!(f, "failed to write sighash data"; error),
-            Self::Sighash(error) => write_err!(f, "failed to compute sighash data"; error),
+            Self::Sighash(error) => write_err_unchecked_source!(f, "failed to compute sighash data"; error),
         }
     }
 }

--- a/bitcoin/src/string.rs
+++ b/bitcoin/src/string.rs
@@ -7,7 +7,7 @@
 
 use core::fmt;
 
-use internals::write_err;
+use internals::write_err_unchecked_source;
 
 use crate::prelude::String;
 
@@ -53,9 +53,9 @@ impl<E: fmt::Display> fmt::Display for FromHexError<E> {
         use FromHexError::*;
 
         match *self {
-            ParseHex(ref e) => write_err!(f, "failed to parse hex string"; e),
+            ParseHex(ref e) => write_err_unchecked_source!(f, "failed to parse hex string"; e),
             MissingPrefix(ref value) =>
-                write_err!(f, "the input value `{}` is missing the `0x` prefix", value; self),
+                write!(f, "the input value `{}` is missing the `0x` prefix", value),
         }
     }
 }

--- a/internals/src/error.rs
+++ b/internals/src/error.rs
@@ -10,18 +10,69 @@ mod parse_error;
 
 pub use input_string::InputString;
 
+/// Helper trait for checking whether something implements [`std::error::Error`].
+///
+/// We use helper trait instead of function to make the compiler handle auto dereferencing.
+#[cfg(feature = "std")]
+pub trait ErrorExt: std::error::Error + 'static {
+    /// Does nothing, just call it
+    #[inline(always)]
+    fn check_is_actually_error_source(&self) {}
+}
+
+#[cfg(feature = "std")]
+impl<T: std::error::Error + 'static> ErrorExt for T { }
+
 /// Formats error.
 ///
 /// If `std` feature is OFF appends error source (delimited by `: `). We do this because
 /// `e.source()` is only available in std builds, without this macro the error source is lost for
 /// no-std builds.
+///
+/// Note: will not compile on std if $source doesn't implement [`std::error::Error`]. This is
+/// intentional because if it doesn't the macro MUST NOT be used. However this check is very rarely
+/// imprecise so if you know what you're doing you can use the unchecked version.
 #[macro_export]
 macro_rules! write_err {
     ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
         {
             #[cfg(feature = "std")]
             {
+                use $crate::error::ErrorExt;
+
+                // Enforces that $source is actually an error.
+                //
+                // Occasionally people accidentally use write_err! with non-error and it's quite
+                // hard to detect otherwise so this gives them compilation error.
+                // Also avoids lints saying $source is unused.
+                ($source).check_is_actually_error_source();
+
+                write!($writer, $string $(, $args)*)
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
+            }
+        }
+    }
+}
+
+/// Formats error.
+///
+/// Unlike [`write_err`] doesn't statically check that `$source` implements `std::error::Error`.
+/// This should be used only in rare generic situations.
+///
+/// If `std` feature is OFF appends error source (delimited by `: `). We do this because
+/// `e.source()` is only available in std builds, without this macro the error source is lost for
+/// no-std builds.
+#[macro_export]
+macro_rules! write_err_unchecked_source {
+    ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
+        {
+            #[cfg(feature = "std")]
+            {
                 let _ = &$source;   // Prevents clippy warnings.
+
                 write!($writer, $string $(, $args)*)
             }
             #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Sometimes people accidentally use `write_err` where `write` should be used or forget to implement `std::error::Error` for their types. So far we've relied mainly on review to catch these but it's difficult to see them and as this commit demonstrates one case slipped in #1400.

This commit add a check to `write_err` that enforces implementation of `std::error::Error + 'static` on types passed to `write_err` as `$source`. This doesn't trigger on `no_std` builds but does in `std` builds. While this would normally be weird in this case it's OK because `std` is tested.

There are still cases where this check is a false positive so the original macro is preserved as `write_err_unchecked_source`.

This change simultaneusly fixes the horrible bug introduced in #1400 which would cause infinite recursion when displaying error on `no_std`.