### PR TITLE
Single patch of changes required by BitVM

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,6 +25,7 @@ jobs:
           bitcoin_deserialize_witness,
           bitcoin_deser_net_msg,
           bitcoin_outpoint_string,
+          bitcoin_script_asm_roundtrip,
           bitcoin_script_bytes_to_asm_fmt,
           hashes_cbor,
           hashes_json,

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -8,7 +8,7 @@
 
 #![allow(non_camel_case_types)]
 
-use core::fmt;
+use core::{fmt, str};
 
 use internals::debug_from_display;
 
@@ -30,7 +30,7 @@ use crate::prelude::*;
 /// </details>
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Opcode {
-    code: u8,
+    pub(crate) code: u8,
 }
 
 use self::all::*;
@@ -69,6 +69,40 @@ macro_rules! all_opcodes {
                    $(
                         $op => core::fmt::Display::fmt(stringify!($op), f),
                     )+
+                }
+            }
+        }
+
+        impl str::FromStr for Opcode {
+            type Err = ();
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    "OP_0" => Ok(OP_0),
+                    "OP_TRUE" | "TRUE" => Ok(OP_TRUE),
+                    "OP_FALSE" | "FALSE" => Ok(OP_FALSE),
+                    "OP_NOP2" | "NOP2" => Ok(OP_NOP2),
+                    "OP_NOP3" | "NOP3" => Ok(OP_NOP3),
+                    "OP_1" => Ok(OP_PUSHNUM_1),
+                    "OP_2" => Ok(OP_PUSHNUM_2),
+                    "OP_3" => Ok(OP_PUSHNUM_3),
+                    "OP_4" => Ok(OP_PUSHNUM_4),
+                    "OP_5" => Ok(OP_PUSHNUM_5),
+                    "OP_6" => Ok(OP_PUSHNUM_6),
+                    "OP_7" => Ok(OP_PUSHNUM_7),
+                    "OP_8" => Ok(OP_PUSHNUM_8),
+                    "OP_9" => Ok(OP_PUSHNUM_9),
+                    "OP_10" => Ok(OP_PUSHNUM_10),
+                    "OP_11" => Ok(OP_PUSHNUM_11),
+                    "OP_12" => Ok(OP_PUSHNUM_12),
+                    "OP_13" => Ok(OP_PUSHNUM_13),
+                    "OP_14" => Ok(OP_PUSHNUM_14),
+                    "OP_15" => Ok(OP_PUSHNUM_15),
+                    "OP_16" => Ok(OP_PUSHNUM_16),
+                    $(
+                        // NB all opcodes begin with OP_
+                        s if s == stringify!($op) || s == &stringify!($op)[3..] => Ok($op),
+                    )+
+                    _ => Err(()),
                 }
             }
         }

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -11,7 +11,8 @@ use crate::blockdata::opcodes::{self, Opcode};
 use crate::blockdata::script::witness_program::WitnessProgram;
 use crate::blockdata::script::witness_version::WitnessVersion;
 use crate::blockdata::script::{
-    opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash,
+    opcode_to_verify, parse_asm, Builder, Instruction, ParseAsmError, PushBytes, Script,
+    ScriptHash, WScriptHash,
 };
 use crate::key::{
     PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
@@ -184,6 +185,13 @@ impl ScriptBuf {
     /// This method doesn't (re)allocate.
     pub fn from_bytes(bytes: Vec<u8>) -> Self { ScriptBuf(bytes) }
 
+    /// Parse a Script in ASM format.
+    ///
+    /// NOTE: Receiving an [Ok] result from this function **ONLY** means that
+    /// our script interpreter could interpret the script, but it gives **no
+    /// guarantees** on the validity of the resulting script.
+    pub fn parse_asm(asm: &str) -> Result<Self, ParseAsmError> { parse_asm(asm) }
+
     /// Converts the script into a byte vector.
     ///
     /// This method doesn't (re)allocate.
@@ -203,7 +211,7 @@ impl ScriptBuf {
     fn push_slice_no_opt(&mut self, data: &PushBytes) {
         // Start with a PUSH opcode
         match data.len() as u64 {
-            n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {
+            n if n < opcodes::Ordinary::OP_PUSHDATA1.to_u8() as u64 => {
                 self.0.push(n as u8);
             }
             n if n < 0x100 => {

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -325,8 +325,8 @@ fn scriptint_round_trip() {
 fn non_minimal_scriptints() {
     assert_eq!(read_scriptint(&[0x80, 0x00]), Ok(0x80));
     assert_eq!(read_scriptint(&[0xff, 0x00]), Ok(0xff));
-    assert_eq!(read_scriptint(&[0x8f, 0x00, 0x00]), Err(Error::NonMinimalPush));
-    assert_eq!(read_scriptint(&[0x7f, 0x00]), Err(Error::NonMinimalPush));
+    assert_eq!(read_scriptint(&[0x8f, 0x00, 0x00]), Err(ScriptIntError::NonMinimalPush));
+    assert_eq!(read_scriptint(&[0x7f, 0x00]), Err(ScriptIntError::NonMinimalPush));
 
     assert_eq!(read_scriptint_non_minimal(&[0x80, 0x00]), Ok(0x80));
     assert_eq!(read_scriptint_non_minimal(&[0xff, 0x00]), Ok(0xff));
@@ -435,21 +435,34 @@ fn script_json_serialize() {
     assert_eq!(original, des);
 }
 
+fn script_asm_pair(script_hex: &str, asm: &str) {
+    let script = ScriptBuf::from_hex(script_hex).unwrap();
+    assert_eq!(script.to_asm_string(), asm, "asm from script fail: {} <> {}", script_hex, asm);
+
+    let parsed = ScriptBuf::parse_asm(asm).expect(&format!("asm err for '{}'", asm));
+    assert_eq!(script, parsed, "parse roundtrip fail: {}: {} <> {}", asm, script_hex, parsed)
+}
+
 #[test]
 fn script_asm() {
-    assert_eq!(
-        ScriptBuf::from_hex("6363636363686868686800").unwrap().to_asm_string(),
+    script_asm_pair(
+        "6363636363686868686800",
         "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
     );
-    assert_eq!(
-        ScriptBuf::from_hex("6363636363686868686800").unwrap().to_asm_string(),
+    script_asm_pair(
+        "6363636363686868686800",
         "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
     );
-    assert_eq!(ScriptBuf::from_hex("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").unwrap().to_asm_string(),
-               "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG");
+    script_asm_pair(
+        "2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac",
+        "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG",
+    );
     // Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to test PUSHDATA1
-    assert_eq!(ScriptBuf::from_hex("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").unwrap().to_asm_string(),
-               "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae");
+    script_asm_pair(
+        "0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae",
+        "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae",
+    );
+
     // Various weird scripts found in transaction 6d7ed9914625c73c0288694a6819196a27ef6c08f98e1270d975a8e65a3dc09a
     // which triggerred overflow bugs on 32-bit machines in script formatting in the past.
     assert_eq!(
@@ -474,6 +487,14 @@ fn script_asm() {
         ScriptBuf::from_hex("4effffffff01").unwrap().to_asm_string(),
         "OP_PUSHDATA4 <push past end>"
     );
+
+    // Parsing tests
+    fn asm_to_hex(asm: &str) -> String {
+        ScriptBuf::parse_asm(asm).expect(&format!("asm: {}", asm)).to_bytes().as_hex().to_string()
+    }
+    assert_eq!(asm_to_hex("<0x01>"), "0101");
+    assert_eq!(asm_to_hex("0x01"), "0101");
+    assert_eq!(asm_to_hex("<01>"), "51");
 }
 
 #[test]

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -349,9 +349,9 @@ impl Sequence {
     /// [BIP-125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki]>
     const MIN_NO_RBF: Self = Sequence(0xFFFFFFFE);
     /// BIP-68 relative lock time disable flag mask.
-    const LOCK_TIME_DISABLE_FLAG_MASK: u32 = 0x80000000;
+    pub(crate) const LOCK_TIME_DISABLE_FLAG_MASK: u32 = 0x80000000;
     /// BIP-68 relative lock time type flag mask.
-    const LOCK_TYPE_MASK: u32 = 0x00400000;
+    pub(crate) const LOCK_TYPE_MASK: u32 = 0x00400000;
 
     /// Returns `true` if the sequence number enables absolute lock-time ([`Transaction::lock_time`]).
     #[inline]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -54,6 +54,10 @@ name = "bitcoin_outpoint_string"
 path = "fuzz_targets/bitcoin/outpoint_string.rs"
 
 [[bin]]
+name = "bitcoin_script_asm_roundtrip"
+path = "fuzz_targets/bitcoin/script_asm_roundtrip.rs"
+
+[[bin]]
 name = "bitcoin_script_bytes_to_asm_fmt"
 path = "fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs"
 

--- a/fuzz/fuzz_targets/bitcoin/script_asm_roundtrip.rs
+++ b/fuzz/fuzz_targets/bitcoin/script_asm_roundtrip.rs
@@ -1,0 +1,43 @@
+use honggfuzz::fuzz;
+
+fn do_test(data: &[u8]) {
+    let asm = bitcoin::Script::from_bytes(data).to_asm_string();
+    let parsed = bitcoin::ScriptBuf::parse_asm(&asm).unwrap();
+    assert_eq!(parsed.as_bytes(), data);
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(all(test, fuzzing))]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("00000", &mut a);
+        super::do_test(&a);
+    }
+}
+


### PR DESCRIPTION
All Steven's changes in a single patch.

Taken from

- repo: github.com/stevenroose/rust-bitcoin
- commit: 639d552ef0080a68b1ea883298aa30c450d9ff0d

Did minor changes to reduce the size of the patch, notably removed the `opcodes::all` re-export.

This is draft until after v0.32.0 release when we can start to think merging stuff from this. I'd pull out discreet PRs of course.