### PR TITLE
Improve taproot builder conversion errors

### DIFF
--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -93,7 +93,7 @@ pub enum Error {
     /// Parsing error indicating a taproot error
     Taproot(&'static str),
     /// Taproot tree deserilaization error
-    TapTree(crate::taproot::IncompleteBuilderError),
+    TapTree(crate::taproot::IntoTapTreeError),
     /// Error related to an xpub key
     XPubKey(&'static str),
     /// Error related to PSBT version


### PR DESCRIPTION
The two conversion functions on `TaprootBuilder` currently return the same error type even though it contains a variant that cannot be returned for `try_into_node_info`.

Split the error up in the customary fashion.

Please note this PR shows a new favouring of named fields in struct errors instead of using a tuple struct. The struct has a single public field so `non_exhaustive` is used.

EDIT: Note also that this PR attempts to clear up the terminology used around "finalized" and "complete" - please holla if you think I am incorrect here. 