### PR TITLE
WIP: hashes: Make hex dependency optional

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "base58check"
 version = "0.1.0"
 dependencies = [
@@ -158,9 +164,12 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_lit"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "base58check"
 version = "0.1.0"
 dependencies = [
@@ -157,9 +163,12 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_lit"

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -24,4 +24,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false, features = ["alloc"] }
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -24,4 +24,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
+

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -264,8 +264,6 @@ impl std::error::Error for Error {
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
 
     #[test]
@@ -292,8 +290,8 @@ mod tests {
         QUdxpGakhqkZFL7RU4yT";
         assert_eq!(&res, exp);
 
-        // Addresses
-        let addr = hex!("00f8917303bfa8ef24f292e8fa1419b20460ba064d");
+        // Address hex: "00f8917303bfa8ef24f292e8fa1419b20460ba064d"
+        let addr = vec![0, 248, 145, 115, 3, 191, 168, 239, 36, 242, 146, 232, 250, 20, 25, 178, 4, 96, 186, 6, 77];
         assert_eq!(&encode_check(&addr[..]), "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH");
     }
 
@@ -309,10 +307,11 @@ mod tests {
         assert_eq!(decode("1211").ok(), Some(vec![0u8, 13, 36]));
         assert_eq!(decode("111211").ok(), Some(vec![0u8, 0, 0, 13, 36]));
 
-        // Addresses
+        // Address hex: "00f8917303bfa8ef24f292e8fa1419b20460ba064d"
+        let addr = vec![0, 248, 145, 115, 3, 191, 168, 239, 36, 242, 146, 232, 250, 20, 25, 178, 4, 96, 186, 6, 77];
         assert_eq!(
             decode_check("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").ok(),
-            Some(hex!("00f8917303bfa8ef24f292e8fa1419b20460ba064d"))
+            Some(addr)
         );
         // Non Base58 char.
         assert_eq!(decode("¢").unwrap_err(), Error::BadByte(194));

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -31,7 +31,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 base58 = { package = "base58check", version = "0.1.0", default-features = false }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc", "io"] }
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false, features = ["alloc"] }
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
 internals = { package = "bitcoin-internals", version = "0.2.0" }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = [ "std", "secp-recovery" ]
-std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "secp256k1/std", "units/std"]
+std = ["base58/std", "bech32/std", "hashes/hex-std", "hex/std", "internals/std", "io/std", "secp256k1/std", "units/std"]
 rand-std = ["secp256k1/rand-std", "std"]
 rand = ["secp256k1/rand"]
 serde = ["actual-serde", "hashes/serde", "secp256k1/serde", "internals/serde", "units/serde"]
@@ -30,7 +30,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 base58 = { package = "base58check", version = "0.1.0", default-features = false }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc", "io"] }
+hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["io", "hex-alloc"] }
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
 internals = { package = "bitcoin-internals", version = "0.2.0" }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -45,7 +45,7 @@ impl_bytes_newtype!(ChainCode, 32);
 
 impl ChainCode {
     fn from_hmac(hmac: Hmac<sha512::Hash>) -> Self {
-        hmac[32..].try_into().expect("half of hmac is guaranteed to be 32 bytes")
+        hmac.as_byte_array()[32..].try_into().expect("half of hmac is guaranteed to be 32 bytes")
     }
 }
 
@@ -554,7 +554,7 @@ impl Xpriv {
             depth: 0,
             parent_fingerprint: Default::default(),
             child_number: ChildNumber::from_normal_idx(0)?,
-            private_key: secp256k1::SecretKey::from_slice(&hmac_result[..32])?,
+            private_key: secp256k1::SecretKey::from_slice(&hmac_result.as_byte_array()[..32])?,
             chain_code: ChainCode::from_hmac(hmac_result),
         })
     }
