### PR TITLE
add `#![allow(unexpected_cfgs]` to every non-example target

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -41,6 +41,8 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
+// This one is just batshit. "Your projects are required to either have a build.rs or allow users' dependencies to disable your crypto."
+#![allow(unexpected_cfgs)]
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]

--- a/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_address.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_address.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)]
 use std::str::FromStr;
 
 use honggfuzz::fuzz;

--- a/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)]
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::address::Address;
 use bitcoin::blockdata::script;
 use bitcoin::consensus::encode;

--- a/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_witness.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_witness.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::consensus::{deserialize, serialize};
 use honggfuzz::fuzz;

--- a/fuzz/fuzz_targets/bitcoin/outpoint_string.rs
+++ b/fuzz/fuzz_targets/bitcoin/outpoint_string.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use std::str::FromStr;
 
 use bitcoin::blockdata::transaction::OutPoint;

--- a/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
+++ b/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use std::fmt;
 
 use honggfuzz::fuzz;

--- a/fuzz/fuzz_targets/hashes/cbor.rs
+++ b/fuzz/fuzz_targets/hashes/cbor.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::hashes::{ripemd160, sha1, sha256d, sha512, Hmac};
 use honggfuzz::fuzz;
 use serde::{Deserialize, Serialize};

--- a/fuzz/fuzz_targets/hashes/json.rs
+++ b/fuzz/fuzz_targets/hashes/json.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::hashes::{ripemd160, sha1, sha256d, sha512, Hmac};
 use honggfuzz::fuzz;
 use serde::{Deserialize, Serialize};

--- a/fuzz/fuzz_targets/hashes/ripemd160.rs
+++ b/fuzz/fuzz_targets/hashes/ripemd160.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::hashes::{ripemd160, Hash, HashEngine};
 use honggfuzz::fuzz;
 

--- a/fuzz/fuzz_targets/hashes/sha1.rs
+++ b/fuzz/fuzz_targets/hashes/sha1.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::hashes::{sha1, Hash, HashEngine};
 use honggfuzz::fuzz;
 

--- a/fuzz/fuzz_targets/hashes/sha256.rs
+++ b/fuzz/fuzz_targets/hashes/sha256.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::hashes::{sha256, Hash, HashEngine};
 use honggfuzz::fuzz;
 

--- a/fuzz/fuzz_targets/hashes/sha512.rs
+++ b/fuzz/fuzz_targets/hashes/sha512.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::hashes::{sha512, Hash, HashEngine};
 use honggfuzz::fuzz;
 

--- a/fuzz/fuzz_targets/hashes/sha512_256.rs
+++ b/fuzz/fuzz_targets/hashes/sha512_256.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use bitcoin::hashes::{sha512_256, Hash, HashEngine};
 use honggfuzz::fuzz;
 

--- a/fuzz/fuzz_targets/units/deserialize_amount.rs
+++ b/fuzz/fuzz_targets/units/deserialize_amount.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use std::str::FromStr;
 
 use honggfuzz::fuzz;

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -74,6 +74,8 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
+// This one is just batshit. "Your projects are required to either have a build.rs or allow users' dependencies to disable your crypto."
+#![allow(unexpected_cfgs)]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -16,6 +16,9 @@
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
+// This one is just batshit. "Your projects are required to either have a build.rs or allow users' dependencies to disable your crypto."
+#![allow(unexpected_cfgs)]
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -14,6 +14,9 @@
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 #![no_std]
 
+// This one is just batshit. "Your projects are required to either have a build.rs or allow users' dependencies to disable your crypto."
+#![allow(unexpected_cfgs)]
+
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]
 compile_error!(


### PR DESCRIPTION
As of Rust 1.80/nightly 2024-05-05, using custom `cfg` attributes requires that we add a build.rs to all our crates. Aside from slowing builds, this is a red flag for people trying to audit our crates because prior to this change, there was no reason for a project to have a build.rs except to interact with some other language -- which itself is something that requires greater scrutiny than a normal Rust crate.

Obviously we are not going to do that for any of our crates except for rust-secp, which wraps a C library.

We use custom cfg attributes to allow disabling our cryptography for certain kinds of fuzztests. The Rust blog suggests using Cargo features for this. This is even more insane, because it would then mean that if *any dependency* in a user's tree were to enable a "disable all the crypto" feature in our projects, the user would be fatally and thoroughly compromised.

No doubt there will be a ton of pushback over the coming weeks but bluntly, the Rust community is a dumpster fire and I have zero interest in participating in this shit. There is an easy way to just disable the new behavior so do that.