### PR TITLE
units: Implement ops::Neg for SignedAmount

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1328,6 +1328,12 @@ impl ops::DivAssign<i64> for SignedAmount {
     fn div_assign(&mut self, rhs: i64) { *self = *self / rhs }
 }
 
+impl ops::Neg for SignedAmount {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output { Self(self.0.neg()) }
+}
+
 impl FromStr for SignedAmount {
     type Err = ParseError;
 


### PR DESCRIPTION
Its useful to be able to do `let x = -btc_amount;`

Implement `core::ops::Neg for SignedAmount`, returning a `SignedAmount`.

Fix: #2470