### PR TITLE
Add an `address::Error` type

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -54,7 +54,7 @@ use self::error::P2shError;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    error::{NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError, },
+    error::{Error, NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError, FromScriptError},
 };
 
 /// The different types of addresses.


### PR DESCRIPTION
If one wants to parse and address and then validate the network in a single statement as such

```
    s.parse::<Address<_>>()?
        .require_network(Network::Bitcoin)?
```

A user is currently required to create a new error type to cover the two error paths (or use `anyhow`) - this is unergonomic for such a common usecase.

We could put the `NetworkValidationError` inside the `ParseError` but another alternative is to provide an additional error for this exact purpose. Since address parsing is a bit unique with respect to network validation it seems reasonable to provide an error specifically for downstream usage even though we do not [often] do this an other places.

Add a new error type that combines the address string parsing error with the network validation error.

Close: #2507