### PR TITLE
CI: Run kani daily job with latest version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -236,5 +236,4 @@ jobs:
       - name: 'Kani build proofs'
         uses: model-checking/kani-github-action@v1.1
         with:
-          kani-version: '0.48.0'
           args: '--only-codegen'


### PR DESCRIPTION
Version `0.49` of `kani` broke our daily CI job, there is now a new release out that fixes the issue.

Remove the explicit `kani` version so we pull the latest version.