### PR TITLE
io: Remove blanket trait impls

### DIFF
--- a/io/src/macros.rs
+++ b/io/src/macros.rs
@@ -45,5 +45,16 @@ macro_rules! impl_write {
                 $flush_fn(self)
             }
         }
+
+        impl<$($bounded_ty: $bounds),*> $crate::Write for $ty {
+            #[inline]
+            fn write(&mut self, buf: &[u8]) -> $crate::Result<usize> {
+                $write_fn(self, buf)
+            }
+            #[inline]
+            fn flush(&mut self) -> $crate::Result<()> {
+                $flush_fn(self)
+            }
+        }
     }
 }


### PR DESCRIPTION
Remove the blanket impls of `Read`, `BufRead`, and `Write`. Replace them with just the impls required to get `rust-bitcoin` building.

Note, the `TcpStream` stuff is used in `examples/handshake.rs`.

Fix: #2432