### PR TITLE
WIP: Encapsulate the hex module

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "base58check"
 version = "0.1.0"
 dependencies = [
@@ -158,9 +164,12 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_lit"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "base58check"
 version = "0.1.0"
 dependencies = [
@@ -157,9 +163,12 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_lit"

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -24,4 +24,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false, features = ["alloc"] }
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -31,7 +31,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 base58 = { package = "base58check", version = "0.1.0", default-features = false }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc", "io"] }
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false, features = ["alloc"] }
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
 internals = { package = "bitcoin-internals", version = "0.2.0" }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }

--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -3,9 +3,10 @@ extern crate bitcoin;
 use std::str::FromStr;
 use std::{env, process};
 
+use hex::FromHex;
+
 use bitcoin::address::{Address, KnownHrp};
 use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
-use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{CompressedPublicKey, NetworkKind};

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -19,6 +19,7 @@ use crate::crypto::key::{CompressedPublicKey, Keypair, PrivateKey};
 use crate::internal_macros::impl_bytes_newtype;
 use crate::prelude::*;
 use crate::network::NetworkKind;
+use crate::{base58, error};
 
 /// Version bytes for extended public keys on the Bitcoin network.
 const VERSION_BYTES_MAINNET_PUBLIC: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];
@@ -486,7 +487,7 @@ pub enum Error {
     /// Base58 encoding error
     Base58(base58::Error),
     /// Hexadecimal decoding error
-    Hex(hex::HexToArrayError),
+    Hex(error::HexToArrayError),
     /// `PublicKey` hex should be 66 or 130 digits long.
     InvalidPublicKeyHexLength(usize),
 }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -19,7 +19,7 @@ use crate::crypto::key::{CompressedPublicKey, Keypair, PrivateKey};
 use crate::internal_macros::impl_bytes_newtype;
 use crate::prelude::*;
 use crate::network::NetworkKind;
-use crate::{base58, error};
+use crate::error;
 
 /// Version bytes for extended public keys on the Bitcoin network.
 const VERSION_BYTES_MAINNET_PUBLIC: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -30,7 +30,7 @@ use crate::parse::impl_parse_str_from_int_infallible;
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::string::FromHexStr;
 use crate::prelude::*;
