### PR TITLE
base58: Re-name crate to base58ck

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "base58check"
+name = "base58ck"
 version = "0.1.0"
 dependencies = [
  "bitcoin-internals",
@@ -49,7 +49,7 @@ dependencies = [
 name = "bitcoin"
 version = "0.31.0"
 dependencies = [
- "base58check",
+ "base58ck",
  "base64",
  "bech32",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "base58check"
+name = "base58ck"
 version = "0.1.0"
 dependencies = [
  "bitcoin-internals",
@@ -48,7 +48,7 @@ dependencies = [
 name = "bitcoin"
 version = "0.31.0"
 dependencies = [
- "base58check",
+ "base58ck",
  "base64",
  "bech32",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["bitcoin", "hashes", "internals", "fuzz", "io", "units", "base58"]
 resolver = "2"
 
-[patch.crates-io.base58check]
+[patch.crates-io.base58ck]
 path = "base58"
 
 [patch.crates-io.bitcoin]

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "base58check"
+name = "base58ck"
 version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"

--- a/base58/README.md
+++ b/base58/README.md
@@ -4,16 +4,22 @@ Bitcoin base58 encoding
 This crate provides encoding and decoding of base58 strings as defined by the Bitcoin ecosystem
 including the checksum.
 
-There are two other crates on crates.io that implement base58 encoding and decoding. This
-crate differs from them because:
+There are a bunch of crates on crates.io that implement base58 encoding and decoding. The more
+obviously named ones differ from this crate because:
 
 1. [bitcoin-base58](https://crates.io/crates/bitcoin-base58) is transpiled from the C++ code in
-   Bitcoin Core as part of a large long-term transpilation project; this crate is a pure Rust
-   implementation intended to be production-ready and to provide an Rust-idiomatic API.
+   Bitcoin Core as part of a large long-term transpilation project, whereas this crate is a pure
+   Rust implementation intended to be production-ready and to provide an Rust-idiomatic API.
 
-2. [base58](https://crates.io/crates/base58) is incomplete and appears unmaintained as of
-   February 2024. It does not validate checksums and will therefore accept invalid Bitcoin
-   addresses. It may be appropriate in cases where performance is more important than safety.
+2. [base58](https://crates.io/crates/base58) implements parsing but does not validate checksums (see
+   `base58check`). It may be appropriate in cases where performance is more important than safety.
+   Appears unmaintained.
+
+3. [base58check](https://crates.io/crates/base58check) Adds checksum to the `base58` crate and
+   depends on [sha2](https://crates.io/crates/sha2/0.8.2) for hashing. Appears unmaintained.
+
+This crate uses [bitcoin_hashes](https://crates.io/crates/bitcoin_hashes) when hashing to calculate
+the checksum.
 
 
 ## Minimum Supported Rust Version (MSRV)

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base58 = { package = "base58check", version = "0.1.0", default-features = false }
+base58 = { package = "base58ck", version = "0.1.0", default-features = false }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc", "io"] }
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -27,7 +27,7 @@ codegen-units = 1 # better optimizations
 debug = true # symbols are nice and they don't increase the size on Flash
 lto = true # better optimizations
 
-[patch.crates-io.base58check]
+[patch.crates-io.base58ck]
 path = "../../base58"
 
 [patch.crates-io.bitcoin_hashes]


### PR DESCRIPTION
The current name `base58check` is taken, as is `base58`. Use `base58ck` instead.

Add a brief section to the readme about the crate naming.