### PR TITLE
Upgrade bitcoinconsenus

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -114,12 +114,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoinconsensus"
-version = "0.20.2-0.5.0"
+version = "0.105.0+25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54505558b77e0aa21b2491a7b39cbae9db22ac8b1bc543ef4600edb762306f9c"
+checksum = "f260ac8fb2c621329013fc0ed371c940fcc512552dcbcb9095ed0179098c9e18"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -113,12 +113,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoinconsensus"
-version = "0.20.2-0.5.0"
+version = "0.105.0+25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54505558b77e0aa21b2491a7b39cbae9db22ac8b1bc543ef4600edb762306f9c"
+checksum = "f260ac8fb2c621329013fc0ed371c940fcc512552dcbcb9095ed0179098c9e18"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -41,7 +41,7 @@ units = { package = "bitcoin-units", version = "0.1.0", default-features = false
 base64 = { version = "0.21.3", optional = true }
 ordered = { version = "0.2.0", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
-bitcoinconsensus = { version = "0.20.2-0.5.0", default-features = false, optional = true }
+bitcoinconsensus = { version = "0.105.0+25.1", default-features = false, optional = true }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }


### PR DESCRIPTION
Upgrade to the most recent `bitcoinconsensus` version that excludes Taproot verification i.e., one version before latest.