### PR TITLE
Improve leaf errors

### DIFF
--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -245,10 +245,14 @@ impl From<TryFromError> for TryFromInstructionError {
 
 /// Error attempting to create a [`WitnessVersion`] from an integer.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct TryFromError {
     /// The invalid non-witness version integer.
-    pub invalid: u8,
+    invalid: u8,
+}
+
+impl TryFromError {
+    /// Returns the invalid non-witness version integer.
+    pub fn invalid_version(&self) -> u8 { self.invalid }
 }
 
 impl fmt::Display for TryFromError {
@@ -258,6 +262,4 @@ impl fmt::Display for TryFromError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for TryFromError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl std::error::Error for TryFromError {}

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -723,22 +723,6 @@ impl<T: Into<u128>> From<T> for U256 {
     fn from(x: T) -> Self { U256(0, x.into()) }
 }
 
-/// Error from `TryFrom<signed type>` implementations, occurs when input is negative.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct TryFromError(i128);
-
-impl fmt::Display for TryFromError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "attempt to create unsigned integer type from negative number: {}", self.0)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for TryFromError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
-
 impl Add for U256 {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -234,10 +234,17 @@ pub trait Hash:
 
 /// Attempted to create a hash from an invalid length slice.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct FromSliceError {
     expected: usize,
     got: usize,
+}
+
+impl FromSliceError {
+    /// Returns the expected slice length.
+    pub fn expected_length(&self) -> usize { self.expected }
+
+    /// Returns the invalid slice length.
+    pub fn invalid_length(&self) -> usize { self.got }
 }
 
 impl fmt::Display for FromSliceError {
@@ -247,9 +254,7 @@ impl fmt::Display for FromSliceError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for FromSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl std::error::Error for FromSliceError {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
In light of recent discussion go over the codebase and look for some places that the leaf errors are wrong. Does not do the whole code base, excludes `p2p` and a couple of other places.