### PR TITLE
hashes: Do not import str

### DIFF
--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -10,7 +10,6 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::str;
 
 use crate::{ripemd160, sha256, FromSliceError};
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -86,7 +86,7 @@ macro_rules! hash_trait_impls {
             }
         }
 
-        impl<$($gen: $gent),*> str::FromStr for Hash<$($gen),*> {
+        impl<$($gen: $gent),*> $crate::_export::_core::str::FromStr for Hash<$($gen),*> {
             type Err = $crate::hex::HexToArrayError;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<Self, Self::Err> {
                 use $crate::{Hash, hex::{FromHex}};

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{FromSliceError, HashEngine as _};
 

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{FromSliceError, HashEngine as _};
 

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -9,7 +9,7 @@ use core::arch::x86::*;
 use core::arch::x86_64::*;
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{sha256d, FromSliceError, HashEngine as _};
 
@@ -126,7 +126,7 @@ impl<I: SliceIndex<[u8]>> Index<I> for Midstate {
     fn index(&self, index: I) -> &Self::Output { &self.0[index] }
 }
 
-impl str::FromStr for Midstate {
+impl core::str::FromStr for Midstate {
     type Err = hex::HexToArrayError;
     fn from_str(s: &str) -> Result<Self, Self::Err> { hex::FromHex::from_hex(s) }
 }

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -5,7 +5,6 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::str;
 
 use crate::{sha256, FromSliceError};
 

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -6,7 +6,7 @@
 use core::marker::PhantomData;
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{sha256, FromSliceError};
 

--- a/hashes/src/sha384.rs
+++ b/hashes/src/sha384.rs
@@ -4,7 +4,6 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::str;
 
 use crate::{sha512, FromSliceError};
 

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, str};
+use core::cmp;
 
 use crate::{FromSliceError, HashEngine as _};
 

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -9,7 +9,6 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::str;
 
 use crate::{sha512, FromSliceError};
 

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Index;
 use core::slice::SliceIndex;
-use core::{cmp, mem, ptr, str};
+use core::{cmp, mem, ptr};
 
 use crate::{FromSliceError, Hash as _, HashEngine as _};
 


### PR DESCRIPTION
Depending on things being in scope for macros to use is bad form, using the fully qualified path is the correct way.

Do not import `str` instead use the fully qualified path to the `core` re-export.

Use fully qualified path instead.