### PR TITLE
Add `NetworkValidationError`

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -9,6 +9,26 @@ use crate::blockdata::script::{witness_program, witness_version};
 use crate::prelude::*;
 use crate::{base58, Network};
 
+/// Address's network differs from required one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkValidationError {
+    /// Network that was required.
+    pub(crate) required: Network,
+    /// The address itself.
+    pub(crate) address: Address<NetworkUnchecked>,
+}
+
+impl fmt::Display for NetworkValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "address ")?;
+        fmt::Display::fmt(&self.address.0, f)?;
+        write!(f, " is not valid on {}", self.required)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NetworkValidationError {}
+
 /// Address error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -29,48 +29,6 @@ impl fmt::Display for NetworkValidationError {
 #[cfg(feature = "std")]
 impl std::error::Error for NetworkValidationError {}
 
-/// Address error.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Error {
-    /// Address's network differs from required one.
-    NetworkValidation {
-        /// Network that was required.
-        required: Network,
-        /// The address itself
-        address: Address<NetworkUnchecked>,
-    },
-    /// Unknown hrp for current bitcoin networks (in bech32 address).
-    UnknownHrp(UnknownHrpError),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Error::*;
-
-        match *self {
-            NetworkValidation { required, ref address } => {
-                write!(f, "address ")?;
-                fmt::Display::fmt(&address.0, f)?;
-                write!(f, " is not valid on {}", required)
-            }
-            Error::UnknownHrp(ref e) => write_err!(f, "unknown hrp"; e),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use Error::*;
-
-        match *self {
-            UnknownHrp(ref e) => Some(e),
-            NetworkValidation { .. } => None,
-        }
-    }
-}
-
 /// Error while generating address from script.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -55,7 +55,7 @@ use self::error::P2shError;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    error::{Error, NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError, },
+    error::{NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError, },
 };
 
 /// The different types of addresses.

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -55,7 +55,7 @@ use self::error::P2shError;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    error::{Error, ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError},
+    error::{Error, NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError, },
 };
 
 /// The different types of addresses.
@@ -667,11 +667,11 @@ impl Address<NetworkUnchecked> {
     /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
     /// on [`Address`].
     #[inline]
-    pub fn require_network(self, required: Network) -> Result<Address, Error> {
+    pub fn require_network(self, required: Network) -> Result<Address, NetworkValidationError> {
         if self.is_valid_for_network(required) {
             Ok(self.assume_checked())
         } else {
-            Err(Error::NetworkValidation { required, address: self })
+            Err(NetworkValidationError { required, address: self })
         }
     }
 


### PR DESCRIPTION
Replaces #2502 because there is going  to be way too much arguing on this to bother a newer contributor with.

This PR takes into consideration #2507 but does not improve the issue, it also does not make it worse. I propose to do this and then consider #2507 since this is a step forwards IMO.

Remove the `address::Error` because its not good. Add a `NetworkValidationError` and return it from `require_network` - leaving the door open for resolving Kix's issue in 2507. 