### PR TITLE
CI: Enable sync-labels for labeler

### DIFF
--- a/.github/workflows/manage-pr.yml
+++ b/.github/workflows/manage-pr.yml
@@ -24,3 +24,4 @@ jobs:
         uses: actions/labeler@v5
         with:
           configuration-path: master/.github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
The `labeler` job has an input `sync-labels` (default `false`) that configures:

> Whether or not to remove labels when matching files are reverted or no
> longer changed by the PR

ref: https://github.com/actions/labeler

Currently we are using the default which means labels are not synced when a PR is modified.

Example

A PR initially touches the `hashes` and `bitcoin` crates and the labeler action adds `C-hashes` and `C-bitcoin`. Later, a force push removes the changes to `hashes`, the labeler will not remove the `C-hashes` label. Now the labels are incorrect.

Note on `pull_request_target`:

We use `on: pull_request_target`, this means the action is run in the target branch not in the PR branch. So the changes in this patch are not run when this PR is pushed up. Therefore we cannot test this patch but have to merge it blindly - please review carefully.

Some further security notes that I learned while doing this patch. The `pull_request_target` has access to GitHub secrets, and in `manage-pr.yaml` we run `./contrib/gen_label_config.sh`. This is safe because its the version of this script on `master` that is run not the version in the PR (so a malicious attacker cannot patch `gen_label_config.sh` and have it be run). However we need to be aware that we do not accidentally merge some funky shell and inadvertently leak secrets.