### PR TITLE
Fix units public re-exports

### DIFF
--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -45,10 +45,11 @@ pub mod parse;
 #[cfg(feature = "alloc")]
 pub mod weight;
 
-pub use self::amount::ParseAmountError;
 #[doc(inline)]
 pub use self::amount::{Amount, SignedAmount};
+// ParseIntError is used by other modules, so we re-export it.
 #[cfg(feature = "alloc")]
+#[doc(inline)]
 pub use self::parse::ParseIntError;
 #[cfg(feature = "alloc")]
 #[doc(inline)]

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -47,13 +47,15 @@ pub mod weight;
 
 #[doc(inline)]
 pub use self::amount::{Amount, SignedAmount};
-// ParseIntError is used by other modules, so we re-export it.
 #[cfg(feature = "alloc")]
 #[doc(inline)]
-pub use self::parse::ParseIntError;
-#[cfg(feature = "alloc")]
-#[doc(inline)]
-pub use self::{fee_rate::FeeRate, weight::Weight};
+#[rustfmt::skip]
+pub use self::{
+    fee_rate::FeeRate,
+    // ParseIntError is used by other modules, so we re-export it.
+    parse::ParseIntError,
+    weight::Weight
+};
 
 #[rustfmt::skip]
 #[allow(unused_imports)]


### PR DESCRIPTION
First patch is the meat and potatoes, second one is just a trivial refactor to the same code, done separately so as to make the changes in the first patch more clear.

From patch 1
```
    units: Fix error re-exports
    
    Currently we re-export two error types at the crate root, this is
    surprising because:
    
    - Why not none or all the rest?
    - Why these two?
    
    Observe that the `ParseIntError` is special in that it is used by
    other modules so its good to have at the crate root (other errors are
    expected to be used with a module prefix eg, `amount::ParseError`).
    
    There is no obvious reason why `ParseAmountError` is re-exported.
    
    Comment and doc inline the `ParesIntError`, remove the re-export of
    the `ParseAmountError`.
```