### PR TITLE
Deprecate the psbt module

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -107,6 +107,7 @@ pub mod merkle_tree;
 pub mod network;
 pub mod policy;
 pub mod pow;
+#[deprecated(since = "TBD", note = "use https://crates.io/crates/psbt-v2 instead")]
 pub mod psbt;
 pub mod sign_message;
 pub mod string;


### PR DESCRIPTION
The newly released `psbt_v2` crate has a `v0` module that is a direct import of code from the `pbst` module of `rust-bitcoin 0.31.0` (and the same module from `rust-miniscript `v11.0.0`).
    
- `psbt_v2::v0::bitcoin` is the `bitcoin::psbt` module.
- `psbt_v2::v0::miniscript` is the `miniscript::psbt` module.
    
For completeness I ported `bdk` over to verify the fact that downstream users can just drop `psbt_v2::v0::Psbt` straight into their code by simply adding a dependency and updating all import paths.

I propose that we deprecate the `psbt` module (then remove it after next release as we do for other deprecated code). We will have to do another release of `psbt_v2` with any code that has been merged into the `v0.32.0` release.

If this gains traction we can do the same in `rust-miniscript`. I look forward to the all red diffs :)