### PR TITLE
Release tracking PR: `io v0.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# 0.1.0 - 2024-02-13
+
+Initial release of the `io` crate. Includes the following traits:
+
+- `Read`
+- `BufRead`
+- `Write`
+
+And types:
+
+- `Result`
+- `Error`
+- `ErrorKind`
+- `Take`
+- `Cursor`
+- `Sink`
+


### PR DESCRIPTION
In preparation for an initial release; add a changelog file. The version number is already set to `v0.1.0`.