-use crate::{Amount, SignedAmount, VarInt};
+use crate::{error, Amount, SignedAmount, VarInt};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[cfg(feature = "bitcoinconsensus")]
@@ -119,7 +119,7 @@ impl fmt::Display for OutPoint {
 #[non_exhaustive]
 pub enum ParseOutPointError {
     /// Error in TXID part.
-    Txid(hex::HexToArrayError),
+    Txid(error::HexToArrayError),
     /// Error in vout part.
     Vout(crate::error::ParseIntError),
     /// Error in general format.
@@ -187,7 +187,7 @@ impl core::str::FromStr for OutPoint {
             return Err(ParseOutPointError::Format);
         }
         Ok(OutPoint {
-            txid: s[..colon].parse().map_err(ParseOutPointError::Txid)?,
+            txid: s[..colon].parse().map_err(error::HexToArrayError).map_err(ParseOutPointError::Txid)?,
             vout: parse_vout(&s[colon + 1..])?,
         })
     }
@@ -1670,17 +1670,19 @@ mod tests {
         );
         assert_eq!(
             OutPoint::from_str("i don't care:1"),
-            Err(ParseOutPointError::Txid("i don't care".parse::<Txid>().unwrap_err()))
+            Err(ParseOutPointError::Txid(
+                error::HexToArrayError("i don't care".parse::<Txid>().unwrap_err())))
         );
         assert_eq!(
             OutPoint::from_str(
                 "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X:1"
             ),
             Err(ParseOutPointError::Txid(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X"
-                    .parse::<Txid>()
-                    .unwrap_err()
-            ))
+                error::HexToArrayError(
+                    "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X"
+                        .parse::<Txid>()
+                        .unwrap_err()
+                )))
         );
         assert_eq!(
             OutPoint::from_str(

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1944,6 +1944,10 @@ mod tests {
             format!("{:x}", tx.compute_txid()),
             "9652aa62b0e748caeec40c4cb7bc17c6792435cc3dfe447dd1ca24f912a1c6ec"
         );
+        assert_eq!(
+            format!("{:.10x}", tx.compute_txid()),
+            "9652aa62b0"
+        );
         assert_eq!(tx.weight(), Weight::from_wu(2718));
 
         // non-segwit tx from my mempool

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -506,18 +506,19 @@ impl<'de> serde::Deserialize<'de> for Witness {
 
                 while let Some(elem) = a.next_element::<String>()? {
                     let vec = Vec::<u8>::from_hex(&elem).map_err(|e| match e {
-                        InvalidChar(b) => match core::char::from_u32(b.into()) {
+                        InvalidChar(ref e) => match core::char::from_u32(e.invalid_char(
+                        ).into()) {
                             Some(c) => de::Error::invalid_value(
                                 Unexpected::Char(c),
                                 &"a valid hex character",
                             ),
                             None => de::Error::invalid_value(
-                                Unexpected::Unsigned(b.into()),
+                                Unexpected::Unsigned(e.invalid_char().into()),
                                 &"a valid hex character",
                             ),
                         },
-                        OddLengthString(len) =>
-                            de::Error::invalid_length(len, &"an even length string"),
+                        OddLengthString(ref e) =>
+                            de::Error::invalid_length(e.length(), &"an even length string"),
                     })?;
                     ret.push(vec);
                 }

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -71,11 +71,11 @@ pub mod hex {
 
     /// Hex byte encoder.
     // We wrap `BufEncoder` to not leak internal representation.
-    pub struct Encoder<C: Case>(BufEncoder<[u8; HEX_BUF_SIZE]>, PhantomData<C>);
+    pub struct Encoder<C: Case>(BufEncoder<{ HEX_BUF_SIZE }>, PhantomData<C>);
 
     impl<C: Case> From<super::Hex<C>> for Encoder<C> {
         fn from(_: super::Hex<C>) -> Self {
-            Encoder(BufEncoder::new([0; HEX_BUF_SIZE]), Default::default())
+            Encoder(BufEncoder::new(), Default::default())
         }
     }
 
@@ -100,15 +100,15 @@ pub mod hex {
     // Newtypes to hide internal details.
 
     /// Error returned when a hex string decoder can't be created.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct DecodeInitError(hex::HexToBytesError);
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct DecodeInitError(hex::OddLengthStringError);
 
     /// Error returned when a hex string contains invalid characters.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct DecodeError(hex::HexToBytesError);
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct DecodeError(hex::InvalidCharError);
 
     /// Hex decoder state.
-    pub struct Decoder<'a>(hex::HexToBytesIter<'a>);
+    pub struct Decoder<'a>(hex::HexSliceToBytesIter<'a>);
 
     impl<'a> Decoder<'a> {
         fn new(s: &'a str) -> Result<Self, DecodeInitError> {
@@ -137,29 +137,19 @@ pub mod hex {
 
     impl super::IntoDeError for DecodeInitError {
         fn into_de_error<E: serde::de::Error>(self) -> E {
-            use hex::HexToBytesError;
-
-            match self.0 {
-                HexToBytesError::OddLengthString(len) =>
-                    E::invalid_length(len, &"an even number of ASCII-encoded hex digits"),
-                error => panic!("unexpected error: {:?}", error),
-            }
+            E::invalid_length(self.0.length(), &"an even number of ASCII-encoded hex digits")
         }
     }
 
     impl super::IntoDeError for DecodeError {
         fn into_de_error<E: serde::de::Error>(self) -> E {
-            use hex::HexToBytesError;
             use serde::de::Unexpected;
 
             const EXPECTED_CHAR: &str = "an ASCII-encoded hex digit";
 
-            match self.0 {
-                HexToBytesError::InvalidChar(c) if c.is_ascii() =>
-                    E::invalid_value(Unexpected::Char(c as _), &EXPECTED_CHAR),
-                HexToBytesError::InvalidChar(c) =>
-                    E::invalid_value(Unexpected::Unsigned(c.into()), &EXPECTED_CHAR),
-                error => panic!("unexpected error: {:?}", error),
+            match self.0.invalid_char() {
+                c if c.is_ascii() => E::invalid_value(Unexpected::Char(c as _), &EXPECTED_CHAR),
+                c => E::invalid_value(Unexpected::Unsigned(c.into()), &EXPECTED_CHAR),
             }
         }
     }

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -11,6 +11,7 @@ use hex::FromHex;
 use internals::write_err;
 use io::Write;
 
+use crate::error;
 use crate::prelude::*;
 use crate::script::PushBytes;
 use crate::sighash::{EcdsaSighashType, NonStandardSighashTypeError};
@@ -85,7 +86,7 @@ impl FromStr for Signature {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = Vec::from_hex(s)?;
+        let bytes = Vec::from_hex(s).map_err(error::HexToBytesError)?;
         let (sighash_byte, signature) = bytes.split_last().ok_or(Error::EmptySignature)?;
         Ok(Signature {
             signature: secp256k1::ecdsa::Signature::from_der(signature)?,
@@ -204,7 +205,7 @@ impl<'a> IntoIterator for &'a SerializedSignature {
 #[non_exhaustive]
 pub enum Error {
     /// Hex decoding error.
-    Hex(hex::HexToBytesError),
+    Hex(error::HexToBytesError),
     /// Non-standard sighash type.
     SighashType(NonStandardSighashTypeError),
     /// Signature was empty.
@@ -248,8 +249,8 @@ impl From<NonStandardSighashTypeError> for Error {
     fn from(e: NonStandardSighashTypeError) -> Self { Self::SighashType(e) }
 }
 
-impl From<hex::HexToBytesError> for Error {
-    fn from(e: hex::HexToBytesError) -> Self { Self::Hex(e) }
+impl From<error::HexToBytesError> for Error {
+    fn from(e: error::HexToBytesError) -> Self { Self::Hex(e) }
 }
 
 #[cfg(test)]

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -241,15 +241,15 @@ impl std::error::Error for Error {
 }
 
 impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
 }
 
 impl From<NonStandardSighashTypeError> for Error {
-    fn from(err: NonStandardSighashTypeError) -> Self { Error::SighashType(err) }
+    fn from(e: NonStandardSighashTypeError) -> Self { Self::SighashType(e) }
 }
 
 impl From<hex::HexToBytesError> for Error {
-    fn from(err: hex::HexToBytesError) -> Self { Error::Hex(err) }
+    fn from(e: hex::HexToBytesError) -> Self { Self::Hex(e) }
 }
 
 #[cfg(test)]

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1007,7 +1007,7 @@ pub enum ParseCompressedPublicKeyError {
     /// Secp256k1 Error.
     Secp256k1(secp256k1::Error),
     /// hex to array conversion error.
-    HexError(hex::HexToArrayError),
+    Hex(hex::HexToArrayError),
 }
 
 impl fmt::Display for ParseCompressedPublicKeyError {
@@ -1015,7 +1015,7 @@ impl fmt::Display for ParseCompressedPublicKeyError {
         use ParseCompressedPublicKeyError::*;
         match self {
             Secp256k1(e) => write_err!(f, "secp256k1 error"; e),
-            HexError(e) => write_err!(f, "invalid hex"; e)
+            Hex(e) => write_err!(f, "invalid hex"; e)
         }
     }
 }
@@ -1027,7 +1027,7 @@ impl std::error::Error for ParseCompressedPublicKeyError {
 
         match self {
             Secp256k1(e) => Some(e),
-            HexError(e) => Some(e),
+            Hex(e) => Some(e),
         }
     }
 }
@@ -1037,7 +1037,7 @@ impl From<secp256k1::Error> for ParseCompressedPublicKeyError {
 }
 
 impl From<hex::HexToArrayError> for ParseCompressedPublicKeyError {
-    fn from(e: hex::HexToArrayError) -> Self { Self::HexError(e) }
+    fn from(e: hex::HexToArrayError) -> Self { Self::Hex(e) }
 }
 
 /// Segwit public keys must always be compressed.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -921,7 +921,7 @@ impl std::error::Error for FromSliceError {
 }
 
 impl From<secp256k1::Error> for FromSliceError {
-    fn from(e: secp256k1::Error) -> FromSliceError { Self::Secp256k1(e) }
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
 }
 
 /// Error generated from WIF key format.
@@ -956,11 +956,11 @@ impl std::error::Error for FromWifError {
 }
 
 impl From<base58::Error> for FromWifError {
-    fn from(e: base58::Error) -> FromWifError { Self::Base58(e) }
+    fn from(e: base58::Error) -> Self { Self::Base58(e) }
 }
 
 impl From<secp256k1::Error> for FromWifError {
-    fn from(e: secp256k1::Error) -> FromWifError { Self::Secp256k1(e) }
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
 }
 
 /// Error returned while constructing public key from string.
@@ -1033,11 +1033,11 @@ impl std::error::Error for ParseCompressedPublicKeyError {
 }
 
 impl From<secp256k1::Error> for ParseCompressedPublicKeyError {
-    fn from(e: secp256k1::Error) -> ParseCompressedPublicKeyError { Self::Secp256k1(e) }
+    fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
 }
 
 impl From<hex::HexToArrayError> for ParseCompressedPublicKeyError {
-    fn from(e: hex::HexToArrayError) -> ParseCompressedPublicKeyError { Self::HexError(e) }
+    fn from(e: hex::HexToArrayError) -> Self { Self::HexError(e) }
 }
 
 /// Segwit public keys must always be compressed.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -21,6 +21,7 @@ use crate::internal_macros::impl_asref_push_bytes;
 use crate::network::NetworkKind;
 use crate::prelude::*;
 use crate::taproot::{TapNodeHash, TapTweakHash};
+use crate::{base58, error, io};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};
@@ -355,7 +356,8 @@ impl FromStr for CompressedPublicKey {
     type Err = ParseCompressedPublicKeyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        CompressedPublicKey::from_slice(&<[u8; 33]>::from_hex(s)?).map_err(Into::into)
+        CompressedPublicKey::from_slice(&<[u8; 33]>::from_hex(s).map_err(error::HexToArrayError)?)
+            .map_err(Into::into)
     }
 }
 
@@ -1007,7 +1009,7 @@ pub enum ParseCompressedPublicKeyError {
     /// Secp256k1 Error.
     Secp256k1(secp256k1::Error),
     /// hex to array conversion error.
-    Hex(hex::HexToArrayError),
+    Hex(error::HexToArrayError),
 }
 
 impl fmt::Display for ParseCompressedPublicKeyError {
@@ -1036,8 +1038,8 @@ impl From<secp256k1::Error> for ParseCompressedPublicKeyError {
     fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
 }
 
-impl From<hex::HexToArrayError> for ParseCompressedPublicKeyError {
-    fn from(e: hex::HexToArrayError) -> Self { Self::Hex(e) }
+impl From<error::HexToArrayError> for ParseCompressedPublicKeyError {
+    fn from(e: error::HexToArrayError) -> Self { Self::Hex(e) }
 }
 
 /// Segwit public keys must always be compressed.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -21,7 +21,7 @@ use crate::internal_macros::impl_asref_push_bytes;
 use crate::network::NetworkKind;
 use crate::prelude::*;
 use crate::taproot::{TapNodeHash, TapTweakHash};
-use crate::{base58, error, io};
+use crate::error;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -2,6 +2,38 @@
 
 //! Contains error types and other error handling tools.
 
+use core::fmt;
+
+use internals::write_err;
+
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use crate::parse::ParseIntError;
+
+/// Error converting hex to bytes.
+// Intentionally opaque so as to hide `hex` from the public API - do not make the inner error pub.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HexToBytesError(pub(crate) hex::HexToBytesError);
+
+impl fmt::Display for HexToBytesError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write_err!(f, "hex to bytes"; self.0) }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HexToBytesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
+/// Error converting hex to an array.
+// Intentionally opaque so as to hide `hex` from the public API - do not make the inner error pub.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HexToArrayError(pub(crate) hex::HexToArrayError);
+
+impl fmt::Display for HexToArrayError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write_err!(f, "hex to array"; self.0) }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HexToArrayError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -68,7 +68,7 @@ pub extern crate base58;
 pub extern crate hashes;
 
 /// Re-export the `hex-conservative` crate.
-pub extern crate hex;
+extern crate hex;
 
 /// Re-export the `bitcoin-io` crate.
 pub extern crate io;

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1025,7 +1025,7 @@ mod tests {
 
     #[track_caller]
     pub fn hex_psbt(s: &str) -> Result<Psbt, crate::psbt::error::Error> {
-        let r: Result<Vec<u8>, hex::HexToBytesError> = Vec::from_hex(s);
+        let r = Vec::from_hex(s);
         match r {
             Err(_e) => panic!("unable to parse hex string {}", s),
             Ok(v) => Psbt::deserialize(&v),

--- a/bitcoin/src/taproot/serialized_signature.rs
+++ b/bitcoin/src/taproot/serialized_signature.rs
@@ -28,8 +28,8 @@ impl fmt::Debug for SerializedSignature {
 
 impl fmt::Display for SerializedSignature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf = [0u8; MAX_LEN * 2];
-        let mut encoder = hex::buf_encoder::BufEncoder::new(&mut buf);
+        const HEX_LEN: usize = MAX_LEN * 2;
+        let mut encoder = hex::buf_encoder::BufEncoder::<HEX_LEN>::new();
         encoder.put_bytes(self, hex::Case::Lower);
         f.pad_integral(true, "0x", encoder.as_str())
     }

--- a/bitcoin/tests/psbt.rs
+++ b/bitcoin/tests/psbt.rs
@@ -4,11 +4,12 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
+use hex::FromHex;
+
 use bitcoin::bip32::{Fingerprint, IntoDerivationPath, KeySource, Xpriv, Xpub};
 use bitcoin::blockdata::opcodes::OP_0;
 use bitcoin::blockdata::{script, transaction};
 use bitcoin::consensus::encode::{deserialize, serialize_hex};
-use bitcoin::hex::FromHex;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::script::PushBytes;
 use bitcoin::secp256k1::Secp256k1;

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
 
 bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
 schemars = { version = "0.8.3", default-features = false, optional = true }

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Contains error types and other error handling tools.
+
+use core::fmt;
+
+/// Error converting hex to an array.
+// Intentionally opaque so as to hide `hex` from the public API - do not make the inner error pub.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HexToArrayError(pub(crate) hex::HexToArrayError);
+
+impl fmt::Display for HexToArrayError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write_err!(f, "hex to array"; self.0) }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HexToArrayError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
+/// Formats error.
+///
+/// If `std` feature is OFF appends error source (delimited by `: `). We do this because
+/// `e.source()` is only available in std builds, without this macro the error source is lost for
+/// no-std builds.
+macro_rules! write_err {
+    ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
+        {
+            #[cfg(feature = "std")]
+            {
+                let _ = &$source;   // Prevents clippy warnings.
+                write!($writer, $string $(, $args)*)
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
+            }
+        }
+    }
+}
+pub(crate) use write_err;

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -89,15 +89,13 @@ macro_rules! hash_trait_impls {
         impl<$($gen: $gent),*> str::FromStr for Hash<$($gen),*> {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<Self, Self::Err> {
-                use $crate::hex::{FromHex, HexToBytesIter};
-                use $crate::Hash;
+                use $crate::{Hash, hex::{FromHex}};
 
-                let inner: [u8; $bits / 8] = if $reverse {
-                    FromHex::from_byte_iter(HexToBytesIter::new(s)?.rev())?
-                } else {
-                    FromHex::from_byte_iter(HexToBytesIter::new(s)?)?
-                };
-                Ok(Self::from_byte_array(inner))
+                let mut bytes = <[u8; $bits / 8]>::from_hex(s)?;
+                if $reverse {
+                    bytes.reverse();
+                }
+                Ok(Self::from_byte_array(bytes))
             }
         }
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -71,22 +71,6 @@ pub(crate) use arr_newtype_fmt_impl;
 macro_rules! hash_trait_impls {
     ($bits:expr, $reverse:expr $(, $gen:ident: $gent:ident)*) => {
         impl<$($gen: $gent),*> Hash<$($gen),*> {
-            /// Displays hex forwards, regardless of how this type would display it naturally.
-            ///
-            /// This is mainly intended as an internal method and you shouldn't need it unless
-            /// you're doing something special.
-            pub fn forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex {
-                $crate::hex::DisplayHex::as_hex(&self.0)
-            }
-
-            /// Displays hex backwards, regardless of how this type would display it naturally.
-            ///
-            /// This is mainly intended as an internal method and you shouldn't need it unless
-            /// you're doing something special.
-            pub fn backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex {
-                $crate::hex::display::DisplayArray::<_, [u8; $bits / 8 * 2]>::new(self.0.iter().rev())
-            }
-
             /// Zero cost conversion between a fixed length byte array shared reference and
             /// a shared reference to this Hash type.
             pub fn from_bytes_ref(bytes: &[u8; $bits / 8]) -> &Self {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -115,6 +115,7 @@ mod util;
 #[macro_use]
 pub mod serde_macros;
 pub mod cmp;
+pub mod error;
 pub mod hash160;
 pub mod hmac;
 #[cfg(feature = "bitcoin-io")]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -273,4 +273,12 @@ mod tests {
         let h2: TestNewtype = h.to_string().parse().unwrap();
         assert_eq!(h2.to_raw_hash(), h);
     }
+
+    #[test]
+    fn newtype_fmt_roundtrip() {
+        let orig = TestNewtype::hash(&[]);
+        let hex = format!("{}", orig);
+        let rinsed = hex.parse::<TestNewtype>().expect("failed to parse hex");
+        assert_eq!(rinsed, orig)
+    }
 }

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -11,7 +11,7 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};
 
-use crate::{sha256d, FromSliceError, HashEngine as _};
+use crate::{error, hex, sha256d, FromSliceError, HashEngine as _};
 
 crate::internal_macros::hash_type! {
     256,
@@ -127,8 +127,10 @@ impl<I: SliceIndex<[u8]>> Index<I> for Midstate {
 }
 
 impl str::FromStr for Midstate {
-    type Err = hex::HexToArrayError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> { hex::FromHex::from_hex(s) }
+    type Err = error::HexToArrayError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        hex::FromHex::from_hex(s).map_err(error::HexToArrayError)
+    }
 }
 
 impl Midstate {

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -884,6 +884,15 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
+    fn fmt_roundtrips() {
+        let hash = sha256::Hash::hash(b"some arbitrary bytes");
+        let hex = format!("{}", hash);
+        let rinsed = hex.parse::<sha256::Hash>().expect("failed to parse hex");
+        assert_eq!(rinsed, hash)
+    }
+
+    #[test]
     #[rustfmt::skip]
     fn midstate() {
         // Test vector obtained by doing an asset issuance on Elements
@@ -988,6 +997,14 @@ mod tests {
                 243, 147, 108, 71, 99, 110, 96, 125, 179, 62, 234, 221, 198, 240, 201,
             ])
         )
+    }
+
+    #[test]
+    fn midstate_fmt_roundtrip() {
+        let midstate = Midstate::hash_tag(b"ArbitraryTag");
+        let hex = format!("{}", midstate);
+        let rinsed = hex.parse::<Midstate>().expect("failed to parse hex");
+        assert_eq!(rinsed, midstate)
     }
 
     #[cfg(feature = "serde")]

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -817,7 +817,8 @@ impl HashEngine {
 
 #[cfg(test)]
 mod tests {
-    use crate::{sha256, Hash, HashEngine};
+    use crate::{sha256, Hash as _, HashEngine};
+    use super::*;
 
     #[test]
     #[cfg(feature = "alloc")]
@@ -964,14 +965,14 @@ mod tests {
 
     #[test]
     fn const_hash() {
-        assert_eq!(super::Hash::hash(&[]), super::Hash::const_hash(&[]));
+        assert_eq!(Hash::hash(&[]), Hash::const_hash(&[]));
 
         let mut bytes = Vec::new();
         for i in 0..256 {
             bytes.push(i as u8);
             assert_eq!(
-                super::Hash::hash(&bytes),
-                super::Hash::const_hash(&bytes),
+                Hash::hash(&bytes),
+                Hash::const_hash(&bytes),
                 "hashes don't match for length {}",
                 i + 1
             );
@@ -980,8 +981,6 @@ mod tests {
 
     #[test]
     fn const_midstate() {
-        use super::Midstate;
-
         assert_eq!(
             Midstate::hash_tag(b"TapLeaf"),
             Midstate([

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -176,15 +176,13 @@ impl Midstate {
 }
 
 impl hex::FromHex for Midstate {
-    type Err = hex::HexToArrayError;
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
-    where
-        I: Iterator<Item = Result<u8, hex::HexToBytesError>>
-            + ExactSizeIterator
-            + DoubleEndedIterator,
-    {
+    type Error = hex::HexToArrayError;
+
+    fn from_hex(s: &str) -> Result<Self, Self::Error> {
         // DISPLAY_BACKWARD is true
-        Ok(Midstate::from_byte_array(hex::FromHex::from_byte_iter(iter.rev())?))
+        let mut bytes = <[u8; 32]>::from_hex(s)?;
+        bytes.reverse();
+        Ok(Midstate(bytes))
     }
 }
 

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -11,7 +11,7 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};
 
-use crate::{error, hex, sha256d, FromSliceError, HashEngine as _};
+use crate::{error, sha256d, FromSliceError, HashEngine as _};
 
 crate::internal_macros::hash_type! {
     256,

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -30,10 +30,12 @@ fn from_engine(e: sha256::HashEngine) -> Hash {
 
 #[cfg(test)]
 mod tests {
+    use crate::{sha256d, Hash as _};
+
     #[test]
     #[cfg(feature = "alloc")]
     fn test() {
-        use crate::{sha256, sha256d, Hash, HashEngine};
+        use crate::{sha256, HashEngine};
 
         #[derive(Clone)]
         struct Test {
@@ -81,12 +83,18 @@ mod tests {
         }
     }
 
+    #[test]
+    fn fmt_roundtrips() {
+        let hash = sha256d::Hash::hash(b"some arbitrary bytes");
+        let hex = format!("{}", hash);
+        let rinsed = hex.parse::<sha256d::Hash>().expect("failed to parse hex");
+        assert_eq!(rinsed, hash)
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn sha256_serde() {
         use serde_test::{assert_tokens, Configure, Token};
-
-        use crate::{sha256d, Hash};
 
         #[rustfmt::skip]
         static HASH_BYTES: [u8; 32] = [

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -3,17 +3,19 @@
 #[macro_export]
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
 macro_rules! hex_fmt_impl(
-    ($reverse:expr, $ty:ident) => (
-        $crate::hex_fmt_impl!($reverse, $ty, );
+    ($reverse:expr, $len:expr, $ty:ident) => (
+        $crate::hex_fmt_impl!($reverse, $len, $ty, );
     );
-    ($reverse:expr, $ty:ident, $($gen:ident: $gent:ident),*) => (
+    ($reverse:expr, $len:expr, $ty:ident, $($gen:ident: $gent:ident),*) => (
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::LowerHex for $ty<$($gen),*> {
             #[inline]
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
+                use $crate::Hash as _;
+
                 if $reverse {
-                    $crate::_export::_core::fmt::LowerHex::fmt(&self.0.backward_hex(), f)
+                    $crate::hex::fmt_hex_exact!(f, $len, self.as_byte_array().iter().rev(), $crate::hex::Case::Lower)
                 } else {
-                    $crate::_export::_core::fmt::LowerHex::fmt(&self.0.forward_hex(), f)
+                    $crate::hex::fmt_hex_exact!(f, $len, self.as_byte_array().iter(), $crate::hex::Case::Lower)
                 }
             }
         }
@@ -21,10 +23,12 @@ macro_rules! hex_fmt_impl(
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::UpperHex for $ty<$($gen),*> {
             #[inline]
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
+                use $crate::Hash as _;
+
                 if $reverse {
-                    $crate::_export::_core::fmt::UpperHex::fmt(&self.0.backward_hex(), f)
+                    $crate::hex::fmt_hex_exact!(f, $len, self.as_byte_array().iter().rev(), $crate::hex::Case::Upper)
                 } else {
-                    $crate::_export::_core::fmt::UpperHex::fmt(&self.0.forward_hex(), f)
+                    $crate::hex::fmt_hex_exact!(f, $len, self.as_byte_array().iter(), $crate::hex::Case::Upper)
                 }
             }
         }
@@ -188,7 +192,7 @@ macro_rules! hash_newtype {
             $({ $($type_attrs)* })*
         }
 
-        $crate::hex_fmt_impl!(<$newtype as $crate::Hash>::DISPLAY_BACKWARD, $newtype);
+        $crate::hex_fmt_impl!(<$newtype as $crate::Hash>::DISPLAY_BACKWARD, <$newtype as $crate::Hash>::LEN, $newtype);
         $crate::serde_impl!($newtype, <$newtype as $crate::Hash>::LEN);
         $crate::borrow_slice_impl!($newtype);
 

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -274,15 +274,13 @@ macro_rules! hash_newtype {
         impl $crate::_export::_core::str::FromStr for $newtype {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<$newtype, Self::Err> {
-                use $crate::hex::{FromHex, HexToBytesIter};
-                use $crate::Hash;
+                use $crate::{Hash, hex::FromHex};
 
-                let inner: <$hash as Hash>::Bytes = if <Self as $crate::Hash>::DISPLAY_BACKWARD {
-                    FromHex::from_byte_iter(HexToBytesIter::new(s)?.rev())?
-                } else {
-                    FromHex::from_byte_iter(HexToBytesIter::new(s)?)?
+                let mut bytes = <[u8; <Self as $crate::Hash>::LEN]>::from_hex(s)?;
+                if <Self as $crate::Hash>::DISPLAY_BACKWARD {
+                    bytes.reverse();
                 };
-                Ok($newtype(<$hash>::from_byte_array(inner)))
+                Ok($newtype(<$hash>::from_byte_array(bytes)))
             }
         }
 


### PR DESCRIPTION
Done on top of #2473. This PR is the last 4 patches.

Incomplete, still have to handle the `hash_newtype` stuff discussed below.

Attempt to fully encapsualte the `hex` crate, I say "attempt" because `hex_conservative` still shows up in the sidebar under "crates" heading when I build docs locally.