### PR TITLE
Fix typo in deprecated type

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -30,12 +30,12 @@ const VERSION_BYTES_TESTNETS_PUBLIC: [u8; 4] = [0x04, 0x35, 0x87, 0xCF];
 const VERSION_BYTES_TESTNETS_PRIVATE: [u8; 4] = [0x04, 0x35, 0x83, 0x94];
 
 /// The old name for xpub, extended public key.
-#[deprecated(since = "0.31.0", note = "use xpub instead")]
-pub type ExtendendPubKey = Xpub;
+#[deprecated(since = "0.31.0", note = "use Xpub instead")]
+pub type ExtendedPubKey = Xpub;
 
 /// The old name for xpriv, extended public key.
-#[deprecated(since = "0.31.0", note = "use xpriv instead")]
-pub type ExtendendPrivKey = Xpriv;
+#[deprecated(since = "0.31.0", note = "use Xpriv instead")]
+pub type ExtendedPrivKey = Xpriv;
 
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
In #2258 we attempted to add back in deprecated BIP-32 types - but we spelled the identifier incorrectly. The patch was then backported to the `0.31.x` branch in December but was only just noticed now.

Fix typo in deprecated type from `Extendend` -> `Extended`.