### PR TITLE
CI: Disable MSAN job

### DIFF
--- a/contrib/run_task.sh
+++ b/contrib/run_task.sh
@@ -212,10 +212,12 @@ do_asan() {
       RUSTFLAGS='-Zsanitizer=address -Clinker=clang -Cforce-frame-pointers=yes'                    \
       ASAN_OPTIONS='detect_leaks=1 detect_invalid_pointer_pairs=1 detect_stack_use_after_return=1' \
       cargo test --lib --no-default-features --features="$ASAN_FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
-    cargo clean
-    CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
-      RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
-      cargo test --lib --no-default-features --features="$ASAN_FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
+    # There is currently a bug in the MemorySanitizer (MSAN) - disable the job for now.
+    #
+    # cargo clean
+    # CC='clang -fsanitize=memory -fno-omit-frame-pointer'                                         \
+    #   RUSTFLAGS='-Zsanitizer=memory -Zsanitizer-memory-track-origins -Cforce-frame-pointers=yes'   \
+    #   cargo test --lib --no-default-features --features="$ASAN_FEATURES" -Zbuild-std --target x86_64-unknown-linux-gnu
 }
 
 # Bench only works with a non-stable toolchain (nightly, beta).


### PR DESCRIPTION
I believe there is currently a bug in the MemorySanitizer, when we pass various types across the FFI boundry MSAN gives a unititialized variable error:

- `usize` passed as `size_t` (cannot be uninitialized)
- byte slice passed as `const char *`

In order to let other work continue disable the MSAN job.

The issue is further described in #2579 