@@ -609,7 +609,7 @@ impl Xpriv {
 
         hmac_engine.input(&u32::from(i).to_be_bytes());
         let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
-        let sk = secp256k1::SecretKey::from_slice(&hmac_result[..32])
+        let sk = secp256k1::SecretKey::from_slice(&hmac_result.as_byte_array()[..32])
             .expect("statistically impossible to hit");
         let tweaked =
             sk.add_tweak(&self.private_key.into()).expect("statistically impossible to hit");
@@ -730,7 +730,7 @@ impl Xpub {
 
                 let hmac_result: Hmac<sha512::Hash> = Hmac::from_engine(hmac_engine);
 
-                let private_key = secp256k1::SecretKey::from_slice(&hmac_result[..32])?;
+                let private_key = secp256k1::SecretKey::from_slice(&hmac_result.as_byte_array()[..32])?;
                 let chain_code = ChainCode::from_hmac(hmac_result);
                 Ok((private_key, chain_code))
             }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1944,6 +1944,10 @@ mod tests {
             format!("{:x}", tx.compute_txid()),
             "9652aa62b0e748caeec40c4cb7bc17c6792435cc3dfe447dd1ca24f912a1c6ec"
         );
+        assert_eq!(
+            format!("{:.10x}", tx.compute_txid()),
+            "9652aa62b0"
+        );
         assert_eq!(tx.weight(), Weight::from_wu(2718));
 
         // non-segwit tx from my mempool

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -187,7 +187,7 @@ impl core::str::FromStr for OutPoint {
             return Err(ParseOutPointError::Format);
         }
         Ok(OutPoint {
-            txid: s[..colon].parse().map_err(ParseOutPointError::Txid)?,
+            txid: s[..colon].parse().map_err(|e: hashes::FromStrError| ParseOutPointError::Txid(e.error()))?,
             vout: parse_vout(&s[colon + 1..])?,
         })
     }
