### PR TITLE
Allow m prefix in derivation paths

### DIFF
--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -26,7 +26,7 @@
 // The xpriv and derivation path from the imported descriptors
 const BENEFACTOR_XPRIV_STR: &str = "tprv8ZgxMBicQKsPd4arFr7sKjSnKFDVMR2JHw9Y8L9nXN4kiok4u28LpHijEudH3mMYoL4pM5UL9Bgdz2M4Cy8EzfErmU9m86ZTw6hCzvFeTg7";
 const BENEFICIARY_XPRIV_STR: &str = "tprv8ZgxMBicQKsPe72C5c3cugP8b7AzEuNjP4NSC17Dkpqk5kaAmsL6FHwPsVxPpURVqbNwdLAbNqi8Cvdq6nycDwYdKHDjDRYcsMzfshimAUq";
-const BIP86_DERIVATION_PATH: &str = "86'/1'/0'/0/0";
+const BIP86_DERIVATION_PATH: &str = "m/86'/1'/0'/0/0";
 
 // Step 3 -
 //          Run `bt generatetoaddress 103 $(bt-benefactor getnewaddress '' bech32m)` to generate 103 new blocks

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -326,12 +326,14 @@ impl FromStr for DerivationPath {
     type Err = Error;
 
     fn from_str(path: &str) -> Result<DerivationPath, Error> {
-        let ret: Result<Vec<ChildNumber>, Error> = if path.is_empty() {
-            Ok(vec![])
-        } else {
-            let parts = path.split('/');
-            parts.map(str::parse).collect()
-        };
+        if path.is_empty() || path == "m" || path == "m/" {
+            return Ok(vec![].into());
+        }
+
+        let path = path.strip_prefix("m/").unwrap_or(path);
+
+        let parts = path.split('/');
+        let ret: Result<Vec<ChildNumber>, Error> = parts.map(str::parse).collect();
         Ok(DerivationPath(ret?))
     }
 }
@@ -412,7 +414,7 @@ impl DerivationPath {
     /// use bitcoin::bip32::{DerivationPath, ChildNumber};
     /// use std::str::FromStr;
     ///
-    /// let base = DerivationPath::from_str("42").unwrap();
+    /// let base = DerivationPath::from_str("m/42").unwrap();
     ///
     /// let deriv_1 = base.extend(DerivationPath::from_str("0/1").unwrap());
     /// let deriv_2 = base.extend(&[
@@ -436,7 +438,7 @@ impl DerivationPath {
     /// use bitcoin::bip32::DerivationPath;
     /// use std::str::FromStr;
     ///
-    /// let path = DerivationPath::from_str("84'/0'/0'/0/1").unwrap();
+    /// let path = DerivationPath::from_str("m/84'/0'/0'/0/1").unwrap();
     /// const HARDENED: u32 = 0x80000000;
     /// assert_eq!(path.to_u32_vec(), vec![84 + HARDENED, HARDENED, HARDENED, 0, 1]);
     /// ```
@@ -916,7 +918,12 @@ mod tests {
 
         assert_eq!(DerivationPath::master(), DerivationPath::from_str("").unwrap());
         assert_eq!(DerivationPath::master(), DerivationPath::default());
-        assert_eq!(DerivationPath::from_str("m"), Err(Error::InvalidChildNumberFormat));
+
+        // Acceptable forms for a master path.
+        assert_eq!(DerivationPath::from_str("m").unwrap(), DerivationPath(vec![]));
+        assert_eq!(DerivationPath::from_str("m/").unwrap(), DerivationPath(vec![]));
+        assert_eq!(DerivationPath::from_str("").unwrap(), DerivationPath(vec![]));
+
         assert_eq!(
             DerivationPath::from_str("0'"),
             Ok(vec![ChildNumber::from_hardened_idx(0).unwrap()].into())
@@ -948,18 +955,21 @@ mod tests {
             ]
             .into())
         );
-        assert_eq!(
-            DerivationPath::from_str("0'/1/2'/2/1000000000"),
-            Ok(vec![
-                ChildNumber::from_hardened_idx(0).unwrap(),
-                ChildNumber::from_normal_idx(1).unwrap(),
-                ChildNumber::from_hardened_idx(2).unwrap(),
-                ChildNumber::from_normal_idx(2).unwrap(),
-                ChildNumber::from_normal_idx(1000000000).unwrap(),
-            ]
-            .into())
-        );
+        let want = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(2).unwrap(),
+            ChildNumber::from_normal_idx(2).unwrap(),
+            ChildNumber::from_normal_idx(1000000000).unwrap(),
+        ]);
+        assert_eq!(DerivationPath::from_str("0'/1/2'/2/1000000000").unwrap(), want);
+        assert_eq!(DerivationPath::from_str("m/0'/1/2'/2/1000000000").unwrap(), want);
+
         let s = "0'/50/3'/5/545456";
+        assert_eq!(DerivationPath::from_str(s), s.into_derivation_path());
+        assert_eq!(DerivationPath::from_str(s), s.to_string().into_derivation_path());
+
+        let s = "m/0'/50/3'/5/545456";
         assert_eq!(DerivationPath::from_str(s), s.into_derivation_path());
         assert_eq!(DerivationPath::from_str(s), s.to_string().into_derivation_path());
     }
