### PR TITLE
units: Add BlockHeight and BlockInterval types

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -269,6 +269,8 @@ impl bitcoin::consensus::encode::Decodable for bitcoin::taproot::TapLeafHash
 impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256::Hash
 impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256d::Hash
 impl bitcoin::consensus::encode::Decodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::block::BlockHeight
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::block::BlockInterval
 impl bitcoin::consensus::encode::Decodable for bool
 impl bitcoin::consensus::encode::Decodable for i16
 impl bitcoin::consensus::encode::Decodable for i32
@@ -370,6 +372,8 @@ impl bitcoin::consensus::encode::Encodable for bitcoin::taproot::TapLeafHash
 impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256::Hash
 impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256d::Hash
 impl bitcoin::consensus::encode::Encodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::block::BlockHeight
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::block::BlockInterval
 impl bitcoin::consensus::encode::Encodable for bool
 impl bitcoin::consensus::encode::Encodable for i16
 impl bitcoin::consensus::encode::Encodable for i32
@@ -5163,17 +5167,17 @@ pub bitcoin::consensus::DecodeError::Other(E)
 pub bitcoin::consensus::DecodeError::TooManyBytes
 pub bitcoin::consensus::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::consensus::Params::bip16_time: u32
-pub bitcoin::consensus::Params::bip34_height: u32
-pub bitcoin::consensus::Params::bip65_height: u32
-pub bitcoin::consensus::Params::bip66_height: u32
+pub bitcoin::consensus::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::consensus::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::consensus::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::Params::network: bitcoin::network::Network
 pub bitcoin::consensus::Params::no_pow_retargeting: bool
 pub bitcoin::consensus::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::consensus::Params::pow_target_spacing: u64
 pub bitcoin::consensus::Params::pow_target_timespan: u64
-pub bitcoin::consensus::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::encode::Error::InvalidChecksum
 pub bitcoin::consensus::encode::Error::InvalidChecksum::actual: [u8; 4]
 pub bitcoin::consensus::encode::Error::InvalidChecksum::expected: [u8; 4]
