### PR TITLE
Impl `From<core::convert::Infallible>` for Errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,6 +290,7 @@ More specifically an error should
 - derive `Debug, Clone, PartialEq, Eq` (and `Copy` iff not `non_exhaustive`).
 - implement Display using `write_err!()` macro if a variant contains an inner error source.
 - have `Error` suffix
+- call `internals::impl_from_infallible!
 - implement `std::error::Error` if they are public (feature gated on "std").
 
 ```rust
@@ -302,6 +303,9 @@ pub enum Error {
     /// Documentation for variant B.
     B,
 }
+
+internals::impl_from_infallible!(Error);
+
 ```
 
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -12,6 +12,7 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 name = "base58check"
 version = "0.1.0"
 dependencies = [
+ "bitcoin-internals",
  "bitcoin_hashes",
  "hex-conservative",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -12,6 +12,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 name = "base58check"
 version = "0.1.0"
 dependencies = [
+ "bitcoin-internals",
  "bitcoin_hashes",
  "hex-conservative",
 ]

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -22,6 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", version = "0.13.0", default-features = false, features = ["alloc"] }
+internals = { package = "bitcoin-internals", version = "0.2.0" }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false, features = ["alloc"] }

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -228,6 +228,8 @@ pub enum Error {
     TooShort(usize),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -41,6 +41,8 @@ pub enum FromScriptError {
     WitnessVersion(witness_version::TryFromError),
 }
 
+internals::impl_from_infallible!(FromScriptError);
+
 impl fmt::Display for FromScriptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use FromScriptError::*;
@@ -81,6 +83,8 @@ pub enum P2shError {
     /// Address size more than 520 bytes is not allowed.
     ExcessiveScriptSize,
 }
+
+internals::impl_from_infallible!(P2shError);
 
 impl fmt::Display for P2shError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -134,6 +138,8 @@ pub enum ParseError {
     /// Tried to parse an unknown HRP.
     UnknownHrp(UnknownHrpError),
 }
+
+internals::impl_from_infallible!(ParseError);
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -28,6 +28,8 @@ pub enum Error {
     InvalidPrefill,
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -77,6 +77,8 @@ pub enum Error {
     Io(io::Error),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         use Error::*;

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -491,6 +491,8 @@ pub enum Error {
     InvalidPublicKeyHexLength(usize),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -420,6 +420,8 @@ pub enum Bip34Error {
     NegativeHeight,
 }
 
+internals::impl_from_infallible!(Bip34Error);
+
 impl fmt::Display for Bip34Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Bip34Error::*;
@@ -455,6 +457,8 @@ pub enum ValidationError {
     /// The `target` field of a block header did not match the expected difficulty.
     BadTarget,
 }
+
+internals::impl_from_infallible!(ValidationError);
 
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -626,6 +626,8 @@ pub enum Error {
     Parse(ParseIntError),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
@@ -723,6 +725,8 @@ pub enum OperationError {
     InvalidComparison,
 }
 
+internals::impl_from_infallible!(OperationError);
+
 impl fmt::Display for OperationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use OperationError::*;
@@ -753,6 +757,8 @@ enum ParseError {
     // we use i64 to have nicer messages for negative values
     Conversion(i64),
 }
+
+internals::impl_from_infallible!(ParseError);
 
 impl ParseError {
     fn invalid_int<S: Into<String>>(s: S) -> impl FnOnce(core::num::ParseIntError) -> Self {

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -282,6 +282,8 @@ pub enum Error {
     IncompatibleTime(LockTime, Time),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -699,6 +699,8 @@ pub enum Error {
     Serialization,
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
@@ -736,6 +738,8 @@ enum UintError {
     EarlyEndOfScript,
     NumericOverflow,
 }
+
+internals::impl_from_infallible!(UintError);
 
 impl From<UintError> for Error {
     fn from(error: UintError) -> Self {

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -135,6 +135,8 @@ pub enum Error {
     InvalidSegwitV0Length(usize),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -175,6 +175,8 @@ pub enum FromStrError {
     Invalid(TryFromError),
 }
 
+internals::impl_from_infallible!(FromStrError);
+
 impl fmt::Display for FromStrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use FromStrError::*;
@@ -215,6 +217,8 @@ pub enum TryFromInstructionError {
     /// Cannot create a witness version from non-zero data push.
     DataPush,
 }
+
+internals::impl_from_infallible!(TryFromInstructionError);
 
 impl fmt::Display for TryFromInstructionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -130,6 +130,8 @@ pub enum ParseOutPointError {
     VoutNotCanonical,
 }
 
+internals::impl_from_infallible!(ParseOutPointError);
+
 impl fmt::Display for ParseOutPointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ParseOutPointError::*;

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -61,6 +61,8 @@ pub enum Error {
     UnsupportedSegwitFlag(u8),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -368,6 +368,8 @@ enum DecodeError<E> {
     Other(E),
 }
 
+internals::impl_from_infallible!(DecodeError<E>);
+
 // not a trait impl because we panic on some variants
 fn consensus_error_into_serde<E: serde::de::Error>(error: ConsensusError) -> E {
     match error {

--- a/bitcoin/src/consensus/validation.rs
+++ b/bitcoin/src/consensus/validation.rs
@@ -209,6 +209,8 @@ pub enum TxVerifyError {
     UnknownSpentOutput(OutPoint),
 }
 
+internals::impl_from_infallible!(TxVerifyError);
+
 impl fmt::Display for TxVerifyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use TxVerifyError::*;

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -213,6 +213,8 @@ pub enum Error {
     Secp256k1(secp256k1::Error),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -896,6 +896,8 @@ pub enum FromSliceError {
     InvalidLength(usize),
 }
 
+internals::impl_from_infallible!(FromSliceError);
+
 impl fmt::Display for FromSliceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use FromSliceError::*;
@@ -933,6 +935,8 @@ pub enum FromWifError {
     /// A secp256k1 error.
     Secp256k1(secp256k1::Error),
 }
+
+internals::impl_from_infallible!(FromWifError);
 
 impl fmt::Display for FromWifError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -974,6 +978,8 @@ pub enum ParsePublicKeyError {
     InvalidHexLength(usize),
 }
 
+internals::impl_from_infallible!(ParsePublicKeyError);
+
 impl fmt::Display for ParsePublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ParsePublicKeyError::*;
@@ -1009,6 +1015,8 @@ pub enum ParseCompressedPublicKeyError {
     /// hex to array conversion error.
     Hex(hex::HexToArrayError),
 }
+
+internals::impl_from_infallible!(ParseCompressedPublicKeyError);
 
 impl fmt::Display for ParseCompressedPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -275,6 +275,8 @@ pub enum PrevoutsIndexError {
     InvalidAllIndex,
 }
 
+internals::impl_from_infallible!(PrevoutsIndexError);
+
 impl fmt::Display for PrevoutsIndexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use PrevoutsIndexError::*;
@@ -1151,6 +1153,8 @@ pub enum TaprootError {
     InvalidSighashType(u32),
 }
 
+internals::impl_from_infallible!(TaprootError);
+
 impl fmt::Display for TaprootError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use TaprootError::*;
@@ -1207,6 +1211,8 @@ pub enum P2wpkhError {
     /// Script is not a witness program for a p2wpkh output.
     NotP2wpkhScript,
 }
+
+internals::impl_from_infallible!(P2wpkhError);
 
 impl From<transaction::InputsIndexError> for P2wpkhError {
     fn from(value: transaction::InputsIndexError) -> Self {
@@ -1272,6 +1278,8 @@ pub enum AnnexError {
     /// Incorrect prefix byte in the annex.
     IncorrectPrefix(u8),
 }
+
+internals::impl_from_infallible!(AnnexError);
 
 impl fmt::Display for AnnexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1378,6 +1386,8 @@ pub enum SigningDataError<E> {
     /// An argument to the called sighash function was invalid.
     Sighash(E),
 }
+
+internals::impl_from_infallible!(SigningDataError<E>);
 
 impl<E> SigningDataError<E> {
     /// Returns the sighash variant, panicking if it's IO.

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -97,6 +97,8 @@ pub enum SigFromSliceError {
     InvalidSignatureSize(usize),
 }
 
+internals::impl_from_infallible!(SigFromSliceError);
+
 impl fmt::Display for SigFromSliceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use SigFromSliceError::*;

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -498,6 +498,8 @@ pub enum MerkleBlockError {
     IdenticalHashesFound,
 }
 
+internals::impl_from_infallible!(MerkleBlockError);
+
 impl fmt::Display for MerkleBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use MerkleBlockError::*;

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -103,6 +103,8 @@ pub enum Error {
     Io(io::Error),
 }
 
+internals::impl_from_infallible!(Error);
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -675,6 +675,8 @@ pub enum GetKeyError {
     NotSupported,
 }
 
+internals::impl_from_infallible!(GetKeyError);
+
 impl fmt::Display for GetKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use GetKeyError::*;
@@ -784,6 +786,8 @@ pub enum SignError {
     Unsupported,
 }
 
+internals::impl_from_infallible!(SignError);
+
 impl fmt::Display for SignError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use SignError::*;
@@ -865,6 +869,8 @@ pub enum ExtractTxError {
     },
 }
 
+internals::impl_from_infallible!(ExtractTxError);
+
 impl fmt::Display for ExtractTxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ExtractTxError::*;
@@ -914,6 +920,8 @@ pub enum IndexOutOfBoundsError {
         length: usize,
     },
 }
+
+internals::impl_from_infallible!(IndexOutOfBoundsError);
 
 impl fmt::Display for IndexOutOfBoundsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -965,6 +973,8 @@ mod display_from_str {
         /// Error in PSBT Base64 encoding.
         Base64Encoding(::base64::DecodeError),
     }
+
+    internals::impl_from_infallible!(PsbtParseError);
 
     impl Display for PsbtParseError {
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -43,6 +43,8 @@ mod message_signing {
         UnsupportedAddressType(AddressType),
     }
 
+    internals::impl_from_infallible!(MessageSignatureError);
+
     impl fmt::Display for MessageSignatureError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             use MessageSignatureError::*;

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -587,6 +587,8 @@ pub enum IncompleteBuilderError {
     HiddenParts(TaprootBuilder),
 }
 
+internals::impl_from_infallible!(IncompleteBuilderError);
+
 impl IncompleteBuilderError {
     /// Converts error into the original incomplete [`TaprootBuilder`] instance.
     pub fn into_builder(self) -> TaprootBuilder {
@@ -630,6 +632,8 @@ pub enum HiddenNodesError {
     /// Indicates an attempt to construct a tap tree from a builder containing hidden parts.
     HiddenParts(NodeInfo),
 }
+
+internals::impl_from_infallible!(HiddenNodesError);
 
 impl HiddenNodesError {
     /// Converts error into the original incomplete [`NodeInfo`] instance.
@@ -1324,6 +1328,8 @@ pub enum TaprootBuilderError {
     EmptyTree,
 }
 
+internals::impl_from_infallible!(TaprootBuilderError);
+
 impl fmt::Display for TaprootBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use TaprootBuilderError::*;
@@ -1383,6 +1389,8 @@ pub enum TaprootError {
     /// Empty tap tree.
     EmptyTree,
 }
+
+internals::impl_from_infallible!(TaprootError);
 
 impl fmt::Display for TaprootError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -113,3 +113,59 @@ macro_rules! const_assert {
         const _: [(); 0 - !$x as usize] = [];
     }};
 }
+
+/// Derives `From<core::convert::Infallible>` for the given type.
+///
+/// Supports types with arbitrary combinations of lifetimes and type parameters.
+///
+/// Note: Paths are not supported (for ex. impl_from_infallible!(Hello<D: std::fmt::Display>).
+///
+/// ## Examples
+///
+/// ```rust
+/// # use core::fmt::{Display, Debug};
+/// use bitcoin_internals::impl_from_infallible;
+///
+/// enum AlphaEnum { Item }
+/// impl_from_infallible!(AlphaEnum);
+///
+/// enum BetaEnum<'b> { Item(&'b usize) }
+/// impl_from_infallible!(BetaEnum<'b>);
+///
+/// enum GammaEnum<T> { Item(T) };
+/// impl_from_infallible!(GammaEnum<T>);
+///
+/// enum DeltaEnum<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a> {
+///     Item((&'b usize, &'a usize, T, D))
+/// }
+/// impl_from_infallible!(DeltaEnum<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a>);
+///
+/// struct AlphaStruct;
+/// impl_from_infallible!(AlphaStruct);
+///
+/// struct BetaStruct<'b>(&'b usize);
+/// impl_from_infallible!(BetaStruct<'b>);
+///
+/// struct GammaStruct<T>(T);
+/// impl_from_infallible!(GammaStruct<T>);
+///
+/// struct DeltaStruct<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a> {
+///     hello: &'a T,
+///     what: &'b D,
+/// }
+/// impl_from_infallible!(DeltaStruct<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a>);
+/// ```
+///
+/// See <https://stackoverflow.com/a/61189128> for more information about this macro.
+#[macro_export]
+macro_rules! impl_from_infallible {
+    ( $name:ident $(< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? ) => {
+        impl $(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)?
+            From<core::convert::Infallible>
+        for $name
+            $(< $( $lt ),+ >)?
+        {
+            fn from(never: core::convert::Infallible) -> Self { match never {} }
+        }
+    }
+}

--- a/io/src/error.rs
+++ b/io/src/error.rs
@@ -116,6 +116,10 @@ macro_rules! define_errorkind {
             ),*
         }
 
