### PR TITLE
Improve `hashes` trait method usage

### DIFF
--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -4,7 +4,7 @@
 
 use std::str::FromStr;
 
-use bitcoin::hashes::Hash;
+use bitcoin::hashes::Hash as _;
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -4,7 +4,7 @@
 
 use std::str::FromStr;
 
-use bitcoin::hashes::Hash;
+use bitcoin::hashes::Hash as _;
 use bitcoin::key::{Keypair, TapTweak, TweakedKeypair, UntweakedPublicKey};
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing, Verification};

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -33,7 +33,7 @@ use core::marker::PhantomData;
 use core::str::FromStr;
 
 use bech32::primitives::hrp::Hrp;
-use hashes::{sha256, Hash, HashEngine};
+use hashes::{sha256, Hash as _, HashEngine as _};
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::blockdata::constants::{

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -468,7 +468,7 @@ mod test {
             {
                 // test serialization
                 let raw: Vec<u8> = serialize(&BlockTransactionsRequest {
-                    block_hash: Hash::all_zeros(),
+                    block_hash: BlockHash::all_zeros(),
                     indexes: testcase.1,
                 });
                 let mut expected_raw: Vec<u8> = [0u8; 32].to_vec();
@@ -491,7 +491,7 @@ mod test {
     #[should_panic] // 'attempt to add with overflow' in consensus_encode()
     fn test_getblocktx_panic_when_encoding_u64_max() {
         serialize(&BlockTransactionsRequest {
-            block_hash: Hash::all_zeros(),
+            block_hash: BlockHash::all_zeros(),
             indexes: vec![u64::MAX],
         });
     }

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -9,7 +9,7 @@ use core::{convert, fmt, mem};
 #[cfg(feature = "std")]
 use std::error;
 
-use hashes::{sha256, siphash24, Hash};
+use hashes::{sha256, siphash24, Hash as _};
 use internals::impl_array_newtype;
 use io::{BufRead, Write};
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -41,7 +41,7 @@
 use core::cmp::{self, Ordering};
 use core::fmt::{self, Display, Formatter};
 
-use hashes::{sha256d, siphash24, Hash};
+use hashes::{sha256d, siphash24, Hash as _};
 use internals::write_err;
 use io::{BufRead, Write};
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -10,7 +10,7 @@ use core::ops::Index;
 use core::str::FromStr;
 use core::{fmt, slice};
 
-use hashes::{hash160, hash_newtype, sha512, Hash, HashEngine, Hmac, HmacEngine};
+use hashes::{hash160, hash_newtype, sha512, Hash as _, HashEngine as _, Hmac, HmacEngine};
 use internals::{impl_array_newtype, write_err};
 use io::Write;
 use secp256k1::{Secp256k1, XOnlyPublicKey};

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -10,7 +10,7 @@
 
 use core::fmt;
 
-use hashes::{sha256d, Hash, HashEngine};
+use hashes::{sha256d, Hash as _, HashEngine as _};
 use io::{BufRead, Write};
 
 use super::Weight;

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -21,7 +21,7 @@ use crate::consensus::Params;
 use crate::internal_macros::impl_bytes_newtype;
 use crate::network::Network;
 use crate::pow::CompactTarget;
-use crate::Amount;
+use crate::{Amount, BlockHash};
 
 /// How many seconds between blocks we expect on average.
 pub const TARGET_BLOCK_SPACING: u32 = 600;
@@ -93,7 +93,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Bitcoin => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1231006505,
                 bits: CompactTarget::from_consensus(0x1d00ffff),
@@ -104,7 +104,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Testnet => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1296688602,
                 bits: CompactTarget::from_consensus(0x1d00ffff),
@@ -115,7 +115,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Signet => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1598918400,
                 bits: CompactTarget::from_consensus(0x1e0377ae),
@@ -126,7 +126,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Regtest => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1296688602,
                 bits: CompactTarget::from_consensus(0x207fffff),
@@ -200,6 +200,7 @@ mod test {
     use super::*;
     use crate::consensus::encode::serialize;
     use crate::consensus::params;
+    use crate::Txid;
 
     #[test]
     fn bitcoin_genesis_first_transaction() {
@@ -207,7 +208,7 @@ mod test {
 
         assert_eq!(gen.version, transaction::Version::ONE);
         assert_eq!(gen.input.len(), 1);
-        assert_eq!(gen.input[0].previous_output.txid, Hash::all_zeros());
+        assert_eq!(gen.input[0].previous_output.txid, Txid::all_zeros());
         assert_eq!(gen.input[0].previous_output.vout, 0xFFFFFFFF);
         assert_eq!(serialize(&gen.input[0].script_sig),
                    hex!("4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"));
@@ -242,7 +243,7 @@ mod test {
         let gen = genesis_block(&params::MAINNET);
 
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
@@ -261,7 +262,7 @@ mod test {
     fn testnet_genesis_full_block() {
         let gen = genesis_block(&params::TESTNET);
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
@@ -279,7 +280,7 @@ mod test {
     fn signet_genesis_full_block() {
         let gen = genesis_block(&params::SIGNET);
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -7,7 +7,7 @@
 //! single transaction.
 //!
 
-use hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash as _};
 use hex_lit::hex;
 use internals::impl_array_newtype;
 

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -5,7 +5,7 @@ use core::ops::{
     Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
-use hashes::Hash;
+use hashes::Hash as _;
 use secp256k1::{Secp256k1, Verification};
 
 use super::PushBytes;

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -2,7 +2,7 @@
 
 use core::str::FromStr;
 
-use hashes::Hash;
+use hashes::Hash as _;
 use hex_lit::hex;
 
 use super::*;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -13,7 +13,7 @@
 
 use core::{cmp, fmt, str};
 
-use hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash as _};
 use internals::write_err;
 use io::{BufRead, Write};
 use units::parse;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -84,7 +84,7 @@ impl OutPoint {
     ///
     /// This value is used for coinbase transactions because they don't have any previous outputs.
     #[inline]
-    pub fn null() -> OutPoint { OutPoint { txid: Hash::all_zeros(), vout: u32::MAX } }
+    pub fn null() -> OutPoint { OutPoint { txid: Txid::all_zeros(), vout: u32::MAX } }
 
     /// Checks if an `OutPoint` is "null".
     ///

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -17,7 +17,7 @@
 
 use core::{fmt, mem};
 
-use hashes::{sha256, sha256d, Hash};
+use hashes::{sha256, sha256d, Hash as _};
 use hex::error::{InvalidCharError, OddLengthStringError};
 use internals::write_err;
 use io::{BufRead, Cursor, Read, Write};
@@ -768,7 +768,7 @@ impl Decodable for Box<[u8]> {
 
 /// Does a double-SHA256 on `data` and returns the first 4 bytes.
 fn sha2_checksum(data: &[u8]) -> [u8; 4] {
-    let checksum = <sha256d::Hash as Hash>::hash(data);
+    let checksum = <sha256d::Hash as hashes::Hash>::hash(data);
     [checksum[0], checksum[1], checksum[2], checksum[3]]
 }
 
@@ -869,7 +869,7 @@ impl Encodable for sha256d::Hash {
 
 impl Decodable for sha256d::Hash {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
-        Ok(Self::from_byte_array(<<Self as Hash>::Bytes>::consensus_decode(r)?))
+        Ok(Self::from_byte_array(<<Self as hashes::Hash>::Bytes>::consensus_decode(r)?))
     }
 }
 
@@ -881,7 +881,7 @@ impl Encodable for sha256::Hash {
 
 impl Decodable for sha256::Hash {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
-        Ok(Self::from_byte_array(<<Self as Hash>::Bytes>::consensus_decode(r)?))
+        Ok(Self::from_byte_array(<<Self as hashes::Hash>::Bytes>::consensus_decode(r)?))
     }
 }
 
@@ -893,7 +893,7 @@ impl Encodable for TapLeafHash {
 
 impl Decodable for TapLeafHash {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
-        Ok(Self::from_byte_array(<<Self as Hash>::Bytes>::consensus_decode(r)?))
+        Ok(Self::from_byte_array(<<Self as hashes::Hash>::Bytes>::consensus_decode(r)?))
     }
 }
 

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -9,7 +9,7 @@ use core::fmt::{self, Write as _};
 use core::ops;
 use core::str::FromStr;
 
-use hashes::{hash160, Hash};
+use hashes::{hash160, Hash as _};
 use hex::{FromHex, HexToArrayError};
 use internals::array_vec::ArrayVec;
 use internals::write_err;

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -13,7 +13,7 @@
 
 use core::{fmt, str};
 
-use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
+use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash as _};
 use internals::write_err;
 use io::Write;
 
@@ -1450,7 +1450,7 @@ impl<E: std::error::Error + 'static> std::error::Error for SigningDataError<E> {
 mod tests {
     use std::str::FromStr;
 
-    use hashes::HashEngine;
+    use hashes::HashEngine as _;
     use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::*;

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -13,7 +13,7 @@ pub use crate::{
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hashes::Hash;
+    use crate::hashes::Hash as _;
     use crate::{
         LegacySighash, PubkeyHash, ScriptHash, SegwitV0Sighash, TapSighash, WPubkeyHash,
         WScriptHash, XKeyIdentifier,

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -199,7 +199,7 @@ macro_rules! impl_hashencode {
 
         impl $crate::consensus::Decodable for $hashtype {
             fn consensus_decode<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
-                use $crate::hashes::Hash;
+                use $crate::hashes::Hash as _;
                 Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode(r)?))
             }
         }
@@ -213,14 +213,14 @@ macro_rules! impl_asref_push_bytes {
         $(
             impl AsRef<$crate::blockdata::script::PushBytes> for $hashtype {
                 fn as_ref(&self) -> &$crate::blockdata::script::PushBytes {
-                    use $crate::hashes::Hash;
+                    use $crate::hashes::Hash as _;
                     self.as_byte_array().into()
                 }
             }
 
             impl From<$hashtype> for $crate::blockdata::script::PushBytesBuf {
                 fn from(hash: $hashtype) -> Self {
-                    use $crate::hashes::Hash;
+                    use $crate::hashes::Hash as _;
                     hash.as_byte_array().into()
                 }
             }

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -40,7 +40,7 @@
 
 use core::fmt;
 
-use hashes::Hash;
+use hashes::Hash as _;
 use io::{BufRead, Write};
 
 use self::MerkleBlockError::*;

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -127,7 +127,7 @@ mod tests {
 
         let hashes_iter = block.txdata.iter().map(|obj| obj.compute_txid().to_raw_hash());
 
-        let mut hashes_array: [sha256d::Hash; 15] = [Hash::all_zeros(); 15];
+        let mut hashes_array = [sha256d::Hash::all_zeros(); 15];
         for (i, hash) in hashes_iter.clone().enumerate() {
             hashes_array[i] = hash;
         }

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! ```
 //! # use bitcoin::{merkle_tree, Txid};
-//! # use bitcoin::hashes::Hash;
+//! # use bitcoin::hashes::Hash as _;
 //! # let tx1 = Txid::all_zeros();  // Dummy hash values.
 //! # let tx2 = Txid::all_zeros();
 //! let tx_hashes = vec![tx1, tx2]; // All the hashes we wish to merkelize.
@@ -18,7 +18,6 @@ mod block;
 use core::cmp::min;
 use core::iter;
 
-use hashes::Hash;
 use io::Write;
 
 use crate::consensus::encode::Encodable;
@@ -40,8 +39,8 @@ pub use self::block::{MerkleBlock, MerkleBlockError, PartialMerkleTree};
 /// - `Some(merkle_root)` if length of `hashes` is greater than one.
 pub fn calculate_root_inline<T>(hashes: &mut [T]) -> Option<T>
 where
-    T: Hash + Encodable,
-    <T as Hash>::Engine: Write,
+    T: hashes::Hash + Encodable,
+    <T as hashes::Hash>::Engine: Write,
 {
     match hashes.len() {
         0 => None,
@@ -58,8 +57,8 @@ where
 /// - `Some(merkle_root)` if length of `hashes` is greater than one.
 pub fn calculate_root<T, I>(mut hashes: I) -> Option<T>
 where
-    T: Hash + Encodable,
-    <T as Hash>::Engine: Write,
+    T: hashes::Hash + Encodable,
+    <T as hashes::Hash>::Engine: Write,
     I: Iterator<Item = T>,
 {
     let first = hashes.next()?;
@@ -90,8 +89,8 @@ where
 // `hashes` must contain at least one hash.
 fn merkle_root_r<T>(hashes: &mut [T]) -> T
 where
-    T: Hash + Encodable,
-    <T as Hash>::Engine: Write,
+    T: hashes::Hash + Encodable,
+    <T as hashes::Hash>::Engine: Write,
 {
     if hashes.len() == 1 {
         return hashes[0];
@@ -112,7 +111,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use hashes::sha256d;
+    use hashes::{sha256d, Hash as _};
 
     use super::*;
     use crate::blockdata::block::Block;

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -304,13 +304,12 @@ impl ToSocketAddrs for AddrV2Message {
 #[cfg(test)]
 mod test {
     use core::str::FromStr;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    use std::net::IpAddr;
 
     use hex::{test_hex_unwrap as hex, FromHex};
 
-    use super::{AddrV2, AddrV2Message, Address};
+    use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::p2p::ServiceFlags;
 
     #[test]
     fn serialize_address_test() {

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -537,11 +537,8 @@ impl Decodable for RawNetworkMessage {
 mod test {
     use std::net::Ipv4Addr;
 
-    use hashes::sha256d::Hash;
-    use hashes::Hash as HashTrait;
     use hex::test_hex_unwrap as hex;
 
-    use super::message_network::{Reject, RejectReason, VersionMessage};
     use super::*;
     use crate::bip152::BlockTransactionsRequest;
     use crate::blockdata::block::Block;
@@ -555,9 +552,10 @@ mod test {
     use crate::p2p::message_filter::{
         CFCheckpt, CFHeaders, CFilter, GetCFCheckpt, GetCFHeaders, GetCFilters,
     };
+    use crate::p2p::message_network::{Reject, RejectReason, VersionMessage};
     use crate::p2p::ServiceFlags;
 
-    fn hash(slice: [u8; 32]) -> Hash { Hash::from_slice(&slice).unwrap() }
+    fn hash(slice: [u8; 32]) -> sha256d::Hash { sha256d::Hash::from_slice(&slice).unwrap() }
 
     #[test]
     fn full_round_ser_der_raw_network_message_test() {

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -8,7 +8,7 @@
 
 use core::{fmt, iter};
 
-use hashes::{sha256d, Hash};
+use hashes::{sha256d, Hash as _};
 use io::{BufRead, Write};
 
 use crate::blockdata::{block, transaction};

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -150,6 +150,7 @@ mod tests {
 
     use super::{GetBlocksMessage, GetHeadersMessage};
     use crate::consensus::encode::{deserialize, serialize};
+    use crate::BlockHash;
 
     #[test]
     fn getblocks_message_test() {
@@ -162,7 +163,7 @@ mod tests {
         assert_eq!(real_decode.version, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
-        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
+        assert_eq!(real_decode.stop_hash, BlockHash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
     }
@@ -178,7 +179,7 @@ mod tests {
         assert_eq!(real_decode.version, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
-        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
+        assert_eq!(real_decode.stop_hash, BlockHash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
     }

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -145,12 +145,10 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {
-    use hashes::Hash;
     use hex::test_hex_unwrap as hex;
 
-    use super::{GetBlocksMessage, GetHeadersMessage};
+    use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::BlockHash;
 
     #[test]
     fn getblocks_message_test() {

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -149,12 +149,10 @@ impl_consensus_encoding!(Reject, message, ccode, reason, hash);
 
 #[cfg(test)]
 mod tests {
-    use hashes::sha256d;
     use hex::test_hex_unwrap as hex;
 
-    use super::{Reject, RejectReason, VersionMessage};
+    use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::p2p::ServiceFlags;
 
     #[test]
     fn version_message_test() {

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -10,6 +10,7 @@ use core::cmp;
 use core::fmt::{self, LowerHex, UpperHex};
 use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 
+use hashes::Hash as _;
 use io::{BufRead, Write};
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
@@ -220,7 +221,6 @@ impl Target {
     /// to the target.
     #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_met_by(&self, hash: BlockHash) -> bool {
-        use hashes::Hash;
         let hash = U256::from_le_bytes(hash.to_byte_array());
         hash <= self.0
     }
@@ -1711,8 +1711,6 @@ mod tests {
     #[test]
     fn target_is_met_by_for_target_equals_hash() {
         use std::str::FromStr;
-
-        use hashes::Hash;
 
         let hash =
             BlockHash::from_str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1205,7 +1205,7 @@ pub use self::display_from_str::PsbtParseError;
 
 #[cfg(test)]
 mod tests {
-    use hashes::{hash160, ripemd160, sha256, Hash};
+    use hashes::{hash160, ripemd160, sha256, Hash as _};
     use hex::{test_hex_unwrap as hex, FromHex};
     #[cfg(feature = "rand-std")]
     use secp256k1::{All, SecretKey};

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -6,7 +6,7 @@
 //! according to the BIP-174 specification.
 //!
 
-use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use hashes::{hash160, ripemd160, sha256, sha256d, Hash as _};
 use secp256k1::XOnlyPublicKey;
 
 use super::map::{Input, Map, Output, PsbtSighashType};

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -6,7 +6,7 @@
 //! library is used with the `secp-recovery` feature.
 //!
 
-use hashes::{sha256d, Hash, HashEngine};
+use hashes::{sha256d, Hash as _, HashEngine as _};
 
 use crate::consensus::{encode, Encodable};
 
@@ -22,7 +22,7 @@ pub const BITCOIN_SIGNED_MSG_PREFIX: &[u8] = b"\x18Bitcoin Signed Message:\n";
 mod message_signing {
     use core::fmt;
 
-    use hashes::{sha256d, Hash};
+    use hashes::{sha256d, Hash as _};
     use internals::write_err;
     use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 

--- a/bitcoin/src/taproot/merkle_branch.rs
+++ b/bitcoin/src/taproot/merkle_branch.rs
@@ -2,7 +2,7 @@
 
 //! Contains `TaprootMerkleBranch` and its associated types.
 
-use hashes::Hash;
+use hashes::Hash as _;
 
 use super::{
     TapNodeHash, TaprootBuilderError, TaprootError, TAPROOT_CONTROL_MAX_NODE_COUNT,

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -12,7 +12,7 @@ use core::cmp::Reverse;
 use core::fmt;
 use core::iter::FusedIterator;
 
-use hashes::{sha256t_hash_newtype, Hash, HashEngine};
+use hashes::{sha256t_hash_newtype, Hash as _, HashEngine as _};
 use internals::write_err;
 use io::Write;
 use secp256k1::{Scalar, Secp256k1};

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -30,7 +30,7 @@ use bitcoin::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
 use bitcoin::blockdata::locktime::{absolute, relative};
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::consensus::encode::deserialize;
-use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash as _};
 use bitcoin::hex::FromHex;
 use bitcoin::psbt::raw::{self, Key, Pair, ProprietaryKey};
 use bitcoin::psbt::{Input, Output, Psbt, PsbtSighashType};


### PR DESCRIPTION
Done as part of the ongoing work to improve the `hashes` API.

- Patch 1: Use concrete type when calling `all_zeros` instead of the trait method.
- Patch 2: Clean up `p2p` unit test imports (preparation for next patch)
- Patch 3: Use `as _` when importing `Hash` and `HashEngine`

This whole PR is refactor only, no logic changes.