### PR TITLE
Add HKDF to bitcoin_hashes

### DIFF
--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -66,6 +66,7 @@ impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
 impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
 impl core::clone::Clone for bitcoin_hashes::FromSliceError
 impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
 impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
 impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
 impl core::clone::Clone for bitcoin_hashes::sha1::Hash
@@ -85,6 +86,7 @@ impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
 impl core::clone::Clone for bitcoin_hashes::siphash24::State
 impl core::cmp::Eq for bitcoin_hashes::FromSliceError
 impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
 impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
 impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
@@ -106,6 +108,7 @@ impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
 impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::FromSliceError
 impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
@@ -153,8 +156,10 @@ impl core::default::Default for bitcoin_hashes::sha512::HashEngine
 impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
 impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
 impl core::error::Error for bitcoin_hashes::FromSliceError
+impl core::error::Error for bitcoin_hashes::hkdf::MaxLengthError
 impl core::fmt::Debug for bitcoin_hashes::FromSliceError
 impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
 impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
 impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
 impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
@@ -168,6 +173,7 @@ impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::siphash24::State
 impl core::fmt::Display for bitcoin_hashes::FromSliceError
 impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
 impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
 impl core::fmt::Display for bitcoin_hashes::sha1::Hash
 impl core::fmt::Display for bitcoin_hashes::sha256::Hash
@@ -208,6 +214,7 @@ impl core::hash::Hash for bitcoin_hashes::sha512::Hash
 impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
 impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
 impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Copy for bitcoin_hashes::sha1::Hash
 impl core::marker::Copy for bitcoin_hashes::sha256::Hash
@@ -219,6 +226,7 @@ impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
 impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
 impl core::marker::Freeze for bitcoin_hashes::FromSliceError
 impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
@@ -238,6 +246,7 @@ impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Freeze for bitcoin_hashes::siphash24::State
 impl core::marker::Send for bitcoin_hashes::FromSliceError
 impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha1::Hash
@@ -257,6 +266,7 @@ impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Send for bitcoin_hashes::siphash24::State
 impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
 impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
@@ -268,6 +278,7 @@ impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
 impl core::marker::Sync for bitcoin_hashes::FromSliceError
 impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha1::Hash
@@ -287,6 +298,7 @@ impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Sync for bitcoin_hashes::siphash24::State
 impl core::marker::Unpin for bitcoin_hashes::FromSliceError
 impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
@@ -306,6 +318,7 @@ impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Unpin for bitcoin_hashes::siphash24::State
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
@@ -325,6 +338,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
@@ -405,6 +419,7 @@ impl<T: bitcoin_hashes::Hash + schemars::JsonSchema> schemars::JsonSchema for bi
 impl<T: bitcoin_hashes::Hash + serde::ser::Serialize> serde::ser::Serialize for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hkdf::Hkdf<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_io::Write for bitcoin_hashes::hmac::HmacEngine<T>
 impl<T: bitcoin_hashes::Hash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
@@ -443,26 +458,32 @@ impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bi
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
@@ -563,6 +584,12 @@ pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes:
 pub fn bitcoin_hashes::hash160::Hash::schema_name() -> alloc::string::String
 pub fn bitcoin_hashes::hash160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand_to_len(&self, info: &[u8], len: usize) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
@@ -914,6 +941,7 @@ pub macro bitcoin_hashes::sha256t_hash_newtype!
 pub mod bitcoin_hashes
 pub mod bitcoin_hashes::cmp
 pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
 pub mod bitcoin_hashes::hmac
 pub mod bitcoin_hashes::ripemd160
 pub mod bitcoin_hashes::serde_macros
@@ -928,6 +956,8 @@ pub mod bitcoin_hashes::sha512_256
 pub mod bitcoin_hashes::siphash24
 pub struct bitcoin_hashes::FromSliceError
 pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
 pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
 pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
 pub struct bitcoin_hashes::ripemd160::HashEngine

--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -51,6 +51,7 @@ impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
 impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
 impl core::clone::Clone for bitcoin_hashes::FromSliceError
 impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
 impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
 impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
 impl core::clone::Clone for bitcoin_hashes::sha1::Hash
@@ -70,6 +71,7 @@ impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
 impl core::clone::Clone for bitcoin_hashes::siphash24::State
 impl core::cmp::Eq for bitcoin_hashes::FromSliceError
 impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
 impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
 impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
@@ -91,6 +93,7 @@ impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
 impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::FromSliceError
 impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
@@ -139,6 +142,7 @@ impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
 impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::FromSliceError
 impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
 impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
 impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
 impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