@@ -1670,7 +1670,7 @@ mod tests {
         );
         assert_eq!(
             OutPoint::from_str("i don't care:1"),
-            Err(ParseOutPointError::Txid("i don't care".parse::<Txid>().unwrap_err()))
+            Err(ParseOutPointError::Txid("i don't care".parse::<Txid>().map_err(|e: hashes::FromStrError| e.to_hex_error()).unwrap_err()))
         );
         assert_eq!(
             OutPoint::from_str(
@@ -1679,6 +1679,7 @@ mod tests {
             Err(ParseOutPointError::Txid(
                 "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X"
                     .parse::<Txid>()
+                    .map_err(|e: hashes::FromStrError| e.to_hex_error())
                     .unwrap_err()
             ))
         );

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -506,18 +506,19 @@ impl<'de> serde::Deserialize<'de> for Witness {
 
                 while let Some(elem) = a.next_element::<String>()? {
                     let vec = Vec::<u8>::from_hex(&elem).map_err(|e| match e {
-                        InvalidChar(b) => match core::char::from_u32(b.into()) {
+                        InvalidChar(ref e) => match core::char::from_u32(e.invalid_char(
+                        ).into()) {
                             Some(c) => de::Error::invalid_value(
                                 Unexpected::Char(c),
                                 &"a valid hex character",
                             ),
                             None => de::Error::invalid_value(
-                                Unexpected::Unsigned(b.into()),
+                                Unexpected::Unsigned(e.invalid_char().into()),
                                 &"a valid hex character",
                             ),
                         },
-                        OddLengthString(len) =>
-                            de::Error::invalid_length(len, &"an even length string"),
+                        OddLengthString(ref e) =>
+                            de::Error::invalid_length(e.length(), &"an even length string"),
                     })?;
                     ret.push(vec);
                 }

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -71,11 +71,11 @@ pub mod hex {
 
     /// Hex byte encoder.
     // We wrap `BufEncoder` to not leak internal representation.
-    pub struct Encoder<C: Case>(BufEncoder<[u8; HEX_BUF_SIZE]>, PhantomData<C>);
+    pub struct Encoder<C: Case>(BufEncoder<{ HEX_BUF_SIZE }>, PhantomData<C>);
 
     impl<C: Case> From<super::Hex<C>> for Encoder<C> {
         fn from(_: super::Hex<C>) -> Self {
-            Encoder(BufEncoder::new([0; HEX_BUF_SIZE]), Default::default())
+            Encoder(BufEncoder::new(), Default::default())
         }
     }
 
@@ -100,15 +100,15 @@ pub mod hex {
     // Newtypes to hide internal details.
 
     /// Error returned when a hex string decoder can't be created.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct DecodeInitError(hex::HexToBytesError);
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct DecodeInitError(hex::OddLengthStringError);
 
     /// Error returned when a hex string contains invalid characters.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct DecodeError(hex::HexToBytesError);
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct DecodeError(hex::InvalidCharError);
 
     /// Hex decoder state.
-    pub struct Decoder<'a>(hex::HexToBytesIter<'a>);
+    pub struct Decoder<'a>(hex::HexSliceToBytesIter<'a>);
 
     impl<'a> Decoder<'a> {
         fn new(s: &'a str) -> Result<Self, DecodeInitError> {
@@ -137,29 +137,19 @@ pub mod hex {
 
     impl super::IntoDeError for DecodeInitError {
         fn into_de_error<E: serde::de::Error>(self) -> E {
-            use hex::HexToBytesError;
-
-            match self.0 {
-                HexToBytesError::OddLengthString(len) =>
-                    E::invalid_length(len, &"an even number of ASCII-encoded hex digits"),
-                error => panic!("unexpected error: {:?}", error),
-            }
+            E::invalid_length(self.0.length(), &"an even number of ASCII-encoded hex digits")
         }
     }
 
     impl super::IntoDeError for DecodeError {
         fn into_de_error<E: serde::de::Error>(self) -> E {
-            use hex::HexToBytesError;
             use serde::de::Unexpected;
 
             const EXPECTED_CHAR: &str = "an ASCII-encoded hex digit";
 
-            match self.0 {
-                HexToBytesError::InvalidChar(c) if c.is_ascii() =>
-                    E::invalid_value(Unexpected::Char(c as _), &EXPECTED_CHAR),
-                HexToBytesError::InvalidChar(c) =>
-                    E::invalid_value(Unexpected::Unsigned(c.into()), &EXPECTED_CHAR),
-                error => panic!("unexpected error: {:?}", error),
+            match self.0.invalid_char() {
+                c if c.is_ascii() => E::invalid_value(Unexpected::Char(c as _), &EXPECTED_CHAR),
+                c => E::invalid_value(Unexpected::Unsigned(c.into()), &EXPECTED_CHAR),
             }
         }
     }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1571,13 +1571,10 @@ mod tests {
 
     #[test]
     fn target_is_met_by_for_target_equals_hash() {
-        use std::str::FromStr;
-
         use hashes::Hash;
 
-        let hash =
-            BlockHash::from_str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")
-                .expect("failed to parse block hash");
+        let hash: BlockHash = "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c".parse()
+            .expect("failed to parse block hash");
         let target = Target(U256::from_le_bytes(hash.to_byte_array()));
         assert!(target.is_met_by(hash));
     }

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1025,7 +1025,7 @@ mod tests {
 
     #[track_caller]
     pub fn hex_psbt(s: &str) -> Result<Psbt, crate::psbt::error::Error> {
-        let r: Result<Vec<u8>, hex::HexToBytesError> = Vec::from_hex(s);
+        let r = Vec::from_hex(s);
         match r {
             Err(_e) => panic!("unable to parse hex string {}", s),
             Ok(v) => Psbt::deserialize(&v),

--- a/bitcoin/src/taproot/serialized_signature.rs
+++ b/bitcoin/src/taproot/serialized_signature.rs
@@ -28,8 +28,8 @@ impl fmt::Debug for SerializedSignature {
 
 impl fmt::Display for SerializedSignature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf = [0u8; MAX_LEN * 2];
-        let mut encoder = hex::buf_encoder::BufEncoder::new(&mut buf);
+        const HEX_LEN: usize = MAX_LEN * 2;
+        let mut encoder = hex::buf_encoder::BufEncoder::<HEX_LEN>::new();
         encoder.put_bytes(self, hex::Case::Lower);
         f.pad_integral(true, "0x", encoder.as_str())
     }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
 
 bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
 schemars = { version = "0.8.3", default-features = false, optional = true }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -15,8 +15,10 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hex/std", "bitcoin-io/std"]
-alloc = ["hex/alloc"]
+std = ["alloc", "bitcoin-io/std"]
+alloc = []
+hex-std = ["std", "hex/std"]
+hex-alloc = ["alloc", "hex/alloc"]
 # If you want I/O you must enable either "std" or "io".
 io = ["bitcoin-io"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
@@ -27,11 +29,13 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
-
 bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
+internals = { package = "bitcoin-internals", version = "0.2.0" }
 schemars = { version = "0.8.3", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
+
+# Only use this feature if you specificaly do not want an allocator, otherwise use "hex-std"/"hex-alloc".
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -35,7 +35,7 @@ fn from_engine(e: HashEngine) -> Hash {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn test() {
         use crate::{hash160, Hash, HashEngine};
 

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -10,7 +10,6 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::str;
 
 use crate::{ripemd160, sha256, FromSliceError};
 

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -72,10 +72,10 @@ impl<T: Hash> HmacEngine<T> {
 
         if key.len() > T::Engine::BLOCK_SIZE {
             let hash = <T as Hash>::hash(key);
-            for (b_i, b_h) in ipad.iter_mut().zip(&hash.as_byte_array()[..]) {
+            for (b_i, b_h) in ipad.iter_mut().zip(&hash.as_ref()[..]) {
                 *b_i ^= *b_h;
             }
-            for (b_o, b_h) in opad.iter_mut().zip(&hash.as_byte_array()[..]) {
+            for (b_o, b_h) in opad.iter_mut().zip(&hash.as_ref()[..]) {
                 *b_o ^= *b_h;
             }
         } else {
@@ -116,16 +116,22 @@ impl<T: Hash> fmt::Debug for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Debug::fmt(&self.0, f) }
 }
 
-impl<T: Hash> fmt::Display for Hmac<T> {
+#[cfg(feature = "hex")]
+impl<T: Hash + fmt::Display> fmt::Display for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
-impl<T: Hash> fmt::LowerHex for Hmac<T> {
+#[cfg(feature = "hex")]
+impl<T: Hash + fmt::LowerHex> fmt::LowerHex for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
 
 impl<T: Hash> borrow::Borrow<[u8]> for Hmac<T> {
-    fn borrow(&self) -> &[u8] { &self.as_byte_array()[..] }
+    fn borrow(&self) -> &[u8] { &self.as_ref()[..] }
+}
+
+impl<T: Hash> AsRef<[u8]> for Hmac<T> {
+    fn as_ref(&self) -> &[u8] { self.0.as_ref() }
 }
 
 impl<T: Hash> Hash for Hmac<T> {
@@ -134,7 +140,7 @@ impl<T: Hash> Hash for Hmac<T> {
 
     fn from_engine(mut e: HmacEngine<T>) -> Hmac<T> {
         let ihash = T::from_engine(e.iengine);
-        e.oengine.input(&ihash.as_byte_array()[..]);
+        e.oengine.input(&ihash.as_ref()[..]);
         let ohash = T::from_engine(e.oengine);
         Hmac(ohash)
     }

--- a/hashes/src/impls.rs
+++ b/hashes/src/impls.rs
@@ -65,6 +65,7 @@ impl_write!(
 );
 
 #[cfg(test)]
+#[cfg(feature = "hex")]
 mod tests {
     use bitcoin_io::Write;
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -86,7 +86,7 @@ macro_rules! hash_trait_impls {
             }
         }
 
-        impl<$($gen: $gent),*> str::FromStr for Hash<$($gen),*> {
+        impl<$($gen: $gent),*> core::str::FromStr for Hash<$($gen),*> {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<Self, Self::Err> {
                 use $crate::{Hash, hex::{FromHex}};

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -89,15 +89,13 @@ macro_rules! hash_trait_impls {
         impl<$($gen: $gent),*> str::FromStr for Hash<$($gen),*> {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<Self, Self::Err> {
-                use $crate::hex::{FromHex, HexToBytesIter};
-                use $crate::Hash;
+                use $crate::{Hash, hex::{FromHex}};
 
-                let inner: [u8; $bits / 8] = if $reverse {
-                    FromHex::from_byte_iter(HexToBytesIter::new(s)?.rev())?
-                } else {
-                    FromHex::from_byte_iter(HexToBytesIter::new(s)?)?
-                };
-                Ok(Self::from_byte_array(inner))
+                let mut bytes = <[u8; $bits / 8]>::from_hex(s)?;
+                if $reverse {
+                    bytes.reverse();
+                }
+                Ok(Self::from_byte_array(bytes))
             }
         }
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -71,22 +71,6 @@ pub(crate) use arr_newtype_fmt_impl;
 macro_rules! hash_trait_impls {
     ($bits:expr, $reverse:expr $(, $gen:ident: $gent:ident)*) => {
         impl<$($gen: $gent),*> Hash<$($gen),*> {
-            /// Displays hex forwards, regardless of how this type would display it naturally.
-            ///
-            /// This is mainly intended as an internal method and you shouldn't need it unless
-            /// you're doing something special.
-            pub fn forward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex {
-                $crate::hex::DisplayHex::as_hex(&self.0)
-            }
-
-            /// Displays hex backwards, regardless of how this type would display it naturally.
-            ///
-            /// This is mainly intended as an internal method and you shouldn't need it unless
-            /// you're doing something special.
-            pub fn backward_hex(&self) -> impl '_ + core::fmt::LowerHex + core::fmt::UpperHex {
-                $crate::hex::display::DisplayArray::<_, [u8; $bits / 8 * 2]>::new(self.0.iter().rev())
-            }
-
             /// Zero cost conversion between a fixed length byte array shared reference and
             /// a shared reference to this Hash type.
             pub fn from_bytes_ref(bytes: &[u8; $bits / 8]) -> &Self {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -273,4 +273,12 @@ mod tests {
         let h2: TestNewtype = h.to_string().parse().unwrap();
         assert_eq!(h2.to_raw_hash(), h);
     }
+
+    #[test]
+    fn newtype_fmt_roundtrip() {
+        let orig = TestNewtype::hash(&[]);
+        let hex = format!("{}", orig);
+        let rinsed = hex.parse::<TestNewtype>().expect("failed to parse hex");
+        assert_eq!(rinsed, orig)
+    }
 }

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -96,6 +96,7 @@ extern crate serde_test;
 extern crate test;
 
 /// Re-export the `hex-conservative` crate.
+#[cfg(feature = "hex")]
 pub extern crate hex;
 
 #[doc(hidden)]
@@ -128,7 +129,7 @@ pub mod sha512;
 pub mod sha512_256;
 pub mod siphash24;
 
-use core::{borrow, fmt, hash, ops};
+use core::{borrow, fmt, hash};
 
 pub use hmac::{Hmac, HmacEngine};
 
@@ -161,9 +162,8 @@ pub trait Hash:
     + Ord
     + hash::Hash
     + fmt::Debug
-    + fmt::Display
-    + fmt::LowerHex
     + borrow::Borrow<[u8]>
+    + AsRef<[u8]>
 {
     /// A hashing engine which bytes can be serialized into. It is expected
     /// to implement the `io::Write` trait, and to never return errors under
@@ -171,14 +171,7 @@ pub trait Hash:
     type Engine: HashEngine;
 
     /// The byte array that represents the hash internally.
-    type Bytes:
-        hex::FromHex
-        + Copy
-        + ops::Index<ops::RangeFull, Output = [u8]>
-        + ops::Index<ops::RangeFrom<usize>, Output = [u8]>
-        + ops::Index<ops::RangeTo<usize>, Output = [u8]>
-        + ops::Index<ops::Range<usize>, Output = [u8]>
-        + ops::Index<usize, Output = u8>;
+    type Bytes: Copy;
 
     /// Constructs a new engine.
     fn engine() -> Self::Engine { Self::Engine::default() }
@@ -234,6 +227,23 @@ pub trait Hash:
     fn all_zeros() -> Self;
 }
 
+/// Attempted to parse a hash (hex string) without the hex feature enabled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(not(feature = "hex"))]
+pub struct HexUnsupportedError {}
+
+#[cfg(not(feature = "hex"))]
+impl fmt::Display for HexUnsupportedError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "attempted to parse a hash (hex string) without the hex feature enabled")
+
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "hex")))]
+impl std::error::Error for HexUnsupportedError {}
+
 /// Attempted to create a hash from an invalid length slice.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -254,8 +264,9 @@ impl std::error::Error for FromSliceError {
 }
 
 #[cfg(test)]
+#[cfg(all(feature = "alloc", feature = "hex"))]
 mod tests {
-    use crate::{sha256d, Hash};
+    use crate::{sha256d, Hash as _};
 
     hash_newtype! {
         /// A test newtype

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -163,11 +163,6 @@ pub trait Hash:
     + fmt::Debug
     + fmt::Display
     + fmt::LowerHex
-    + ops::Index<ops::RangeFull, Output = [u8]>
-    + ops::Index<ops::RangeFrom<usize>, Output = [u8]>
-    + ops::Index<ops::RangeTo<usize>, Output = [u8]>
-    + ops::Index<ops::Range<usize>, Output = [u8]>
-    + ops::Index<usize, Output = u8>
     + borrow::Borrow<[u8]>
 {
     /// A hashing engine which bytes can be serialized into. It is expected
@@ -176,7 +171,14 @@ pub trait Hash:
     type Engine: HashEngine;
 
     /// The byte array that represents the hash internally.
-    type Bytes: hex::FromHex + Copy;
+    type Bytes:
+        hex::FromHex
+        + Copy
+        + ops::Index<ops::RangeFull, Output = [u8]>
+        + ops::Index<ops::RangeFrom<usize>, Output = [u8]>
+        + ops::Index<ops::RangeTo<usize>, Output = [u8]>
+        + ops::Index<ops::Range<usize>, Output = [u8]>
+        + ops::Index<usize, Output = u8>;
 
     /// Constructs a new engine.
     fn engine() -> Self::Engine { Self::Engine::default() }

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{FromSliceError, HashEngine as _};
 

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -409,7 +409,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn test() {
         use std::convert::TryFrom;
 

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{FromSliceError, HashEngine as _};
 

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -128,7 +128,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn test() {
         use crate::{sha1, Hash, HashEngine};
 

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -884,6 +884,15 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
+    fn fmt_roundtrips() {
+        let hash = sha256::Hash::hash(b"some arbitrary bytes");
+        let hex = format!("{}", hash);
+        let rinsed = hex.parse::<sha256::Hash>().expect("failed to parse hex");
+        assert_eq!(rinsed, hash)
+    }
+
+    #[test]
     #[rustfmt::skip]
     fn midstate() {
         // Test vector obtained by doing an asset issuance on Elements
@@ -988,6 +997,14 @@ mod tests {
                 243, 147, 108, 71, 99, 110, 96, 125, 179, 62, 234, 221, 198, 240, 201,
             ])
         )
+    }
+
+    #[test]
+    fn midstate_fmt_roundtrip() {
+        let midstate = Midstate::hash_tag(b"ArbitraryTag");
+        let hex = format!("{}", midstate);
+        let rinsed = hex.parse::<Midstate>().expect("failed to parse hex");
+        assert_eq!(rinsed, midstate)
     }
 
     #[cfg(feature = "serde")]

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -817,7 +817,8 @@ impl HashEngine {
 
 #[cfg(test)]
 mod tests {
-    use crate::{sha256, Hash, HashEngine};
+    use crate::{sha256, Hash as _, HashEngine};
+    use super::*;
 
     #[test]
     #[cfg(feature = "alloc")]
@@ -964,14 +965,14 @@ mod tests {
 
     #[test]
     fn const_hash() {
-        assert_eq!(super::Hash::hash(&[]), super::Hash::const_hash(&[]));
+        assert_eq!(Hash::hash(&[]), Hash::const_hash(&[]));
 
         let mut bytes = Vec::new();
         for i in 0..256 {
             bytes.push(i as u8);
             assert_eq!(
-                super::Hash::hash(&bytes),
-                super::Hash::const_hash(&bytes),
+                Hash::hash(&bytes),
+                Hash::const_hash(&bytes),
                 "hashes don't match for length {}",
                 i + 1
             );
@@ -980,8 +981,6 @@ mod tests {
 
     #[test]
     fn const_midstate() {
-        use super::Midstate;
-
         assert_eq!(
             Midstate::hash_tag(b"TapLeaf"),
             Midstate([

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -176,15 +176,13 @@ impl Midstate {
 }
 
 impl hex::FromHex for Midstate {
-    type Err = hex::HexToArrayError;
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
-    where
-        I: Iterator<Item = Result<u8, hex::HexToBytesError>>
-            + ExactSizeIterator
-            + DoubleEndedIterator,
-    {
+    type Error = hex::HexToArrayError;
+
+    fn from_hex(s: &str) -> Result<Self, Self::Error> {
         // DISPLAY_BACKWARD is true
-        Ok(Midstate::from_byte_array(hex::FromHex::from_byte_iter(iter.rev())?))
+        let mut bytes = <[u8; 32]>::from_hex(s)?;
+        bytes.reverse();
+        Ok(Midstate(bytes))
     }
 }
 

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -9,7 +9,7 @@ use core::arch::x86::*;
 use core::arch::x86_64::*;
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{sha256d, FromSliceError, HashEngine as _};
 
@@ -126,7 +126,8 @@ impl<I: SliceIndex<[u8]>> Index<I> for Midstate {
     fn index(&self, index: I) -> &Self::Output { &self.0[index] }
 }
 
-impl str::FromStr for Midstate {
+#[cfg(feature = "hex")]
+impl core::str::FromStr for Midstate {
     type Err = hex::HexToArrayError;
     fn from_str(s: &str) -> Result<Self, Self::Err> { hex::FromHex::from_hex(s) }
 }
@@ -175,6 +176,7 @@ impl Midstate {
     }
 }
 
+#[cfg(feature = "hex")]
 impl hex::FromHex for Midstate {
     type Error = hex::HexToArrayError;
 
@@ -819,7 +821,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn test() {
         #[derive(Clone)]
         struct Test {
@@ -882,7 +884,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn fmt_roundtrips() {
         let hash = sha256::Hash::hash(b"some arbitrary bytes");
         let hex = format!("{}", hash);
@@ -998,6 +1000,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn midstate_fmt_roundtrip() {
         let midstate = Midstate::hash_tag(b"ArbitraryTag");
         let hex = format!("{}", midstate);

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -30,10 +30,12 @@ fn from_engine(e: sha256::HashEngine) -> Hash {
 
 #[cfg(test)]
 mod tests {
+    use crate::{sha256d, Hash as _};
+
     #[test]
     #[cfg(feature = "alloc")]
     fn test() {
-        use crate::{sha256, sha256d, Hash, HashEngine};
+        use crate::{sha256, HashEngine};
 
         #[derive(Clone)]
         struct Test {
@@ -81,12 +83,18 @@ mod tests {
         }
     }
 
+    #[test]
+    fn fmt_roundtrips() {
+        let hash = sha256d::Hash::hash(b"some arbitrary bytes");
+        let hex = format!("{}", hash);
+        let rinsed = hex.parse::<sha256d::Hash>().expect("failed to parse hex");
+        assert_eq!(rinsed, hash)
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn sha256_serde() {
         use serde_test::{assert_tokens, Configure, Token};
-
-        use crate::{sha256d, Hash};
 
         #[rustfmt::skip]
         static HASH_BYTES: [u8; 32] = [

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -5,7 +5,6 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::str;
 
 use crate::{sha256, FromSliceError};
 

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -29,10 +29,11 @@ fn from_engine(e: sha256::HashEngine) -> Hash {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     use crate::{sha256d, Hash as _};
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn test() {
         use crate::{sha256, HashEngine};
 
@@ -83,6 +84,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn fmt_roundtrips() {
         let hash = sha256d::Hash::hash(b"some arbitrary bytes");
         let hex = format!("{}", hash);

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -165,8 +165,6 @@ macro_rules! sha256t_hash_newtype_tag_constructor {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "alloc")]
-    use crate::Hash;
     use crate::{sha256, sha256t};
 
     const TEST_MIDSTATE: [u8; 32] = [
@@ -201,7 +199,7 @@ mod tests {
     }
 
     /// A hash tagged with `$name`.
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     pub type TestHash = sha256t::Hash<TestHashTag>;
 
     sha256t_hash_newtype! {
@@ -214,8 +212,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn test_sha256t() {
+        use crate::Hash;
+
         assert_eq!(
             TestHash::hash(&[0]).to_string(),
             "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
@@ -224,5 +224,17 @@ mod tests {
             NewTypeHash::hash(&[0]).to_string(),
             "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
         );
+    }
+
+    // This test verifies that the `sha256t_hash_newtype` macro implements `FromStr`.
+    #[test]
+    #[cfg(feature = "hex-std")]
+    fn parse_hex() {
+        use crate::Hash;
+
+        let hex = "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed";
+        let want = TestHash::hash(&[0]);
+        let got = hex.parse::<TestHash>().expect("failed to parse hex");
+        assert_eq!(got, want)
     }
 }

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -6,7 +6,7 @@
 use core::marker::PhantomData;
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{sha256, FromSliceError};
 

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{FromSliceError, HashEngine as _};
 

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -293,7 +293,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn test() {
         use crate::{sha512, Hash, HashEngine};
 

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -9,7 +9,6 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::str;
 
 use crate::{sha512, FromSliceError};
 

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -55,7 +55,7 @@ impl crate::HashEngine for HashEngine {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     fn test() {
         use crate::{sha512_256, Hash, HashEngine};
 

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, mem, ptr, str};
+use core::{cmp, mem, ptr};
 
 use crate::{FromSliceError, Hash as _, HashEngine as _};
 

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -2,6 +2,14 @@
 
 #[macro_export]
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
+#[cfg(not(feature = "hex"))]
+macro_rules! hex_fmt_impl(
+    ($reverse:expr, $len:expr, $ty:ident) => {};
+);
+
+#[macro_export]
+/// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
+#[cfg(feature = "hex")]
 macro_rules! hex_fmt_impl(
     ($reverse:expr, $len:expr, $ty:ident) => (
         $crate::hex_fmt_impl!($reverse, $len, $ty, );
@@ -264,6 +272,7 @@ macro_rules! hash_newtype {
             }
         }
 
+        #[cfg(feature = "hex")]
         impl $crate::_export::_core::str::FromStr for $newtype {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<$newtype, Self::Err> {
@@ -274,6 +283,14 @@ macro_rules! hash_newtype {
                     bytes.reverse();
                 };
                 Ok($newtype(<$hash>::from_byte_array(bytes)))
+            }
+        }
+
+        #[cfg(not(feature = "hex"))]
+        impl $crate::_export::_core::str::FromStr for $newtype {
+            type Err = $crate::HexUnsupportedError;
+            fn from_str(_: &str) -> $crate::_export::_core::result::Result<$newtype, Self::Err> {
+                Err($crate::HexUnsupportedError {})
             }
         }
 
@@ -414,6 +431,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "hex")]
     fn display() {
         let want = "0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{}", TestHash::all_zeros());
@@ -421,6 +439,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "hex")]
     fn display_alternate() {
         let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{:#}", TestHash::all_zeros());
@@ -428,6 +447,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "hex")]
     fn lower_hex() {
         let want = "0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{:x}", TestHash::all_zeros());
@@ -435,6 +455,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "hex")]
     fn lower_hex_alternate() {
         let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{:#x}", TestHash::all_zeros());

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -3,17 +3,19 @@
 #[macro_export]
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
 macro_rules! hex_fmt_impl(
-    ($reverse:expr, $ty:ident) => (
-        $crate::hex_fmt_impl!($reverse, $ty, );
+    ($reverse:expr, $len:expr, $ty:ident) => (
+        $crate::hex_fmt_impl!($reverse, $len, $ty, );
     );
-    ($reverse:expr, $ty:ident, $($gen:ident: $gent:ident),*) => (
+    ($reverse:expr, $len:expr, $ty:ident, $($gen:ident: $gent:ident),*) => (
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::LowerHex for $ty<$($gen),*> {
             #[inline]
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
+                use $crate::Hash as _;
+
                 if $reverse {
-                    $crate::_export::_core::fmt::LowerHex::fmt(&self.0.backward_hex(), f)
+                    $crate::hex::fmt_hex_exact!(f, $len, self.as_byte_array().iter().rev(), $crate::hex::Case::Lower)
                 } else {
-                    $crate::_export::_core::fmt::LowerHex::fmt(&self.0.forward_hex(), f)
+                    $crate::hex::fmt_hex_exact!(f, $len, self.as_byte_array().iter(), $crate::hex::Case::Lower)
                 }
             }
         }
@@ -21,10 +23,12 @@ macro_rules! hex_fmt_impl(
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::UpperHex for $ty<$($gen),*> {
             #[inline]
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
+                use $crate::Hash as _;
+
                 if $reverse {
-                    $crate::_export::_core::fmt::UpperHex::fmt(&self.0.backward_hex(), f)
+                    $crate::hex::fmt_hex_exact!(f, $len, self.as_byte_array().iter().rev(), $crate::hex::Case::Upper)
                 } else {
-                    $crate::_export::_core::fmt::UpperHex::fmt(&self.0.forward_hex(), f)
+                    $crate::hex::fmt_hex_exact!(f, $len, self.as_byte_array().iter(), $crate::hex::Case::Upper)
                 }
             }
         }
@@ -188,7 +192,7 @@ macro_rules! hash_newtype {
             $({ $($type_attrs)* })*
         }
 
-        $crate::hex_fmt_impl!(<$newtype as $crate::Hash>::DISPLAY_BACKWARD, $newtype);
+        $crate::hex_fmt_impl!(<$newtype as $crate::Hash>::DISPLAY_BACKWARD, <$newtype as $crate::Hash>::LEN, $newtype);
         $crate::serde_impl!($newtype, <$newtype as $crate::Hash>::LEN);
         $crate::borrow_slice_impl!($newtype);
 

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -39,13 +39,6 @@ macro_rules! hex_fmt_impl(
                 $crate::_export::_core::fmt::LowerHex::fmt(&self, f)
             }
         }
-
-        impl<$($gen: $gent),*> $crate::_export::_core::fmt::Debug for $ty<$($gen),*> {
-            #[inline]
-            fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
-                write!(f, "{:#}", self)
-            }
-        }
     );
 );
 
@@ -317,7 +310,7 @@ macro_rules! hash_newtype {
 macro_rules! hash_newtype_struct {
     ($(#[$other_attrs:meta])* $type_vis:vis struct $newtype:ident($(#[$field_attrs:meta])* $field_vis:vis $hash:path);) => {
         $(#[$other_attrs])*
-        #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
         $type_vis struct $newtype($(#[$field_attrs])* $field_vis $hash);
     };
     ($(#[$other_attrs:meta])* $type_vis:vis struct $newtype:ident($(#[$field_attrs:meta])* $field_vis:vis $hash:path); { hash_newtype($($ignore:tt)*) } $($type_attrs:tt)*) => {

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -274,15 +274,13 @@ macro_rules! hash_newtype {
         impl $crate::_export::_core::str::FromStr for $newtype {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<$newtype, Self::Err> {
-                use $crate::hex::{FromHex, HexToBytesIter};
-                use $crate::Hash;
+                use $crate::{Hash, hex::FromHex};
 
-                let inner: <$hash as Hash>::Bytes = if <Self as $crate::Hash>::DISPLAY_BACKWARD {
-                    FromHex::from_byte_iter(HexToBytesIter::new(s)?.rev())?
-                } else {
-                    FromHex::from_byte_iter(HexToBytesIter::new(s)?)?
+                let mut bytes = <[u8; <Self as $crate::Hash>::LEN]>::from_hex(s)?;
+                if <Self as $crate::Hash>::DISPLAY_BACKWARD {
+                    bytes.reverse();
                 };
-                Ok($newtype(<$hash>::from_byte_array(inner)))
+                Ok($newtype(<$hash>::from_byte_array(bytes)))
             }
         }
 


### PR DESCRIPTION
WIP because its broken.

It seems reasonable to expect to be able to hash some data without a `hex` dependency if one is not parsing strings or printing them.

Make the `hex` dependency optional. To handle trait bounds add some custom traits that use conditional compilation to include or not include the hex trait bounds. Provide empty blanket impls for all types.