### PR TITLE
docs: Make rustdoc imports more terse

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -12,8 +12,7 @@
 //! Hashing a single byte slice or a string:
 //!
 //! ```rust
-//! use bitcoin_hashes::sha256;
-//! use bitcoin_hashes::Hash;
+//! use bitcoin_hashes::{sha256, Hash as _};
 //!
 //! let bytes = [0u8; 5];
 //! let hash_of_bytes = sha256::Hash::hash(&bytes);
@@ -24,8 +23,7 @@
 //! Hashing content from a reader:
 //!
 //! ```rust
-//! use bitcoin_hashes::sha256;
-//! use bitcoin_hashes::Hash;
+//! use bitcoin_hashes::{sha256, Hash as _};
 //!
 //! #[cfg(std)]
 //! # fn main() -> std::io::Result<()> {
@@ -44,8 +42,7 @@
 //! Hashing content by [`std::io::Write`] on HashEngine:
 //!
 //! ```rust
-//! use bitcoin_hashes::sha256;
-//! use bitcoin_hashes::Hash;
+//! use bitcoin_hashes::{sha256, Hash as _};
 //! use std::io::Write;
 //!
 //! #[cfg(std)]


### PR DESCRIPTION
Make the rustdoc imports in `hashes/src/lib.rs` more terse and also use as-underscore.
