### PR TITLE
Remove broken kani test

### DIFF
--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1742,11 +1742,12 @@ mod verification {
         let _ = x.mul_u64(y);
     }
 
-    #[kani::unwind(5)]   // I can't remember exactly why we need this.
+    #[kani::unwind(5)]          // Same as above.
     #[kani::proof]
     fn check_div_rem() {
         let x: U256 = kani::any();
         let y: U256 = kani::any();
+        kani::assume(x < U256::from(u128::MAX) && y < U256::from(u128::MAX) && y != U256::ZERO);
 
         assert_eq!(x * y / y, x);
     }


### PR DESCRIPTION
Recently we added a kani test that doesn't work because of `debug_assert` calls in ops traits.

Instead of opening the can of worms that is correct panic behaviour in ops lets just remove the test.