### PR TITLE
release 0.31.2

### DIFF
--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.31.2 - 2024-04-01
+
+- Fix parsing bug in `merkle_block::deserialize` [#2614](https://github.com/rust-bitcoin/rust-bitcoin/pull/2614)
+
 # 0.31.1 - 2024-01-09
 
 - Fix bug in `FeeRate::checked_mul_by_weight` [#2128](https://github.com/rust-bitcoin/rust-bitcoin/pull/2182)

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.31.1"
+version = "0.31.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
We forgot to add a release commit to the backport #2614.