### PR TITLE
Splitting up errors inside `Address::Error`

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -46,34 +46,6 @@ impl std::error::Error for NetworkError {
     }
 }
 
-/// Address error.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Error {
-    /// Unknown hrp for current bitcoin networks (in bech32 address).
-    UnknownHrp(UnknownHrpError),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-
-        match *self {
-            Error::UnknownHrp(ref e) => write_err!(f, "unknown hrp"; e),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use Error::*;
-
-        match *self {
-            UnknownHrp(ref e) => Some(e),
-        }
-    }
-}
-
 /// Error while generating address from script.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -10,41 +10,25 @@ use crate::prelude::*;
 use crate::{base58, Network};
 
 /// Network error inside address.
+/// Address's network differs from required one.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NetworkError {
-    /// Address's network differs from required one.
-    NetworkValidation {
-        /// Network that was required.
-        required: Network,
-        /// The address itself
-        address: Address<NetworkUnchecked>,
-    },
+pub struct NetworkValidationError {
+    /// Network that was required.
+    pub required: Network,
+    /// The address itself
+    pub address: Address<NetworkUnchecked>,
 }
 
-impl fmt::Display for NetworkError {
+impl fmt::Display for NetworkValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use NetworkError::*;
-
-        match *self {
-            NetworkValidation { required, ref address } => {
-                write!(f, "address ")?;
-                fmt::Display::fmt(&address.0, f)?;
-                write!(f, " is not valid on {}", required)
-            }
-        }
+        write!(f, "address ")?;
+        fmt::Display::fmt(&self.address.0, f)?;
+        write!(f, " is not valid on {}", self.required)
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for NetworkError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use NetworkError::*;
-
-        match self {
-            NetworkValidation { .. } => None,
-        }
-    }
-}
+impl std::error::Error for NetworkValidationError {}
 
 /// Error while generating address from script.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -51,7 +51,7 @@ use crate::network::{Network, NetworkKind};
 use crate::prelude::*;
 use crate::taproot::TapNodeHash;
 
-use self::error::{NetworkError, P2shError};
+use self::error::{NetworkValidationError, P2shError};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
@@ -667,11 +667,11 @@ impl Address<NetworkUnchecked> {
     /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
     /// on [`Address`].
     #[inline]
-    pub fn require_network(self, required: Network) -> Result<Address, NetworkError> {
+    pub fn require_network(self, required: Network) -> Result<Address, NetworkValidationError> {
         if self.is_valid_for_network(required) {
             Ok(self.assume_checked())
         } else {
-            Err(NetworkError::NetworkValidation { required, address: self })
+            Err(NetworkValidationError { required, address: self })
         }
     }
 

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -51,7 +51,7 @@ use crate::network::{Network, NetworkKind};
 use crate::prelude::*;
 use crate::taproot::TapNodeHash;
 
-use self::error::P2shError;
+use self::error::{NetworkError, P2shError};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
@@ -667,11 +667,11 @@ impl Address<NetworkUnchecked> {
     /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
     /// on [`Address`].
     #[inline]
-    pub fn require_network(self, required: Network) -> Result<Address, Error> {
+    pub fn require_network(self, required: Network) -> Result<Address, NetworkError> {
         if self.is_valid_for_network(required) {
             Ok(self.assume_checked())
         } else {
-            Err(Error::NetworkValidation { required, address: self })
+            Err(NetworkError::NetworkValidation { required, address: self })
         }
     }
 

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -55,7 +55,7 @@ use self::error::{NetworkError, P2shError};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    error::{Error, ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError},
+    error::{ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError},
 };
 
 /// The different types of addresses.


### PR DESCRIPTION
This PR includes the following :

- Introduce a new error type `NetworkError`
- Removes the `Address::Error`

fixes #2290 