### PR TITLE
Remove `Hash` impl from new hash types created with `hash_newtype`

### DIFF
--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -4,7 +4,6 @@
 
 use std::str::FromStr;
 
-use bitcoin::hashes::Hash;
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -4,7 +4,6 @@
 
 use std::str::FromStr;
 
-use bitcoin::hashes::Hash;
 use bitcoin::key::{Keypair, TapTweak, TweakedKeypair, UntweakedPublicKey};
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing, Verification};

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -468,7 +468,7 @@ mod test {
             {
                 // test serialization
                 let raw: Vec<u8> = serialize(&BlockTransactionsRequest {
-                    block_hash: Hash::all_zeros(),
+                    block_hash: BlockHash::all_zeros(),
                     indexes: testcase.1,
                 });
                 let mut expected_raw: Vec<u8> = [0u8; 32].to_vec();
@@ -491,7 +491,7 @@ mod test {
     #[should_panic] // 'attempt to add with overflow' in consensus_encode()
     fn test_getblocktx_panic_when_encoding_u64_max() {
         serialize(&BlockTransactionsRequest {
-            block_hash: Hash::all_zeros(),
+            block_hash: BlockHash::all_zeros(),
             indexes: vec![u64::MAX],
         });
     }

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -41,7 +41,7 @@
 use core::cmp::{self, Ordering};
 use core::fmt::{self, Display, Formatter};
 
-use hashes::{sha256d, siphash24, Hash};
+use hashes::{sha256d, siphash24};
 use internals::write_err;
 use io::{BufRead, Write};
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -10,7 +10,7 @@
 
 use core::fmt;
 
-use hashes::{sha256d, Hash, HashEngine};
+use hashes::{sha256d, HashEngine};
 use io::{BufRead, Write};
 
 use super::Weight;

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -11,7 +11,7 @@ use hashes::{sha256d, Hash};
 use hex_lit::hex;
 use internals::impl_array_newtype;
 
-use crate::blockdata::block::{self, Block};
+use crate::blockdata::block::{self, Block, BlockHash};
 use crate::blockdata::locktime::absolute;
 use crate::blockdata::opcodes::all::*;
 use crate::blockdata::script;
@@ -93,7 +93,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Bitcoin => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1231006505,
                 bits: CompactTarget::from_consensus(0x1d00ffff),
@@ -104,7 +104,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Testnet => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1296688602,
                 bits: CompactTarget::from_consensus(0x1d00ffff),
@@ -115,7 +115,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Signet => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1598918400,
                 bits: CompactTarget::from_consensus(0x1e0377ae),
@@ -126,7 +126,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Regtest => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1296688602,
                 bits: CompactTarget::from_consensus(0x207fffff),
@@ -200,6 +200,7 @@ mod test {
     use super::*;
     use crate::consensus::encode::serialize;
     use crate::consensus::params;
+    use crate::Txid;
 
     #[test]
     fn bitcoin_genesis_first_transaction() {
@@ -207,7 +208,7 @@ mod test {
 
         assert_eq!(gen.version, transaction::Version::ONE);
         assert_eq!(gen.input.len(), 1);
-        assert_eq!(gen.input[0].previous_output.txid, Hash::all_zeros());
+        assert_eq!(gen.input[0].previous_output.txid, Txid::all_zeros());
         assert_eq!(gen.input[0].previous_output.vout, 0xFFFFFFFF);
         assert_eq!(serialize(&gen.input[0].script_sig),
                    hex!("4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"));
@@ -242,7 +243,7 @@ mod test {
         let gen = genesis_block(&params::MAINNET);
 
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
@@ -261,7 +262,7 @@ mod test {
     fn testnet_genesis_full_block() {
         let gen = genesis_block(&params::TESTNET);
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
@@ -279,7 +280,7 @@ mod test {
     fn signet_genesis_full_block() {
         let gen = genesis_block(&params::SIGNET);
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -7,7 +7,7 @@
 //! single transaction.
 //!
 
-use hashes::{sha256d, Hash};
+use hashes::sha256d;
 use hex_lit::hex;
 use internals::impl_array_newtype;
 
@@ -297,7 +297,7 @@ mod test {
     // The *_chain_hash tests are sanity/regression tests, they verify that the const byte array
     // representing the genesis block is the same as that created by hashing the genesis block.
     fn chain_hash_and_genesis_block(network: Network) {
-        use hashes::sha256;
+        use hashes::{sha256, Hash};
 
         // The genesis block hash is a double-sha256 and it is displayed backwards.
         let genesis_hash = genesis_block(network).block_hash();

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -5,7 +5,6 @@ use core::ops::{
     Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
-use hashes::Hash;
 use secp256k1::{Secp256k1, Verification};
 
 use super::PushBytes;

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -2,7 +2,6 @@
 
 use core::str::FromStr;
 
-use hashes::Hash;
 use hex_lit::hex;
 
 use super::*;

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -9,7 +9,6 @@
 
 use core::fmt;
 
-use hashes::Hash as _;
 use internals::array_vec::ArrayVec;
 use secp256k1::{Secp256k1, Verification};
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -13,7 +13,7 @@
 
 use core::{cmp, fmt, str};
 
-use hashes::{sha256d, Hash};
+use hashes::sha256d;
 use internals::write_err;
 use io::{BufRead, Write};
 use units::parse;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -84,7 +84,7 @@ impl OutPoint {
     ///
     /// This value is used for coinbase transactions because they don't have any previous outputs.
     #[inline]
-    pub fn null() -> OutPoint { OutPoint { txid: Hash::all_zeros(), vout: u32::MAX } }
+    pub fn null() -> OutPoint { OutPoint { txid: Txid::all_zeros(), vout: u32::MAX } }
 
     /// Checks if an `OutPoint` is "null".
     ///

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -893,7 +893,8 @@ impl Encodable for TapLeafHash {
 
 impl Decodable for TapLeafHash {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
-        Ok(Self::from_byte_array(<<Self as Hash>::Bytes>::consensus_decode(r)?))
+        let digest = <[u8; Self::digest_length()]>::consensus_decode(r)?;
+        Ok(Self::from_byte_array(digest))
     }
 }
 

--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -130,7 +130,7 @@ pub static SIGNET: Params = Params::SIGNET;
 /// The regtest parameters.
 pub static REGTEST: Params = Params::REGTEST;
 
-#[allow(deprecated)]            // For `pow_limit`.
+#[allow(deprecated)] // For `pow_limit`.
 impl Params {
     /// The mainnet parameters (alias for `Params::MAINNET`).
     pub const BITCOIN: Params = Params::MAINNET;

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1344,10 +1344,10 @@ impl<E> EncodeSigningDataResult<E> {
     ///
     /// ```rust
     /// # use bitcoin::consensus::deserialize;
-    /// # use bitcoin::hashes::{Hash, hex::FromHex};
-    /// # use bitcoin::sighash::{LegacySighash, SighashCache};
+    /// # use bitcoin::hashes::{sha256d, Hash, hex::FromHex};
+    /// # use bitcoin::sighash::SighashCache;
     /// # use bitcoin::Transaction;
-    /// # let mut writer = LegacySighash::engine();
+    /// # let mut writer = sha256d::Hash::engine();
     /// # let input_index = 0;
     /// # let script_pubkey = bitcoin::ScriptBuf::new();
     /// # let sighash_u32 = 0u32;

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -13,7 +13,6 @@ pub use crate::{
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hashes::Hash;
     use crate::{
         LegacySighash, PubkeyHash, ScriptHash, SegwitV0Sighash, TapSighash, WPubkeyHash,
         WScriptHash, XKeyIdentifier,

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -199,8 +199,8 @@ macro_rules! impl_hashencode {
 
         impl $crate::consensus::Decodable for $hashtype {
             fn consensus_decode<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
-                use $crate::hashes::Hash;
-                Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode(r)?))
+                let digest = <[u8; { $hashtype::digest_length() }]>::consensus_decode(r)?;
+                Ok(Self::from_byte_array(digest))
             }
         }
     };
@@ -213,14 +213,12 @@ macro_rules! impl_asref_push_bytes {
         $(
             impl AsRef<$crate::blockdata::script::PushBytes> for $hashtype {
                 fn as_ref(&self) -> &$crate::blockdata::script::PushBytes {
-                    use $crate::hashes::Hash;
                     self.as_byte_array().into()
                 }
             }
 
             impl From<$hashtype> for $crate::blockdata::script::PushBytesBuf {
                 fn from(hash: $hashtype) -> Self {
-                    use $crate::hashes::Hash;
                     hash.as_byte_array().into()
                 }
             }

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -40,7 +40,6 @@
 
 use core::fmt;
 
-use hashes::Hash;
 use io::{BufRead, Write};
 
 use self::MerkleBlockError::*;

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -6,11 +6,10 @@
 //!
 //! ```
 //! # use bitcoin::{merkle_tree, Txid};
-//! # use bitcoin::hashes::Hash;
 //! # let tx1 = Txid::all_zeros();  // Dummy hash values.
 //! # let tx2 = Txid::all_zeros();
 //! let tx_hashes = vec![tx1, tx2]; // All the hashes we wish to merkelize.
-//! let root = merkle_tree::calculate_root(tx_hashes.into_iter());
+//! let root = merkle_tree::calculate_root(tx_hashes.iter().map(|txid| txid.to_raw_hash()));
 //! ```
 
 mod block;

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -145,10 +145,9 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {
-    use hashes::Hash;
     use hex::test_hex_unwrap as hex;
 
-    use super::{GetBlocksMessage, GetHeadersMessage};
+    use super::*;
     use crate::consensus::encode::{deserialize, serialize};
 
     #[test]
@@ -162,7 +161,7 @@ mod tests {
         assert_eq!(real_decode.version, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
-        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
+        assert_eq!(real_decode.stop_hash, BlockHash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
     }
@@ -178,7 +177,7 @@ mod tests {
         assert_eq!(real_decode.version, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
-        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
+        assert_eq!(real_decode.stop_hash, BlockHash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
     }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -220,7 +220,6 @@ impl Target {
     /// to the target.
     #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_met_by(&self, hash: BlockHash) -> bool {
-        use hashes::Hash;
         let hash = U256::from_le_bytes(hash.to_byte_array());
         hash <= self.0
     }
@@ -1711,8 +1710,6 @@ mod tests {
     #[test]
     fn target_is_met_by_for_target_equals_hash() {
         use std::str::FromStr;
-
-        use hashes::Hash;
 
         let hash =
             BlockHash::from_str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")

--- a/bitcoin/src/taproot/merkle_branch.rs
+++ b/bitcoin/src/taproot/merkle_branch.rs
@@ -2,8 +2,6 @@
 
 //! Contains `TaprootMerkleBranch` and its associated types.
 
-use hashes::Hash;
-
 use super::{
     TapNodeHash, TaprootBuilderError, TaprootError, TAPROOT_CONTROL_MAX_NODE_COUNT,
     TAPROOT_CONTROL_NODE_SIZE,
@@ -87,7 +85,7 @@ impl TaprootMerkleBranch {
         for hash in self {
             writer.write_all(hash.as_ref())?;
         }
-        Ok(self.len() * TapNodeHash::LEN)
+        Ok(self.len() * TapNodeHash::digest_length())
     }
 
     /// Serializes `self` as bytes.

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -12,7 +12,7 @@ use core::cmp::Reverse;
 use core::fmt;
 use core::iter::FusedIterator;
 
-use hashes::{sha256t_hash_newtype, Hash, HashEngine};
+use hashes::{sha256t_hash_newtype, HashEngine};
 use internals::write_err;
 use io::Write;
 use secp256k1::{Scalar, Secp256k1};
@@ -1443,8 +1443,8 @@ impl std::error::Error for TaprootError {
 mod test {
     use core::str::FromStr;
 
-    use hashes::sha256;
     use hashes::sha256t::Tag;
+    use hashes::{sha256, Hash};
     use hex::FromHex;
     use secp256k1::VerifyOnly;
 

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -31,13 +31,12 @@ fn psbt_sign_taproot() {
             _secp: &Secp256k1<C>,
         ) -> Result<Option<PrivateKey>, Self::Error> {
             match key_request {
-                KeyRequest::Bip32((mfp, _)) => {
+                KeyRequest::Bip32((mfp, _)) =>
                     if mfp == self.mfp {
                         Ok(Some(self.sk))
                     } else {
                         Err(SignError::KeyNotFound)
-                    }
-                }
+                    },
                 _ => Err(SignError::KeyNotFound),
             }
         }

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -104,9 +104,7 @@ macro_rules! hash_trait_impls {
         borrow_slice_impl!(Hash $(, $gen: $gent)*);
 
         impl<$($gen: $gent),*> $crate::_export::_core::convert::AsRef<[u8; $bits / 8]> for Hash<$($gen),*> {
-            fn as_ref(&self) -> &[u8; $bits / 8] {
-                &self.0
-            }
+            fn as_ref(&self) -> &[u8; $bits / 8] { &self.0 }
         }
 
         impl<I: SliceIndex<[u8]> $(, $gen: $gent)*> Index<I> for Hash<$($gen),*> {
@@ -125,13 +123,9 @@ macro_rules! hash_trait_impls {
             const LEN: usize = $bits / 8;
             const DISPLAY_BACKWARD: bool = $reverse;
 
-            fn engine() -> Self::Engine {
-                Self::internal_engine()
-            }
+            fn engine() -> Self::Engine { Self::internal_engine() }
 
-            fn from_engine(e: HashEngine) -> Hash<$($gen),*> {
-                from_engine(e)
-            }
+            fn from_engine(e: HashEngine) -> Hash<$($gen),*> { from_engine(e) }
 
             fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<Hash<$($gen),*>, FromSliceError> {
                 if sl.len() != $bits / 8 {
@@ -143,21 +137,13 @@ macro_rules! hash_trait_impls {
                 }
             }
 
-            fn to_byte_array(self) -> Self::Bytes {
-                self.0
-            }
+            fn to_byte_array(self) -> Self::Bytes { self.0 }
 
-            fn as_byte_array(&self) -> &Self::Bytes {
-                &self.0
-            }
+            fn as_byte_array(&self) -> &Self::Bytes { &self.0 }
 
-            fn from_byte_array(bytes: Self::Bytes) -> Self {
-                Self::internal_new(bytes)
-            }
+            fn from_byte_array(bytes: Self::Bytes) -> Self { Self::internal_new(bytes) }
 
-            fn all_zeros() -> Self {
-                Hash::internal_new([0x00; $bits / 8])
-            }
+            fn all_zeros() -> Self { Hash::internal_new([0x00; $bits / 8]) }
         }
     }
 }

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -84,7 +84,7 @@ fn from_engine<T: Tag>(e: sha256::HashEngine) -> Hash<T> {
 /// The syntax is:
 ///
 /// ```
-/// # use bitcoin_hashes::sha256t_hash_newtype;
+/// # use bitcoin_hashes::{sha256t_hash_newtype, Hash};
 /// sha256t_hash_newtype! {
 ///     /// Optional documentation details here.
 ///     /// Summary is always generated.

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -214,8 +214,7 @@ macro_rules! hash_newtype {
 
         impl $crate::_export::_core::convert::From<$hash> for $newtype {
             fn from(inner: $hash) -> $newtype {
-                // Due to rust 1.22 we have to use this instead of simple `Self(inner)`
-                Self { 0: inner }
+                Self(inner)
             }
         }
 


### PR DESCRIPTION
If #2708 gets any traction this PR is not needed.

The first 4 patches are preparation, the last patch is:

    New hash types created with `hash_newtype` are not meant to be general
    purpose hashes but currently we implement `Hash` for the newtype, this
    makes the API for the newtype misleading.
    
    Instead of implementing `Hash` we can make the `Hash` trait methods
    inherent on the new type, this allows the module that creates the new
    type to hash stuff ergonomically but does not pollute the public API for
    the type.
 
Please note the changes to the docs on `is_sighash_single_bug` - shows that now the new hash types don't enable getting an engine that can be used as a writer to pass to the encode to writer functions in `sighash` (eg, `legacy_encode_signing_data_to`). Is this acceptable?
