### PR TITLE
Fix CI new build warnings

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -28,7 +28,6 @@
 //!    `bt listunspent`
 //!
 
-use std::boxed::Box;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;

--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -7,7 +7,6 @@ use std::{env, process};
 
 use bitcoin::consensus::{encode, Decodable};
 use bitcoin::p2p::{self, address, message, message_network};
-use bitcoin::secp256k1;
 use bitcoin::secp256k1::rand::Rng;
 
 fn main() {

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -6,7 +6,7 @@ use internals::write_err;
 
 use crate::address::{Address, NetworkUnchecked};
 use crate::blockdata::script::{witness_program, witness_version};
-use crate::prelude::String;
+use crate::prelude::*;
 use crate::{base58, Network};
 
 /// Address error.

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -28,7 +28,6 @@
 
 pub mod error;
 
-use core::convert::{TryFrom, TryInto};
 use core::fmt;
 use core::marker::PhantomData;
 use core::str::FromStr;
@@ -778,13 +777,9 @@ fn segwit_redeem_hash(pubkey_hash: &PubkeyHash) -> crate::hashes::hash160::Hash 
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
     use hex_lit::hex;
-    use secp256k1::XOnlyPublicKey;
 
     use super::*;
-    use crate::crypto::key::PublicKey;
     use crate::network::Network::{Bitcoin, Testnet};
 
     fn roundtrips(addr: &Address, network: Network) {

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -5,7 +5,6 @@
 //! Implementation of compact blocks data structure and algorithms.
 //!
 
-use core::convert::{TryFrom, TryInto};
 use core::{convert, fmt, mem};
 #[cfg(feature = "std")]
 use std::error;
@@ -17,7 +16,7 @@ use io::{BufRead, Write};
 use crate::consensus::encode::{self, Decodable, Encodable, VarInt};
 use crate::internal_macros::{impl_bytes_newtype, impl_consensus_encoding};
 use crate::prelude::*;
-use crate::{block, io, Block, BlockHash, Transaction};
+use crate::{block, Block, BlockHash, Transaction};
 
 /// A BIP-152 error
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -379,7 +378,7 @@ mod test {
     use crate::blockdata::transaction;
     use crate::consensus::encode::{deserialize, serialize};
     use crate::{
-        Amount, CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
+        Amount, CompactTarget, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Txid,
         Witness,
     };
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -565,7 +565,6 @@ mod test {
     use serde_json::Value;
 
     use super::*;
-    use crate::blockdata::block::BlockHash;
     use crate::consensus::encode::deserialize;
     use crate::ScriptBuf;
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -6,7 +6,6 @@
 //! at <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>.
 //!
 
-use core::default::Default;
 use core::ops::Index;
 use core::str::FromStr;
 use core::{fmt, slice};
@@ -14,15 +13,13 @@ use core::{fmt, slice};
 use hashes::{hash160, hash_newtype, sha512, Hash, HashEngine, Hmac, HmacEngine};
 use internals::{impl_array_newtype, write_err};
 use io::Write;
-use secp256k1::{self, Secp256k1, XOnlyPublicKey};
-#[cfg(feature = "serde")]
-use serde;
+use secp256k1::{Secp256k1, XOnlyPublicKey};
 
 use crate::base58;
 use crate::crypto::key::{CompressedPublicKey, Keypair, PrivateKey};
 use crate::internal_macros::impl_bytes_newtype;
-use crate::network::NetworkKind;
 use crate::prelude::*;
+use crate::network::NetworkKind;
 
 /// Version bytes for extended public keys on the Bitcoin network.
 const VERSION_BYTES_MAINNET_PUBLIC: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];
@@ -867,10 +864,7 @@ impl From<&Xpub> for XKeyIdentifier {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
     use hex::test_hex_unwrap as hex;
-    use secp256k1::{self, Secp256k1};
 
     use super::ChildNumber::{Hardened, Normal};
     use super::*;

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -7,8 +7,6 @@
 //! single transaction.
 //!
 
-use core::default::Default;
-
 use hashes::{sha256d, Hash};
 use hex_lit::hex;
 use internals::impl_array_newtype;
@@ -189,10 +187,7 @@ mod test {
     use hex::test_hex_unwrap as hex;
 
     use super::*;
-    use crate::blockdata::locktime::absolute;
-    use crate::blockdata::transaction;
     use crate::consensus::encode::serialize;
-    use crate::network::Network;
 
     #[test]
     fn bitcoin_genesis_first_transaction() {

--- a/bitcoin/src/blockdata/fee_rate.rs
+++ b/bitcoin/src/blockdata/fee_rate.rs
@@ -5,9 +5,8 @@
 use core::fmt;
 use core::ops::{Div, Mul};
 
-use super::Weight;
-use crate::prelude::*;
-use crate::Amount;
+use crate::amount::Amount;
+use crate::blockdata::weight::Weight;
 
 /// Represents fee rate.
 ///

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -12,7 +12,6 @@ use core::fmt;
 use mutagen::mutate;
 
 use crate::parse::impl_parse_str_from_int_infallible;
-use crate::prelude::*;
 #[cfg(doc)]
 use crate::relative;
 

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -8,12 +8,9 @@
 
 #![allow(non_camel_case_types)]
 
-use core::convert::From;
 use core::fmt;
 
 use internals::debug_from_display;
-#[cfg(feature = "serde")]
-use serde;
 
 #[cfg(feature = "serde")]
 use crate::prelude::*;

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use core::convert::TryFrom;
 use core::fmt;
 use core::ops::{
     Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use core::default::Default;
 use core::fmt;
 
 use secp256k1::XOnlyPublicKey;

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -60,22 +60,19 @@ pub mod witness_version;
 use alloc::rc::Rc;
 #[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
 use alloc::sync::Arc;
-use core::borrow::{Borrow, BorrowMut};
 use core::cmp::Ordering;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
 
 use hashes::{hash160, sha256};
 use io::{BufRead, Write};
-#[cfg(feature = "serde")]
-use serde;
 
 use crate::blockdata::opcodes::all::*;
 use crate::blockdata::opcodes::{self, Opcode};
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::impl_asref_push_bytes;
 use crate::prelude::*;
-use crate::{io, OutPoint};
+use crate::OutPoint;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -3,6 +3,7 @@
 #[cfg(doc)]
 use core::ops::Deref;
 
+use hex::FromHex;
 use secp256k1::{Secp256k1, Verification};
 
 use crate::blockdata::opcodes::all::*;
@@ -15,8 +16,8 @@ use crate::blockdata::script::{
 use crate::key::{
     PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
 };
-use crate::prelude::*;
 use crate::taproot::TapNodeHash;
+use crate::prelude::*;
 
 /// An owned, growable script.
 ///
@@ -173,8 +174,6 @@ impl ScriptBuf {
 
     /// Creates a [`ScriptBuf`] from a hex string.
     pub fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError> {
-        use hex::FromHex;
-
         let v = Vec::from_hex(s)?;
         Ok(ScriptBuf::from_bytes(v))
     }

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -2,7 +2,6 @@
 
 //! Contains `PushBytes` & co
 
-use core::borrow::{Borrow, BorrowMut};
 use core::ops::{Deref, DerefMut};
 
 #[allow(unused)]
@@ -15,7 +14,6 @@ pub use self::primitive::*;
 /// This module only contains required operations so that outside functions wouldn't accidentally
 /// break invariants. Therefore auditing this module should be sufficient.
 mod primitive {
-    use core::convert::{TryFrom, TryInto};
     use core::ops::{
         Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
     };

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -6,7 +6,6 @@ use hashes::Hash;
 use hex_lit::hex;
 
 use super::*;
-use crate::blockdata::opcodes;
 use crate::consensus::encode::{deserialize, serialize};
 use crate::crypto::key::{PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey};
 use crate::FeeRate;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -11,10 +11,9 @@
 //! This module provides the structures and functions needed to support transactions.
 //!
 
-use core::default::Default;
 use core::{cmp, fmt, str};
 
-use hashes::{self, sha256d, Hash};
+use hashes::{sha256d, Hash};
 use internals::write_err;
 use io::{BufRead, Write};
 
@@ -27,10 +26,10 @@ use crate::blockdata::FeeRate;
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::parse::impl_parse_str_from_int_infallible;
-use crate::prelude::*;
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::string::FromHexStr;
+use crate::prelude::*;
 use crate::{Amount, SignedAmount, VarInt};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -1622,8 +1621,6 @@ mod tests {
 
     use super::*;
     use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
-    use crate::blockdata::locktime::absolute;
-    use crate::blockdata::script::ScriptBuf;
     use crate::consensus::encode::{deserialize, serialize};
     use crate::sighash::EcdsaSighashType;
 

--- a/bitcoin/src/blockdata/weight.rs
+++ b/bitcoin/src/blockdata/weight.rs
@@ -5,8 +5,6 @@
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-use crate::prelude::*;
-
 /// Represents block weight - the weight of a transaction or block.
 ///
 /// This is an integer newtype representing weigth in `wu`. It provides protection against mixing

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -13,8 +13,8 @@ use io::{BufRead, Write};
 use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::crypto::ecdsa;
-use crate::prelude::*;
 use crate::taproot::{self, TAPROOT_ANNEX_PREFIX};
+use crate::prelude::*;
 use crate::{Script, VarInt};
 
 /// The Witness is the data used to unlock bitcoin since the [segwit upgrade].
@@ -545,7 +545,7 @@ impl From<Vec<&[u8]>> for Witness {
 
 #[cfg(test)]
 mod test {
-    use hex::test_hex_unwrap as hex;
+    use hex::{test_hex_unwrap as hex};
 
     use super::*;
     use crate::consensus::{deserialize, serialize};

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -15,7 +15,6 @@
 //! typically big-endian decimals, etc.)
 //!
 
-use core::convert::{From, TryFrom};
 use core::{fmt, mem, u32};
 
 use hashes::{sha256, sha256d, Hash};
@@ -840,13 +839,9 @@ impl Decodable for TapLeafHash {
 
 #[cfg(test)]
 mod tests {
-    use core::fmt;
-    use core::mem::{self, discriminant};
+    use core::mem::discriminant;
 
     use super::*;
-    use crate::consensus::{deserialize_partial, Decodable, Encodable};
-    #[cfg(feature = "std")]
-    use crate::p2p::{message_blockdata::Inventory, Address};
 
     #[test]
     fn serialize_int_test() {

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -10,7 +10,6 @@ use core::{fmt, iter};
 use hex::FromHex;
 use internals::write_err;
 use io::Write;
-use secp256k1;
 
 use crate::prelude::*;
 use crate::script::PushBytes;

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -21,10 +21,10 @@ use crate::internal_macros::impl_asref_push_bytes;
 use crate::network::NetworkKind;
 use crate::prelude::*;
 use crate::taproot::{TapNodeHash, TapTweakHash};
-use crate::{base58, io};
+use crate::base58;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use secp256k1::{self, constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};
+pub use secp256k1::{constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};
 
 #[cfg(feature = "rand-std")]
 pub use secp256k1::rand;
@@ -303,6 +303,7 @@ impl CompressedPublicKey {
         let mut bytes = [0; 33];
 
         reader.read_exact(&mut bytes)?;
+        #[allow(unused_variables)] // e when std not enabled
         Self::from_slice(&bytes).map_err(|e| {
             // Need a static string for no-std io
             #[cfg(feature = "std")]
@@ -1058,14 +1059,8 @@ impl std::error::Error for UncompressedPublicKeyError {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use hex::FromHex;
-    use secp256k1::Secp256k1;
-
     use super::*;
     use crate::address::Address;
-    use crate::network::NetworkKind;
 
     #[test]
     fn test_key_derivation() {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -11,7 +11,6 @@
 //! handle its complexity efficiently. Computing these hashes is as simple as creating
 //! [`SighashCache`] and calling its methods.
 
-use core::borrow::{Borrow, BorrowMut};
 use core::{fmt, str};
 
 use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
@@ -20,8 +19,8 @@ use io::Write;
 
 use crate::blockdata::witness::Witness;
 use crate::consensus::{encode, Encodable};
-use crate::prelude::*;
 use crate::taproot::{LeafVersion, TapLeafHash, TAPROOT_ANNEX_PREFIX};
+use crate::prelude::*;
 use crate::{transaction, Amount, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut};
 
 /// Used for signature hash for invalid use of SIGHASH_SINGLE.
@@ -1432,10 +1431,7 @@ mod tests {
 
     use super::*;
     use crate::blockdata::locktime::absolute;
-    use crate::blockdata::transaction;
     use crate::consensus::deserialize;
-    use crate::crypto::sighash::{LegacySighash, TapSighash};
-    use crate::taproot::TapLeafHash;
 
     extern crate serde_json;
 
@@ -1750,6 +1746,8 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn bip_341_sighash_tests() {
+        use hex::DisplayHex;
+
         fn sighash_deser_numeric<'de, D>(deserializer: D) -> Result<TapSighashType, D::Error>
         where
             D: actual_serde::Deserializer<'de>,
@@ -1765,7 +1763,7 @@ mod tests {
             })
         }
 
-        use secp256k1::{self, SecretKey, XOnlyPublicKey};
+        use secp256k1::{SecretKey, XOnlyPublicKey};
 
         use crate::consensus::serde as con_serde;
         use crate::taproot::{TapNodeHash, TapTweakHash};

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -10,9 +10,9 @@ use core::fmt;
 use internals::write_err;
 use io::Write;
 
-use crate::prelude::*;
 use crate::sighash::{InvalidSighashTypeError, TapSighashType};
 use crate::taproot::serialized_signature::{self, SerializedSignature};
+use crate::prelude::*;
 
 /// A BIP340-341 serialized taproot signature with the corresponding hash type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -143,6 +143,7 @@ pub use crate::{
 };
 
 #[rustfmt::skip]
+#[allow(unused_imports)]
 mod prelude {
     #[cfg(all(not(feature = "std"), not(test)))]
     pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, slice, rc};

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -532,15 +532,11 @@ impl std::error::Error for MerkleBlockError {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "rand-std")]
-    use hashes::Hash;
-    use hex::test_hex_unwrap as hex;
+    use hex::{test_hex_unwrap as hex};
     #[cfg(feature = "rand-std")]
     use secp256k1::rand::prelude::*;
-
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::{Block, Txid};
 
     #[cfg(feature = "rand-std")]
     macro_rules! pmt_tests {

--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use crate::consensus::Params;
 use crate::constants::ChainHash;
 use crate::p2p::Magic;
-use crate::prelude::{String, ToOwned};
+use crate::prelude::*;
 
 /// What kind of network we are on.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -83,7 +83,6 @@ impl Network {
     /// ```rust
     /// use bitcoin::p2p::Magic;
     /// use bitcoin::Network;
-    /// use std::convert::TryFrom;
     ///
     /// assert_eq!(Ok(Network::Bitcoin), Network::try_from(Magic::from_bytes([0xF9, 0xBE, 0xB4, 0xD9])));
     /// assert_eq!(None, Network::from_magic(Magic::from_bytes([0xFF, 0xFF, 0xFF, 0xFF])));
@@ -164,7 +163,6 @@ impl Network {
     /// ```rust
     /// use bitcoin::Network;
     /// use bitcoin::blockdata::constants::ChainHash;
-    /// use std::convert::TryFrom;
     ///
     /// assert_eq!(Ok(Network::Bitcoin), Network::try_from(ChainHash::BITCOIN));
     /// ```
@@ -188,8 +186,6 @@ impl Network {
 pub mod as_core_arg {
     //! Module for serialization/deserialization of network variants into/from Bitcoin Core values
     #![allow(missing_docs)]
-
-    use serde;
 
     use crate::Network;
 

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -13,7 +13,6 @@ use io::{BufRead, Read, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable, ReadExt, VarInt, WriteExt};
 use crate::p2p::ServiceFlags;
-use crate::prelude::*;
 
 /// A message which can be sent on the Bitcoin network
 #[derive(Clone, PartialEq, Eq, Hash)]

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -542,20 +542,20 @@ mod test {
     use hex::test_hex_unwrap as hex;
 
     use super::message_network::{Reject, RejectReason, VersionMessage};
-    use super::{CommandString, NetworkMessage, RawNetworkMessage, *};
+    use super::*;
     use crate::bip152::BlockTransactionsRequest;
-    use crate::blockdata::block::{self, Block};
+    use crate::blockdata::block::Block;
     use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::Transaction;
     use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
-    use crate::p2p::address::{AddrV2, AddrV2Message, Address};
+    use crate::p2p::address::AddrV2;
     use crate::p2p::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};
     use crate::p2p::message_bloom::{BloomFlags, FilterAdd, FilterLoad};
     use crate::p2p::message_compact_blocks::{GetBlockTxn, SendCmpct};
     use crate::p2p::message_filter::{
         CFCheckpt, CFHeaders, CFilter, GetCFCheckpt, GetCFHeaders, GetCFilters,
     };
-    use crate::p2p::{Magic, ServiceFlags};
+    use crate::p2p::ServiceFlags;
 
     fn hash(slice: [u8; 32]) -> Hash { Hash::from_slice(&slice).unwrap() }
 

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -13,8 +13,7 @@ use crate::blockdata::block::BlockHash;
 use crate::blockdata::transaction::{Txid, Wtxid};
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::internal_macros::impl_consensus_encoding;
-use crate::prelude::*;
-use crate::{io, p2p};
+use crate::p2p;
 
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]
@@ -149,7 +148,7 @@ mod tests {
     use hashes::Hash;
     use hex::test_hex_unwrap as hex;
 
-    use super::{GetBlocksMessage, GetHeadersMessage, Vec};
+    use super::{GetBlocksMessage, GetHeadersMessage};
     use crate::consensus::encode::{deserialize, serialize};
 
     #[test]

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -14,7 +14,7 @@ use crate::internal_macros::impl_consensus_encoding;
 use crate::p2p::address::Address;
 use crate::p2p::ServiceFlags;
 use crate::prelude::*;
-use crate::{io, p2p};
+use crate::p2p;
 
 /// Some simple messages
 

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -28,8 +28,8 @@ use internals::{debug_from_display, write_err};
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable};
-use crate::prelude::{Borrow, BorrowMut, String, ToOwned};
-use crate::{io, Network};
+use crate::prelude::*;
+use crate::Network;
 
 #[rustfmt::skip]
 #[doc(inline)]

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -122,7 +122,7 @@ pub(crate) use impl_tryfrom_str_from_int_infallible;
 /// The `Error` type is `ParseIntError`
 macro_rules! impl_parse_str_from_int_infallible {
     ($to:ident, $inner:ident, $fn:ident) => {
-        $crate::parse::impl_tryfrom_str_from_int_infallible!(&str, $to, $inner, $fn; String, $to, $inner, $fn; Box<str>, $to, $inner, $fn);
+        $crate::parse::impl_tryfrom_str_from_int_infallible!(&str, $to, $inner, $fn; $crate::prelude::String, $to, $inner, $fn; $crate::prelude::Box<str>, $to, $inner, $fn);
 
         impl core::str::FromStr for $to {
             type Err = $crate::error::ParseIntError;

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -17,8 +17,8 @@ use crate::blockdata::block::BlockHash;
 use crate::consensus::encode::{self, Decodable, Encodable};
 #[cfg(doc)]
 use crate::consensus::Params;
-use crate::prelude::String;
 use crate::string::FromHexStr;
+use crate::prelude::*;
 use crate::Network;
 
 /// Implement traits and methods shared by `Target` and `Work`.

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -9,7 +9,6 @@ use crate::blockdata::transaction::Transaction;
 use crate::consensus::encode;
 use crate::prelude::*;
 use crate::psbt::raw;
-use crate::{hashes, io};
 
 /// Enum for marking psbt hash error.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-use hashes::{self, hash160, ripemd160, sha256, sha256d};
+use hashes::{hash160, ripemd160, sha256, sha256d};
 use secp256k1::XOnlyPublicKey;
 
 use crate::bip32::KeySource;

--- a/bitcoin/src/psbt/map/output.rs
+++ b/bitcoin/src/psbt/map/output.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 use secp256k1::XOnlyPublicKey;
-use {core, secp256k1};
 
 use crate::bip32::KeySource;
 use crate::blockdata::script::ScriptBuf;

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1009,23 +1009,18 @@ pub use self::display_from_str::PsbtParseError;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use hashes::{hash160, ripemd160, sha256, Hash};
+    use hashes::{hash160, ripemd160, sha256};
     use hex::{test_hex_unwrap as hex, FromHex};
-    use secp256k1::{self, Secp256k1};
     #[cfg(feature = "rand-std")]
     use secp256k1::{All, SecretKey};
 
     use super::*;
-    use crate::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
+    use crate::bip32::ChildNumber;
     use crate::blockdata::locktime::absolute;
     use crate::blockdata::script::ScriptBuf;
-    use crate::blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut};
+    use crate::blockdata::transaction::{self, OutPoint, Sequence, TxIn};
     use crate::blockdata::witness::Witness;
     use crate::network::NetworkKind;
-    use crate::psbt::map::{Input, Output};
-    use crate::psbt::raw;
     use crate::psbt::serialize::{Deserialize, Serialize};
 
     #[track_caller]
@@ -1376,18 +1371,11 @@ mod tests {
     }
 
     mod bip_vectors {
-        use std::collections::BTreeMap;
         #[cfg(feature = "base64")]
         use std::str::FromStr;
 
         use super::*;
-        use crate::blockdata::locktime::absolute;
-        use crate::blockdata::script::ScriptBuf;
-        use crate::blockdata::transaction::{OutPoint, Sequence, Transaction, TxIn, TxOut};
-        use crate::blockdata::witness::Witness;
-        use crate::psbt::map::{Input, Map, Output};
-        use crate::psbt::{raw, Psbt};
-        use crate::sighash::EcdsaSighashType;
+        use crate::psbt::map::Map;
 
         #[test]
         #[should_panic(expected = "InvalidMagic")]

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -7,7 +7,7 @@
 //!
 
 use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
-use secp256k1::{self, XOnlyPublicKey};
+use secp256k1::XOnlyPublicKey;
 
 use super::map::{Input, Map, Output, PsbtSighashType};
 use crate::bip32::{ChildNumber, Fingerprint, KeySource};
@@ -22,7 +22,7 @@ use crate::psbt::{Error, Psbt};
 use crate::taproot::{
     ControlBlock, LeafVersion, TapLeafHash, TapNodeHash, TapTree, TaprootBuilder,
 };
-use crate::{io, VarInt};
+use crate::VarInt;
 /// A trait for serializing a value as raw data for insertion into PSBT
 /// key-value maps.
 pub(crate) trait Serialize {

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -25,7 +25,6 @@ pub mod btreemap_byte_values {
     // NOTE: This module can be exactly copied to use with HashMap.
 
     use hex::FromHex;
-    use serde;
 
     use crate::prelude::*;
 
@@ -93,8 +92,6 @@ pub mod btreemap_as_seq {
     #![allow(missing_docs)]
 
     // NOTE: This module can be exactly copied to use with HashMap.
-
-    use serde;
 
     use crate::prelude::*;
 
@@ -165,8 +162,6 @@ pub mod btreemap_as_seq_byte_values {
     #![allow(missing_docs)]
 
     // NOTE: This module can be exactly copied to use with HashMap.
-
-    use serde;
 
     use crate::prelude::*;
 
@@ -249,7 +244,6 @@ pub mod hex_bytes {
     #![allow(missing_docs)]
 
     use hex::FromHex;
-    use serde;
 
     pub fn serialize<T, S>(bytes: &T, s: S) -> Result<S::Ok, S::Error>
     where

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -24,7 +24,6 @@ mod message_signing {
 
     use hashes::{sha256d, Hash};
     use internals::write_err;
-    use secp256k1;
     use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 
     use crate::address::{Address, AddressType};
@@ -165,7 +164,7 @@ mod message_signing {
         use base64::prelude::{Engine as _, BASE64_STANDARD};
 
         use super::*;
-        use crate::prelude::String;
+        use crate::prelude::*;
 
         impl MessageSignature {
             /// Convert a signature from base64 encoding.

--- a/bitcoin/src/string.rs
+++ b/bitcoin/src/string.rs
@@ -9,7 +9,7 @@ use core::fmt;
 
 use internals::write_err;
 
-use crate::prelude::String;
+use crate::prelude::*;
 
 /// Trait that allows types to be initialized from hex strings
 pub trait FromHexStr: Sized {

--- a/bitcoin/src/taproot/merkle_branch.rs
+++ b/bitcoin/src/taproot/merkle_branch.rs
@@ -2,16 +2,13 @@
 
 //! Contains `TaprootMerkleBranch` and its associated types.
 
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use core::borrow::{Borrow, BorrowMut};
-
 use hashes::Hash;
 
 use super::{
     TapNodeHash, TaprootBuilderError, TaprootError, TAPROOT_CONTROL_MAX_NODE_COUNT,
     TAPROOT_CONTROL_NODE_SIZE,
 };
+use crate::prelude::*;
 
 /// The merkle proof for inclusion of a tree in a taptree hash.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -15,12 +15,12 @@ use core::iter::FusedIterator;
 use hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use internals::write_err;
 use io::Write;
-use secp256k1::{self, Scalar, Secp256k1};
+use secp256k1::{Scalar, Secp256k1};
 
 use crate::consensus::Encodable;
 use crate::crypto::key::{TapTweak, TweakedPublicKey, UntweakedPublicKey, XOnlyPublicKey};
 use crate::prelude::*;
-use crate::{io, Script, ScriptBuf};
+use crate::{Script, ScriptBuf};
 
 // Re-export these so downstream only has to use one `taproot` module.
 #[rustfmt::skip]
@@ -1436,9 +1436,9 @@ mod test {
     use core::str::FromStr;
 
     use hashes::sha256t::Tag;
-    use hashes::{sha256, Hash, HashEngine};
+    use hashes::sha256;
     use hex::FromHex;
-    use secp256k1::{VerifyOnly, XOnlyPublicKey};
+    use secp256k1::VerifyOnly;
 
     use super::*;
     use crate::sighash::{TapSighash, TapSighashTag};

--- a/bitcoin/src/taproot/serialized_signature.rs
+++ b/bitcoin/src/taproot/serialized_signature.rs
@@ -6,7 +6,6 @@
 //! serialized signatures and since it's a bit more complicated it has its own module.
 
 use core::borrow::Borrow;
-use core::convert::TryFrom;
 use core::{fmt, ops};
 
 pub use into_iter::IntoIter;

--- a/bitcoin/tests/psbt.rs
+++ b/bitcoin/tests/psbt.rs
@@ -11,7 +11,7 @@ use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::script::PushBytes;
-use bitcoin::secp256k1::{self, Secp256k1};
+use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{
     absolute, Amount, Denomination, NetworkKind, OutPoint, PrivateKey, PublicKey, ScriptBuf,
     Sequence, Transaction, TxIn, TxOut, Witness,

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -23,7 +23,6 @@
 #![cfg(feature = "serde")]
 
 use std::collections::BTreeMap;
-use std::convert::TryFrom;
 use std::str::FromStr;
 
 use bincode::serialize;

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -3,7 +3,6 @@
 //! RIPEMD160 implementation.
 //!
 
-use core::convert::TryInto;
 use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -3,7 +3,6 @@
 //! SHA1 implementation.
 //!
 
-use core::convert::TryInto;
 use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -3,16 +3,15 @@
 //! SHA256 implementation.
 //!
 
-#[cfg(target_arch = "x86")]
+#[cfg(all(feature = "std", target_arch = "x86"))]
 use core::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "std", target_arch = "x86_64"))]
 use core::arch::x86_64::*;
-use core::convert::TryInto;
 use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};
 
-use crate::{hex, sha256d, FromSliceError, HashEngine as _};
+use crate::{sha256d, FromSliceError, HashEngine as _};
 
 crate::internal_macros::hash_type! {
     256,

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -3,7 +3,6 @@
 //! SHA512 implementation.
 //!
 
-use core::convert::TryInto;
 use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, str};

--- a/io/src/error.rs
+++ b/io/src/error.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "alloc", feature = "std"))]
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;
 use core::fmt::{Debug, Display, Formatter};
 

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -26,10 +26,9 @@ extern crate alloc;
 mod error;
 mod macros;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::vec::Vec;
 use core::cmp;
-use core::convert::TryInto;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use self::error::{Error, ErrorKind};
@@ -328,7 +327,7 @@ pub fn sink() -> Sink { Sink }
 mod tests {
     use super::*;
 
-    #[cfg(feature = "alloc")]
+    #[cfg(all(not(feature = "std"), feature = "alloc"))]
     use alloc::{string::ToString, vec};
 
     #[test]

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1838,16 +1838,11 @@ mod verification {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
     #[cfg(feature = "alloc")]
     use alloc::format;
 
     #[cfg(feature = "std")]
     use std::panic;
-
-    #[cfg(feature = "serde")]
-    use serde_test;
 
     use super::*;
 
@@ -2321,9 +2316,9 @@ mod tests {
         let sa = SignedAmount::from_sat;
         let ua = Amount::from_sat;
 
-        assert_eq!(Amount::MAX.to_signed(), Err(OutOfRangeError::too_big(true).into()));
+        assert_eq!(Amount::MAX.to_signed(), Err(OutOfRangeError::too_big(true)));
         assert_eq!(ua(i64::MAX as u64).to_signed(), Ok(sa(i64::MAX)));
-        assert_eq!(ua(i64::MAX as u64 + 1).to_signed(), Err(OutOfRangeError::too_big(true).into()));
+        assert_eq!(ua(i64::MAX as u64 + 1).to_signed(), Err(OutOfRangeError::too_big(true)));
 
         assert_eq!(sa(i64::MAX).to_unsigned(), Ok(ua(i64::MAX as u64)));
 


### PR DESCRIPTION
The latest nightly toolchain introduced a whole bunch of new warnings and errors, mostly to do with import statements - fix them all.

 
