### PR TITLE
Call is_witness_program from witness_version

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -660,3 +660,31 @@ delegate_index!(
     RangeToInclusive<usize>,
     (Bound<usize>, Bound<usize>)
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blockdata::script::witness_program::WitnessProgram;
+
+    #[test]
+    fn shortest_witness_program() {
+        let bytes = [0x00; 2]; // Arbitrary bytes, witprog must be between 2 and 40.
+        let version = WitnessVersion::V15; // Arbitrary version number, intentionally not 0 or 1.
+
+        let p = WitnessProgram::new(version, &bytes).expect("failed to create witness program");
+        let script = ScriptBuf::new_witness_program(&p);
+
+        assert_eq!(script.witness_version(), Some(version));
+    }
+
+    #[test]
+    fn longest_witness_program() {
+        let bytes = [0x00; 40]; // Arbitrary bytes, witprog must be between 2 and 40.
+        let version = WitnessVersion::V16; // Arbitrary version number, intentionally not 0 or 1.
+
+        let p = WitnessProgram::new(version, &bytes).expect("failed to create witness program");
+        let script = ScriptBuf::new_witness_program(&p);
+
+        assert_eq!(script.witness_version(), Some(version));
+    }
+}


### PR DESCRIPTION
Refactor `witness_version` and `is_witness_program`.

- Patch 2 adds a couple of preparatory unit tests.
- Patch 2 does the refactor
    
Fix: #2618