### PR TITLE
Play around with `hashes`

### DIFF
--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -13,7 +13,7 @@
 
 use core::{fmt, str};
 
-use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
+use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash, HashEngine};
 use internals::write_err;
 use io::Write;
 
@@ -56,14 +56,22 @@ impl_message_from_hash!(LegacySighash);
 impl_message_from_hash!(SegwitV0Sighash);
 
 sha256t_hash_newtype! {
-    pub struct TapSighashTag = hash_str("TapSighash");
-
     /// Taproot-tagged hash with tag \"TapSighash\".
     ///
     /// This hash type is used for computing taproot signature hash."
     #[hash_newtype(forward)]
     pub struct TapSighash(_);
+
+    pub struct TapSighashEngine(_) = hash_str("TapSighash");
 }
+io::impl_write!(
+    TapSighashEngine,
+    |us: &mut TapSighashEngine, buf| {
+        us.input(buf);
+        Ok(buf.len())
+    },
+    |_us| { Ok(()) }
+);
 
 impl_message_from_hash!(TapSighash);
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -132,13 +132,13 @@ pub use crate::{
     consensus::params,
     crypto::ecdsa,
     crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, CompressedPublicKey, WPubkeyHash, XOnlyPublicKey},
-    crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},
+    crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashEngine},
     merkle_tree::MerkleBlock,
     network::{Network, NetworkKind},
     pow::{CompactTarget, Target, Work},
     psbt::Psbt,
     sighash::{EcdsaSighashType, TapSighashType},
-    taproot::{TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash, TapTweakHash, TapTweakTag},
+    taproot::{TapNodeHashEngine, TapLeafHash, TapLeafHashEngine, TapNodeHash, TapTweakHash, TapTweakHashEngine},
 };
 
 #[rustfmt::skip]

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -36,3 +36,4 @@ serde = { version = "1.0", default-features = false, optional = true }
 [dev-dependencies]
 serde_test = "1.0"
 serde_json = "1.0"
+jsonschema-valid = "0.4.0"

--- a/hashes/extended_tests/schemars/src/main.rs
+++ b/hashes/extended_tests/schemars/src/main.rs
@@ -117,27 +117,12 @@ mod tests {
             147, 108, 71, 99, 110, 96, 125, 179, 62, 234, 221, 198, 240, 201,
         ];
 
-        #[derive(
-            Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash, schemars::JsonSchema,
-        )]
-        pub struct TestHashTag;
-
-        impl sha256t::Tag for TestHashTag {
-            fn engine() -> sha256::HashEngine {
-                // The TapRoot TapLeaf midstate.
-                let midstate = sha256::Midstate::from_byte_array(TEST_MIDSTATE);
-                sha256::HashEngine::from_midstate(midstate, 64)
-            }
-        }
-
-        /// A hash tagged with `$name`.
-        pub type TestHash = sha256t::Hash<TestHashTag>;
-
         sha256t_hash_newtype! {
-            struct NewTypeTag = raw(TEST_MIDSTATE, 64);
-
+            /// A test hash.
             #[hash_newtype(backward)]
-            struct NewTypeHash(_);
+            struct TestHash(_);
+
+            struct TestHashEngine(_) = raw(TEST_MIDSTATE, 64);
         }
         static HASH_BYTES: [u8; 32] = [
             0xef, 0x53, 0x7f, 0x25, 0xc8, 0x95, 0xbf, 0xa7, 0x82, 0x52, 0x65, 0x29, 0xa9, 0xb6,

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -104,7 +104,7 @@ pub mod _export {
 }
 
 #[cfg(feature = "schemars")]
-extern crate schemars;
+pub extern crate schemars;
 
 mod internal_macros;
 #[macro_use]

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -50,7 +50,8 @@ fn from_engine(e: HashEngine) -> Hash {
     Hash(hash)
 }
 
-const BLOCK_SIZE: usize = 64;
+/// Length of the SHA256 hash's internal block size, in bytes.
+pub const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute SHA256 hash function.
 #[derive(Clone)]

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -225,4 +225,22 @@ mod tests {
             "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
         );
     }
+
+    sha256t_hash_newtype! {
+        /// Test detailed explanation.
+        struct FooTag = hash_str("foo");
+
+        /// A test hash.
+        #[hash_newtype(backward)]
+        struct FooHash(_);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn tagged_hash() {
+        assert_eq!(
+            FooHash::hash(&[0]).to_string(),
+            "cee837ec9192cfdb0e5762e9dd1881e9b4147fce76aea79f3b34cbc765935da6",
+        );
+    }
 }

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -113,7 +113,10 @@ fn from_engine<T: Tag>(e: sha256::HashEngine) -> Hash<T> {
 /// [`hash_newtype`]: crate::hash_newtype
 #[macro_export]
 macro_rules! sha256t_hash_newtype {
-    ($($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+); $(#[$($hash_attr:tt)*])* $hash_vis:vis struct $hash_name:ident($(#[$($field_attr:tt)*])* _);)+) => {
+    ($(
+        $(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+);
+        $(#[$($hash_attr:tt)*])* $hash_vis:vis struct $hash_name:ident($(#[$($field_attr:tt)*])* _);
+    )+) => {
         $(
         $crate::sha256t_hash_newtype_tag!($tag_vis, $tag, stringify!($hash_name), $(#[$($tag_attr)*])*);
 


### PR DESCRIPTION
There are a few problems with `hashes`, mainly:

- We want to stabalise it
- We pretty much agree the API as designed is undiscoverable
- https://github.com/rust-bitcoin/rust-bitcoin/issues/2197
- https://github.com/rust-bitcoin/rust-bitcoin/issues/2654

I've played with `hashes` at least 5 times over the last 3 months and I always get in knots without making any progress. Today I went wikipedia to try and understand the high level functions so I could better understand the current code design. #2663 fell out of this too.

Can you review the last 2 patches please Andrew and tell me if they are even close to being correct and/or acceptable.

- second to last is just docs in the top level readme
- last patch is tree restructure, non-API-breaking, with my new high level understanding of all the modules.

The first 4 patches could go in but its not worth the bother till we release I rekon.