### PR TITLE
Fix kani codegen CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -236,4 +236,5 @@ jobs:
       - name: 'Kani build proofs'
         uses: model-checking/kani-github-action@v1.1
         with:
+          kani-version: '0.48.0'
           args: '--only-codegen'

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1885,7 +1885,6 @@ pub mod serde {
 #[cfg(kani)]
 mod verification {
     use std::cmp;
-    use std::convert::TryInto;
 
     use super::*;
 

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1902,7 +1902,7 @@ mod verification {
     // CI it fails, so we need to set it higher.
     #[kani::unwind(4)]
     #[kani::proof]
-    fn u_amount_add_homomorphic() {
+    fn u_amount_homomorphic() {
         let n1 = kani::any::<u64>();
         let n2 = kani::any::<u64>();
         kani::assume(n1.checked_add(n2).is_some()); // assume we don't overflow in the actual test
@@ -1932,7 +1932,7 @@ mod verification {
 
     #[kani::unwind(4)]
     #[kani::proof]
-    fn u_amount_add_homomorphic_checked() {
+    fn u_amount_homomorphic_checked() {
         let n1 = kani::any::<u64>();
         let n2 = kani::any::<u64>();
         assert_eq!(
@@ -1947,7 +1947,7 @@ mod verification {
 
     #[kani::unwind(4)]
     #[kani::proof]
-    fn s_amount_add_homomorphic() {
+    fn s_amount_homomorphic() {
         let n1 = kani::any::<i64>();
         let n2 = kani::any::<i64>();
         kani::assume(n1.checked_add(n2).is_some()); // assume we don't overflow in the actual test
@@ -1980,7 +1980,7 @@ mod verification {
 
     #[kani::unwind(4)]
     #[kani::proof]
-    fn s_amount_add_homomorphic_checked() {
+    fn s_amount_homomorphic_checked() {
         let n1 = kani::any::<i64>();
         let n2 = kani::any::<i64>();
         assert_eq!(


### PR DESCRIPTION
Fix the current failing Kani job on todays PRs. 

FTR our daily `kani` job has been red for ages, perhaps since we created the `units` crate? But today the `--codege-only` job broke (on all PRs). `kani` released a new version 10 days ago, pinning to the previous version seems to resolve the issue. I raised a bug report but did not investigate further. 

- Patch 1: Remove redundant import
- Patch 2: Rename the tests
- Patch 3: Pin kani version

File bug report: https://github.com/model-checking/kani/issues/3142

PR is CI only, can go in with one ack.

(Patch 2 is the result of debugging the _real_ kani failure we have at the moment, I'll save the rant for the PR that fixes it.)