### PR TITLE
just: Use pinned nightly

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,11 +11,11 @@ check:
 
 # Lint everything.
 lint:
-  cargo +nightly clippy --workspace --all-targets --all-features -- --deny warnings
+  cargo +$(cat .github/nightly-version) clippy --workspace --all-targets --all-features -- --deny warnings
 
 # Check the formatting
 format:
-  cargo +nightly fmt --all --check
+  cargo +$(cat .github/nightly-version) fmt --all --check
 
 # Quick and dirty CI useful for pre-push checks.
 sane: lint


### PR DESCRIPTION
Use the nightly version that we use in CI when running `just` commands that use the nightly toolchain.