+        impl From<core::convert::Infallible> for ErrorKind {
+            fn from(never: core::convert::Infallible) -> Self { match never {} }
+        }
+
         impl ErrorKind {
             fn description(&self) -> &'static str {
                 match self {

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -161,6 +161,8 @@ pub enum ParseError {
     MissingDenomination(MissingDenominationError),
 }
 
+internals::impl_from_infallible!(ParseError);
+
 impl From<ParseAmountError> for ParseError {
     fn from(e: ParseAmountError) -> Self { Self::Amount(e) }
 }
@@ -254,6 +256,8 @@ impl From<InvalidCharacterError> for ParseAmountError {
         Self::InvalidCharacter(value)
     }
 }
+
+internals::impl_from_infallible!(ParseAmountError);
 
 impl fmt::Display for ParseAmountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -447,6 +451,8 @@ pub enum ParseDenominationError {
     PossiblyConfusing(PossiblyConfusingDenominationError),
 }
 
+internals::impl_from_infallible!(ParseDenominationError);
+
 impl fmt::Display for ParseDenominationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ParseDenominationError::*;
@@ -620,6 +626,8 @@ enum InnerParseError {
     InputTooLarge(usize),
     InvalidCharacter(InvalidCharacterError),
 }
+
+internals::impl_from_infallible!(InnerParseError);
 
 impl InnerParseError {
     fn convert(self, is_signed: bool) -> ParseAmountError {


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/1222

Example usage
```rust
use internals::impl_from_infallible;

#[derive(Debug, Clone, PartialEq, Eq)]
enum Error {
    SomeError(u8),
    SomeOtherError(u32, u32),
}

impl_from_infallible!(Error);
```

Feel free to request changes :)