### PR TITLE
just: Add just fmt

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,6 +13,10 @@ check:
 lint:
   cargo +$(cat ./nightly-version) clippy --workspace --all-targets --all-features -- --deny warnings
 
+# Run cargo fmt
+fmt:
+  cargo +$(cat ./nightly-version) fmt --all
+
 # Check the formatting
 format:
   cargo +$(cat ./nightly-version) fmt --all --check


### PR DESCRIPTION
We already have a `just` command to check the formatting, add one to run the formatter. Use the more terse `just fmt` although the difference from `just format` is not super obvious it is documented in the default output of `just`.

With this applied we have
```bash
$ just
Available recipes:
    build             # Cargo build everything.
    check             # Cargo check everything.
    default
    fmt               # Run cargo fmt
    format            # Check the formatting
    lint              # Lint everything.
    sane              # Quick and dirty CI useful for pre-push checks.
    update-lock-files # Update the recent and minimal lock files.
```