### PR TITLE
bitcoin: Stop slicing hashes

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -154,7 +154,7 @@ impl fmt::Display for AddressInner {
                     NetworkKind::Main => PUBKEY_ADDRESS_PREFIX_MAIN,
                     NetworkKind::Test => PUBKEY_ADDRESS_PREFIX_TEST,
                 };
-                prefixed[1..].copy_from_slice(&hash[..]);
+                prefixed[1..].copy_from_slice(hash.as_byte_array());
                 base58::encode_check_to_fmt(fmt, &prefixed[..])
             }
             P2sh { hash, network } => {
@@ -163,7 +163,7 @@ impl fmt::Display for AddressInner {
                     NetworkKind::Main => SCRIPT_ADDRESS_PREFIX_MAIN,
                     NetworkKind::Test => SCRIPT_ADDRESS_PREFIX_TEST,
                 };
-                prefixed[1..].copy_from_slice(&hash[..]);
+                prefixed[1..].copy_from_slice(hash.as_byte_array());
                 base58::encode_check_to_fmt(fmt, &prefixed[..])
             }
             Segwit { program, hrp } => {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -818,9 +818,9 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
             let mut single_enc = LegacySighash::engine();
             self.tx.borrow().output[input_index].consensus_encode(&mut single_enc)?;
             let hash = LegacySighash::from_engine(single_enc);
-            writer.write_all(&hash[..])?;
+            writer.write_all(hash.as_byte_array())?;
         } else {
-            writer.write_all(&zero_hash[..])?;
+            writer.write_all(zero_hash.as_byte_array())?;
         }
 
         self.tx.borrow().lock_time.consensus_encode(writer)?;


### PR DESCRIPTION
As part of the ongoing effort to improve `hashes`; stop using slicing of hash types and use `as_byte_array()` to get an array reference instead. This gives us more flexability to modify the `hashes` module.