### PR TITLE
Release tracking PR: `base58ck v0.1.0`

### DIFF
--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 0.1.0 - 2024-03-14
+
+Initial release of the `base58ck` crate. This crate was cut out of
+`rust-bitcoin` and cleaned up for release as a separate crate.


### PR DESCRIPTION
In preparation for release add a minimal changelog to the `base58ck` crate.

This crate is currently unreleased and has the version number correctly set to `v0.1.0` - as of today, the crate name `base58ck` is available on crates.io.
