### PR TITLE
CI: sync labels

### DIFF
--- a/.github/workflows/manage-pr.yml
+++ b/.github/workflows/manage-pr.yml
@@ -23,4 +23,5 @@ jobs:
       - name: Update labels
         uses: actions/labeler@v5
         with:
+          sync-labels: true
           configuration-path: master/.github/labeler.yml


### PR DESCRIPTION
Draft while I push various other patches to test the change.

Currently the labeler action does not update labels if the files touched in a PR change. Said another way, if a PR gets labelled `C-units` and `C-bitcoin` then a later force push removes the changes to `units` the `C-units` label should be removed.

Set `sync-lablels` to true and see if this solves the problem.