### PR TITLE
base58: Use pub extern crate instead of module

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -7,7 +7,7 @@ use internals::write_err;
 use crate::address::{Address, NetworkUnchecked};
 use crate::blockdata::script::{witness_program, witness_version};
 use crate::prelude::*;
-use crate::{base58, Network};
+use crate::Network;
 
 /// Address error.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -36,7 +36,6 @@ use bech32::primitives::hrp::Hrp;
 use hashes::{sha256, Hash, HashEngine};
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 
-use crate::base58;
 use crate::blockdata::constants::{
     MAX_SCRIPT_ELEMENT_SIZE, PUBKEY_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST,
     SCRIPT_ADDRESS_PREFIX_MAIN, SCRIPT_ADDRESS_PREFIX_TEST,

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -15,7 +15,6 @@ use internals::{impl_array_newtype, write_err};
 use io::Write;
 use secp256k1::{Secp256k1, XOnlyPublicKey};
 
-use crate::base58;
 use crate::crypto::key::{CompressedPublicKey, Keypair, PrivateKey};
 use crate::internal_macros::impl_bytes_newtype;
 use crate::prelude::*;

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -21,7 +21,6 @@ use crate::internal_macros::impl_asref_push_bytes;
 use crate::network::NetworkKind;
 use crate::prelude::*;
 use crate::taproot::{TapNodeHash, TapTweakHash};
-use crate::base58;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Keypair, Parity, Secp256k1, Verification, XOnlyPublicKey};

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -61,6 +61,9 @@ extern crate alloc;
 /// Encodes and decodes base64 as bytes or utf8.
 pub extern crate base64;
 
+/// Bitcoin base58 encoding and decoding.
+pub extern crate base58;
+
 /// Rust implementation of cryptographic hash function algorithms.
 pub extern crate hashes;
 
@@ -194,9 +197,4 @@ pub mod amount {
             self.to_sat().consensus_encode(w)
         }
     }
-}
-
-pub mod base58 {
-    //! Bitcoin base58 encoding and decoding.
-    pub use base58::{decode, decode_check, encode, encode_check, encode_check_to_fmt, Error};
 }


### PR DESCRIPTION
We don't add any implementations to the `base58` types so we can just `pub extern` the crate instead of using a module and re-exporting.