### PR TITLE
io: Bump version to 0.1.1

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "bitcoin-units"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "bitcoin-units"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -33,7 +33,7 @@ hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = fa
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
 internals = { package = "bitcoin-internals", version = "0.2.0" }
-io = { package = "bitcoin-io", version = "0.1", default-features = false, features = ["alloc"] }
+io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.28.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false, features = ["alloc"] }
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -29,7 +29,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 
-bitcoin-io = { version = "0.1", default-features = false, optional = true }
+bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
 schemars = { version = "0.8.3", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1 - Initial Release - 2023-01-18
+# 0.1.1 - Initial Release - 2024-02-18
 
 Create the `io` crate, add basic I/O traits, types, and implementations.
 
@@ -13,3 +13,7 @@ Types:
 - `Take`
 - `Cursor`
 - `Sink`
+
+# 0.1.0 - Placeholder release
+
+Empty crate to reserve the name on crates.io

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-io"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"


### PR DESCRIPTION
We attempted to release with the current 0.1.0 version forgetting that we had previously released an empty crate with that version to reserve the name on crates.io.

Bump the version to 0.1.1 and release the actual code.