### PR TITLE
Try to make some forward progress on the absolute locktime unit types

### DIFF
--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -796,8 +796,9 @@ impl ParseError {
 }
 
 impl From<ParseIntError> for ParseError {
-    fn from(value: ParseIntError) -> Self {
-        Self::InvalidInteger { source: value.source, input: value.input }
+    fn from(error: ParseIntError) -> Self {
+        let (input, source) = error.into_parts();
+        Self::InvalidInteger { source, input }
     }
 }
 

--- a/bitcoin/src/parse.rs
+++ b/bitcoin/src/parse.rs
@@ -19,19 +19,22 @@ use crate::prelude::*;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ParseIntError {
-    pub(crate) input: String,
+    input: String,
     // for displaying - see Display impl with nice error message below
     bits: u8,
     // We could represent this as a single bit but it wouldn't actually derease the cost of moving
     // the struct because String contains pointers so there will be padding of bits at least
     // pointer_size - 1 bytes: min 1B in practice.
     is_signed: bool,
-    pub(crate) source: core::num::ParseIntError,
+    source: core::num::ParseIntError,
 }
 
 impl ParseIntError {
     /// Returns the input that was attempted to be parsed.
     pub fn input(&self) -> &str { &self.input }
+
+    /// Returns the input that was attempted to be parsed and the source error.
+    pub fn into_parts(self) -> (String, core::num::ParseIntError) { (self.input, self.source) }
 }
 
 impl fmt::Display for ParseIntError {


### PR DESCRIPTION
We would like to move the `Height` and `Time` types out of `absolute` and into `units` but the error code is holding us up, specifically the use of an inner `String`. This PR attempts to make some forward progress, please note another approach is to just use `Debug` to print the inner string instead of adding the `internals::error::Raw` type, I'm not sure which approach is better since both have their problems IMO.

Please see the last patch of #2537 for an alternate approach to the last patch of this PR.