### PR TITLE
fuzz: Use path in manifest instead of version

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { version = "0.31.0", features = [ "serde" ] }
+bitcoin = { path = "../bitcoin", features = [ "serde" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
Using `path` instead of `version` makes the `fuzz` crate easier to maintain because we don't have to update the version number to do releases.