### PR TITLE
Put back in deprecated dust_value

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -386,6 +386,12 @@ impl Script {
     }
 
     /// Returns the minimum value an output with this script should have in order to be
+    /// broadcastable on today’s Bitcoin network.
+    #[deprecated(since = "0.32.0", note = "use minimal_non_dust and friends")]
+    pub fn dust_value(&self) -> crate::Amount { self.minimal_non_dust() }
+
+
+    /// Returns the minimum value an output with this script should have in order to be
     /// broadcastable on today's Bitcoin network.
     ///
     /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.


### PR DESCRIPTION
When we renamed `dust_value` to `minimal_non_dust` we forgot to keep the original and deprecated it, doing so assists with the upgrade path.

Put back in deprecated `dust_value`, linking to the rename.

Renamed in #2255, found while testing upgrade of downstream software.