### PR TITLE
Move the `ParseIntError` to units crate

### DIFF
--- a/bitcoin/src/blockdata/fee_rate.rs
+++ b/bitcoin/src/blockdata/fee_rate.rs
@@ -154,7 +154,7 @@ impl Div<Weight> for Amount {
     fn div(self, rhs: Weight) -> Self::Output { FeeRate(self.to_sat() * 1000 / rhs.to_wu()) }
 }
 
-crate::parse::impl_parse_str_from_int_infallible!(FeeRate, u64, from_sat_per_kwu);
+units::impl_parse_str_from_int_infallible!(FeeRate, u64, from_sat_per_kwu);
 
 #[cfg(test)]
 mod tests {

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -13,12 +13,12 @@ use internals::write_err;
 use io::{BufRead, Write};
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
+use units::{impl_parse_str, impl_parse_str_from_int_infallible, parse};
 
 #[cfg(doc)]
 use crate::absolute;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::error::ParseIntError;
-use crate::parse::{impl_parse_str, impl_parse_str_from_int_infallible};
 use crate::prelude::*;
 use crate::string::FromHexStr;
 
@@ -330,7 +330,7 @@ impl FromHexStr for LockTime {
 
     #[inline]
     fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
-        let packed_lock_time = crate::parse::hex_u32(s)?;
+        let packed_lock_time = parse::hex_u32(s)?;
         Ok(Self::from_consensus(packed_lock_time))
     }
 }
@@ -758,7 +758,8 @@ impl ParseError {
 
 impl From<ParseIntError> for ParseError {
     fn from(value: ParseIntError) -> Self {
-        Self::InvalidInteger { source: value.source, input: value.input }
+        let (input, source) = value.into_input_source();
+        Self::InvalidInteger { source, input }
     }
 }
 

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -616,8 +616,6 @@ fn is_block_time(n: u32) -> bool { n >= LOCK_TIME_THRESHOLD }
 pub enum Error {
     /// An error occurred while converting a `u32` to a lock time variant.
     Conversion(ConversionError),
-    /// An error occurred while operating on lock times.
-    Operation(OperationError),
     /// An error occurred while parsing a string into an `u32`.
     Parse(ParseIntError),
 }
@@ -628,7 +626,6 @@ impl fmt::Display for Error {
 
         match *self {
             Conversion(ref e) => write_err!(f, "error converting lock time value"; e),
-            Operation(ref e) => write_err!(f, "error during lock time operation"; e),
             Parse(ref e) => write_err!(f, "failed to parse lock time from string"; e),
         }
     }
@@ -641,7 +638,6 @@ impl std::error::Error for Error {
 
         match *self {
             Conversion(ref e) => Some(e),
-            Operation(ref e) => Some(e),
             Parse(ref e) => Some(e),
         }
     }
@@ -650,11 +646,6 @@ impl std::error::Error for Error {
 impl From<ConversionError> for Error {
     #[inline]
     fn from(e: ConversionError) -> Self { Self::Conversion(e) }
-}
-
-impl From<OperationError> for Error {
-    #[inline]
-    fn from(e: OperationError) -> Self { Self::Operation(e) }
 }
 
 impl From<ParseIntError> for Error {
@@ -707,36 +698,6 @@ impl fmt::Display for LockTimeUnit {
         match *self {
             Blocks => write!(f, "expected lock-by-blockheight (must be < {})", LOCK_TIME_THRESHOLD),
             Seconds => write!(f, "expected lock-by-blocktime (must be >= {})", LOCK_TIME_THRESHOLD),
-        }
-    }
-}
-
-/// Errors than occur when operating on lock times.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum OperationError {
-    /// Cannot compare different lock time units (height vs time).
-    InvalidComparison,
-}
-
-impl fmt::Display for OperationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use OperationError::*;
-
-        match *self {
-            InvalidComparison =>
-                f.write_str("cannot compare different lock units (height vs time)"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for OperationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use OperationError::*;
-
-        match *self {
-            InvalidComparison => None,
         }
     }
 }

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -10,8 +10,8 @@ use core::fmt;
 
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
+use units::impl_parse_str_from_int_infallible;
 
-use crate::parse::impl_parse_str_from_int_infallible;
 use crate::prelude::*;
 #[cfg(doc)]
 use crate::relative;

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -12,6 +12,7 @@ use core::str::FromStr;
 
 use bech32::Fe32;
 use internals::write_err;
+use units::parse;
 
 use crate::blockdata::opcodes::all::*;
 use crate::blockdata::opcodes::Opcode;
@@ -87,7 +88,7 @@ impl FromStr for WitnessVersion {
     type Err = FromStrError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let version: u8 = crate::parse::int(s)?;
+        let version: u8 = parse::int(s)?;
         Ok(WitnessVersion::try_from(version)?)
     }
 }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -17,6 +17,7 @@ use core::{cmp, fmt, str};
 use hashes::{self, sha256d, Hash};
 use internals::write_err;
 use io::{BufRead, Write};
