### PR TITLE
Add hex parsing to `pow` types

### DIFF
--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -88,17 +88,6 @@ pub fn int<T: Integer, S: AsRef<str> + Into<String>>(s: S) -> Result<T, ParseInt
     })
 }
 
-/// Strips the hex prefix off `s` if one is present.
-pub(crate) fn strip_hex_prefix(s: &str) -> &str {
-    if let Some(stripped) = s.strip_prefix("0x") {
-        stripped
-    } else if let Some(stripped) = s.strip_prefix("0X") {
-        stripped
-    } else {
-        s
-    }
-}
-
 /// Parses a u32 from a hex string.
 ///
 /// Input string may or may not contain a `0x` prefix.
@@ -109,6 +98,17 @@ pub fn hex_u32<S: AsRef<str> + Into<String>>(s: S) -> Result<u32, ParseIntError>
         is_signed: false,
         source: error,
     })
+}
+
+/// Strips the hex prefix off `s` if one is present.
+pub(crate) fn strip_hex_prefix(s: &str) -> &str {
+    if let Some(stripped) = s.strip_prefix("0x") {
+        stripped
+    } else if let Some(stripped) = s.strip_prefix("0X") {
+        stripped
+    } else {
+        s
+    }
 }
 
 /// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using infallible

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -88,7 +88,7 @@ pub fn int<T: Integer, S: AsRef<str> + Into<String>>(s: S) -> Result<T, ParseInt
     })
 }
 
-/// Parses a u32 from a hex string.
+/// Parses a `u32` from a hex string.
 ///
 /// Input string may or may not contain a `0x` prefix.
 pub fn hex_u32<S: AsRef<str> + Into<String>>(s: S) -> Result<u32, ParseIntError> {

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -92,7 +92,8 @@ pub fn int<T: Integer, S: AsRef<str> + Into<String>>(s: S) -> Result<T, ParseInt
 ///
 /// Input string may or may not contain a `0x` prefix.
 pub fn hex_u32<S: AsRef<str> + Into<String>>(s: S) -> Result<u32, ParseIntError> {
-    u32::from_str_radix(strip_hex_prefix(s.as_ref()), 16).map_err(|error| ParseIntError {
+    let stripped = strip_hex_prefix(s.as_ref());
+    u32::from_str_radix(stripped, 16).map_err(|error| ParseIntError {
         input: s.into(),
         bits: 32,
         is_signed: false,

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -182,3 +182,22 @@ macro_rules! impl_parse_str {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_u32_from_hex_prefixed() {
+        let want = 171;
+        let got = hex_u32("0xab").expect("failed to parse prefixed hex");
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn parse_u32_from_hex_no_prefix() {
+        let want = 171;
+        let got = hex_u32("ab").expect("failed to parse non-prefixed hex");
+        assert_eq!(got, want);
+    }
+}

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -101,6 +101,19 @@ pub fn hex_u32<S: AsRef<str> + Into<String>>(s: S) -> Result<u32, ParseIntError>
     })
 }
 
+/// Parses a `u128` from a hex string.
+///
+/// Input string may or may not contain a `0x` prefix.
+pub fn hex_u128<S: AsRef<str> + Into<String>>(s: S) -> Result<u128, ParseIntError> {
+    let stripped = strip_hex_prefix(s.as_ref());
+    u128::from_str_radix(stripped, 16).map_err(|error| ParseIntError {
+        input: s.into(),
+        bits: 128,
+        is_signed: false,
+        source: error,
+    })
+}
+
 /// Strips the hex prefix off `s` if one is present.
 pub(crate) fn strip_hex_prefix(s: &str) -> &str {
     if let Some(stripped) = s.strip_prefix("0x") {
@@ -199,6 +212,20 @@ mod tests {
     fn parse_u32_from_hex_no_prefix() {
         let want = 171;
         let got = hex_u32("ab").expect("failed to parse non-prefixed hex");
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn parse_u128_from_hex_prefixed() {
+        let want = 3735928559;
+        let got = hex_u128("0xdeadbeef").expect("failed to parse prefixed hex");
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn parse_u128_from_hex_no_prefix() {
+        let want = 3735928559;
+        let got = hex_u128("deadbeef").expect("failed to parse non-prefixed hex");
         assert_eq!(got, want);
     }
 }


### PR DESCRIPTION
The `pow` types implement `fmt::LowerHex` but do not implement hex parsing.
    
Add inherent methods `from_hex` and `from_prefixed_hex` to the  `pow` types - as we did for locktime types.
