### PR TITLE
Release tracking PR: `units v0.1.0`

### DIFF
--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,0 +1,6 @@
+# 0.1.0 - 2024-02-05
+
+Initial release of the `units` crate. Includes the following types
+
+- `Amount`
+- `SignedAmount`


### PR DESCRIPTION
We likely want to release this just a week or so before doing the next `rust-bitcoin` release (end of March) since `rust-bitcoin` will be using everything that gets moved here. We'll need to freeze work on `units` after it is released until `rust-bitcoin` is released.

Raising this PR now so we have a place to track and discuss what we want to go into the release.

The changeset is trivial: Add a changelog file to the `units` crate.