@@ -152,6 +156,7 @@ impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::siphash24::State
 impl core::fmt::Display for bitcoin_hashes::FromSliceError
 impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
 impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
 impl core::fmt::Display for bitcoin_hashes::sha1::Hash
 impl core::fmt::Display for bitcoin_hashes::sha256::Hash
@@ -192,6 +197,7 @@ impl core::hash::Hash for bitcoin_hashes::sha512::Hash
 impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
 impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
 impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Copy for bitcoin_hashes::sha1::Hash
 impl core::marker::Copy for bitcoin_hashes::sha256::Hash
@@ -203,6 +209,7 @@ impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
 impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
 impl core::marker::Freeze for bitcoin_hashes::FromSliceError
 impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
@@ -222,6 +229,7 @@ impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Freeze for bitcoin_hashes::siphash24::State
 impl core::marker::Send for bitcoin_hashes::FromSliceError
 impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha1::Hash
@@ -241,6 +249,7 @@ impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Send for bitcoin_hashes::siphash24::State
 impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
 impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
@@ -252,6 +261,7 @@ impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
 impl core::marker::Sync for bitcoin_hashes::FromSliceError
 impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha1::Hash
@@ -271,6 +281,7 @@ impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Sync for bitcoin_hashes::siphash24::State
 impl core::marker::Unpin for bitcoin_hashes::FromSliceError
 impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
@@ -290,6 +301,7 @@ impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Unpin for bitcoin_hashes::siphash24::State
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
@@ -309,6 +321,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
@@ -351,6 +364,7 @@ impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bit
 impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hkdf::Hkdf<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
 impl<T: bitcoin_hashes::Hash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
@@ -384,26 +398,32 @@ impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bi
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
@@ -486,6 +506,12 @@ pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state
 pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand_to_len(&self, info: &[u8], len: usize) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
@@ -757,6 +783,7 @@ pub macro bitcoin_hashes::sha256t_hash_newtype!
 pub mod bitcoin_hashes
 pub mod bitcoin_hashes::cmp
 pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
 pub mod bitcoin_hashes::hmac
 pub mod bitcoin_hashes::ripemd160
 pub mod bitcoin_hashes::serde_macros
@@ -770,6 +797,8 @@ pub mod bitcoin_hashes::sha512_256
 pub mod bitcoin_hashes::siphash24
 pub struct bitcoin_hashes::FromSliceError
 pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
 pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
 pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
 pub struct bitcoin_hashes::ripemd160::HashEngine

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -51,6 +51,7 @@ impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
 impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
 impl core::clone::Clone for bitcoin_hashes::FromSliceError
 impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
 impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
 impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
 impl core::clone::Clone for bitcoin_hashes::sha1::Hash
@@ -70,6 +71,7 @@ impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
 impl core::clone::Clone for bitcoin_hashes::siphash24::State
 impl core::cmp::Eq for bitcoin_hashes::FromSliceError
 impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
 impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
 impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
@@ -91,6 +93,7 @@ impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
 impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::FromSliceError
 impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
 impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
@@ -139,6 +142,7 @@ impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
 impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::FromSliceError
 impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
 impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
 impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
 impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
@@ -152,6 +156,7 @@ impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::siphash24::State
 impl core::fmt::Display for bitcoin_hashes::FromSliceError
 impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
 impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
 impl core::fmt::Display for bitcoin_hashes::sha1::Hash
 impl core::fmt::Display for bitcoin_hashes::sha256::Hash
@@ -192,6 +197,7 @@ impl core::hash::Hash for bitcoin_hashes::sha512::Hash
 impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
 impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
 impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Copy for bitcoin_hashes::sha1::Hash
 impl core::marker::Copy for bitcoin_hashes::sha256::Hash
@@ -203,6 +209,7 @@ impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
 impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
 impl core::marker::Freeze for bitcoin_hashes::FromSliceError
 impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
@@ -222,6 +229,7 @@ impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Freeze for bitcoin_hashes::siphash24::State
 impl core::marker::Send for bitcoin_hashes::FromSliceError
 impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha1::Hash
@@ -241,6 +249,7 @@ impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Send for bitcoin_hashes::siphash24::State
 impl core::marker::StructuralPartialEq for bitcoin_hashes::FromSliceError
 impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
@@ -252,6 +261,7 @@ impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
 impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
 impl core::marker::Sync for bitcoin_hashes::FromSliceError
 impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha1::Hash
