### PR TITLE
Remove useless convertion

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -2493,7 +2493,7 @@ mod tests {
 
         use super::ParseAmountError as E;
 
-        assert_eq!(Amount::from_str("x BTC"), Err(E::from(E::from(InvalidCharacterError { invalid_char: 'x', position: 0 })).into()));
+        assert_eq!(Amount::from_str("x BTC"), Err(E::from(InvalidCharacterError { invalid_char: 'x', position: 0 }).into()));
         assert_eq!(
             Amount::from_str("xBTC"),
             Err(Unknown(UnknownDenominationError("xBTC".into())).into()),


### PR DESCRIPTION
No clue how this got into master, I thought pinning nightly stopped things like this; found with `just sane`.

Clippy emits:

 useless conversion to the same type: `amount::ParseAmountError`

As suggested, remove the useless conversion.