### PR TITLE
Release tracking PR: `io v0.1.2`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.2 - 2024-03-14
+
+* Implement `From<core::convert::Infallible>` for Errors [#2516](https://github.com/rust-bitcoin/rust-bitcoin/pull/2516)
+* Fix new CI build warnings [#2488](https://github.com/rust-bitcoin/rust-bitcoin/pull/2488)
+
 # 0.1.1 - Initial Release - 2024-02-18
 
 Create the `io` crate, add basic I/O traits, types, and implementations.

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-io"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"


### PR DESCRIPTION
There have only been two PRs merged that touched the `io` crate since it as last released. The changes are additive so we can do a pre-0.1 point release.

In preparation for release bump the version and add a changelog entry.