### PR TITLE
Explicitly depend on newly released bech32 version

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -16,9 +16,9 @@ checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-beta"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+checksum = "0f9cd5c4ae44c0514f7831a2b5519ffd02f9759c2b8d2b6c7d00135e390d3ea1"
 
 [[package]]
 name = "bincode"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -16,9 +16,9 @@ checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-beta"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+checksum = "0f9cd5c4ae44c0514f7831a2b5519ffd02f9759c2b8d2b6c7d00135e390d3ea1"
 
 [[package]]
 name = "bincode"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-bech32 = { version = "0.10.0-beta", default-features = false, features = ["alloc"] }
+bech32 = { version = "0.10.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc", "io"] }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -169,9 +169,9 @@ impl fmt::Display for AddressInner {
                 let program = program.program().as_ref();
 
                 if fmt.alternate() {
-                    bech32::segwit::encode_upper_to_fmt_unchecked(fmt, &hrp, version, program)
+                    bech32::segwit::encode_upper_to_fmt_unchecked(fmt, hrp, version, program)
                 } else {
-                    bech32::segwit::encode_lower_to_fmt_unchecked(fmt, &hrp, version, program)
+                    bech32::segwit::encode_lower_to_fmt_unchecked(fmt, hrp, version, program)
                 }
             }
         }


### PR DESCRIPTION
I woke up this morning to the compiler emitting:
    
        error[E0308]: mismatched types
    
At first I thought it was another nightly thing like yesterday but it
turns out its because of the latest `bech32` release.
    
Because we use `0.10.0-beta` the new release gets pulled down
automatically (well at least I think it does), but I'm getting strange
errors in CI so lets just explicitly depend on the new release.
