### PR TITLE
psbt: documentation examples for PsbtSighashType

### DIFF
--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -136,6 +136,16 @@ pub struct Input {
 /// type can be either [`EcdsaSighashType`] or [`TapSighashType`] but it is not possible to know
 /// directly which signature hash type the user is dealing with. Therefore, the user is responsible
 /// for converting to/from [`PsbtSighashType`] from/to the desired signature hash type they need.
+///
+/// # Examples
+///
+/// ```
+/// use bitcoin::{EcdsaSighashType, TapSighashType};
+/// use bitcoin::psbt::PsbtSighashType;
+///
+/// let ecdsa_sighash_all: PsbtSighashType = EcdsaSighashType::All.into();
+/// let tap_sighash_all: PsbtSighashType = TapSighashType::All.into();
+/// ```
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]


### PR DESCRIPTION
Partially addresses #2751 by adding examples (testable code) for `PsbtSighashType`