### PR TITLE
bitcoin: Set version number

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.0-rc1"
+version = "0.33.0-unreleased"
 dependencies = [
  "base58ck",
  "base64",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.0-rc1"
+version = "0.33.0-unreleased"
 dependencies = [
  "base58ck",
  "base64",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.32.0-rc1"
+version = "0.33.0-unreleased"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
During the recent release cycle we left `bitcoin` on the last rc version.

Set the version number to `v0.33.0-unreleased` to make it obvious what it is.

Close: #2724