### PR TITLE
Remove broken kani test

### DIFF
--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1741,14 +1741,4 @@ mod verification {
 
         let _ = x.mul_u64(y);
     }
-
-    #[kani::unwind(5)]          // Same as above.
-    #[kani::proof]
-    fn check_div_rem() {
-        let x: U256 = kani::any();
-        let y: U256 = kani::any();
-        kani::assume(x < U256::from(u128::MAX) && y < U256::from(u128::MAX) && y != U256::ZERO);
-
-        assert_eq!(x * y / y, x);
-    }
 }


### PR DESCRIPTION
This test is failing. I do not want to dive back into kani right now, just remove it.

This is what I originally did in #2454 but changed directions and tried to fix it. Running kani test takes ages and I'd need to dig back to refresh my memory to work with kani. I don't have the motivation to do that at the moment. Just remove the test.

FTR I added the test recently without fulling thinking it through and it has never passed so we are not loosing any coverage. Doing this was the original mistake I should not have made.