### PR TITLE
internals: Implement Default for ArrayVec

### DIFF
--- a/internals/src/array_vec.rs
+++ b/internals/src/array_vec.rs
@@ -95,6 +95,10 @@ mod safety_boundary {
     }
 }
 
+impl<T: Copy, const CAP: usize> Default for ArrayVec<T, CAP> {
+    fn default() -> Self { Self::new() }
+}
+
 /// Clones the value *faster* than using `Copy`.
 ///
 /// Because we avoid copying the uninitialized part of the array this copies the value faster than


### PR DESCRIPTION
In an unrelated PR CI run we got the following error:

```
error: you should consider adding a `Default` implementation for `ArrayVec<T, CAP>`
```

I did not bother to dig any deeper since this seems like a reasonable suggestion by the compiler since we provide a `new` function that takes zero arguments.

Add a `Default` implementation to `ArrayVec`.