### PR TITLE
Set release version in deprecated attribute

### DIFF
--- a/bitcoin/src/consensus/params.rs
+++ b/bitcoin/src/consensus/params.rs
@@ -91,7 +91,7 @@ pub struct Params {
     /// Number of blocks with the same set of rules.
     pub miner_confirmation_window: u32,
     /// Proof of work limit value. It contains the lowest possible difficulty.
-    #[deprecated(since = "TBD", note = "field renamed to max_attainable_target")]
+    #[deprecated(since = "0.32.0", note = "field renamed to max_attainable_target")]
     pub pow_limit: Target,
     /// The maximum **attainable** target value for these params.
     ///

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -280,12 +280,12 @@ impl Target {
 
     /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
     /// adjustment occurs.
-    #[deprecated(since = "TBD", note = "use min_transition_threshold instead")]
+    #[deprecated(since = "0.32.0", note = "use min_transition_threshold instead")]
     pub fn min_difficulty_transition_threshold(&self) -> Self { self.min_transition_threshold() }
 
     /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
     /// adjustment occurs.
-    #[deprecated(since = "TBD", note = "use max_transition_threshold instead")]
+    #[deprecated(since = "0.32.0", note = "use max_transition_threshold instead")]
     pub fn max_difficulty_transition_threshold(&self) -> Self {
         self.max_transition_threshold_unchecked()
     }


### PR DESCRIPTION
In preparation for release replace "TBD" with the next release version - `v0.32.0`.