### PR TITLE
Removes txid prefix in transaction IDs

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -2444,6 +2444,29 @@ mod tests {
         let seq = Sequence::from_seconds_floor(1000);
         println!("{:?}", seq)
     }
+
+    #[test]
+    fn outpoint_format() {
+        let outpoint = OutPoint::default();
+
+        let debug = "OutPoint { txid: 0000000000000000000000000000000000000000000000000000000000000000, vout: 4294967295 }";
+        assert_eq!(debug, format!("{:?}", &outpoint));
+
+        let display = "0000000000000000000000000000000000000000000000000000000000000000:4294967295";
+        assert_eq!(display, format!("{}", &outpoint));
+
+        let pretty_debug = "OutPoint {\n    txid: 0000000000000000000000000000000000000000000000000000000000000000,\n    vout: 4294967295,\n}";
+        assert_eq!(pretty_debug, format!("{:#?}", &outpoint));
+
+        let debug_txid = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(debug_txid, format!("{:?}", &outpoint.txid));
+
+        let display_txid = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(display_txid, format!("{}", &outpoint.txid));
+
+        let pretty_txid = "0x0000000000000000000000000000000000000000000000000000000000000000";
+        assert_eq!(pretty_txid, format!("{:#}", &outpoint.txid));
+    }
 }
 
 #[cfg(bench)]

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -39,7 +39,7 @@ macro_rules! hex_fmt_impl(
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::Debug for $ty<$($gen),*> {
             #[inline]
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
-                write!(f, "{:#}", self)
+                write!(f, "{}", self)
             }
         }
     );


### PR DESCRIPTION
This commit attempts to solve #2505  by ensuring that formatting is not forced using the `:#` in the hex macro code generating in macro rule `hex_fmt_impl` in the hashes/utils.rs file.

The write! macro forces all formatting to add the prefix `0x` by adding an alternate by (#) default 

```rust
impl<$($gen: $gent),*> $crate::_export::_core::fmt::Debug for $ty<$($gen),*> {
            #[inline]
            fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
                write!(f, "{:#}", self) // <-- This is where the formatting is being forced.
            }
        }
```

By removing this formatting, the `:#` must be specified by the user in order for a prefix to be added.

```rust
let outpoint = bitcoin::OutPoint::default();
    println!("{:?}", &outpoint);
    println!("{:#?}", &outpoint);
    println!("{:#}", &outpoint);
    println!("{:x}", &outpoint.txid);
    // `{:#}` must be specified to pretty print with a prefix
    println!("{:#}", &outpoint.txid);
    dbg!(&outpoint);
    dbg!(&outpoint.txid);
```

The PR also adds testcase for this when running `cargo test` .