### PR TITLE
units: Release tracking PR: `0.1.1`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -92,7 +92,7 @@ version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitcoin-internals",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -91,7 +91,7 @@ version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitcoin-internals",
  "serde",

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", version = "0.3.0" }
+internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -33,7 +33,7 @@ bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc", "io"] }
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
-internals = { package = "bitcoin-internals", version = "0.3.0" }
+internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false, features = ["alloc"] }

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.1 - 2024-04-04
+
+* Enable "alloc" feature for `internals` dependency - enables caching
+  of parsed input strings in a couple of `amount` error types.
+
 # 0.1.0 - Initial Release - 2024-04-03
 
 Initial release of the `bitcoin-units` crate. These unit types are

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.3.0" }
+internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
 


### PR DESCRIPTION
Fix a minor internal bug in error code in `units` and bump the version number so we can do a point release.

This can go in after the RC drops as part of the release candidate cycle if its easier - as long as its in and released before the finale `v0.32.0` release.