### PR TITLE
Minor fixes for latest rustc nightly

### DIFF
--- a/.github/workflows/cron-daily-update-nightly.yml
+++ b/.github/workflows/cron-daily-update-nightly.yml
@@ -17,7 +17,7 @@ jobs:
           # version of the compiler dtolnay/rust-toolchain gives us.
           NIGHTLY_DATE=$(rustc +nightly --verbose --version | sed -ne 's/^commit-date: //p')
           # Update the nightly version in the reference file.
-          echo "nightly-${NIGHTLY_DATE}" > .github/nightly-version
+          echo "nightly-${NIGHTLY_DATE}" > nightly-version
           echo "nightly_date=${NIGHTLY_DATE}" >> $GITHUB_ENV
           # Some days there is no new nightly. In this case don't make an empty PR.
           if ! git diff --exit-code > /dev/null; then

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -61,7 +61,7 @@ fn psbt_sign_taproot() {
     let script3 = create_basic_single_sig_script(secp, sk_path[2].0); // m/86'/1'/0'/0/2
 
     // Just use one of the secret keys for the key path spend.
-    let kp = Keypair::from_seckey_str(secp, &sk_path[2].0).expect("failed to create keypair");
+    let kp = Keypair::from_seckey_str(secp, sk_path[2].0).expect("failed to create keypair");
 
     let internal_key = kp.x_only_public_key().0; // Ignore the parity.
 
@@ -118,7 +118,7 @@ fn psbt_sign_taproot() {
     // script path spend
     {
         // use private key of path "m/86'/1'/0'/0/1" as signing key
-        let kp = Keypair::from_seckey_str(secp, &sk_path[1].0).expect("failed to create keypair");
+        let kp = Keypair::from_seckey_str(secp, sk_path[1].0).expect("failed to create keypair");
         let x_only_pubkey = kp.x_only_public_key().0;
         let signing_key_path = sk_path[1].1;
 


### PR DESCRIPTION
Fixes an issue with #2658 which accidentally disabled our nightly rustc update cronjob, and also fixes a small clippy lint.

After this, we should be able to get back onto the latest nightly :).