### PR TITLE
Add unchecked arithmetic to weight

### DIFF
--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -120,6 +120,20 @@ impl Weight {
     /// Computes `self / rhs` returning `None` if `rhs == 0`.
     pub fn checked_div(self, rhs: u64) -> Option<Self> { self.0.checked_div(rhs).map(Self) }
 
+    /// Unchecked addition.
+    ///
+    /// Computes `self + rhs`.  Panics in debug mode, wraps in release mode.
+    pub fn unchecked_add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
+
+    /// Unchecked subtraction.
+    ///
+    /// Computes `self - rhs`.  Panics in debug mode, wraps in release mode.
+    pub fn unchecked_sub(self, rhs: Self) -> Self {
+        Self(self.0 - rhs.0)
+    }
+
     /// Scale by witness factor.
     ///
     /// Computes `self * WITNESS_SCALE_FACTOR` returning `None` if an overflow occurred.
@@ -230,6 +244,20 @@ mod tests {
 
         let result = Weight::MIN.checked_sub(Weight(1));
         assert_eq!(None, result);
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn unchecked_weight_add() {
+        let w = Weight::MAX.unchecked_add(Weight::from_wu(1));
+        assert_eq!(w, Weight::ZERO);
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn unchecked_weight_sub() {
+        let w = Weight::ZERO.unchecked_sub(Weight::from_wu(1));
+        assert_eq!(w, Weight::MAX);
     }
 
     #[test]

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -864,6 +864,20 @@ impl Amount {
     /// Returns [None] if overflow occurred.
     pub fn checked_rem(self, rhs: u64) -> Option<Amount> { self.0.checked_rem(rhs).map(Amount) }
 
+    /// Unchecked addition.
+    ///
+    /// Computes `self + rhs`.  Panics in debug mode, wraps in release mode.
+    pub fn unchecked_add(self, rhs: Amount) -> Amount {
+        Self(self.0 + rhs.0)
+    }
+
+    /// Unchecked subtraction.
+    ///
+    /// Computes `self - rhs`.  Panics in debug mode, wraps in release mode.
+    pub fn unchecked_sub(self, rhs: Amount) -> Amount {
+        Self(self.0 - rhs.0)
+    }
+
     /// Convert to a signed amount.
     pub fn to_signed(self) -> Result<SignedAmount, ParseAmountError> {
         if self.to_sat() > SignedAmount::MAX.to_sat() as u64 {
@@ -1227,6 +1241,20 @@ impl SignedAmount {
     /// Returns [None] if overflow occurred.
     pub fn checked_rem(self, rhs: i64) -> Option<SignedAmount> {
         self.0.checked_rem(rhs).map(SignedAmount)
+    }
+
+    /// Unchecked addition.
+    ///
+    /// Computes `self + rhs`.  Panics in debug mode, wraps in release mode.
+    pub fn unchecked_add(self, rhs: SignedAmount) -> SignedAmount {
+        Self(self.0 + rhs.0)
+    }
+
+    /// Unchecked subtraction.
+    ///
+    /// Computes `self - rhs`.  Panics in debug mode, wraps in release mode.
+    pub fn unchecked_sub(self, rhs: SignedAmount) -> SignedAmount {
+        Self(self.0 - rhs.0)
     }
 
     /// Subtraction that doesn't allow negative [SignedAmount]s.
@@ -1876,6 +1904,34 @@ mod tests {
 
         assert_eq!(sat(5).checked_div(2), Some(sat(2))); // integer division
         assert_eq!(ssat(-6).checked_div(2), Some(ssat(-3)));
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn unchecked_amount_add() {
+        let amt = Amount::MAX.unchecked_add(Amount::ONE_SAT);
+        assert_eq!(amt, Amount::ZERO);
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn unchecked_signed_amount_add() {
+        let signed_amt = SignedAmount::MAX.unchecked_add(SignedAmount::ONE_SAT);
+        assert_eq!(signed_amt, SignedAmount::MIN);
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn unchecked_amount_subtract() {
+        let amt = Amount::ZERO.unchecked_sub(Amount::ONE_SAT);
+        assert_eq!(amt, Amount::MAX);
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn unchecked_signed_amount_subtract() {
+        let signed_amt = SignedAmount::MIN.unchecked_sub(SignedAmount::ONE_SAT);
+        assert_eq!(signed_amt, SignedAmount::MAX);
     }
 
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
This PR adds `unchecked_add` and `unchecked_sub` to `Weight`.  Is there any other types that we might like to add `unchecked_` to?  Looking to start a conversation about deliberately adding unchecked to other parts of the API that may be needed.