### PR TITLE
bitcoin: Depend on and export hex-conservative

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -38,6 +38,7 @@ bitcoin-internals = { path = "../internals", package = "bitcoin-private", versio
 bech32 = { version = "0.9.0", default-features = false }
 bitcoin_hashes = { version = "0.12.0", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = ["bitcoin_hashes"] }
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
 
 base64 = { version = "0.13.0", optional = true }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -64,6 +64,7 @@ pub extern crate bitcoin_hashes as hashes;
 #[cfg(feature = "bitcoinconsensus")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bitcoinconsensus")))]
 pub extern crate bitcoinconsensus;
+pub extern crate hex;
 pub extern crate secp256k1;
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
When we did the `rust-bitcoin v0.30.0` release we had not yet released the `hex-conservative` crate so we forced users to reach into `bitcoin-internals` to get at hex stuff e.g., `DisplayHex`.

To ease the upgrade path for any remaining upgraders add a dependency on the now released `hex-conservative` crate and re-export it from the crate root as `hex` (bit late I know, sorry).

Idea came from: https://github.com/rust-bitcoin/rust-bitcoin/issues/2482#issuecomment-1947075032

We should have done this soon as we released `hex-conservative`.