### PR TITLE
Replace TBD with 0.32.0

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -349,7 +349,7 @@ impl Script {
     /// This method has potentially confusing semantics and an unclear purpose, so it's going to be
     /// removed. Use `is_op_return` if you want `OP_RETURN` semantics.
     #[deprecated(
-        since = "TBD",
+        since = "0.32.0",
         note = "The method is not very useful, you might want `is_op_return`"
     )]
     #[inline]

--- a/bitcoin/src/taproot/merkle_branch.rs
+++ b/bitcoin/src/taproot/merkle_branch.rs
@@ -20,7 +20,7 @@ pub struct TaprootMerkleBranch(Vec<TapNodeHash>);
 
 impl TaprootMerkleBranch {
     /// Returns a reference to the slice of hashes.
-    #[deprecated(since = "TBD", note = "Use `as_slice` instead")]
+    #[deprecated(since = "0.32.0", note = "Use `as_slice` instead")]
     #[inline]
     pub fn as_inner(&self) -> &[TapNodeHash] { &self.0 }
 
@@ -106,7 +106,7 @@ impl TaprootMerkleBranch {
     }
 
     /// Returns the inner list of hashes.
-    #[deprecated(since = "TBD", note = "Use `into_vec` instead")]
+    #[deprecated(since = "0.32.0", note = "Use `into_vec` instead")]
     #[inline]
     pub fn into_inner(self) -> Vec<TapNodeHash> { self.0 }
 


### PR DESCRIPTION
We are gearing up for the 0.32.0 release; replace all instances of TBD with the version number of the upcoming release.