### PR TITLE
units: Release tracking PR: `0.1.0` - BOOM!

### DIFF
--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,0 +1,17 @@
+# 0.1.0 - Initial Release - 2024-04-03
+
+Initial release of the `bitcoin-units` crate. These unit types are
+integer wrapper types used by the `rust-bitcoin` ecosystem. Note
+please that this release relies heavily on the "alloc" feature.
+
+The main types are:
+
+- `Amount`
+- `locktime::absolute::{Height, Time}`
+- `locktime::relative::{Height, Time}`
+- `FeeRate`
+- `Weight`
+
+# 0.0.0 - Placeholder release
+
+Empty crate to reserve the name on crates.io

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -46,9 +46,16 @@ pub mod parse;
 pub mod weight;
 
 #[doc(inline)]
-pub use self::amount::{Amount, ParseAmountError, SignedAmount};
+pub use self::amount::{Amount, SignedAmount};
+pub use self::amount::ParseAmountError;
 #[cfg(feature = "alloc")]
 pub use self::parse::ParseIntError;
+#[cfg(feature = "alloc")]
+#[doc(inline)]
+pub use self::{
+    fee_rate::FeeRate,
+    weight::Weight,
+};
 
 #[rustfmt::skip]
 #[allow(unused_imports)]


### PR DESCRIPTION
In preparation for release do two things:

- Patch 1: Attempt to improve the re-exports and HTML docs
- Patch 2: Add an initial changelog file

Note the version number is set already and does not conflict with the current `v0.0.0` version: https://crates.io/crates/bitcoin-units