### PR TITLE
Reduce usage of `Network` in the public API

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -91,10 +91,11 @@ impl OutPoint {
     /// # Examples
     ///
     /// ```rust
+    /// use bitcoin::consensus::params;
     /// use bitcoin::constants::genesis_block;
     /// use bitcoin::Network;
     ///
-    /// let block = genesis_block(Network::Bitcoin);
+    /// let block = genesis_block(&params::MAINNET);
     /// let tx = &block.txdata[0];
     ///
     /// // Coinbase transactions don't have any previous output.

--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -56,6 +56,21 @@ pub struct Params {
     pub no_pow_retargeting: bool,
 }
 
+/// The mainnet parameters.
+///
+/// Use this for a static reference e.g., `&params::MAINNET`.
+///
+/// For more on static vs const see The Rust Reference [using-statics-or-consts] section.
+///
+/// [using-statics-or-consts]: <https://doc.rust-lang.org/reference/items/static-items.html#using-statics-or-consts>
+pub static MAINNET: Params = Params::MAINNET;
+/// The testnet parameters.
+pub static TESTNET: Params = Params::TESTNET;
+/// The signet parameters.
+pub static SIGNET: Params = Params::SIGNET;
+/// The regtest parameters.
+pub static REGTEST: Params = Params::REGTEST;
+
 impl Params {
     /// The mainnet parameters (alias for `Params::MAINNET`).
     pub const BITCOIN: Params = Params::MAINNET;
@@ -162,4 +177,15 @@ impl From<&Network> for &'static Params {
 
 impl AsRef<Params> for Params {
     fn as_ref(&self) -> &Params { self }
+}
+
+impl AsRef<Params> for Network {
+    fn as_ref(&self) -> &Params {
+        match *self {
+            Network::Bitcoin => &MAINNET,
+            Network::Testnet => &TESTNET,
+            Network::Signet => &SIGNET,
+            Network::Regtest => &REGTEST,
+        }
+    }
 }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -129,6 +129,7 @@ pub use crate::{
     blockdata::weight::Weight,
     blockdata::witness::{self, Witness},
     consensus::encode::VarInt,
+    consensus::params,
     crypto::ecdsa,
     crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, CompressedPublicKey, WPubkeyHash, XOnlyPublicKey},
     crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},

--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -154,7 +154,7 @@ impl Network {
     /// let network = Network::Bitcoin;
     /// assert_eq!(network.chain_hash(), ChainHash::BITCOIN);
     /// ```
-    pub fn chain_hash(self) -> ChainHash { ChainHash::using_genesis_block(self) }
+    pub fn chain_hash(self) -> ChainHash { ChainHash::using_genesis_block_const(self) }
 
     /// Creates a `Network` from the chain hash (genesis block hash).
     ///

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -28,6 +28,7 @@ use internals::{debug_from_display, write_err};
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::Params;
 use crate::prelude::*;
 use crate::Network;
 
@@ -226,6 +227,11 @@ impl Magic {
 
     /// Get network magic bytes.
     pub fn to_bytes(self) -> [u8; 4] { self.0 }
+
+    /// Returns the magic bytes for the network defined by `params`.
+    pub fn from_params(params: impl AsRef<Params>) -> Self {
+        params.as_ref().network.into()
+    }
 }
 
 impl FromStr for Magic {


### PR DESCRIPTION
Minimize usage of the `Network` enum in the public API.

See #2225 for context, and https://github.com/rust-bitcoin/rust-bitcoin/pull/1291#discussion_r1492993788 for an interpretation of that long discussion.

Close: #2169