@@ -271,6 +281,7 @@ impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Sync for bitcoin_hashes::siphash24::State
 impl core::marker::Unpin for bitcoin_hashes::FromSliceError
 impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
 impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
 impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
@@ -290,6 +301,7 @@ impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Unpin for bitcoin_hashes::siphash24::State
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::FromSliceError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
@@ -309,6 +321,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::FromSliceError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
@@ -351,6 +364,7 @@ impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bit
 impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hkdf::Hkdf<T>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
 impl<T: bitcoin_hashes::Hash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
@@ -384,26 +398,32 @@ impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bi
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Freeze
 impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Send
 impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::marker::Unpin
 impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::panic::unwind_safe::UnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacMidState<T> where <<T as bitcoin_hashes::Hash>::Engine as bitcoin_hashes::HashEngine>::MidState: core::panic::unwind_safe::UnwindSafe
@@ -486,6 +506,11 @@ pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state
 pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::hmac::Hmac<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
@@ -757,6 +782,7 @@ pub macro bitcoin_hashes::sha256t_hash_newtype!
 pub mod bitcoin_hashes
 pub mod bitcoin_hashes::cmp
 pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
 pub mod bitcoin_hashes::hmac
 pub mod bitcoin_hashes::ripemd160
 pub mod bitcoin_hashes::serde_macros
@@ -770,6 +796,8 @@ pub mod bitcoin_hashes::sha512_256
 pub mod bitcoin_hashes::siphash24
 pub struct bitcoin_hashes::FromSliceError
 pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::Hash>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
 pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
 pub struct bitcoin_hashes::hmac::HmacMidState<T: bitcoin_hashes::Hash>
 pub struct bitcoin_hashes::ripemd160::HashEngine

