### PR TITLE
Remove deprecated legacy numeric methods

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -495,7 +495,7 @@ mod test {
     fn test_getblocktx_panic_when_encoding_u64_max() {
         serialize(&BlockTransactionsRequest {
             block_hash: Hash::all_zeros(),
-            indexes: vec![core::u64::MAX],
+            indexes: vec![u64::MAX],
         });
     }
 }

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -15,7 +15,7 @@
 //! typically big-endian decimals, etc.)
 //!
 
-use core::{fmt, mem, u32};
+use core::{fmt, mem};
 
 use hashes::{sha256, sha256d, Hash};
 use hex::error::{InvalidCharError, OddLengthStringError};

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -214,7 +214,7 @@ impl<T: AsRef<[u8]>> Read for Cursor<T> {
         let read = core::cmp::min(inner.len().saturating_sub(start_pos), buf.len());
         buf[..read].copy_from_slice(&inner[start_pos..start_pos + read]);
         self.pos =
-            self.pos.saturating_add(read.try_into().unwrap_or(u64::max_value() /* unreachable */));
+            self.pos.saturating_add(read.try_into().unwrap_or(u64::MAX /* unreachable */));
         Ok(read)
     }
 }

--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -132,7 +132,7 @@ impl Time {
     pub const MIN: Self = Time(LOCK_TIME_THRESHOLD);
 
     /// The maximum absolute block time (Sun Feb 07 2106 06:28:15 GMT+0000).
-    pub const MAX: Self = Time(u32::max_value());
+    pub const MAX: Self = Time(u32::MAX);
 
     /// Creates a `Time` from a hex string.
     ///

--- a/units/src/locktime/relative.rs
+++ b/units/src/locktime/relative.rs
@@ -20,7 +20,7 @@ impl Height {
     pub const MIN: Self = Self::ZERO;
 
     /// The maximum relative block height.
-    pub const MAX: Self = Height(u16::max_value());
+    pub const MAX: Self = Height(u16::MAX);
 
     /// Create a [`Height`] using a count of blocks.
     #[inline]
@@ -62,7 +62,7 @@ impl Time {
     pub const MIN: Self = Time::ZERO;
 
     /// The maximum relative block time (33,554,432 seconds or approx 388 days).
-    pub const MAX: Self = Time(u16::max_value());
+    pub const MAX: Self = Time(u16::MAX);
 
     /// Create a [`Time`] using time intervals where each interval is equivalent to 512 seconds.
     ///


### PR DESCRIPTION
As `rustc 1.79.0-nightly (9d79cd5f7 2024-04-05)` is released which solves the issue mentioned , but the release has deperacted legacy numeric methods. 
Thus replaced `u16::max_value()` etc with `u32::MAX` & `core::u16` to directly `u16`.

fix #2639