### PR TITLE
Fix kani test

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1973,7 +1973,7 @@ mod verification {
             if n1 >= 0 {
                 Ok(Amount::from_sat(n1.try_into().unwrap()))
             } else {
-                Err(OutOfRangeError { is_signed: true, is_greater_than_max: false })
+                Err(OutOfRangeError { is_signed: false, is_greater_than_max: false })
             },
         );
     }


### PR DESCRIPTION
In a kani test we are checking if the result of `to_unsigned()` is an error but setting `is_signed` to `true`, this field represents the signed-ness of the return type of `to_unsigned` (`Amount`) so should be `false`.

Fix kani daily job.