### PR TITLE
Improve deprecation notice

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -359,7 +359,7 @@ impl Script {
     /// removed. Use `is_op_return` if you want `OP_RETURN` semantics.
     #[deprecated(
         since = "0.32.0",
-        note = "The method is not very useful, you might want `is_op_return`"
+        note = "The method has potentially confusing semantics and is going to be removed, you might want `is_op_return`"
     )]
     #[inline]
     pub fn is_provably_unspendable(&self) -> bool {


### PR DESCRIPTION
The deprecation notice for `is_provably_unspendable` contains "is not very useful" which is a bit presumptuous to tell to users, it may very well be useful to them. Use the more helpful text that already exists in rustdoc on the function.

Function was deprecated in #2294