--- a/hashes/src/hkdf.rs
+++ b/hashes/src/hkdf.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! HMAC-based Extract-and-Expand Key Derivation Function (HKDF).
+//!
+//! Implementation based on RFC5869, but the interface is scoped
+//! to BIP324's requirements.
+
+use core::fmt;
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::vec;
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::vec::Vec;
+
+use crate::{Hash, HashEngine, Hmac, HmacEngine};
+
+/// Output keying material max length multiple.
+const MAX_OUTPUT_BLOCKS: usize = 255;
+
+/// Size of output exceeds maximum length allowed.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct MaxLengthError {
+    max: usize,
+}
+
+impl fmt::Display for MaxLengthError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "exceeds {} byte max output material limit", self.max)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MaxLengthError {}
+
+/// HMAC-based Extract-and-Expand Key Derivation Function (HKDF).
+pub struct Hkdf<T: Hash> {
+    /// Pseudorandom key based on the extract step.
+    prk: Hmac<T>,
+}
+
+impl<T: Hash> Hkdf<T> {
+    /// Initialize a HKDF by performing the extract step.
+    pub fn new(salt: &[u8], ikm: &[u8]) -> Self {
+        let mut hmac_engine: HmacEngine<T> = HmacEngine::new(salt);
+        hmac_engine.input(ikm);
+        Self { prk: Hmac::from_engine(hmac_engine) }
+    }
+
+    /// Expand the key to generate output key material in okm.
+    ///
+    /// Expand may be called multiple times to derive multiple keys,
+    /// but the info must be independent from the ikm for security.
+    pub fn expand(&self, info: &[u8], okm: &mut [u8]) -> Result<(), MaxLengthError> {
+        // Length of output keying material in bytes must be less than 255 * hash length.
+        if okm.len() > (MAX_OUTPUT_BLOCKS * T::LEN) {
+            return Err(MaxLengthError { max: MAX_OUTPUT_BLOCKS * T::LEN });
+        }
+
+        // Counter starts at "1" based on RFC5869 spec and is committed to in the hash.
+        let mut counter = 1u8;
+        // Ceiling calculation for the total number of blocks (iterations) required for the expand.
+        let total_blocks = (okm.len() + T::LEN - 1) / T::LEN;
+
+        while counter <= total_blocks as u8 {
+            let mut hmac_engine: HmacEngine<T> = HmacEngine::new(self.prk.as_ref());
+
+            // First block does not have a previous block,
+            // all other blocks include last block in the HMAC input.
+            if counter != 1u8 {
+                let previous_start_index = (counter as usize - 2) * T::LEN;
+                let previous_end_index = (counter as usize - 1) * T::LEN;
+                hmac_engine.input(&okm[previous_start_index..previous_end_index]);
+            }
+            hmac_engine.input(info);
+            hmac_engine.input(&[counter]);
+
+            let t = Hmac::from_engine(hmac_engine);
+            let start_index = (counter as usize - 1) * T::LEN;
+            // Last block might not take full hash length.
+            let end_index =
+                if counter == (total_blocks as u8) { okm.len() } else { counter as usize * T::LEN };
+
+            okm[start_index..end_index].copy_from_slice(&t.as_ref()[0..(end_index - start_index)]);
+
+            counter += 1;
+        }
+
+        Ok(())
+    }
+
+    /// Expand the key to specified length.
+    ///
+    /// Expand may be called multiple times to derive multiple keys,
+    /// but the info must be independent from the ikm for security.
+    #[cfg(feature = "alloc")]
+    pub fn expand_to_len(&self, info: &[u8], len: usize) -> Result<Vec<u8>, MaxLengthError> {
+        let mut okm = vec![0u8; len];
+        self.expand(info, &mut okm)?;
+        Ok(okm)
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "alloc")]
+mod tests {
+    use hex::prelude::*;
+
+    use super::*;
+    use crate::sha256;
+
+    #[test]
+    fn test_rfc5869_basic() {
+        let salt = Vec::from_hex("000102030405060708090a0b0c").unwrap();
+        let ikm = Vec::from_hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
+        let info = Vec::from_hex("f0f1f2f3f4f5f6f7f8f9").unwrap();
+
+        let hkdf = Hkdf::<sha256::Hash>::new(&salt, &ikm);
+        let mut okm = [0u8; 42];
+        hkdf.expand(&info, &mut okm).unwrap();
+
+        assert_eq!(
+            okm.to_lower_hex_string(),
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+        );
+    }
+
+    #[test]
+    fn test_rfc5869_longer_inputs_outputs() {
+        let salt = Vec::from_hex(
+            "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+        ).unwrap();
+        let ikm = Vec::from_hex(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f"
+        ).unwrap();
+        let info = Vec::from_hex(
+            "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        ).unwrap();
+
+        let hkdf = Hkdf::<sha256::Hash>::new(&salt, &ikm);
+        let mut okm = [0u8; 82];
+        hkdf.expand(&info, &mut okm).unwrap();
+
+        assert_eq!(
+            okm.to_lower_hex_string(),
+            "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
+        );
+    }
+
+    #[test]
+    fn test_too_long_okm() {
+        let salt = Vec::from_hex("000102030405060708090a0b0c").unwrap();
+        let ikm = Vec::from_hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
+        let info = Vec::from_hex("f0f1f2f3f4f5f6f7f8f9").unwrap();
+
+        let hkdf = Hkdf::<sha256::Hash>::new(&salt, &ikm);
+        let mut okm = [0u8; 256 * 32];
+        let e = hkdf.expand(&info, &mut okm);
+
+        assert!(e.is_err());
+    }
+
+    #[test]
+    fn test_short_okm() {
+        let salt = Vec::from_hex("000102030405060708090a0b0c").unwrap();
+        let ikm = Vec::from_hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
+        let info = Vec::from_hex("f0f1f2f3f4f5f6f7f8f9").unwrap();
+
+        let hkdf = Hkdf::<sha256::Hash>::new(&salt, &ikm);
+        let mut okm = [0u8; 1];
+        hkdf.expand(&info, &mut okm).unwrap();
+
+        assert_eq!(okm.to_lower_hex_string(), "3c");
+    }
+
+    #[test]
+    fn test_alloc_wrapper() {
+        let salt = Vec::from_hex("000102030405060708090a0b0c").unwrap();
+        let ikm = Vec::from_hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
+        let info = Vec::from_hex("f0f1f2f3f4f5f6f7f8f9").unwrap();
+
+        let hkdf = Hkdf::<sha256::Hash>::new(&salt, &ikm);
+        let okm = hkdf.expand_to_len(&info, 42).unwrap();
+
+        assert_eq!(
+            okm.to_lower_hex_string(),
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+        );
+    }
+}

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -110,6 +110,7 @@ mod util;
 pub mod serde_macros;
 pub mod cmp;
 pub mod hash160;
+pub mod hkdf;
 pub mod hmac;
 #[cfg(feature = "bitcoin-io")]
 mod impls;


### PR DESCRIPTION
rustaceanrob and I have been working on a Rust-based BIP324 implementation over at https://github.com/rustaceanrob/bip324. We have been attempting to keep the code pretty clean in hopes of a future "soft landing" in rust-bitcoin. I figured the HKDF implementation is a small, self-contained chunk that might allow us to learn the ropes here first.

There was a mention in the [discussion thread on BIP324](https://github.com/rust-bitcoin/rust-bitcoin/discussions/1691) that the hashes interface may be changing in the near future. I am not sure the effect that would have on this implementation, but happy to work through any issues.

Closes #2551 