+use units::{impl_parse_str_from_int_infallible, parse};
 
 use super::Weight;
 use crate::blockdata::locktime::absolute::{self, Height, Time};
@@ -26,7 +27,6 @@ use crate::blockdata::witness::Witness;
 use crate::blockdata::FeeRate;
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
-use crate::parse::impl_parse_str_from_int_infallible;
 use crate::prelude::*;
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
@@ -168,7 +168,7 @@ fn parse_vout(s: &str) -> Result<u32, ParseOutPointError> {
             return Err(ParseOutPointError::VoutNotCanonical);
         }
     }
-    crate::parse::int(s).map_err(ParseOutPointError::Vout)
+    parse::int(s).map_err(ParseOutPointError::Vout)
 }
 
 impl core::str::FromStr for OutPoint {
@@ -475,10 +475,10 @@ impl Sequence {
 }
 
 impl FromHexStr for Sequence {
-    type Error = crate::parse::ParseIntError;
+    type Error = parse::ParseIntError;
 
     fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
-        let sequence = crate::parse::hex_u32(s)?;
+        let sequence = parse::hex_u32(s)?;
         Ok(Self::from_consensus(sequence))
     }
 }
@@ -1614,6 +1614,7 @@ mod tests {
     use core::str::FromStr;
 
     use hex::{test_hex_unwrap as hex, FromHex};
+    use units::parse;
 
     use super::*;
     use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
@@ -1684,7 +1685,7 @@ mod tests {
             OutPoint::from_str(
                 "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:lol"
             ),
-            Err(ParseOutPointError::Vout(crate::parse::int::<u32, _>("lol").unwrap_err()))
+            Err(ParseOutPointError::Vout(parse::int::<u32, _>("lol").unwrap_err()))
         );
 
         assert_eq!(

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -333,4 +333,4 @@ impl<'a> core::iter::Sum<&'a Weight> for Weight {
     }
 }
 
-crate::parse::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);
+units::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -2,6 +2,7 @@
 
 //! Contains error types and other error handling tools.
 
+#[deprecated(since = "TBD", note = "use bitcoin::units::ParseIntError instead")]
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use crate::parse::ParseIntError;
+pub use units::parse::ParseIntError;

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -74,6 +74,9 @@ pub extern crate io;
 #[cfg(feature = "ordered")]
 pub extern crate ordered;
 
+/// Re-export the `units` crate.
+pub extern crate units;
+
 /// Rust wrapper library for Pieter Wuille's libsecp256k1.  Implements ECDSA and BIP 340 signatures
 /// for the SECG elliptic curve group secp256k1 and related utilities.
 pub extern crate secp256k1;
@@ -86,7 +89,6 @@ extern crate actual_serde as serde;
 #[macro_use]
 mod test_macros;
 mod internal_macros;
-mod parse;
 #[cfg(feature = "serde")]
 mod serde_utils;
 
@@ -141,6 +143,10 @@ pub use crate::{
     sighash::{EcdsaSighashType, TapSighashType},
     taproot::{TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash, TapTweakHash, TapTweakTag},
 };
+
+/// Re-exports from the `units` crate.
+#[doc(inline)]
+pub use units::ParseIntError;
 
 #[rustfmt::skip]
 mod prelude {

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -12,6 +12,7 @@ use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 use io::{BufRead, Write};
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
+use units::{parse, ParseIntError};
 
 use crate::blockdata::block::BlockHash;
 use crate::consensus::encode::{self, Decodable, Encodable};
@@ -284,10 +285,10 @@ impl From<CompactTarget> for Target {
 }
 
 impl FromHexStr for CompactTarget {
-    type Error = crate::parse::ParseIntError;
+    type Error = ParseIntError;
 
     fn from_hex_str_no_prefix<S: AsRef<str> + Into<String>>(s: S) -> Result<Self, Self::Error> {
-        let compact_target = crate::parse::hex_u32(s)?;
+        let compact_target = parse::hex_u32(s)?;
         Ok(Self::from_consensus(compact_target))
     }
 }

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -34,6 +34,11 @@ extern crate std;
 pub extern crate serde;
 
 pub mod amount;
+#[cfg(feature = "alloc")]
+pub mod parse;
 
 #[doc(inline)]
 pub use self::amount::{Amount, ParseAmountError, SignedAmount};
+#[doc(inline)]
+#[cfg(feature = "alloc")]
+pub use self::parse::ParseIntError;


### PR DESCRIPTION
We need this error type if we are to move absolute/relative `Height` and `Time` types to `units`.

Move the `ParseIntError` type to the `units` crate. Add re-expots to rust-bitcoin including a public re-export of the whole `units crate.

Remove `parse` module because it was private, keep the `errors` re-export but deprecate it because it was public.

Fix: #2282