@@ -1076,32 +1086,32 @@ mod tests {
         let seed = hex!("000102030405060708090a0b0c0d0e0f");
 
         // m
-        test_path(&secp, NetworkKind::Main, &seed, "".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m".parse().unwrap(),
                   "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
                   "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8");
 
         // m/0h
-        test_path(&secp, NetworkKind::Main, &seed, "0h".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h".parse().unwrap(),
                   "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
                   "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw");
 
         // m/0h/1
-        test_path(&secp, NetworkKind::Main, &seed, "0h/1".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h/1".parse().unwrap(),
                    "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
                    "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ");
 
         // m/0h/1/2h
-        test_path(&secp, NetworkKind::Main, &seed, "0h/1/2h".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h/1/2h".parse().unwrap(),
                   "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
                   "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5");
 
         // m/0h/1/2h/2
-        test_path(&secp, NetworkKind::Main, &seed, "0h/1/2h/2".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h/1/2h/2".parse().unwrap(),
                   "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
                   "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV");
 
         // m/0h/1/2h/2/1000000000
-        test_path(&secp, NetworkKind::Main, &seed, "0h/1/2h/2/1000000000".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h/1/2h/2/1000000000".parse().unwrap(),
                   "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
                   "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy");
     }
@@ -1112,32 +1122,32 @@ mod tests {
         let seed = hex!("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542");
 
         // m
-        test_path(&secp, NetworkKind::Main, &seed, "".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m".parse().unwrap(),
                   "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U",
                   "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB");
 
         // m/0
-        test_path(&secp, NetworkKind::Main, &seed, "0".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0".parse().unwrap(),
                   "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
                   "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH");
 
         // m/0/2147483647h
-        test_path(&secp, NetworkKind::Main, &seed, "0/2147483647h".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0/2147483647h".parse().unwrap(),
                   "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
                   "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a");
 
         // m/0/2147483647h/1
-        test_path(&secp, NetworkKind::Main, &seed, "0/2147483647h/1".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0/2147483647h/1".parse().unwrap(),
                   "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
                   "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon");
 
         // m/0/2147483647h/1/2147483646h
-        test_path(&secp, NetworkKind::Main, &seed, "0/2147483647h/1/2147483646h".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0/2147483647h/1/2147483646h".parse().unwrap(),
                   "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
                   "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL");
 
         // m/0/2147483647h/1/2147483646h/2
-        test_path(&secp, NetworkKind::Main, &seed, "0/2147483647h/1/2147483646h/2".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0/2147483647h/1/2147483646h/2".parse().unwrap(),
                   "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
                   "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt");
     }
@@ -1148,12 +1158,12 @@ mod tests {
         let seed = hex!("4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be");
 
         // m
-        test_path(&secp, NetworkKind::Main, &seed, "".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m".parse().unwrap(),
                   "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6",
                   "xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13");
 
         // m/0h
-        test_path(&secp, NetworkKind::Main, &seed, "0h".parse().unwrap(),
+        test_path(&secp, NetworkKind::Main, &seed, "m/0h".parse().unwrap(),
                   "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L",
                   "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y");
     }

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -31,12 +31,13 @@ fn psbt_sign_taproot() {
             _secp: &Secp256k1<C>,
         ) -> Result<Option<PrivateKey>, Self::Error> {
             match key_request {
-                KeyRequest::Bip32((mfp, _)) =>
+                KeyRequest::Bip32((mfp, _)) => {
                     if mfp == self.mfp {
                         Ok(Some(self.sk))
                     } else {
                         Err(SignError::KeyNotFound)
-                    },
+                    }
+                }
                 _ => Err(SignError::KeyNotFound),
             }
         }
@@ -45,9 +46,9 @@ fn psbt_sign_taproot() {
     let secp = &Secp256k1::new();
 
     let sk_path = [
-        ("dff1c8c2c016a572914b4c5adb8791d62b4768ae9d0a61be8ab94cf5038d7d90", "86'/1'/0'/0/0"),
-        ("1ede31b0e7e47c2afc65ffd158b1b1b9d3b752bba8fd117dc8b9e944a390e8d9", "86'/1'/0'/0/1"),
-        ("1fb777f1a6fb9b76724551f8bc8ad91b77f33b8c456d65d746035391d724922a", "86'/1'/0'/0/2"),
+        ("dff1c8c2c016a572914b4c5adb8791d62b4768ae9d0a61be8ab94cf5038d7d90", "m/86'/1'/0'/0/0"),
+        ("1ede31b0e7e47c2afc65ffd158b1b1b9d3b752bba8fd117dc8b9e944a390e8d9", "m/86'/1'/0'/0/1"),
+        ("1fb777f1a6fb9b76724551f8bc8ad91b77f33b8c456d65d746035391d724922a", "m/86'/1'/0'/0/2"),
     ];
     let mfp = "73c5da0a";
 
@@ -225,7 +226,7 @@ fn create_psbt_for_taproot_key_path_spend(
     let mut psbt = Psbt::from_unsigned_tx(transaction).unwrap();
 
     let mfp = "73c5da0a";
-    let internal_key_path = "86'/1'/0'/0/2";
+    let internal_key_path = "m/86'/1'/0'/0/2";
 
     let mut origins = BTreeMap::new();
     origins.insert(


### PR DESCRIPTION
This PR contains a single patch that was created using `cargo cherry-pick 830c1e9c` - i.e., it is a backport of #2677.

----

Recently in #2451 we disallowed bip32 derivation paths with the leading 'm' variable.

There is some confusion as to what exactly the bip specifies however Bitcoin Core RPC call `getaddressinfo` returns a derivation path with a leading "m/". This means we need to be able to parse it irrespective of what the bip says.

Be more liberal in what we accept as a derivation path, including both with and without the leading 'm/'.

Leave the full investigation of the bip to a later date.

Change back some of the test strings as makes sense and include test strings to showcase the full current behaviour.