### PR TITLE
tweak nightly CI update

### DIFF
--- a/.github/workflows/cron-daily-update-nightly.yml
+++ b/.github/workflows/cron-daily-update-nightly.yml
@@ -31,6 +31,7 @@ jobs:
         if: env.changes_made == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.APOELSTRA_CREATE_PR_TOKEN }}
           author: Update Nightly Rustc Bot <bot@example.com>
           committer: Update Nightly Rustc Bot <bot@example.com>
           title: Automated daily update to rustc (to nightly-${{ env.nightly_date }})

--- a/.github/workflows/cron-daily-update-nightly.yml
+++ b/.github/workflows/cron-daily-update-nightly.yml
@@ -36,3 +36,4 @@ jobs:
           body: |
            Automated update to Github CI workflow `rust.yml` by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
           commit-message: Automated update to Github CI to rustc nightly-${{ env.nightly_date }}
+          branch: create-pull-request/daily-nightly-update

--- a/.github/workflows/cron-daily-update-nightly.yml
+++ b/.github/workflows/cron-daily-update-nightly.yml
@@ -32,6 +32,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           author: Update Nightly Rustc Bot <bot@example.com>
+          committer: Update Nightly Rustc Bot <bot@example.com>
           title: Automated daily update to rustc (to nightly-${{ env.nightly_date }})
           body: |
            Automated update to Github CI workflow `rust.yml` by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action


### PR DESCRIPTION
Rename the bot's committer name to not have special characters, which causes some problem in tcharding's locale; also change the branch name to not overlap with the "weekly CI" job, since it's causing the two jobs to overwrite each others' PRs.

Was part of #2531 but pulled out here to be in a branch that isn't getting clobbered every 24 hours :).