### PR TITLE
Remove link to std from rustdoc

### DIFF
--- a/internals/src/error/parse_error.rs
+++ b/internals/src/error/parse_error.rs
@@ -6,7 +6,7 @@
 /// [`InputString`](super::InputString), the type of `source` is specified as the second argument
 /// to the macro.
 ///
-/// The resulting type is public, conditionally implements [`std::error::Error`] and has a private
+/// The resulting type is public, conditionally implements `std::error::Error` and has a private
 /// `new()` method for convenience.
 ///
 /// ## Parameters


### PR DESCRIPTION
We can't link to `std::error::Error` in rustdoc because it breaks non-std builds. Just use backticks - this is not an optimal solution but I know no other.

I have no clue why this is showing up now.