### PR TITLE
Allow deprecated Params field

### DIFF
--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -71,6 +71,7 @@ pub static SIGNET: Params = Params::SIGNET;
 /// The regtest parameters.
 pub static REGTEST: Params = Params::REGTEST;
 
+#[allow(deprecated)]            // For `pow_limit`.
 impl Params {
     /// The mainnet parameters (alias for `Params::MAINNET`).
     pub const BITCOIN: Params = Params::MAINNET;


### PR DESCRIPTION
I'm not sure why I haven't see this before during the whole test cycle but while running `cargo kani --only-codegen` we get a bunch of warnings of form:

  warning: use of deprecated field `consensus::params::Params::pow_limit`

We deprecated the `pow_limit` field but still set it (obviously) in const structs - just shoosh the warning.

Found while investigating the current kani CI failures.