### PR TITLE
Fix example spend amount

### DIFF
--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -61,7 +61,7 @@ fn main() {
     let sighash_type = EcdsaSighashType::All;
     let mut sighasher = SighashCache::new(&mut unsigned_tx);
     let sighash = sighasher
-        .p2wpkh_signature_hash(input_index, &dummy_utxo.script_pubkey, SPEND_AMOUNT, sighash_type)
+        .p2wpkh_signature_hash(input_index, &dummy_utxo.script_pubkey, DUMMY_UTXO_AMOUNT, sighash_type)
         .expect("failed to create sighash");
 
     // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).


### PR DESCRIPTION
In the segwit signing example we are using the incorrect value when creating the signature - we should be using the utxo amount (input amount) not the spend amount (output spend amount).

Close: #2680