### PR TITLE
Add new() functions

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -368,6 +368,9 @@ impl<'a> Iterator for DerivationPathIterator<'a> {
 }
 
 impl DerivationPath {
+    /// Creates a new master derivation path.
+    pub fn new() -> Self { DerivationPath::master() }
+
     /// Returns length of the derivation path
     pub fn len(&self) -> usize { self.0.len() }
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -166,6 +166,9 @@ impl Version {
     /// The value has the top three bits `001` which enables the use of version bits to signal for soft forks.
     const USE_VERSION_BITS: u32 = 0x2000_0000;
 
+    /// Creates a new version, equivalent to [`Version::NO_SOFT_FORK_SIGNALLING`].
+    pub fn new() -> Version { Self::NO_SOFT_FORK_SIGNALLING }
+
     /// Creates a [`Version`] from a signed 32 bit integer value.
     ///
     /// This is the data type used in consensus code in Bitcoin Core.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -232,6 +232,16 @@ impl TxIn {
     const BASE_WEIGHT: Weight =
         Weight::from_vb_unwrap(OutPoint::SIZE as u64 + Sequence::SIZE as u64);
 
+    /// Creates a new empty [`TxIn`] with the provided [`Sequence`].
+    pub fn new(sequence: Sequence) -> TxIn {
+        TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence,
+            witness: Witness::new(),
+        }
+    }
+
     /// Returns true if this input enables the [`absolute::LockTime`] (aka `nLockTime`) of its
     /// [`Transaction`].
     ///

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -290,17 +290,6 @@ impl TxIn {
     pub fn total_size(&self) -> usize { self.base_size() + self.witness.size() }
 }
 
-impl Default for TxIn {
-    fn default() -> TxIn {
-        TxIn {
-            previous_output: OutPoint::default(),
-            script_sig: ScriptBuf::new(),
-            sequence: Sequence::MAX,
-            witness: Witness::default(),
-        }
-    }
-}
-
 /// Bitcoin transaction input sequence number.
 ///
 /// The sequence field is used for:
@@ -1715,16 +1704,6 @@ mod tests {
     fn txin() {
         let txin: Result<TxIn, _> = deserialize(&hex!("a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff"));
         assert!(txin.is_ok());
-    }
-
-    #[test]
-    fn txin_default() {
-        let txin = TxIn::default();
-        assert_eq!(txin.previous_output, OutPoint::default());
-        assert_eq!(txin.script_sig, ScriptBuf::new());
-        assert_eq!(txin.sequence, Sequence::from_consensus(0xFFFFFFFF));
-        assert_eq!(txin.previous_output, OutPoint::default());
-        assert_eq!(txin.witness.len(), 0);
     }
 
     #[test]

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -27,7 +27,7 @@ use crate::{Script, VarInt};
 /// saving some allocations.
 ///
 /// [segwit upgrade]: <https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki>
-#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Witness {
     /// Contains the witness `Vec<Vec<u8>>` serialization without the initial varint indicating the
     /// number of elements (which is stored in `witness_elements`).
@@ -233,7 +233,13 @@ impl Encodable for Witness {
 
 impl Witness {
     /// Creates a new empty [`Witness`].
-    pub fn new() -> Self { Witness::default() }
+    pub const fn new() -> Self {
+        Witness {
+            content: Vec::new(),
+            witness_elements: 0,
+            indices_start: 0,
+        }
+    }
 
     /// Creates a witness required to spend a P2WPKH output.
     ///
@@ -410,6 +416,10 @@ impl Witness {
             .and_then(|script_pos_from_last| self.nth(len - script_pos_from_last))
             .map(Script::from_bytes)
     }
+}
+
+impl Default for Witness {
+    fn default() -> Self { Witness::new() }
 }
 
 impl Index<usize> for Witness {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1434,12 +1434,21 @@ mod tests {
 
     use super::*;
     use crate::blockdata::locktime::absolute;
-    use crate::blockdata::transaction;
+    use crate::blockdata::transaction::{self, OutPoint};
     use crate::consensus::deserialize;
     use crate::crypto::sighash::{LegacySighash, TapSighash};
     use crate::taproot::TapLeafHash;
 
     extern crate serde_json;
+
+    fn tx_in() -> TxIn {
+        TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }
+    }
 
     #[test]
     fn sighash_single_bug() {
@@ -1449,7 +1458,7 @@ mod tests {
         let tx = Transaction {
             version: transaction::Version::ONE,
             lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn::default(), TxIn::default()],
+            input: vec![tx_in(), tx_in()],
             output: vec![TxOut::NULL],
         };
         let script = ScriptBuf::new();
@@ -1638,7 +1647,7 @@ mod tests {
         let dumb_tx = Transaction {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn::default()],
+            input: vec![tx_in()],
             output: vec![],
         };
         let mut c = SighashCache::new(&dumb_tx);

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1969,8 +1969,9 @@ mod tests {
                             txid: "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126".parse().unwrap(),
                             vout: 0,
                         },
+                        script_sig: ScriptBuf::new(),
                         sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
-                        ..Default::default()
+                        witness: Witness::new(),
                     }
                 ],
                 output: vec![
@@ -2000,16 +2001,18 @@ mod tests {
                                     txid: "e567952fb6cc33857f392efa3a46c995a28f69cca4bb1b37e0204dab1ec7a389".parse().unwrap(),
                                     vout: 1,
                                 },
+                                script_sig: ScriptBuf::new(),
                                 sequence: Sequence::MAX,
-                                ..Default::default()
+                                witness: Witness::new(),
                             },
                             TxIn {
                                 previous_output: OutPoint {
                                     txid: "b490486aec3ae671012dddb2bb08466bef37720a533a894814ff1da743aaf886".parse().unwrap(),
                                     vout: 1,
                                 },
+                                script_sig: ScriptBuf::new(),
                                 sequence: Sequence::MAX,
-                                ..Default::default()
+                                witness: Witness::new(),
                             }
                         ],
                         output: vec![
@@ -2069,10 +2072,17 @@ mod tests {
         use crate::witness_version::WitnessVersion;
         use crate::{WPubkeyHash, WitnessProgram};
 
+        let tx_in = TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+        };
+
         let unsigned_tx = Transaction {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn::default(), TxIn::default()],
+            input: vec![tx_in.clone(), tx_in],
             output: vec![TxOut::NULL],
         };
         let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();


### PR DESCRIPTION
Add public `new` functions to types that it makes sense, especially ones that already have a `Default` impl.