@@ -5188,17 +5192,17 @@ pub bitcoin::consensus::encode::FromHexError::Decode(bitcoin::consensus::DecodeE
 pub bitcoin::consensus::encode::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
 pub bitcoin::consensus::params::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::consensus::params::Params::bip16_time: u32
-pub bitcoin::consensus::params::Params::bip34_height: u32
-pub bitcoin::consensus::params::Params::bip65_height: u32
-pub bitcoin::consensus::params::Params::bip66_height: u32
+pub bitcoin::consensus::params::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::params::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::params::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::consensus::params::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::consensus::params::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::params::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::params::Params::network: bitcoin::network::Network
 pub bitcoin::consensus::params::Params::no_pow_retargeting: bool
 pub bitcoin::consensus::params::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::consensus::params::Params::pow_target_spacing: u64
 pub bitcoin::consensus::params::Params::pow_target_timespan: u64
-pub bitcoin::consensus::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::params::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::validation::TxVerifyError::ScriptVerification(bitcoin::consensus::validation::BitcoinconsensusError)
 pub bitcoin::consensus::validation::TxVerifyError::UnknownSpentOutput(bitcoin::blockdata::transaction::OutPoint)
 pub bitcoin::ecdsa::Error::EmptySignature
@@ -5357,10 +5361,10 @@ pub bitcoin::p2p::message_filter::CFilter::filter_type: u8
 pub bitcoin::p2p::message_filter::GetCFCheckpt::filter_type: u8
 pub bitcoin::p2p::message_filter::GetCFCheckpt::stop_hash: bitcoin::blockdata::block::BlockHash
 pub bitcoin::p2p::message_filter::GetCFHeaders::filter_type: u8
-pub bitcoin::p2p::message_filter::GetCFHeaders::start_height: u32
+pub bitcoin::p2p::message_filter::GetCFHeaders::start_height: bitcoin_units::block::BlockHeight
 pub bitcoin::p2p::message_filter::GetCFHeaders::stop_hash: bitcoin::blockdata::block::BlockHash
 pub bitcoin::p2p::message_filter::GetCFilters::filter_type: u8
-pub bitcoin::p2p::message_filter::GetCFilters::start_height: u32
+pub bitcoin::p2p::message_filter::GetCFilters::start_height: bitcoin_units::block::BlockHeight
 pub bitcoin::p2p::message_filter::GetCFilters::stop_hash: bitcoin::blockdata::block::BlockHash
 pub bitcoin::p2p::message_network::Reject::ccode: bitcoin::p2p::message_network::RejectReason
 pub bitcoin::p2p::message_network::Reject::hash: bitcoin_hashes::sha256d::Hash
@@ -5385,17 +5389,17 @@ pub bitcoin::p2p::message_network::VersionMessage::user_agent: alloc::string::St
 pub bitcoin::p2p::message_network::VersionMessage::version: u32
 pub bitcoin::params::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::params::Params::bip16_time: u32
-pub bitcoin::params::Params::bip34_height: u32
-pub bitcoin::params::Params::bip65_height: u32
-pub bitcoin::params::Params::bip66_height: u32
+pub bitcoin::params::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::params::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::params::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::params::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::params::Params::miner_confirmation_window: u32
+pub bitcoin::params::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::params::Params::network: bitcoin::network::Network
 pub bitcoin::params::Params::no_pow_retargeting: bool
 pub bitcoin::params::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::params::Params::pow_target_spacing: u64
 pub bitcoin::params::Params::pow_target_timespan: u64
-pub bitcoin::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::params::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::psbt::Error::CombineInconsistentKeySources(alloc::boxed::Box<bitcoin::bip32::Xpub>)
 pub bitcoin::psbt::Error::ConsensusEncoding(bitcoin::consensus::encode::Error)
 pub bitcoin::psbt::Error::DuplicateKey(bitcoin::psbt::raw::Key)
@@ -9874,6 +9878,10 @@ pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>::from(hashtyp
 pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>::from(hashtype: bitcoin::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin_units::amount::Amount::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin_units::amount::Amount::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::block::BlockHeight::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::block::BlockHeight::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::block::BlockInterval::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::block::BlockInterval::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bool::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
 pub fn bool::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn core::convert::Infallible::input_len(&self) -> usize
@@ -10450,6 +10458,8 @@ pub type bitcoin::taproot::serialized_signature::SerializedSignature::Target = [
 pub type std::collections::hash::map::HashMap<bitcoin::PublicKey, bitcoin::PrivateKey>::Error = bitcoin::psbt::GetKeyError
 pub type std::collections::hash::set::HashSet<bitcoin::bip32::Xpriv>::Error = bitcoin::psbt::GetKeyError
 pub use bitcoin::Amount
+pub use bitcoin::BlockHeight
+pub use bitcoin::BlockInterval
 pub use bitcoin::Denomination
 pub use bitcoin::FeeRate
 pub use bitcoin::SignedAmount

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -262,6 +262,8 @@ impl bitcoin::consensus::encode::Decodable for bitcoin::taproot::TapLeafHash
 impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256::Hash
 impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256d::Hash
 impl bitcoin::consensus::encode::Decodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::block::BlockHeight
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::block::BlockInterval
 impl bitcoin::consensus::encode::Decodable for bool
 impl bitcoin::consensus::encode::Decodable for i16
 impl bitcoin::consensus::encode::Decodable for i32
@@ -363,6 +365,8 @@ impl bitcoin::consensus::encode::Encodable for bitcoin::taproot::TapLeafHash
 impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256::Hash
 impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256d::Hash
 impl bitcoin::consensus::encode::Encodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::block::BlockHeight
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::block::BlockInterval
 impl bitcoin::consensus::encode::Encodable for bool
 impl bitcoin::consensus::encode::Encodable for i16
 impl bitcoin::consensus::encode::Encodable for i32
@@ -4887,17 +4891,17 @@ pub bitcoin::consensus::DecodeError::Other(E)
 pub bitcoin::consensus::DecodeError::TooManyBytes
 pub bitcoin::consensus::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::consensus::Params::bip16_time: u32
-pub bitcoin::consensus::Params::bip34_height: u32
-pub bitcoin::consensus::Params::bip65_height: u32
-pub bitcoin::consensus::Params::bip66_height: u32
+pub bitcoin::consensus::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::consensus::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::consensus::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::Params::network: bitcoin::network::Network
 pub bitcoin::consensus::Params::no_pow_retargeting: bool
 pub bitcoin::consensus::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::consensus::Params::pow_target_spacing: u64
 pub bitcoin::consensus::Params::pow_target_timespan: u64
-pub bitcoin::consensus::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::encode::Error::InvalidChecksum
 pub bitcoin::consensus::encode::Error::InvalidChecksum::actual: [u8; 4]
 pub bitcoin::consensus::encode::Error::InvalidChecksum::expected: [u8; 4]
@@ -4912,17 +4916,17 @@ pub bitcoin::consensus::encode::FromHexError::Decode(bitcoin::consensus::DecodeE
 pub bitcoin::consensus::encode::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
 pub bitcoin::consensus::params::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::consensus::params::Params::bip16_time: u32
-pub bitcoin::consensus::params::Params::bip34_height: u32
-pub bitcoin::consensus::params::Params::bip65_height: u32
-pub bitcoin::consensus::params::Params::bip66_height: u32
+pub bitcoin::consensus::params::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::params::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::params::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::consensus::params::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::consensus::params::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::params::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::params::Params::network: bitcoin::network::Network
 pub bitcoin::consensus::params::Params::no_pow_retargeting: bool
 pub bitcoin::consensus::params::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::consensus::params::Params::pow_target_spacing: u64
 pub bitcoin::consensus::params::Params::pow_target_timespan: u64
-pub bitcoin::consensus::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::params::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::ecdsa::Error::EmptySignature
 pub bitcoin::ecdsa::Error::Hex(hex_conservative::error::HexToBytesError)
 pub bitcoin::ecdsa::Error::Secp256k1(secp256k1::Error)
@@ -5079,10 +5083,10 @@ pub bitcoin::p2p::message_filter::CFilter::filter_type: u8
 pub bitcoin::p2p::message_filter::GetCFCheckpt::filter_type: u8
 pub bitcoin::p2p::message_filter::GetCFCheckpt::stop_hash: bitcoin::blockdata::block::BlockHash
 pub bitcoin::p2p::message_filter::GetCFHeaders::filter_type: u8
-pub bitcoin::p2p::message_filter::GetCFHeaders::start_height: u32
+pub bitcoin::p2p::message_filter::GetCFHeaders::start_height: bitcoin_units::block::BlockHeight
 pub bitcoin::p2p::message_filter::GetCFHeaders::stop_hash: bitcoin::blockdata::block::BlockHash
 pub bitcoin::p2p::message_filter::GetCFilters::filter_type: u8
-pub bitcoin::p2p::message_filter::GetCFilters::start_height: u32
+pub bitcoin::p2p::message_filter::GetCFilters::start_height: bitcoin_units::block::BlockHeight
 pub bitcoin::p2p::message_filter::GetCFilters::stop_hash: bitcoin::blockdata::block::BlockHash
 pub bitcoin::p2p::message_network::Reject::ccode: bitcoin::p2p::message_network::RejectReason
 pub bitcoin::p2p::message_network::Reject::hash: bitcoin_hashes::sha256d::Hash
@@ -5107,17 +5111,17 @@ pub bitcoin::p2p::message_network::VersionMessage::user_agent: alloc::string::St
 pub bitcoin::p2p::message_network::VersionMessage::version: u32
 pub bitcoin::params::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::params::Params::bip16_time: u32
-pub bitcoin::params::Params::bip34_height: u32
-pub bitcoin::params::Params::bip65_height: u32
-pub bitcoin::params::Params::bip66_height: u32
+pub bitcoin::params::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::params::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::params::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::params::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::params::Params::miner_confirmation_window: u32
+pub bitcoin::params::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::params::Params::network: bitcoin::network::Network
 pub bitcoin::params::Params::no_pow_retargeting: bool
 pub bitcoin::params::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::params::Params::pow_target_spacing: u64
 pub bitcoin::params::Params::pow_target_timespan: u64
-pub bitcoin::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::params::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::psbt::Error::CombineInconsistentKeySources(alloc::boxed::Box<bitcoin::bip32::Xpub>)
 pub bitcoin::psbt::Error::ConsensusEncoding(bitcoin::consensus::encode::Error)
 pub bitcoin::psbt::Error::DuplicateKey(bitcoin::psbt::raw::Key)
@@ -9358,6 +9362,10 @@ pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>::from(hashtyp
 pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>::from(hashtype: bitcoin::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin_units::amount::Amount::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin_units::amount::Amount::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::block::BlockHeight::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::block::BlockHeight::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::block::BlockInterval::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::block::BlockInterval::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bool::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
 pub fn bool::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn core::convert::Infallible::input_len(&self) -> usize
@@ -9908,6 +9916,8 @@ pub type bitcoin::taproot::serialized_signature::SerializedSignature::Target = [
 pub type std::collections::hash::map::HashMap<bitcoin::PublicKey, bitcoin::PrivateKey>::Error = bitcoin::psbt::GetKeyError
 pub type std::collections::hash::set::HashSet<bitcoin::bip32::Xpriv>::Error = bitcoin::psbt::GetKeyError
 pub use bitcoin::Amount
+pub use bitcoin::BlockHeight
+pub use bitcoin::BlockInterval
 pub use bitcoin::Denomination
 pub use bitcoin::FeeRate
 pub use bitcoin::SignedAmount

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -233,6 +233,8 @@ impl bitcoin::consensus::encode::Decodable for bitcoin::taproot::TapLeafHash
 impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256::Hash
 impl bitcoin::consensus::encode::Decodable for bitcoin_hashes::sha256d::Hash
 impl bitcoin::consensus::encode::Decodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::block::BlockHeight
+impl bitcoin::consensus::encode::Decodable for bitcoin_units::block::BlockInterval
 impl bitcoin::consensus::encode::Decodable for bool
 impl bitcoin::consensus::encode::Decodable for i16
 impl bitcoin::consensus::encode::Decodable for i32
@@ -306,6 +308,8 @@ impl bitcoin::consensus::encode::Encodable for bitcoin::taproot::TapLeafHash
 impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256::Hash
 impl bitcoin::consensus::encode::Encodable for bitcoin_hashes::sha256d::Hash
 impl bitcoin::consensus::encode::Encodable for bitcoin_units::amount::Amount
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::block::BlockHeight
+impl bitcoin::consensus::encode::Encodable for bitcoin_units::block::BlockInterval
 impl bitcoin::consensus::encode::Encodable for bool
 impl bitcoin::consensus::encode::Encodable for i16
 impl bitcoin::consensus::encode::Encodable for i32
@@ -4401,17 +4405,17 @@ pub bitcoin::consensus::DecodeError::Other(E)
 pub bitcoin::consensus::DecodeError::TooManyBytes
 pub bitcoin::consensus::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::consensus::Params::bip16_time: u32
-pub bitcoin::consensus::Params::bip34_height: u32
-pub bitcoin::consensus::Params::bip65_height: u32
-pub bitcoin::consensus::Params::bip66_height: u32
+pub bitcoin::consensus::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::consensus::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::consensus::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::Params::network: bitcoin::network::Network
 pub bitcoin::consensus::Params::no_pow_retargeting: bool
 pub bitcoin::consensus::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::consensus::Params::pow_target_spacing: u64
 pub bitcoin::consensus::Params::pow_target_timespan: u64
-pub bitcoin::consensus::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::encode::Error::InvalidChecksum
 pub bitcoin::consensus::encode::Error::InvalidChecksum::actual: [u8; 4]
 pub bitcoin::consensus::encode::Error::InvalidChecksum::expected: [u8; 4]
@@ -4426,17 +4430,17 @@ pub bitcoin::consensus::encode::FromHexError::Decode(bitcoin::consensus::DecodeE
 pub bitcoin::consensus::encode::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
 pub bitcoin::consensus::params::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::consensus::params::Params::bip16_time: u32
-pub bitcoin::consensus::params::Params::bip34_height: u32
-pub bitcoin::consensus::params::Params::bip65_height: u32
-pub bitcoin::consensus::params::Params::bip66_height: u32
+pub bitcoin::consensus::params::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::params::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::consensus::params::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::consensus::params::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::consensus::params::Params::miner_confirmation_window: u32
+pub bitcoin::consensus::params::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::consensus::params::Params::network: bitcoin::network::Network
 pub bitcoin::consensus::params::Params::no_pow_retargeting: bool
 pub bitcoin::consensus::params::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::consensus::params::Params::pow_target_spacing: u64
 pub bitcoin::consensus::params::Params::pow_target_timespan: u64
-pub bitcoin::consensus::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::consensus::params::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::ecdsa::Error::EmptySignature
 pub bitcoin::ecdsa::Error::Hex(hex_conservative::error::HexToBytesError)
 pub bitcoin::ecdsa::Error::Secp256k1(secp256k1::Error)
@@ -4497,17 +4501,17 @@ pub bitcoin::opcodes::ClassifyContext::Legacy
 pub bitcoin::opcodes::ClassifyContext::TapScript
 pub bitcoin::params::Params::allow_min_difficulty_blocks: bool
 pub bitcoin::params::Params::bip16_time: u32
-pub bitcoin::params::Params::bip34_height: u32
-pub bitcoin::params::Params::bip65_height: u32
-pub bitcoin::params::Params::bip66_height: u32
+pub bitcoin::params::Params::bip34_height: bitcoin_units::block::BlockHeight
+pub bitcoin::params::Params::bip65_height: bitcoin_units::block::BlockHeight
+pub bitcoin::params::Params::bip66_height: bitcoin_units::block::BlockHeight
 pub bitcoin::params::Params::max_attainable_target: bitcoin::pow::Target
-pub bitcoin::params::Params::miner_confirmation_window: u32
+pub bitcoin::params::Params::miner_confirmation_window: bitcoin_units::block::BlockInterval
 pub bitcoin::params::Params::network: bitcoin::network::Network
 pub bitcoin::params::Params::no_pow_retargeting: bool
 pub bitcoin::params::Params::pow_limit: bitcoin::pow::Target
 pub bitcoin::params::Params::pow_target_spacing: u64
 pub bitcoin::params::Params::pow_target_timespan: u64
-pub bitcoin::params::Params::rule_change_activation_threshold: u32
+pub bitcoin::params::Params::rule_change_activation_threshold: bitcoin_units::block::BlockInterval
 pub bitcoin::psbt::Error::CombineInconsistentKeySources(alloc::boxed::Box<bitcoin::bip32::Xpub>)
 pub bitcoin::psbt::Error::ConsensusEncoding(bitcoin::consensus::encode::Error)
 pub bitcoin::psbt::Error::DuplicateKey(bitcoin::psbt::raw::Key)
@@ -8468,6 +8472,10 @@ pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>::from(hashtyp
 pub fn bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>::from(hashtype: bitcoin::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin_units::amount::Amount::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin_units::amount::Amount::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::block::BlockHeight::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::block::BlockHeight::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+pub fn bitcoin_units::block::BlockInterval::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
+pub fn bitcoin_units::block::BlockInterval::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bool::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bool, bitcoin::consensus::encode::Error>
 pub fn bool::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn core::convert::Infallible::input_len(&self) -> usize
@@ -8979,6 +8987,8 @@ pub type bitcoin::taproot::serialized_signature::SerializedSignature::IntoIter =
 pub type bitcoin::taproot::serialized_signature::SerializedSignature::Item = u8
 pub type bitcoin::taproot::serialized_signature::SerializedSignature::Target = [u8]
 pub use bitcoin::Amount
+pub use bitcoin::BlockHeight
+pub use bitcoin::BlockInterval
 pub use bitcoin::Denomination
 pub use bitcoin::FeeRate
 pub use bitcoin::SignedAmount

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -17,6 +17,8 @@ impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::amount::Amount
 impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::amount::SignedAmount
 impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::amount::Amount
 impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::amount::SignedAmount
+impl bitcoin_units::block::BlockHeight
+impl bitcoin_units::block::BlockInterval
 impl bitcoin_units::fee_rate::FeeRate
 impl bitcoin_units::locktime::absolute::Height
 impl bitcoin_units::locktime::absolute::Time
@@ -50,6 +52,9 @@ impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenomination
 impl core::clone::Clone for bitcoin_units::amount::SignedAmount
 impl core::clone::Clone for bitcoin_units::amount::TooPreciseError
 impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockInterval
+impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::clone::Clone for bitcoin_units::fee_rate::FeeRate
 impl core::clone::Clone for bitcoin_units::locktime::absolute::ConversionError
 impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
@@ -79,6 +84,9 @@ impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
 impl core::cmp::Eq for bitcoin_units::amount::SignedAmount
 impl core::cmp::Eq for bitcoin_units::amount::TooPreciseError
 impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::block::BlockHeight
+impl core::cmp::Eq for bitcoin_units::block::BlockInterval
+impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::cmp::Eq for bitcoin_units::fee_rate::FeeRate
 impl core::cmp::Eq for bitcoin_units::locktime::absolute::ConversionError
 impl core::cmp::Eq for bitcoin_units::locktime::absolute::Height
@@ -96,6 +104,8 @@ impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::weight::Weight
 impl core::cmp::Ord for bitcoin_units::amount::Amount
 impl core::cmp::Ord for bitcoin_units::amount::SignedAmount
+impl core::cmp::Ord for bitcoin_units::block::BlockHeight
+impl core::cmp::Ord for bitcoin_units::block::BlockInterval
 impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
 impl core::cmp::Ord for bitcoin_units::locktime::absolute::Height
 impl core::cmp::Ord for bitcoin_units::locktime::absolute::Time
@@ -116,6 +126,9 @@ impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominati
 impl core::cmp::PartialEq for bitcoin_units::amount::SignedAmount
 impl core::cmp::PartialEq for bitcoin_units::amount::TooPreciseError
 impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialEq for bitcoin_units::block::BlockInterval
+impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::cmp::PartialEq for bitcoin_units::fee_rate::FeeRate
 impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ConversionError
 impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Height
@@ -133,6 +146,8 @@ impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::weight::Weight
 impl core::cmp::PartialOrd for bitcoin_units::amount::Amount
 impl core::cmp::PartialOrd for bitcoin_units::amount::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
 impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Height
 impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Time
@@ -152,7 +167,11 @@ impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_un
 impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
 impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseAmountError
 impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
+impl core::convert::From<bitcoin_units::block::BlockInterval> for u32
 impl core::convert::From<bitcoin_units::fee_rate::FeeRate> for u64
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_units::block::BlockHeight
+impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_units::block::BlockInterval
 impl core::convert::From<bitcoin_units::parse::ContainsPrefixError> for bitcoin_units::parse::UnprefixedHexError
 impl core::convert::From<bitcoin_units::parse::MissingPrefixError> for bitcoin_units::parse::PrefixedHexError
 impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
@@ -163,18 +182,26 @@ impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::P
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseDenominationError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseError
 impl core::convert::From<u16> for bitcoin_units::locktime::relative::Height
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
+impl core::convert::From<u32> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockInterval
 impl core::convert::TryFrom<&str> for bitcoin_units::fee_rate::FeeRate
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Height
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Time
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Height
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Time
 impl core::convert::TryFrom<&str> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockInterval
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::fee_rate::FeeRate
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Height
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Time
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::Height
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::Time
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockInterval
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::fee_rate::FeeRate
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Height
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Time
@@ -183,6 +210,8 @@ impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::weight::Weight
 impl core::convert::TryFrom<bitcoin_units::amount::Amount> for bitcoin_units::amount::SignedAmount
 impl core::convert::TryFrom<bitcoin_units::amount::SignedAmount> for bitcoin_units::amount::Amount
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeight> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<bitcoin_units::block::BlockInterval> for bitcoin_units::locktime::relative::Height
 impl core::default::Default for bitcoin_units::amount::Amount
 impl core::default::Default for bitcoin_units::amount::SignedAmount
 impl core::default::Default for bitcoin_units::locktime::relative::Height
@@ -197,6 +226,7 @@ impl core::error::Error for bitcoin_units::amount::ParseError
 impl core::error::Error for bitcoin_units::amount::PossiblyConfusingDenominationError
 impl core::error::Error for bitcoin_units::amount::TooPreciseError
 impl core::error::Error for bitcoin_units::amount::UnknownDenominationError
+impl core::error::Error for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::error::Error for bitcoin_units::locktime::absolute::ConversionError
 impl core::error::Error for bitcoin_units::locktime::absolute::ParseHeightError
 impl core::error::Error for bitcoin_units::locktime::absolute::ParseTimeError
@@ -221,6 +251,9 @@ impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationEr
 impl core::fmt::Debug for bitcoin_units::amount::SignedAmount
 impl core::fmt::Debug for bitcoin_units::amount::TooPreciseError
 impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockInterval
+impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::fmt::Debug for bitcoin_units::fee_rate::FeeRate
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::ConversionError
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
@@ -250,6 +283,9 @@ impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenomination
 impl core::fmt::Display for bitcoin_units::amount::SignedAmount
 impl core::fmt::Display for bitcoin_units::amount::TooPreciseError
 impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::block::BlockHeight
+impl core::fmt::Display for bitcoin_units::block::BlockInterval
+impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::fmt::Display for bitcoin_units::fee_rate::FeeRate
 impl core::fmt::Display for bitcoin_units::locktime::absolute::ConversionError
 impl core::fmt::Display for bitcoin_units::locktime::absolute::Height
@@ -268,6 +304,8 @@ impl core::fmt::Display for bitcoin_units::weight::Weight
 impl core::hash::Hash for bitcoin_units::amount::Amount
 impl core::hash::Hash for bitcoin_units::amount::Denomination
 impl core::hash::Hash for bitcoin_units::amount::SignedAmount
+impl core::hash::Hash for bitcoin_units::block::BlockHeight
+impl core::hash::Hash for bitcoin_units::block::BlockInterval
 impl core::hash::Hash for bitcoin_units::fee_rate::FeeRate
 impl core::hash::Hash for bitcoin_units::locktime::absolute::Height
 impl core::hash::Hash for bitcoin_units::locktime::absolute::Time
@@ -281,6 +319,8 @@ impl core::marker::Copy for bitcoin_units::amount::Amount
 impl core::marker::Copy for bitcoin_units::amount::Denomination
 impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
 impl core::marker::Copy for bitcoin_units::amount::SignedAmount
+impl core::marker::Copy for bitcoin_units::block::BlockHeight
+impl core::marker::Copy for bitcoin_units::block::BlockInterval
 impl core::marker::Copy for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Copy for bitcoin_units::locktime::absolute::Height
 impl core::marker::Copy for bitcoin_units::locktime::absolute::Time
@@ -302,6 +342,9 @@ impl core::marker::Freeze for bitcoin_units::amount::PossiblyConfusingDenominati
 impl core::marker::Freeze for bitcoin_units::amount::SignedAmount
 impl core::marker::Freeze for bitcoin_units::amount::TooPreciseError
 impl core::marker::Freeze for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::block::BlockHeight
+impl core::marker::Freeze for bitcoin_units::block::BlockInterval
+impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::Freeze for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
@@ -332,6 +375,9 @@ impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenomination
 impl core::marker::Send for bitcoin_units::amount::SignedAmount
 impl core::marker::Send for bitcoin_units::amount::TooPreciseError
 impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::block::BlockHeight
+impl core::marker::Send for bitcoin_units::block::BlockInterval
+impl core::marker::Send for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::Send for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Send for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::Send for bitcoin_units::locktime::absolute::Height
@@ -361,6 +407,9 @@ impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfus
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::SignedAmount
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::TooPreciseError
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::FeeRate
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Height
@@ -391,6 +440,9 @@ impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenomination
 impl core::marker::Sync for bitcoin_units::amount::SignedAmount
 impl core::marker::Sync for bitcoin_units::amount::TooPreciseError
 impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::block::BlockHeight
+impl core::marker::Sync for bitcoin_units::block::BlockInterval
+impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::Sync for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Sync for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
@@ -421,6 +473,9 @@ impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominatio
 impl core::marker::Unpin for bitcoin_units::amount::SignedAmount
 impl core::marker::Unpin for bitcoin_units::amount::TooPreciseError
 impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::block::BlockHeight
+impl core::marker::Unpin for bitcoin_units::block::BlockInterval
+impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::Unpin for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Unpin for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::Unpin for bitcoin_units::locktime::absolute::Height
@@ -438,9 +493,12 @@ impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
 impl core::marker::Unpin for bitcoin_units::weight::Weight
 impl core::ops::arith::Add for bitcoin_units::amount::Amount
 impl core::ops::arith::Add for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Add for bitcoin_units::block::BlockInterval
 impl core::ops::arith::Add for bitcoin_units::weight::Weight
+impl core::ops::arith::Add<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
 impl core::ops::arith::AddAssign for bitcoin_units::amount::Amount
 impl core::ops::arith::AddAssign for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockInterval
 impl core::ops::arith::AddAssign for bitcoin_units::weight::Weight
 impl core::ops::arith::Div for bitcoin_units::weight::Weight
 impl core::ops::arith::Div<bitcoin_units::weight::Weight> for bitcoin_units::amount::Amount
@@ -466,9 +524,13 @@ impl core::ops::arith::RemAssign<i64> for bitcoin_units::amount::SignedAmount
 impl core::ops::arith::RemAssign<u64> for bitcoin_units::amount::Amount
 impl core::ops::arith::Sub for bitcoin_units::amount::Amount
 impl core::ops::arith::Sub for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockInterval
 impl core::ops::arith::Sub for bitcoin_units::weight::Weight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
 impl core::ops::arith::SubAssign for bitcoin_units::amount::Amount
 impl core::ops::arith::SubAssign for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockInterval
 impl core::ops::arith::SubAssign for bitcoin_units::weight::Weight
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Amount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
@@ -485,6 +547,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Possibly
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::SignedAmount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::TooPreciseError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::FeeRate
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ConversionError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Height
@@ -515,6 +580,9 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyCon
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::SignedAmount
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::TooPreciseError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::FeeRate
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ConversionError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Height
@@ -533,6 +601,8 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::weight::Weight
 impl core::str::traits::FromStr for bitcoin_units::amount::Amount
 impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
 impl core::str::traits::FromStr for bitcoin_units::amount::SignedAmount
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeight
+impl core::str::traits::FromStr for bitcoin_units::block::BlockInterval
 impl core::str::traits::FromStr for bitcoin_units::fee_rate::FeeRate
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Time
@@ -540,6 +610,8 @@ impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Height
 impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Time
 impl core::str::traits::FromStr for bitcoin_units::weight::Weight
 impl serde::ser::Serialize for bitcoin_units::amount::Amount
+impl serde::ser::Serialize for bitcoin_units::block::BlockHeight
+impl serde::ser::Serialize for bitcoin_units::block::BlockInterval
 impl serde::ser::Serialize for bitcoin_units::fee_rate::FeeRate
 impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Height
 impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Time
@@ -548,6 +620,8 @@ impl serde::ser::Serialize for bitcoin_units::locktime::relative::Time
 impl serde::ser::Serialize for bitcoin_units::weight::Weight
 impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::weight::Weight> for bitcoin_units::weight::Weight
 impl<'de> serde::de::Deserialize<'de> for bitcoin_units::amount::Amount
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::block::BlockHeight
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::block::BlockInterval
 impl<'de> serde::de::Deserialize<'de> for bitcoin_units::fee_rate::FeeRate
 impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Height
 impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Time
@@ -594,6 +668,12 @@ pub const bitcoin_units::amount::SignedAmount::MIN: bitcoin_units::amount::Signe
 pub const bitcoin_units::amount::SignedAmount::ONE_BTC: bitcoin_units::amount::SignedAmount
 pub const bitcoin_units::amount::SignedAmount::ONE_SAT: bitcoin_units::amount::SignedAmount
 pub const bitcoin_units::amount::SignedAmount::ZERO: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::block::BlockHeight::MAX: Self
+pub const bitcoin_units::block::BlockHeight::MIN: Self
+pub const bitcoin_units::block::BlockHeight::ZERO: Self
+pub const bitcoin_units::block::BlockInterval::MAX: Self
+pub const bitcoin_units::block::BlockInterval::MIN: Self
+pub const bitcoin_units::block::BlockInterval::ZERO: Self
 pub const bitcoin_units::fee_rate::FeeRate::BROADCAST_MIN: bitcoin_units::fee_rate::FeeRate
 pub const bitcoin_units::fee_rate::FeeRate::DUST: bitcoin_units::fee_rate::FeeRate
 pub const bitcoin_units::fee_rate::FeeRate::MAX: bitcoin_units::fee_rate::FeeRate
@@ -621,6 +701,10 @@ pub const bitcoin_units::weight::Weight::ZERO: bitcoin_units::weight::Weight
 pub const fn bitcoin_units::amount::Amount::from_int_btc(btc: u64) -> bitcoin_units::amount::Amount
 pub const fn bitcoin_units::amount::Amount::from_sat(satoshi: u64) -> bitcoin_units::amount::Amount
 pub const fn bitcoin_units::amount::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::amount::SignedAmount
+pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeight::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockInterval::to_u32(&self) -> u32
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_vb_unchecked(sat_vb: u64) -> Self
 pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_kwu(self) -> u64
@@ -830,6 +914,44 @@ pub fn bitcoin_units::amount::serde::as_sat::deserialize<'d, A: bitcoin_units::a
 pub fn bitcoin_units::amount::serde::as_sat::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::amount::serde::as_sat::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::serde::as_sat::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
+pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeight::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::block::BlockHeight::eq(&self, other: &bitcoin_units::block::BlockHeight) -> bool
+pub fn bitcoin_units::block::BlockHeight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_units::block::BlockHeight::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeight::partial_cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeight::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::clone(&self) -> bitcoin_units::block::BlockInterval
+pub fn bitcoin_units::block::BlockInterval::cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockInterval::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::block::BlockInterval::eq(&self, other: &bitcoin_units::block::BlockInterval) -> bool
+pub fn bitcoin_units::block::BlockInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockInterval::from(h: bitcoin_units::locktime::relative::Height) -> Self
+pub fn bitcoin_units::block::BlockInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockInterval::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::block::BlockInterval::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::clone(&self) -> bitcoin_units::block::TooBigForRelativeBlockHeightError
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::eq(&self, other: &bitcoin_units::block::TooBigForRelativeBlockHeightError) -> bool
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
 pub fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::amount::Amount>
@@ -865,6 +987,7 @@ pub fn bitcoin_units::locktime::absolute::Height::hash<__H: core::hash::Hasher>(
 pub fn bitcoin_units::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::locktime::absolute::Height::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin_units::locktime::absolute::Height::to_consensus_u32(self) -> u32
+pub fn bitcoin_units::locktime::absolute::Height::try_from(h: bitcoin_units::block::BlockHeight) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
@@ -905,6 +1028,7 @@ pub fn bitcoin_units::locktime::relative::Height::hash<__H: core::hash::Hasher>(
 pub fn bitcoin_units::locktime::relative::Height::partial_cmp(&self, other: &bitcoin_units::locktime::relative::Height) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::locktime::relative::Height::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin_units::locktime::relative::Height::to_consensus_u32(&self) -> u32
+pub fn bitcoin_units::locktime::relative::Height::try_from(h: bitcoin_units::block::BlockInterval) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::relative::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::relative::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::relative::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
@@ -995,6 +1119,8 @@ pub fn bitcoin_units::weight::Weight::try_from(s: &str) -> core::result::Result<
 pub fn bitcoin_units::weight::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::weight::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
 pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockHeight) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockInterval) -> Self
 pub fn u64::from(value: bitcoin_units::fee_rate::FeeRate) -> Self
 pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
@@ -1009,6 +1135,7 @@ pub mod bitcoin_units::amount::serde::as_btc
 pub mod bitcoin_units::amount::serde::as_btc::opt
 pub mod bitcoin_units::amount::serde::as_sat
 pub mod bitcoin_units::amount::serde::as_sat::opt
+pub mod bitcoin_units::block
 pub mod bitcoin_units::fee_rate
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
@@ -1016,6 +1143,8 @@ pub mod bitcoin_units::locktime::relative
 pub mod bitcoin_units::parse
 pub mod bitcoin_units::weight
 pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::BlockHeight(pub u32)
+pub struct bitcoin_units::BlockInterval(pub u32)
 pub struct bitcoin_units::FeeRate(_)
 pub struct bitcoin_units::SignedAmount(_)
 pub struct bitcoin_units::Weight(_)
@@ -1027,6 +1156,9 @@ pub struct bitcoin_units::amount::MissingDigitsError
 pub struct bitcoin_units::amount::OutOfRangeError
 pub struct bitcoin_units::amount::SignedAmount(_)
 pub struct bitcoin_units::amount::TooPreciseError
+pub struct bitcoin_units::block::BlockHeight(pub u32)
+pub struct bitcoin_units::block::BlockInterval(pub u32)
+pub struct bitcoin_units::block::TooBigForRelativeBlockHeightError(_)
 pub struct bitcoin_units::fee_rate::FeeRate(_)
 pub struct bitcoin_units::locktime::absolute::Height(_)
 pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
@@ -1050,14 +1182,23 @@ pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::Parse
 pub type bitcoin_units::amount::SignedAmount::Err = bitcoin_units::amount::ParseError
 pub type bitcoin_units::amount::SignedAmount::Error = bitcoin_units::amount::OutOfRangeError
 pub type bitcoin_units::amount::SignedAmount::Output = bitcoin_units::amount::SignedAmount
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockInterval
+pub type bitcoin_units::block::BlockInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Output = bitcoin_units::block::BlockInterval
 pub type bitcoin_units::fee_rate::FeeRate::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::fee_rate::FeeRate::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::amount::Amount
 pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ConversionError
 pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ParseHeightError
 pub type bitcoin_units::locktime::absolute::Time::Err = bitcoin_units::locktime::absolute::ParseTimeError
 pub type bitcoin_units::locktime::absolute::Time::Error = bitcoin_units::locktime::absolute::ParseTimeError
 pub type bitcoin_units::locktime::relative::Height::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::block::TooBigForRelativeBlockHeightError
 pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::locktime::relative::Time::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::locktime::relative::Time::Error = bitcoin_units::parse::ParseIntError

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -13,6 +13,8 @@ impl bitcoin_units::amount::Denomination
 impl bitcoin_units::amount::Display
 impl bitcoin_units::amount::OutOfRangeError
 impl bitcoin_units::amount::SignedAmount
+impl bitcoin_units::block::BlockHeight
+impl bitcoin_units::block::BlockInterval
 impl bitcoin_units::fee_rate::FeeRate
 impl bitcoin_units::locktime::absolute::Height
 impl bitcoin_units::locktime::absolute::Time
@@ -46,6 +48,9 @@ impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenomination
 impl core::clone::Clone for bitcoin_units::amount::SignedAmount
 impl core::clone::Clone for bitcoin_units::amount::TooPreciseError
 impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockInterval
+impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::clone::Clone for bitcoin_units::fee_rate::FeeRate
 impl core::clone::Clone for bitcoin_units::locktime::absolute::ConversionError
 impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
@@ -75,6 +80,9 @@ impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
 impl core::cmp::Eq for bitcoin_units::amount::SignedAmount
 impl core::cmp::Eq for bitcoin_units::amount::TooPreciseError
 impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::block::BlockHeight
+impl core::cmp::Eq for bitcoin_units::block::BlockInterval
+impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::cmp::Eq for bitcoin_units::fee_rate::FeeRate
 impl core::cmp::Eq for bitcoin_units::locktime::absolute::ConversionError
 impl core::cmp::Eq for bitcoin_units::locktime::absolute::Height
@@ -92,6 +100,8 @@ impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::weight::Weight
 impl core::cmp::Ord for bitcoin_units::amount::Amount
 impl core::cmp::Ord for bitcoin_units::amount::SignedAmount
+impl core::cmp::Ord for bitcoin_units::block::BlockHeight
+impl core::cmp::Ord for bitcoin_units::block::BlockInterval
 impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
 impl core::cmp::Ord for bitcoin_units::locktime::absolute::Height
 impl core::cmp::Ord for bitcoin_units::locktime::absolute::Time
@@ -112,6 +122,9 @@ impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominati
 impl core::cmp::PartialEq for bitcoin_units::amount::SignedAmount
 impl core::cmp::PartialEq for bitcoin_units::amount::TooPreciseError
 impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialEq for bitcoin_units::block::BlockInterval
+impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::cmp::PartialEq for bitcoin_units::fee_rate::FeeRate
 impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ConversionError
 impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Height
@@ -129,6 +142,8 @@ impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::weight::Weight
 impl core::cmp::PartialOrd for bitcoin_units::amount::Amount
 impl core::cmp::PartialOrd for bitcoin_units::amount::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
 impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Height
 impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Time
@@ -148,7 +163,11 @@ impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_un
 impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
 impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseAmountError
 impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
+impl core::convert::From<bitcoin_units::block::BlockInterval> for u32
 impl core::convert::From<bitcoin_units::fee_rate::FeeRate> for u64
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_units::block::BlockHeight
+impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_units::block::BlockInterval
 impl core::convert::From<bitcoin_units::parse::ContainsPrefixError> for bitcoin_units::parse::UnprefixedHexError
 impl core::convert::From<bitcoin_units::parse::MissingPrefixError> for bitcoin_units::parse::PrefixedHexError
 impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
@@ -159,18 +178,26 @@ impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::P
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseDenominationError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseError
 impl core::convert::From<u16> for bitcoin_units::locktime::relative::Height
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
+impl core::convert::From<u32> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockInterval
 impl core::convert::TryFrom<&str> for bitcoin_units::fee_rate::FeeRate
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Height
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Time
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Height
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Time
 impl core::convert::TryFrom<&str> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockInterval
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::fee_rate::FeeRate
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Height
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Time
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::Height
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::Time
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockInterval
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::fee_rate::FeeRate
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Height
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Time
@@ -179,6 +206,8 @@ impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::weight::Weight
 impl core::convert::TryFrom<bitcoin_units::amount::Amount> for bitcoin_units::amount::SignedAmount
 impl core::convert::TryFrom<bitcoin_units::amount::SignedAmount> for bitcoin_units::amount::Amount
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeight> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<bitcoin_units::block::BlockInterval> for bitcoin_units::locktime::relative::Height
 impl core::default::Default for bitcoin_units::amount::Amount
 impl core::default::Default for bitcoin_units::amount::SignedAmount
 impl core::default::Default for bitcoin_units::locktime::relative::Height
@@ -198,6 +227,9 @@ impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationEr
 impl core::fmt::Debug for bitcoin_units::amount::SignedAmount
 impl core::fmt::Debug for bitcoin_units::amount::TooPreciseError
 impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockInterval
+impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::fmt::Debug for bitcoin_units::fee_rate::FeeRate
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::ConversionError
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
@@ -227,6 +259,9 @@ impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenomination
 impl core::fmt::Display for bitcoin_units::amount::SignedAmount
 impl core::fmt::Display for bitcoin_units::amount::TooPreciseError
 impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::block::BlockHeight
+impl core::fmt::Display for bitcoin_units::block::BlockInterval
+impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::fmt::Display for bitcoin_units::fee_rate::FeeRate
 impl core::fmt::Display for bitcoin_units::locktime::absolute::ConversionError
 impl core::fmt::Display for bitcoin_units::locktime::absolute::Height
@@ -245,6 +280,8 @@ impl core::fmt::Display for bitcoin_units::weight::Weight
 impl core::hash::Hash for bitcoin_units::amount::Amount
 impl core::hash::Hash for bitcoin_units::amount::Denomination
 impl core::hash::Hash for bitcoin_units::amount::SignedAmount
+impl core::hash::Hash for bitcoin_units::block::BlockHeight
+impl core::hash::Hash for bitcoin_units::block::BlockInterval
 impl core::hash::Hash for bitcoin_units::fee_rate::FeeRate
 impl core::hash::Hash for bitcoin_units::locktime::absolute::Height
 impl core::hash::Hash for bitcoin_units::locktime::absolute::Time
@@ -258,6 +295,8 @@ impl core::marker::Copy for bitcoin_units::amount::Amount
 impl core::marker::Copy for bitcoin_units::amount::Denomination
 impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
 impl core::marker::Copy for bitcoin_units::amount::SignedAmount
+impl core::marker::Copy for bitcoin_units::block::BlockHeight
+impl core::marker::Copy for bitcoin_units::block::BlockInterval
 impl core::marker::Copy for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Copy for bitcoin_units::locktime::absolute::Height
 impl core::marker::Copy for bitcoin_units::locktime::absolute::Time
@@ -279,6 +318,9 @@ impl core::marker::Freeze for bitcoin_units::amount::PossiblyConfusingDenominati
 impl core::marker::Freeze for bitcoin_units::amount::SignedAmount
 impl core::marker::Freeze for bitcoin_units::amount::TooPreciseError
 impl core::marker::Freeze for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::block::BlockHeight
+impl core::marker::Freeze for bitcoin_units::block::BlockInterval
+impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::Freeze for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
@@ -309,6 +351,9 @@ impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenomination
 impl core::marker::Send for bitcoin_units::amount::SignedAmount
 impl core::marker::Send for bitcoin_units::amount::TooPreciseError
 impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::block::BlockHeight
+impl core::marker::Send for bitcoin_units::block::BlockInterval
+impl core::marker::Send for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::Send for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Send for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::Send for bitcoin_units::locktime::absolute::Height
@@ -338,6 +383,9 @@ impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfus
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::SignedAmount
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::TooPreciseError
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::FeeRate
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Height
@@ -368,6 +416,9 @@ impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenomination
 impl core::marker::Sync for bitcoin_units::amount::SignedAmount
 impl core::marker::Sync for bitcoin_units::amount::TooPreciseError
 impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::block::BlockHeight
+impl core::marker::Sync for bitcoin_units::block::BlockInterval
+impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::Sync for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Sync for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
@@ -398,6 +449,9 @@ impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominatio
 impl core::marker::Unpin for bitcoin_units::amount::SignedAmount
 impl core::marker::Unpin for bitcoin_units::amount::TooPreciseError
 impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::block::BlockHeight
+impl core::marker::Unpin for bitcoin_units::block::BlockInterval
+impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::marker::Unpin for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Unpin for bitcoin_units::locktime::absolute::ConversionError
 impl core::marker::Unpin for bitcoin_units::locktime::absolute::Height
@@ -415,9 +469,12 @@ impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
 impl core::marker::Unpin for bitcoin_units::weight::Weight
 impl core::ops::arith::Add for bitcoin_units::amount::Amount
 impl core::ops::arith::Add for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Add for bitcoin_units::block::BlockInterval
 impl core::ops::arith::Add for bitcoin_units::weight::Weight
+impl core::ops::arith::Add<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
 impl core::ops::arith::AddAssign for bitcoin_units::amount::Amount
 impl core::ops::arith::AddAssign for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockInterval
 impl core::ops::arith::AddAssign for bitcoin_units::weight::Weight
 impl core::ops::arith::Div for bitcoin_units::weight::Weight
 impl core::ops::arith::Div<bitcoin_units::weight::Weight> for bitcoin_units::amount::Amount
@@ -443,9 +500,13 @@ impl core::ops::arith::RemAssign<i64> for bitcoin_units::amount::SignedAmount
 impl core::ops::arith::RemAssign<u64> for bitcoin_units::amount::Amount
 impl core::ops::arith::Sub for bitcoin_units::amount::Amount
 impl core::ops::arith::Sub for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockInterval
 impl core::ops::arith::Sub for bitcoin_units::weight::Weight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
 impl core::ops::arith::SubAssign for bitcoin_units::amount::Amount
 impl core::ops::arith::SubAssign for bitcoin_units::amount::SignedAmount
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockInterval
 impl core::ops::arith::SubAssign for bitcoin_units::weight::Weight
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Amount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
@@ -462,6 +523,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Possibly
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::SignedAmount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::TooPreciseError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::FeeRate
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ConversionError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Height
@@ -492,6 +556,9 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyCon
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::SignedAmount
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::TooPreciseError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::FeeRate
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ConversionError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Height
@@ -510,6 +577,8 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::weight::Weight
 impl core::str::traits::FromStr for bitcoin_units::amount::Amount
 impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
 impl core::str::traits::FromStr for bitcoin_units::amount::SignedAmount
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeight
+impl core::str::traits::FromStr for bitcoin_units::block::BlockInterval
 impl core::str::traits::FromStr for bitcoin_units::fee_rate::FeeRate
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Time
@@ -557,6 +626,12 @@ pub const bitcoin_units::amount::SignedAmount::MIN: bitcoin_units::amount::Signe
 pub const bitcoin_units::amount::SignedAmount::ONE_BTC: bitcoin_units::amount::SignedAmount
 pub const bitcoin_units::amount::SignedAmount::ONE_SAT: bitcoin_units::amount::SignedAmount
 pub const bitcoin_units::amount::SignedAmount::ZERO: bitcoin_units::amount::SignedAmount
+pub const bitcoin_units::block::BlockHeight::MAX: Self
+pub const bitcoin_units::block::BlockHeight::MIN: Self
+pub const bitcoin_units::block::BlockHeight::ZERO: Self
+pub const bitcoin_units::block::BlockInterval::MAX: Self
+pub const bitcoin_units::block::BlockInterval::MIN: Self
+pub const bitcoin_units::block::BlockInterval::ZERO: Self
 pub const bitcoin_units::fee_rate::FeeRate::BROADCAST_MIN: bitcoin_units::fee_rate::FeeRate
 pub const bitcoin_units::fee_rate::FeeRate::DUST: bitcoin_units::fee_rate::FeeRate
 pub const bitcoin_units::fee_rate::FeeRate::MAX: bitcoin_units::fee_rate::FeeRate
@@ -584,6 +659,10 @@ pub const bitcoin_units::weight::Weight::ZERO: bitcoin_units::weight::Weight
 pub const fn bitcoin_units::amount::Amount::from_int_btc(btc: u64) -> bitcoin_units::amount::Amount
 pub const fn bitcoin_units::amount::Amount::from_sat(satoshi: u64) -> bitcoin_units::amount::Amount
 pub const fn bitcoin_units::amount::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::amount::SignedAmount
+pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeight::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockInterval::to_u32(&self) -> u32
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_vb_unchecked(sat_vb: u64) -> Self
 pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_kwu(self) -> u64
@@ -756,6 +835,40 @@ pub fn bitcoin_units::amount::TooPreciseError::fmt(&self, f: &mut core::fmt::For
 pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
 pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
 pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
+pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeight::eq(&self, other: &bitcoin_units::block::BlockHeight) -> bool
+pub fn bitcoin_units::block::BlockHeight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_units::block::BlockHeight::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeight::partial_cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::clone(&self) -> bitcoin_units::block::BlockInterval
+pub fn bitcoin_units::block::BlockInterval::cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockInterval::eq(&self, other: &bitcoin_units::block::BlockInterval) -> bool
+pub fn bitcoin_units::block::BlockInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockInterval::from(h: bitcoin_units::locktime::relative::Height) -> Self
+pub fn bitcoin_units::block::BlockInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockInterval::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::clone(&self) -> bitcoin_units::block::TooBigForRelativeBlockHeightError
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::eq(&self, other: &bitcoin_units::block::TooBigForRelativeBlockHeightError) -> bool
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
 pub fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::amount::Amount>
@@ -786,6 +899,7 @@ pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::res
 pub fn bitcoin_units::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::locktime::absolute::Height::to_consensus_u32(self) -> u32
+pub fn bitcoin_units::locktime::absolute::Height::try_from(h: bitcoin_units::block::BlockHeight) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
@@ -820,6 +934,7 @@ pub fn bitcoin_units::locktime::relative::Height::from_str(s: &str) -> core::res
 pub fn bitcoin_units::locktime::relative::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::locktime::relative::Height::partial_cmp(&self, other: &bitcoin_units::locktime::relative::Height) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::locktime::relative::Height::to_consensus_u32(&self) -> u32
+pub fn bitcoin_units::locktime::relative::Height::try_from(h: bitcoin_units::block::BlockInterval) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::relative::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::relative::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::relative::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
@@ -903,6 +1018,8 @@ pub fn bitcoin_units::weight::Weight::try_from(s: &str) -> core::result::Result<
 pub fn bitcoin_units::weight::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::weight::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
 pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockHeight) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockInterval) -> Self
 pub fn u64::from(value: bitcoin_units::fee_rate::FeeRate) -> Self
 pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
@@ -912,6 +1029,7 @@ pub macro bitcoin_units::impl_tryfrom_str!
 pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
+pub mod bitcoin_units::block
 pub mod bitcoin_units::fee_rate
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
@@ -919,6 +1037,8 @@ pub mod bitcoin_units::locktime::relative
 pub mod bitcoin_units::parse
 pub mod bitcoin_units::weight
 pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::BlockHeight(pub u32)
+pub struct bitcoin_units::BlockInterval(pub u32)
 pub struct bitcoin_units::FeeRate(_)
 pub struct bitcoin_units::SignedAmount(_)
 pub struct bitcoin_units::Weight(_)
@@ -930,6 +1050,9 @@ pub struct bitcoin_units::amount::MissingDigitsError
 pub struct bitcoin_units::amount::OutOfRangeError
 pub struct bitcoin_units::amount::SignedAmount(_)
 pub struct bitcoin_units::amount::TooPreciseError
+pub struct bitcoin_units::block::BlockHeight(pub u32)
+pub struct bitcoin_units::block::BlockInterval(pub u32)
+pub struct bitcoin_units::block::TooBigForRelativeBlockHeightError(_)
 pub struct bitcoin_units::fee_rate::FeeRate(_)
 pub struct bitcoin_units::locktime::absolute::Height(_)
 pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
@@ -951,14 +1074,23 @@ pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::Parse
 pub type bitcoin_units::amount::SignedAmount::Err = bitcoin_units::amount::ParseError
 pub type bitcoin_units::amount::SignedAmount::Error = bitcoin_units::amount::OutOfRangeError
 pub type bitcoin_units::amount::SignedAmount::Output = bitcoin_units::amount::SignedAmount
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockInterval
+pub type bitcoin_units::block::BlockInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Output = bitcoin_units::block::BlockInterval
 pub type bitcoin_units::fee_rate::FeeRate::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::fee_rate::FeeRate::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::amount::Amount
 pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ConversionError
 pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ParseHeightError
 pub type bitcoin_units::locktime::absolute::Time::Err = bitcoin_units::locktime::absolute::ParseTimeError
 pub type bitcoin_units::locktime::absolute::Time::Error = bitcoin_units::locktime::absolute::ParseTimeError
 pub type bitcoin_units::locktime::relative::Height::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::block::TooBigForRelativeBlockHeightError
 pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::locktime::relative::Time::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::locktime::relative::Time::Error = bitcoin_units::parse::ParseIntError

--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -65,6 +65,8 @@
 //! # }
 //! ```
 
+use units::{BlockHeight, BlockInterval};
+
 use crate::network::Network;
 #[cfg(doc)]
 use crate::pow::CompactTarget;
@@ -79,17 +81,17 @@ pub struct Params {
     /// Time when BIP16 becomes active.
     pub bip16_time: u32,
     /// Block height at which BIP34 becomes active.
-    pub bip34_height: u32,
+    pub bip34_height: BlockHeight,
     /// Block height at which BIP65 becomes active.
-    pub bip65_height: u32,
+    pub bip65_height: BlockHeight,
     /// Block height at which BIP66 becomes active.
-    pub bip66_height: u32,
+    pub bip66_height: BlockHeight,
     /// Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
     /// (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.
     /// Examples: 1916 for 95%, 1512 for testchains.
-    pub rule_change_activation_threshold: u32,
+    pub rule_change_activation_threshold: BlockInterval,
     /// Number of blocks with the same set of rules.
-    pub miner_confirmation_window: u32,
+    pub miner_confirmation_window: BlockInterval,
     /// Proof of work limit value. It contains the lowest possible difficulty.
     #[deprecated(since = "0.32.0", note = "field renamed to max_attainable_target")]
     pub pow_limit: Target,
@@ -138,12 +140,12 @@ impl Params {
     /// The mainnet parameters.
     pub const MAINNET: Params = Params {
         network: Network::Bitcoin,
-        bip16_time: 1333238400,                 // Apr 1 2012
-        bip34_height: 227931, // 000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8
-        bip65_height: 388381, // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
-        bip66_height: 363725, // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
-        rule_change_activation_threshold: 1916, // 95%
-        miner_confirmation_window: 2016,
+        bip16_time: 1333238400,                      // Apr 1 2012
+        bip34_height: BlockHeight::from_u32(227931), // 000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8
+        bip65_height: BlockHeight::from_u32(388381), // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
+        bip66_height: BlockHeight::from_u32(363725), // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        rule_change_activation_threshold: BlockInterval::from_u32(1916), // 95%
+        miner_confirmation_window: BlockInterval::from_u32(2016),
         pow_limit: Target::MAX_ATTAINABLE_MAINNET,
         max_attainable_target: Target::MAX_ATTAINABLE_MAINNET,
         pow_target_spacing: 10 * 60,            // 10 minutes.
@@ -155,12 +157,12 @@ impl Params {
     /// The testnet parameters.
     pub const TESTNET: Params = Params {
         network: Network::Testnet,
-        bip16_time: 1333238400,                 // Apr 1 2012
-        bip34_height: 21111, // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
-        bip65_height: 581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
-        bip66_height: 330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
-        rule_change_activation_threshold: 1512, // 75%
-        miner_confirmation_window: 2016,
+        bip16_time: 1333238400,                      // Apr 1 2012
+        bip34_height: BlockHeight::from_u32(21111), // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
+        bip65_height: BlockHeight::from_u32(581885), // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+        bip66_height: BlockHeight::from_u32(330776), // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        rule_change_activation_threshold: BlockInterval::from_u32(1512), // 75%
+        miner_confirmation_window: BlockInterval::from_u32(2016),
         pow_limit: Target::MAX_ATTAINABLE_TESTNET,
         max_attainable_target: Target::MAX_ATTAINABLE_TESTNET,
         pow_target_spacing: 10 * 60,            // 10 minutes.
@@ -173,11 +175,11 @@ impl Params {
     pub const SIGNET: Params = Params {
         network: Network::Signet,
         bip16_time: 1333238400, // Apr 1 2012
-        bip34_height: 1,
-        bip65_height: 1,
-        bip66_height: 1,
-        rule_change_activation_threshold: 1916, // 95%
-        miner_confirmation_window: 2016,
+        bip34_height: BlockHeight::from_u32(1),
+        bip65_height: BlockHeight::from_u32(1),
+        bip66_height: BlockHeight::from_u32(1),
+        rule_change_activation_threshold: BlockInterval::from_u32(1916), // 95%
+        miner_confirmation_window: BlockInterval::from_u32(2016),
         pow_limit: Target::MAX_ATTAINABLE_SIGNET,
         max_attainable_target: Target::MAX_ATTAINABLE_SIGNET,
         pow_target_spacing: 10 * 60,            // 10 minutes.
@@ -189,12 +191,12 @@ impl Params {
     /// The regtest parameters.
     pub const REGTEST: Params = Params {
         network: Network::Regtest,
-        bip16_time: 1333238400,  // Apr 1 2012
-        bip34_height: 100000000, // not activated on regtest
-        bip65_height: 1351,
-        bip66_height: 1251,                    // used only in rpc tests
-        rule_change_activation_threshold: 108, // 75%
-        miner_confirmation_window: 144,
+        bip16_time: 1333238400,                         // Apr 1 2012
+        bip34_height: BlockHeight::from_u32(100000000), // not activated on regtest
+        bip65_height: BlockHeight::from_u32(1351),
+        bip66_height: BlockHeight::from_u32(1251), // used only in rpc tests
+        rule_change_activation_threshold: BlockInterval::from_u32(108), // 75%
+        miner_confirmation_window: BlockInterval::from_u32(144),
         pow_limit: Target::MAX_ATTAINABLE_REGTEST,
         max_attainable_target: Target::MAX_ATTAINABLE_REGTEST,
         pow_target_spacing: 10 * 60,            // 10 minutes.

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -537,6 +537,7 @@ mod test {
     use std::net::Ipv4Addr;
 
     use hex::test_hex_unwrap as hex;
+    use units::BlockHeight;
 
     use super::*;
     use crate::bip152::BlockTransactionsRequest;
@@ -608,7 +609,7 @@ mod test {
             NetworkMessage::FilterClear,
             NetworkMessage::GetCFilters(GetCFilters {
                 filter_type: 2,
-                start_height: 52,
+                start_height: BlockHeight::from(52),
                 stop_hash: hash([42u8; 32]).into(),
             }),
             NetworkMessage::CFilter(CFilter {
@@ -618,7 +619,7 @@ mod test {
             }),
             NetworkMessage::GetCFHeaders(GetCFHeaders {
                 filter_type: 4,
-                start_height: 102,
+                start_height: BlockHeight::from(102),
                 stop_hash: hash([47u8; 32]).into(),
             }),
             NetworkMessage::CFHeaders(CFHeaders {

--- a/bitcoin/src/p2p/message_filter.rs
+++ b/bitcoin/src/p2p/message_filter.rs
@@ -4,6 +4,8 @@
 //!
 //! This module describes BIP157 Client Side Block Filtering network messages.
 
+use units::BlockHeight;
+
 use crate::bip158::{FilterHash, FilterHeader};
 use crate::blockdata::block::BlockHash;
 use crate::internal_macros::impl_consensus_encoding;
@@ -14,7 +16,7 @@ pub struct GetCFilters {
     /// Filter type for which headers are requested
     pub filter_type: u8,
     /// The height of the first block in the requested range
-    pub start_height: u32,
+    pub start_height: BlockHeight,
     /// The hash of the last block in the requested range
     pub stop_hash: BlockHash,
 }
@@ -38,7 +40,7 @@ pub struct GetCFHeaders {
     /// Byte identifying the type of filter being returned
     pub filter_type: u8,
     /// The height of the first block in the requested range
-    pub start_height: u32,
+    pub start_height: BlockHeight,
     /// The hash of the last block in the requested range
     pub stop_hash: BlockHash,
 }

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Block height and interval types.
+//!
+//! These types are thin wrappers around `u32`, no invariants implemented or implied.
+//!
+//! These are general types for abstracting over block heights, they are not designed to use with
+//! lock times. If you are creating lock times you should be using the
+//! [`locktime::absolute::Height`] and [`locktime::relative::Height`] types.
+//!
+//! The difference between these types and the locktime types is that these types are thin wrappers
+//! whereas the locktime types contain more complex locktime specific abstractions.
+
+use core::{fmt, ops};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(doc)]
+use crate::locktime;
+use crate::locktime::{absolute, relative};
+
+/// The block height, zero denotes the genesis block.
+///
+/// This type is not meant for constructing height based timelocks, this is a general purpose block
+/// height abstraction. For locktimes please see [`locktime::absolute::Height`].
+///
+/// This is a thin wrapper around a `u32` that may take on all values of a `u32`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+// Public to try and make it really clear that there are no invariants.
+pub struct BlockHeight(pub u32);
+
+impl BlockHeight {
+    /// Block height 0, the genesis block.
+    pub const ZERO: Self = BlockHeight(0);
+
+    /// The minimum block height (0), the genesis block.
+    pub const MIN: Self = Self::ZERO;
+
+    /// The maximum block height.
+    pub const MAX: Self = BlockHeight(u32::MAX);
+
+    /// Creates a block height from a `u32`.
+    // Because From<u32> is not const.
+    pub const fn from_u32(inner: u32) -> Self { Self(inner) }
+
+    /// Returns block height as a `u32`.
+    // Because type inference doesn't always work using `Into`.
+    pub const fn to_u32(&self) -> u32 { self.0 }
+}
+
+impl fmt::Display for BlockHeight {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+crate::impl_parse_str_from_int_infallible!(BlockHeight, u32, from);
+
+impl From<u32> for BlockHeight {
+    fn from(inner: u32) -> Self { Self::from_u32(inner) }
+}
+
+impl From<BlockHeight> for u32 {
+    fn from(height: BlockHeight) -> Self { height.to_u32() }
+}
+
+impl From<absolute::Height> for BlockHeight {
+    /// Converts [`locktime::absolute::Height`] to a [`BlockHeight`].
+    ///
+    /// An absolute locktime block height has a maximum value of `absolute::LOCK_TIME_THRESHOLD`
+    /// (500,000,000) where as a `BlockHeight` is a thin wrapper around a `u32`, the two types are
+    /// not interchangeable.
+    fn from(h: absolute::Height) -> Self { Self::from_u32(h.to_consensus_u32()) }
+}
+
+impl TryFrom<BlockHeight> for absolute::Height {
+    type Error = absolute::ConversionError;
+
+    /// Converts [`BlockHeight`] to a [`locktime::absolute::Height`].
+    ///
+    /// An absolute locktime block height has a maximum value of `absolute::LOCK_TIME_THRESHOLD`
+    /// (500,000,000) where as a `BlockHeight` is a thin wrapper around a `u32`, the two types are
+    /// not interchangeable.
+    fn try_from(h: BlockHeight) -> Result<Self, Self::Error> {
+        absolute::Height::from_consensus(h.to_u32())
+    }
+}
+
+/// The block interval.
+///
+/// Block interval is an integer type denoting the number of blocks that has passed since some point
+/// i.e., this type is meant for usage as a relative block measure.
+///
+/// This type is not meant for constructing relative height based timelocks, this is a general
+/// purpose block interval abstraction. For locktimes please see [`locktime::relative::Height`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+// Public to try and make it really clear that there are no invariants.
+pub struct BlockInterval(pub u32);
+
+impl BlockInterval {
+    /// Block interval 0 i.e., the current block.
+    pub const ZERO: Self = BlockInterval(0);
+
+    /// The minimum block interval (0).
+    pub const MIN: Self = Self::ZERO;
+
+    /// The maximum block interval.
+    pub const MAX: Self = BlockInterval(u32::MAX);
+
+    /// Creates a block interval from a `u32`.
+    // Because From<u32> is not const.
+    pub const fn from_u32(inner: u32) -> Self { Self(inner) }
+
+    /// Returns block interval as a `u32`.
+    // Because type inference doesn't always work using `Into`.
+    pub const fn to_u32(&self) -> u32 { self.0 }
+}
+
+impl fmt::Display for BlockInterval {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+crate::impl_parse_str_from_int_infallible!(BlockInterval, u32, from);
+
+impl From<u32> for BlockInterval {
+    fn from(inner: u32) -> Self { Self::from_u32(inner) }
+}
+
+impl From<BlockInterval> for u32 {
+    fn from(height: BlockInterval) -> Self { height.to_u32() }
+}
+
+impl From<relative::Height> for BlockInterval {
+    /// Converts [`locktime::relative::Height`] to a [`BlockInterval`].
+    ///
+    /// A relative locktime block height has a maximum value of `u16::MAX` where as a
+    /// `BlockInterval` is a thin wrapper around a `u32`, the two types are not interchangeable.
+    fn from(h: relative::Height) -> Self { Self::from_u32(h.value().into()) }
+}
+
+impl TryFrom<BlockInterval> for relative::Height {
+    type Error = TooBigForRelativeBlockHeightError;
+
+    /// Converts [`BlockInterval`] to a [`locktime::relative::Height`].
+    ///
+    /// A relative locktime block height has a maximum value of `u16::MAX` where as a
+    /// `BlockInterval` is a thin wrapper around a `u32`, the two types are not interchangeable.
+    fn try_from(h: BlockInterval) -> Result<Self, Self::Error> {
+        let h = h.to_u32();
+        if h > u16::MAX as u32 {
+            return Err(TooBigForRelativeBlockHeightError(h));
+        }
+        Ok(relative::Height::from(h as u16)) // Cast ok, value checked above
+    }
+}
+
+/// The block interval is too big to be used as a relative lock time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TooBigForRelativeBlockHeightError(u32);
+
+impl fmt::Display for TooBigForRelativeBlockHeightError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "block interval is too big to be used as a relative lock time: {} (max: {})",
+            self.0,
+            relative::Height::MAX
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TooBigForRelativeBlockHeightError {}
+
+// height - height = interval
+impl ops::Sub<BlockHeight> for BlockHeight {
+    type Output = BlockInterval;
+
+    fn sub(self, rhs: BlockHeight) -> Self::Output {
+        let interval = self.to_u32() - rhs.to_u32();
+        BlockInterval::from_u32(interval)
+    }
+}
+
+// height + interval = height
+impl ops::Add<BlockInterval> for BlockHeight {
+    type Output = BlockHeight;
+
+    fn add(self, rhs: BlockInterval) -> Self::Output {
+        let height = self.to_u32() + rhs.to_u32();
+        BlockHeight::from_u32(height)
+    }
+}
+
+// height - interval = height
+impl ops::Sub<BlockInterval> for BlockHeight {
+    type Output = BlockHeight;
+
+    fn sub(self, rhs: BlockInterval) -> Self::Output {
+        let height = self.to_u32() - rhs.to_u32();
+        BlockHeight::from_u32(height)
+    }
+}
+
+// interval + interval = interval
+impl ops::Add<BlockInterval> for BlockInterval {
+    type Output = BlockInterval;
+
+    fn add(self, rhs: BlockInterval) -> Self::Output {
+        let height = self.to_u32() + rhs.to_u32();
+        BlockInterval::from_u32(height)
+    }
+}
+
+impl ops::AddAssign<BlockInterval> for BlockInterval {
+    fn add_assign(&mut self, rhs: BlockInterval) { self.0 = self.to_u32() + rhs.to_u32(); }
+}
+
+// interval - interval = interval
+impl ops::Sub<BlockInterval> for BlockInterval {
+    type Output = BlockInterval;
+
+    fn sub(self, rhs: BlockInterval) -> Self::Output {
+        let height = self.to_u32() - rhs.to_u32();
+        BlockInterval::from_u32(height)
+    }
+}
+
+impl ops::SubAssign<BlockInterval> for BlockInterval {
+    fn sub_assign(&mut self, rhs: BlockInterval) { self.0 = self.to_u32() - rhs.to_u32(); }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests are supposed to comprise an exhaustive list of available operations.
+    #[test]
+    fn all_available_ops() {
+        // height - height = interval
+        assert!(BlockHeight(100) - BlockHeight(99) == BlockInterval(1));
+
+        // height + interval = height
+        assert!(BlockHeight(100) + BlockInterval(1) == BlockHeight(101));
+
+        // height - interval == height
+        assert!(BlockHeight(100) - BlockInterval(1) == BlockHeight(99));
+
+        // interval + interval = interval
+        assert!(BlockInterval(1) + BlockInterval(2) == BlockInterval(3));
+
+        // interval - interval = interval
+        assert!(BlockInterval(3) - BlockInterval(2) == BlockInterval(1));
+
+        // interval += interval
+        let mut int = BlockInterval(1);
+        int += BlockInterval(2);
+        assert_eq!(int, BlockInterval(3));
+
+        // interval -= interval
+        let mut int = BlockInterval(3);
+        int -= BlockInterval(2);
+        assert_eq!(int, BlockInterval(1));
+    }
+}

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -37,6 +37,8 @@ mod test_macros;
 
 pub mod amount;
 #[cfg(feature = "alloc")]
+pub mod block;
+#[cfg(feature = "alloc")]
 pub mod fee_rate;
 #[cfg(feature = "alloc")]
 pub mod locktime;
@@ -51,6 +53,7 @@ pub use self::amount::{Amount, SignedAmount};
 #[doc(inline)]
 #[rustfmt::skip]
 pub use self::{
+    block::{BlockHeight, BlockInterval},
     fee_rate::FeeRate,
     // ParseIntError is used by other modules, so we re-export it.
     parse::ParseIntError,


### PR DESCRIPTION
Add two simple integer wrapper types for abstracting over block height (from genesis block) and block interval.

This does not include hex because block height is typically written in decimal.

These types are very thin wrappers, their usecase is to assist in code readability instead of enforcing any logic.

Based on discussion in #2533

Close: #2532 