### PR TITLE
CI: Update nightly semi-weekly

### DIFF
--- a/.github/workflows/cron-semi-weekly-update-nightly.yml
+++ b/.github/workflows/cron-semi-weekly-update-nightly.yml
@@ -1,7 +1,7 @@
 name: Update Nightly rustc
 on:
   schedule:
-    - cron: "0 0 * * *" # runs daily at 00:00
+    - cron: "0 0 * * 1,4" # runs every Monday and Thursday at 00:00
   workflow_dispatch: # allows manual triggering
 jobs:
   format:


### PR DESCRIPTION
Updating the nightly toolchain every day is overly arduous, lets just update it twice a week.