### PR TITLE
move `all_zeroes` & `from_byte_array` to inherents & make them const.

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -6849,7 +6849,7 @@ pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self
 pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::EcdsaSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
-pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub const fn bitcoin::LegacySighash::all_zeros() -> Self
 pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
@@ -6862,7 +6862,7 @@ pub fn bitcoin::LegacySighash::engine() -> Self::Engine
 pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
 pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
-pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::LegacySighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
@@ -6898,7 +6898,7 @@ pub fn bitcoin::PrivateKey::public_key<C: secp256k1::context::Signing>(&self, se
 pub fn bitcoin::PrivateKey::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
-pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub const fn bitcoin::PubkeyHash::all_zeros() -> Self
 pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -6916,7 +6916,7 @@ pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
-pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::PubkeyHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
@@ -6951,7 +6951,7 @@ pub fn bitcoin::PublicKey::to_sort_key(self) -> bitcoin::key::SortKey
 pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), secp256k1::Error>
 pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPublicKeyError>
 pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
-pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub const fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
 pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
@@ -6964,7 +6964,7 @@ pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
 pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
 pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
-pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
@@ -6976,7 +6976,7 @@ pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sig
 pub fn bitcoin::SegwitV0Sighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub const fn bitcoin::TapSighash::all_zeros() -> Self
 pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
@@ -6989,7 +6989,7 @@ pub fn bitcoin::TapSighash::engine() -> Self::Engine
 pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
 pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
-pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::TapSighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
@@ -7019,7 +7019,7 @@ pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, 
 pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::TapSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
-pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub const fn bitcoin::WPubkeyHash::all_zeros() -> Self
 pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -7035,7 +7035,7 @@ pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> cor
 pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
-pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::WPubkeyHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
@@ -7263,7 +7263,7 @@ pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
 pub fn bitcoin::bip158::Error::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin::bip158::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub const fn bitcoin::bip158::FilterHash::all_zeros() -> Self
 pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
@@ -7279,7 +7279,7 @@ pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHas
 pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
-pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
@@ -7291,7 +7291,7 @@ pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::
 pub fn bitcoin::bip158::FilterHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub const fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
 pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
@@ -7306,7 +7306,7 @@ pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
 pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
 pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
-pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
@@ -7438,7 +7438,7 @@ pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::clone(&self) -> bitcoin:
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::eq(&self, other: &bitcoin::bip32::InvalidBase58PayloadLengthError) -> bool
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::invalid_base58_payload_length(&self) -> usize
-pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub const fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
@@ -7453,7 +7453,7 @@ pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'
 pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
-pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
@@ -7524,7 +7524,7 @@ pub fn bitcoin::blockdata::block::Block::serialize<__S>(&self, __serializer: __S
 pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
 pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
-pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
@@ -7543,7 +7543,7 @@ pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::blo
 pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
-pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
@@ -7564,7 +7564,7 @@ pub fn bitcoin::blockdata::block::Header::consensus_encode<R: bitcoin_io::Write 
 pub fn bitcoin::blockdata::block::Header::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
 pub fn bitcoin::blockdata::block::Header::difficulty(&self, params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> u128
 pub fn bitcoin::blockdata::block::Header::difficulty_float(&self) -> f64
-pub fn bitcoin::blockdata::block::Header::eq(&self, other: &bitcoin::blockdata::block::Header) -> bool
+pub fn bitcoin::blockdata::block::Header::eq(&self, : &bitcoin::blockdata::block::Header) -> bool
 pub fn bitcoin::blockdata::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::blockdata::block::Header::partial_cmp(&self, other: &bitcoin::blockdata::block::Header) -> core::option::Option<core::cmp::Ordering>
@@ -7572,7 +7572,7 @@ pub fn bitcoin::blockdata::block::Header::serialize<__S>(&self, __serializer: __
 pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
 pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
 pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
-pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -7588,7 +7588,7 @@ pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::block
 pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
-pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
@@ -7618,7 +7618,7 @@ pub fn bitcoin::blockdata::block::Version::is_signalling_soft_fork(&self, bit: u
 pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
-pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
@@ -7631,7 +7631,7 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
 pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
 pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
-pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
@@ -7643,7 +7643,7 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &
 pub fn bitcoin::blockdata::block::WitnessCommitment::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -7659,7 +7659,7 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
@@ -8147,7 +8147,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::reserve_exact(&mut self, additiona
 pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
 pub fn bitcoin::blockdata::script::ScriptBuf::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
-pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
@@ -8164,7 +8164,7 @@ pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash1
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
-pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
@@ -8176,7 +8176,7 @@ pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoi
 pub fn bitcoin::blockdata::script::ScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
-pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
@@ -8193,7 +8193,7 @@ pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha2
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
-pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
@@ -8388,7 +8388,7 @@ pub fn bitcoin::blockdata::transaction::TxOut::partial_cmp(&self, other: &bitcoi
 pub fn bitcoin::blockdata::transaction::TxOut::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
 pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin_units::weight::Weight
-pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub const fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
 pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
@@ -8405,7 +8405,7 @@ pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Form
 pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
-pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
@@ -8429,7 +8429,7 @@ pub fn bitcoin::blockdata::transaction::Version::is_standard(&self) -> bool
 pub fn bitcoin::blockdata::transaction::Version::non_standard(version: i32) -> bitcoin::blockdata::transaction::Version
 pub fn bitcoin::blockdata::transaction::Version::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::transaction::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-pub fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
+pub const fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
@@ -8446,7 +8446,7 @@ pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::For
 pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
-pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
@@ -9456,7 +9456,7 @@ pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapLeaf::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
@@ -9472,7 +9472,7 @@ pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLea
 pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
-pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
@@ -9492,7 +9492,7 @@ pub fn bitcoin::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEng
 pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeafTag) -> bool
 pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
@@ -9509,7 +9509,7 @@ pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
-pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
@@ -9535,7 +9535,7 @@ pub fn bitcoin::taproot::TapTree::script_leaves(&self) -> bitcoin::taproot::Scri
 pub fn bitcoin::taproot::TapTree::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
-pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
@@ -9550,7 +9550,7 @@ pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'
 pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
-pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -6539,7 +6539,7 @@ pub fn bitcoin::EcdsaSighashType::from_standard(n: u32) -> core::result::Result<
 pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
-pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub const fn bitcoin::LegacySighash::all_zeros() -> Self
 pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
@@ -6551,7 +6551,7 @@ pub fn bitcoin::LegacySighash::engine() -> Self::Engine
 pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
 pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
-pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::LegacySighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
@@ -6582,7 +6582,7 @@ pub fn bitcoin::PrivateKey::new_uncompressed(key: secp256k1::key::SecretKey, net
 pub fn bitcoin::PrivateKey::public_key<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::PublicKey
 pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
-pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub const fn bitcoin::PubkeyHash::all_zeros() -> Self
 pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -6599,7 +6599,7 @@ pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
-pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::PubkeyHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
@@ -6629,8 +6629,8 @@ pub fn bitcoin::PublicKey::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::PublicKey::to_sort_key(self) -> bitcoin::key::SortKey
 pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), secp256k1::Error>
 pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPublicKeyError>
-pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
-pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub const fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub const fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
 pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
@@ -6642,7 +6642,7 @@ pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
 pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
 pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
-pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
@@ -6652,7 +6652,7 @@ pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub const fn bitcoin::TapSighash::all_zeros() -> Self
 pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
@@ -6664,7 +6664,7 @@ pub fn bitcoin::TapSighash::engine() -> Self::Engine
 pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
 pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
-pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::TapSighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
@@ -6690,7 +6690,7 @@ pub fn bitcoin::TapSighashType::from_consensus_u8(sighash_type: u8) -> core::res
 pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub const fn bitcoin::WPubkeyHash::all_zeros() -> Self
 pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -6705,7 +6705,7 @@ pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> cor
 pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
-pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::WPubkeyHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
@@ -6927,7 +6927,7 @@ pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
 pub fn bitcoin::bip158::Error::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin::bip158::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub const fn bitcoin::bip158::FilterHash::all_zeros() -> Self
 pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
@@ -6942,7 +6942,7 @@ pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHas
 pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
-pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
@@ -6952,7 +6952,7 @@ pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub const fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
 pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
@@ -6966,7 +6966,7 @@ pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
 pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
 pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
-pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
@@ -7088,7 +7088,7 @@ pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::clone(&self) -> bitcoin:
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::eq(&self, other: &bitcoin::bip32::InvalidBase58PayloadLengthError) -> bool
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::invalid_base58_payload_length(&self) -> usize
-pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub const fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
@@ -7102,7 +7102,7 @@ pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'
 pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
-pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
@@ -7165,7 +7165,7 @@ pub fn bitcoin::blockdata::block::Block::fmt(&self, f: &mut core::fmt::Formatter
 pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
 pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
-pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
@@ -7183,7 +7183,7 @@ pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::blo
 pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
-pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
@@ -7208,7 +7208,7 @@ pub fn bitcoin::blockdata::block::Header::partial_cmp(&self, other: &bitcoin::bl
 pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
 pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
 pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
-pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -7223,7 +7223,7 @@ pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::block
 pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
-pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
@@ -7249,7 +7249,7 @@ pub fn bitcoin::blockdata::block::Version::hash<__H: core::hash::Hasher>(&self, 
 pub fn bitcoin::blockdata::block::Version::is_signalling_soft_fork(&self, bit: u8) -> bool
 pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
-pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
@@ -7261,7 +7261,7 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
 pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
 pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
-pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
@@ -7271,7 +7271,7 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &
 pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -7286,7 +7286,7 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
@@ -7758,7 +7758,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::reserve(&mut self, additional_len:
 pub fn bitcoin::blockdata::script::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
 pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
 pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
-pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
@@ -7774,7 +7774,7 @@ pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash1
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
-pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
@@ -7784,7 +7784,7 @@ pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::
 pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
-pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
@@ -7800,7 +7800,7 @@ pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha2
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
-pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
@@ -7981,7 +7981,7 @@ pub fn bitcoin::blockdata::transaction::TxOut::minimal_non_dust_custom(script_pu
 pub fn bitcoin::blockdata::transaction::TxOut::partial_cmp(&self, other: &bitcoin::blockdata::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
 pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin_units::weight::Weight
-pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub const fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
 pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
@@ -7997,7 +7997,7 @@ pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Form
 pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
-pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
@@ -8017,7 +8017,7 @@ pub fn bitcoin::blockdata::transaction::Version::hash<__H: core::hash::Hasher>(&
 pub fn bitcoin::blockdata::transaction::Version::is_standard(&self) -> bool
 pub fn bitcoin::blockdata::transaction::Version::non_standard(version: i32) -> bitcoin::blockdata::transaction::Version
 pub fn bitcoin::blockdata::transaction::Version::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
+pub const fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
@@ -8033,7 +8033,7 @@ pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::For
 pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
-pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
@@ -8953,7 +8953,7 @@ pub fn bitcoin::taproot::TapLeaf::eq(&self, other: &bitcoin::taproot::TapLeaf) -
 pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
@@ -8968,7 +8968,7 @@ pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLea
 pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
-pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
@@ -8986,7 +8986,7 @@ pub fn bitcoin::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEng
 pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeafTag) -> bool
 pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
@@ -9002,7 +9002,7 @@ pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
-pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
@@ -9024,7 +9024,7 @@ pub fn bitcoin::taproot::TapTree::root_hash(&self) -> bitcoin::taproot::TapNodeH
 pub fn bitcoin::taproot::TapTree::script_leaves(&self) -> bitcoin::taproot::ScriptLeaves<'_>
 pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
-pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
@@ -9038,7 +9038,7 @@ pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'
 pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
-pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -5910,7 +5910,7 @@ pub fn bitcoin::EcdsaSighashType::from_standard(n: u32) -> core::result::Result<
 pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
-pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub const fn bitcoin::LegacySighash::all_zeros() -> Self
 pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
@@ -5922,7 +5922,7 @@ pub fn bitcoin::LegacySighash::engine() -> Self::Engine
 pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
 pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
-pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::LegacySighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
@@ -5953,7 +5953,7 @@ pub fn bitcoin::PrivateKey::new_uncompressed(key: secp256k1::key::SecretKey, net
 pub fn bitcoin::PrivateKey::public_key<C: secp256k1::context::Signing>(&self, secp: &secp256k1::Secp256k1<C>) -> bitcoin::PublicKey
 pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
-pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub const fn bitcoin::PubkeyHash::all_zeros() -> Self
 pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -5970,7 +5970,7 @@ pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
-pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::PubkeyHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
@@ -6001,7 +6001,7 @@ pub fn bitcoin::PublicKey::to_sort_key(self) -> bitcoin::key::SortKey
 pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, secp: &secp256k1::Secp256k1<C>, msg: &secp256k1::Message, sig: &bitcoin::ecdsa::Signature) -> core::result::Result<(), secp256k1::Error>
 pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPublicKeyError>
 pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
-pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub const fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
 pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
@@ -6013,7 +6013,7 @@ pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
 pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
 pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
-pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
@@ -6023,7 +6023,7 @@ pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub const fn bitcoin::TapSighash::all_zeros() -> Self
 pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
@@ -6035,7 +6035,7 @@ pub fn bitcoin::TapSighash::engine() -> Self::Engine
 pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
 pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
-pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::TapSighash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
@@ -6061,7 +6061,7 @@ pub fn bitcoin::TapSighashType::from_consensus_u8(sighash_type: u8) -> core::res
 pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub const fn bitcoin::WPubkeyHash::all_zeros() -> Self
 pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -6076,7 +6076,7 @@ pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> cor
 pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
-pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::WPubkeyHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
@@ -6290,7 +6290,7 @@ pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
 pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
 pub fn bitcoin::bip158::Error::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub const fn bitcoin::bip158::FilterHash::all_zeros() -> Self
 pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
@@ -6305,7 +6305,7 @@ pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHas
 pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
-pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
@@ -6315,7 +6315,7 @@ pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub const fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
 pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
@@ -6329,7 +6329,7 @@ pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
 pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
 pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
-pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
@@ -6450,7 +6450,7 @@ pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::clone(&self) -> bitcoin:
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::eq(&self, other: &bitcoin::bip32::InvalidBase58PayloadLengthError) -> bool
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::invalid_base58_payload_length(&self) -> usize
-pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub const fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
@@ -6464,7 +6464,7 @@ pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'
 pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
-pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
@@ -6526,7 +6526,7 @@ pub fn bitcoin::blockdata::block::Block::fmt(&self, f: &mut core::fmt::Formatter
 pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
 pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
-pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
@@ -6544,7 +6544,7 @@ pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::blo
 pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
-pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
@@ -6569,7 +6569,7 @@ pub fn bitcoin::blockdata::block::Header::partial_cmp(&self, other: &bitcoin::bl
 pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
 pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
 pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
-pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -6584,7 +6584,7 @@ pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::block
 pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
-pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
@@ -6609,7 +6609,7 @@ pub fn bitcoin::blockdata::block::Version::hash<__H: core::hash::Hasher>(&self, 
 pub fn bitcoin::blockdata::block::Version::is_signalling_soft_fork(&self, bit: u8) -> bool
 pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
-pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
@@ -6621,7 +6621,7 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
 pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
 pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
-pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
@@ -6631,7 +6631,7 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &
 pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub const fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -6646,7 +6646,7 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
@@ -7113,7 +7113,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::reserve(&mut self, additional_len:
 pub fn bitcoin::blockdata::script::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
 pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
 pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
-pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
@@ -7129,7 +7129,7 @@ pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash1
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
-pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
@@ -7139,7 +7139,7 @@ pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::
 pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
-pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub const fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
@@ -7155,7 +7155,7 @@ pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha2
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
-pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
@@ -7326,7 +7326,7 @@ pub fn bitcoin::blockdata::transaction::TxOut::minimal_non_dust_custom(script_pu
 pub fn bitcoin::blockdata::transaction::TxOut::partial_cmp(&self, other: &bitcoin::blockdata::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
 pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin_units::weight::Weight
-pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub const fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
 pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
@@ -7342,7 +7342,7 @@ pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Form
 pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
-pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
@@ -7378,7 +7378,7 @@ pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::For
 pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
-pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
@@ -8065,7 +8065,7 @@ pub fn bitcoin::taproot::TapLeaf::eq(&self, other: &bitcoin::taproot::TapLeaf) -
 pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
@@ -8080,7 +8080,7 @@ pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLea
 pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
-pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
@@ -8098,7 +8098,7 @@ pub fn bitcoin::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEng
 pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeafTag) -> bool
 pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
@@ -8114,7 +8114,7 @@ pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
-pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
@@ -8136,7 +8136,7 @@ pub fn bitcoin::taproot::TapTree::root_hash(&self) -> bitcoin::taproot::TapNodeH
 pub fn bitcoin::taproot::TapTree::script_leaves(&self) -> bitcoin::taproot::ScriptLeaves<'_>
 pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
-pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub const fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
 pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
@@ -8150,7 +8150,7 @@ pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'
 pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
-pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes)  -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash

--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -528,7 +528,7 @@ pub fn bitcoin_hashes::FromSliceError::invalid_length(&self) -> usize
 pub fn bitcoin_hashes::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
-pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
@@ -549,7 +549,7 @@ pub fn bitcoin_hashes::hash160::Hash::deserialize<D: serde::de::Deserializer<'de
 pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
 pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
@@ -571,7 +571,7 @@ pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::H
 pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
 pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
@@ -604,7 +604,7 @@ pub fn bitcoin_hashes::ripemd160::Hash::deserialize<D: serde::de::Deserializer<'
 pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
 pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
@@ -641,7 +641,7 @@ pub fn bitcoin_hashes::sha1::Hash::deserialize<D: serde::de::Deserializer<'de>>(
 pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
 pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
@@ -675,7 +675,7 @@ pub fn bitcoin_hashes::sha256::Hash::deserialize<D: serde::de::Deserializer<'de>
 pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
 pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
@@ -728,7 +728,7 @@ pub fn bitcoin_hashes::sha256d::Hash::deserialize<D: serde::de::Deserializer<'de
 pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
 pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
@@ -754,7 +754,7 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde::de::Deserializer<
 pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
 pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
@@ -780,7 +780,7 @@ pub fn bitcoin_hashes::sha384::Hash::deserialize<D: serde::de::Deserializer<'de>
 pub fn bitcoin_hashes::sha384::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
 pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
 pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
 pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> bitcoin_hashes::sha384::Hash
@@ -810,7 +810,7 @@ pub fn bitcoin_hashes::sha512::Hash::deserialize<D: serde::de::Deserializer<'de>
 pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
 pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
 pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
 pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
@@ -844,7 +844,7 @@ pub fn bitcoin_hashes::sha512_256::Hash::deserialize<D: serde::de::Deserializer<
 pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
 pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
@@ -875,7 +875,7 @@ pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde::de::Deserializer<'
 pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
 pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
 pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash

--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -453,10 +453,10 @@ pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSli
 pub fn bitcoin_hashes::FromSliceError::expected_length(&self) -> usize
 pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::FromSliceError::invalid_length(&self) -> usize
-pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
-pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
@@ -466,7 +466,7 @@ pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
 pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
 pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
-pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
 pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
@@ -476,7 +476,7 @@ pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160
 pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
 pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
@@ -486,14 +486,14 @@ pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state
 pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
-pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub const fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
 pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
 pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
@@ -507,7 +507,7 @@ pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
-pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
 pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
@@ -517,7 +517,7 @@ pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripem
 pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
 pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
@@ -532,7 +532,7 @@ pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
 pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
 pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
 pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
@@ -542,7 +542,7 @@ pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
 pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
@@ -557,7 +557,7 @@ pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
 pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
 pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
@@ -567,7 +567,7 @@ pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::
 pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
 pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
@@ -598,7 +598,7 @@ pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, st
 pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
-pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
@@ -608,7 +608,7 @@ pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d
 pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
 pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
@@ -618,7 +618,7 @@ pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state
 pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
-pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
@@ -629,7 +629,7 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
 pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
@@ -640,7 +640,7 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
-pub fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8; 48]
 pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
@@ -650,7 +650,7 @@ pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::
 pub fn bitcoin_hashes::sha384::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
 pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
 pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
 pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> bitcoin_hashes::sha384::Hash
@@ -665,7 +665,7 @@ pub fn bitcoin_hashes::sha384::HashEngine::default() -> Self
 pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha384::HashEngine::midstate(&self) -> [u8; 64]
 pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
 pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
@@ -675,7 +675,7 @@ pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::
 pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
 pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
 pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
 pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
@@ -690,7 +690,7 @@ pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
 pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
 pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
@@ -700,7 +700,7 @@ pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha5
 pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
 pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
@@ -715,7 +715,7 @@ pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
 pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
 pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
 pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
@@ -726,7 +726,7 @@ pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::sipha
 pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
 pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
 pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -453,10 +453,10 @@ pub fn bitcoin_hashes::FromSliceError::eq(&self, other: &bitcoin_hashes::FromSli
 pub fn bitcoin_hashes::FromSliceError::expected_length(&self) -> usize
 pub fn bitcoin_hashes::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::FromSliceError::invalid_length(&self) -> usize
-pub fn bitcoin_hashes::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::Hash::engine() -> Self::Engine
-pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::Hash::from_engine(e: Self::Engine) -> Self
 pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::Hash::hash(data: &[u8]) -> Self
@@ -466,7 +466,7 @@ pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::HashEngine::midstate(&self) -> Self::MidState
 pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> usize
 pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
-pub fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
 pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
@@ -476,7 +476,7 @@ pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160
 pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
 pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
@@ -486,14 +486,14 @@ pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state
 pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
-pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
+pub const fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
 pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
 pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
@@ -507,7 +507,7 @@ pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::midstate(&self) -> Self::MidState
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T>
-pub fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
 pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
@@ -517,7 +517,7 @@ pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripem
 pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
 pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
@@ -532,7 +532,7 @@ pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
 pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::ripemd160::HashEngine::midstate(&self) -> [u8; 20]
 pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
 pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
@@ -542,7 +542,7 @@ pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
 pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
@@ -557,7 +557,7 @@ pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
 pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha1::HashEngine::midstate(&self) -> [u8; 20]
 pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
@@ -567,7 +567,7 @@ pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::
 pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
 pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
@@ -598,7 +598,7 @@ pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, st
 pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
-pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
@@ -608,7 +608,7 @@ pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d
 pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
 pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
@@ -618,7 +618,7 @@ pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state
 pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
-pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
@@ -629,7 +629,7 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
 pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
@@ -640,7 +640,7 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
-pub fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8; 48]
 pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
@@ -650,7 +650,7 @@ pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::
 pub fn bitcoin_hashes::sha384::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
 pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
 pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
 pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> bitcoin_hashes::sha384::Hash
@@ -665,7 +665,7 @@ pub fn bitcoin_hashes::sha384::HashEngine::default() -> Self
 pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha384::HashEngine::midstate(&self) -> [u8; 64]
 pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
 pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
@@ -675,7 +675,7 @@ pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::
 pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
 pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
 pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
 pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
@@ -690,7 +690,7 @@ pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
 pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512::HashEngine::midstate(&self) -> [u8; 64]
 pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
@@ -700,7 +700,7 @@ pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha5
 pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
 pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
@@ -715,7 +715,7 @@ pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
 pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512_256::HashEngine::midstate(&self) -> [u8; 64]
 pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> usize
-pub fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
 pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
@@ -726,7 +726,7 @@ pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::sipha
 pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: <Self as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
 pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
 pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -4,7 +4,6 @@
 
 use std::str::FromStr;
 
-use bitcoin::hashes::Hash;
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -4,7 +4,6 @@
 
 use std::str::FromStr;
 
-use bitcoin::hashes::Hash;
 use bitcoin::key::{Keypair, TapTweak, TweakedKeypair, UntweakedPublicKey};
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing, Verification};

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -213,7 +213,6 @@ mod test {
 
     use super::*;
     use crate::consensus::encode::serialize;
-    use crate::consensus::params;
     use crate::Txid;
 
     #[test]
@@ -243,7 +242,7 @@ mod test {
     #[test]
     fn bitcoin_genesis_block_calling_convention() {
         // This is the best.
-        let _ = genesis_block(&params::MAINNET);
+        let _ = genesis_block(&Params::MAINNET);
         // this works and is ok too.
         let _ = genesis_block(&Network::Bitcoin);
         let _ = genesis_block(Network::Bitcoin);
@@ -254,7 +253,7 @@ mod test {
 
     #[test]
     fn bitcoin_genesis_full_block() {
-        let gen = genesis_block(&params::MAINNET);
+        let gen = genesis_block(&Params::MAINNET);
 
         assert_eq!(gen.header.version, block::Version::ONE);
         assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
@@ -274,7 +273,7 @@ mod test {
 
     #[test]
     fn testnet_genesis_full_block() {
-        let gen = genesis_block(&params::TESTNET);
+        let gen = genesis_block(&Params::TESTNET);
         assert_eq!(gen.header.version, block::Version::ONE);
         assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
@@ -292,7 +291,7 @@ mod test {
 
     #[test]
     fn signet_genesis_full_block() {
-        let gen = genesis_block(&params::SIGNET);
+        let gen = genesis_block(&Params::SIGNET);
         assert_eq!(gen.header.version, block::Version::ONE);
         assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -198,7 +198,6 @@ macro_rules! impl_hashencode {
 
         impl $crate::consensus::Decodable for $hashtype {
             fn consensus_decode<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
-                use $crate::hashes::Hash;
                 Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode(r)?))
             }
         }

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -144,7 +144,6 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {
-    use hashes::Hash;
     use hex::test_hex_unwrap as hex;
 
     use super::*;

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1776,7 +1776,6 @@ mod tests {
 
     #[test]
     fn compact_target_from_upwards_difficulty_adjustment_using_headers() {
-        use hashes::Hash;
 
         use crate::block::Version;
         use crate::constants::genesis_block;
@@ -1801,7 +1800,6 @@ mod tests {
 
     #[test]
     fn compact_target_from_downwards_difficulty_adjustment_using_headers() {
-        use hashes::Hash;
 
         use crate::block::Version;
         use crate::TxMerkleNode;

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -145,13 +145,6 @@ impl<T: Hash> Hash for Hmac<T> {
     fn to_byte_array(self) -> Self::Bytes { self.0.to_byte_array() }
 
     fn as_byte_array(&self) -> &Self::Bytes { self.0.as_byte_array() }
-
-    fn from_byte_array(bytes: T::Bytes) -> Self { Hmac(T::from_byte_array(bytes)) }
-
-    fn all_zeros() -> Self {
-        let zeros = T::all_zeros();
-        Hmac(zeros)
-    }
 }
 
 #[cfg(feature = "serde")]

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -89,13 +89,13 @@ macro_rules! hash_trait_impls {
         impl<$($gen: $gent),*> $crate::_export::_core::str::FromStr for Hash<$($gen),*> {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<Self, Self::Err> {
-                use $crate::{Hash, hex::{FromHex}};
+                use $crate::{ hex::{FromHex}};
 
                 let mut bytes = <[u8; $bits / 8]>::from_hex(s)?;
                 if $reverse {
                     bytes.reverse();
                 }
-                Ok(Self::from_byte_array(bytes))
+                Ok(Hash::from_byte_array(bytes))
             }
         }
 
@@ -150,14 +150,6 @@ macro_rules! hash_trait_impls {
             fn as_byte_array(&self) -> &Self::Bytes {
                 &self.0
             }
-
-            fn from_byte_array(bytes: Self::Bytes) -> Self {
-                Self::internal_new(bytes)
-            }
-
-            fn all_zeros() -> Self {
-                Hash::internal_new([0x00; $bits / 8])
-            }
         }
     }
 }
@@ -188,6 +180,18 @@ macro_rules! hash_type {
             fn internal_new(arr: [u8; $bits / 8]) -> Self { Hash(arr) }
 
             fn internal_engine() -> HashEngine { Default::default() }
+
+            /// Constructs a hash from the underlying byte array.
+            pub const fn from_byte_array(bytes: <Self as crate::Hash>::Bytes) -> Self {
+                Hash(bytes)
+            }
+
+            /// Returns an all zero hash.
+            ///
+            /// An all zeros hash is a made up construct because there is not a known input that can create
+            /// it. However, it is used in various places in Bitcoin e.g., the Bitcoin genesis block's
+            /// previous blockhash and the coinbase transaction's outpoint txid.
+            pub const fn all_zeros() -> Self { Hash([0x00; $bits / 8]) }
         }
 
         #[cfg(feature = "schemars")]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -210,16 +210,6 @@ pub trait Hash:
 
     /// Returns a reference to the underlying byte array.
     fn as_byte_array(&self) -> &Self::Bytes;
-
-    /// Constructs a hash from the underlying byte array.
-    fn from_byte_array(bytes: Self::Bytes) -> Self;
-
-    /// Returns an all zero hash.
-    ///
-    /// An all zeros hash is a made up construct because there is not a known input that can create
-    /// it, however it is used in various places in Bitcoin e.g., the Bitcoin genesis block's
-    /// previous blockhash and the coinbase transaction's outpoint txid.
-    fn all_zeros() -> Self;
 }
 
 /// Attempted to create a hash from an invalid length slice.

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -101,9 +101,9 @@ impl crate::HashEngine for HashEngine {
 impl Hash {
     /// Iterate the sha256 algorithm to turn a sha256 hash into a sha256d hash
     pub fn hash_again(&self) -> sha256d::Hash {
-        crate::Hash::from_byte_array(<Self as crate::Hash>::hash(&self.0).0)
+        let sha256_hash = Hash::from_byte_array(<Self as crate::Hash>::hash(&self.0).0);
+        sha256d::Hash::from_byte_array(sha256_hash.0)
     }
-
     /// Computes hash from `bytes` in `const` context.
     ///
     /// Warning: this function is inefficient. It should be only used in `const` context.

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -40,6 +40,18 @@ impl<T: Tag> Hash<T> {
     fn internal_new(arr: [u8; 32]) -> Self { Hash(arr, Default::default()) }
 
     fn internal_engine() -> HashEngine { T::engine() }
+
+    /// Constructs a hash from the underlying byte array.
+    pub const fn from_byte_array(bytes: <Self as crate::Hash>::Bytes) -> Self {
+        Hash(bytes, PhantomData)
+    }
+
+    /// Returns an all zero hash.
+    ///
+    /// An all zeros hash is a made up construct because there is not a known input that can create
+    /// it. However, it is used in various places in Bitcoin e.g., the Bitcoin genesis block's
+    /// previous blockhash and the coinbase transaction's outpoint txid.
+    pub const fn all_zeros() -> Self { Hash([0x00; 32], PhantomData) }
 }
 
 impl<T: Tag> Copy for Hash<T> {}

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -210,7 +210,27 @@ macro_rules! hash_newtype {
             pub fn as_raw_hash(&self) -> &$hash {
                 &self.0
             }
+
+            #[allow(unused)]
+            /// Constructs a hash from the underlying byte array.
+            pub const fn from_byte_array(bytes: <Self as $crate::Hash>::Bytes) -> Self {
+                $newtype(<$hash>::from_byte_array(bytes))
+            }
+
+
+            #[allow(unused)]
+            /// Returns an all zero hash.
+            ///
+            /// An all zeros hash is a made up construct because there is not a known input that can create
+            /// it. However, it is used in various places in Bitcoin e.g., the Bitcoin genesis block's
+            /// previous blockhash and the coinbase transaction's outpoint txid.
+            pub const fn all_zeros() -> Self {
+                let zeros = <$hash>::all_zeros();
+                $newtype(zeros)
+            }
         }
+
+
 
         impl $crate::_export::_core::convert::From<$hash> for $newtype {
             fn from(inner: $hash) -> $newtype {
@@ -246,11 +266,6 @@ macro_rules! hash_newtype {
             }
 
             #[inline]
-            fn from_byte_array(bytes: Self::Bytes) -> Self {
-                $newtype(<$hash as $crate::Hash>::from_byte_array(bytes))
-            }
-
-            #[inline]
             fn to_byte_array(self) -> Self::Bytes {
                 self.0.to_byte_array()
             }
@@ -259,18 +274,12 @@ macro_rules! hash_newtype {
             fn as_byte_array(&self) -> &Self::Bytes {
                 self.0.as_byte_array()
             }
-
-            #[inline]
-            fn all_zeros() -> Self {
-                let zeros = <$hash>::all_zeros();
-                $newtype(zeros)
-            }
         }
 
         impl $crate::_export::_core::str::FromStr for $newtype {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<$newtype, Self::Err> {
-                use $crate::{Hash, hex::FromHex};
+                use $crate::hex::FromHex;
 
                 let mut bytes = <[u8; <Self as $crate::Hash>::LEN]>::from_hex(s)?;
                 if <Self as $crate::Hash>::DISPLAY_BACKWARD {


### PR DESCRIPTION
Made these functions const fn & move them from the `Hash` trait to `hash_type` & `hash_newtype` macros

fix #2377