### PR TITLE
Return error when constructing pubkey from slice

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -241,14 +241,14 @@ impl FromStr for PublicKey {
                     InvalidChar(e) => ParsePublicKeyError::InvalidChar(e.invalid_char()),
                     InvalidLength(_) => unreachable!("length checked already")
                 })?;
-                Ok(PublicKey::from_slice(&bytes).expect("length checked already"))
+                Ok(PublicKey::from_slice(&bytes)?)
             },
             130 => {
                 let bytes = <[u8; 65]>::from_hex(s).map_err(|e| match e {
                     InvalidChar(e) => ParsePublicKeyError::InvalidChar(e.invalid_char()),
                     InvalidLength(_) => unreachable!("length checked already")
                 })?;
-                Ok(PublicKey::from_slice(&bytes).expect("length checked already"))
+                Ok(PublicKey::from_slice(&bytes)?)
             }
             len => Err(ParsePublicKeyError::InvalidHexLength(len)),
         }


### PR DESCRIPTION
This PR fixes a bug introduced by me in #2473, and uncovered by #2563 - amazing that it was found so quickly!

Constructing a pubkey using `PublicKey::from_slice` can fail for reasons other than just incorrect length - we should not be using `expect` but rather returning the error.

A purist might argue that we are now returning a nested error type with an unreachable variant:

  `ParsePublicKeyError::Encoding(FromSliceError::InvalidLength)`

Is this acceptable or do we want to further improve this?