### PR TITLE
fix: Manually implement serde traits

### DIFF
--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -33,6 +33,10 @@ extern crate std;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
+#[cfg(test)]
+#[macro_use]
+mod test_macros;
+
 pub mod amount;
 #[cfg(feature = "alloc")]
 pub mod locktime;

--- a/units/src/test_macros.rs
+++ b/units/src/test_macros.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin serde macros.
+//!
+//! This module provides internal macros used for unit tests.
+
+#[cfg(feature = "serde")]
+macro_rules! serde_round_trip (
+    ($var:expr) => ({
+        use serde_json;
+
+        let encoded = serde_json::to_value(&$var).unwrap();
+        let decoded = serde_json::from_value(encoded).unwrap();
+        assert_eq!($var, decoded);
+    })
+);


### PR DESCRIPTION
Currently we are deriving the serde traits for the `absolute::{Height, Time}` types, this is incorrect because we maintain an invariant on the inner `u32` of both types that it is above or below the threshold.

Manually implement the serde traits and pass the deserialized `u32` to `from_consensus` to maintain the invariant.

Close: #2559