### PR TITLE
Document CompactTarget order/equality

### DIFF
--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -337,6 +337,13 @@ do_impl!(Target);
 ///
 /// OpenSSL's bignum (BN) type has an encoding, which is even called "compact" as in bitcoin, which
 /// is exactly this format.
+///
+/// # Note on order/equality
+///
+/// Usage of the ordering and equality traits for this type may be surprising. Converting between
+/// `CompactTarget` and `Target` is lossy *in both directions* (there are multiple `CompactTarget`
+/// values that map to the same `Target` value). Ordering and equality for this type are defined in
+/// terms of the underlying `u32`.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]


### PR DESCRIPTION
Add documentation to the `CompactTarget` type explaining the nuance surrounding order/equality.

Close: #2110