### PR TITLE
Remove non_exhaustive from struct errors with pub inner

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1042,7 +1042,6 @@ impl Transaction {
 
 /// Error attempting to do an out of bounds access on the transaction inputs vector.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct InputsIndexError(pub IndexOutOfBoundsError);
 
 impl fmt::Display for InputsIndexError {
@@ -1062,7 +1061,6 @@ impl From<IndexOutOfBoundsError> for InputsIndexError {
 
 /// Error attempting to do an out of bounds access on the transaction outputs vector.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct OutputsIndexError(pub IndexOutOfBoundsError);
 
 impl fmt::Display for OutputsIndexError {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -504,7 +504,6 @@ impl TapSighashType {
 
 /// Integer is not a consensus valid sighash type.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct InvalidSighashTypeError(pub u32);
 
 impl fmt::Display for InvalidSighashTypeError {
@@ -521,7 +520,6 @@ impl std::error::Error for InvalidSighashTypeError {
 /// This type is consensus valid but an input including it would prevent the transaction from
 /// being relayed on today's Bitcoin network.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct NonStandardSighashTypeError(pub u32);
 
 impl fmt::Display for NonStandardSighashTypeError {


### PR DESCRIPTION
Using `non_exhaustive` as well as a public inner field is incorrect, it prohibits users from creating or matching on the error and does not achieve forward comparability.

This was never right, we shouldn't have done it.