### PR TITLE
bitcoin: Upgrade base64 dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "bech32"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "bech32"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -38,7 +38,7 @@ io = { package = "bitcoin-io", version = "0.1.1", default-features = false, feat
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false, features = ["alloc"] }
 
-base64 = { version = "0.21.3", optional = true }
+base64 = { version = "0.22.0", optional = true }
 ordered = { version = "0.2.0", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
 bitcoinconsensus = { version = "0.105.0+25.1", default-features = false, optional = true }


### PR DESCRIPTION
Upgrade to the latest release of `base64`. Version 0.22.0 came out about 2 months ago.

No code changes needed and from the release notes it doesn't look like anything that will effect us too much.

https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md

The `base64` crate is part of our public API so this is a breaking change.