### PR TITLE
Re-export `address::error::P2shError` from `address` module 

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -54,7 +54,7 @@ use self::error::P2shError;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    error::{NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError, },
+    error::{FromScriptError, NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError},
 };
 
 /// The different types of addresses.

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -50,11 +50,10 @@ use crate::network::{Network, NetworkKind};
 use crate::prelude::*;
 use crate::taproot::TapNodeHash;
 
-use self::error::P2shError;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    error::{FromScriptError, NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError},
+    error::{FromScriptError, NetworkValidationError, ParseError, P2shError, UnknownAddressTypeError, UnknownHrpError},
 };
 
 /// The different types of addresses.


### PR DESCRIPTION
As with the rest of the errors in `address::error` that are returned by a pubic function from the `address` module.

Note please, this PR just makes the `address/mod.rs` file uniform, debating the merit of the re-exports is out of scope.