### PR TITLE
Add commit template git hook

### DIFF
--- a/githooks/commit-template.txt
+++ b/githooks/commit-template.txt
@@ -1,0 +1,5 @@
+# Title -                              width limit ->|
+
+# Explain *why* this change is being made                width limit ->|
+#
+# Explain *what* change is being made

--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# A hook that adds a commit template.
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+# Remove the default message.
+/usr/bin/env perl -i.bak -ne 'print unless(m/^. Please enter the commit message/..m/^#$/)' "$COMMIT_MSG_FILE"
+
+# Print our custom commit template.
+/usr/bin/env perl -le 'open FH, "./commit-template.txt"; while(<FH>){print "foo"}; print "\n"'


### PR DESCRIPTION
High quality commit messages make for easier reviews, easier `git blame`, and help catch bugs.

In an effort to encourage high quality commits add a commit template by way of a git hook.