### PR TITLE
ci: shellcheck checks

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,15 @@
+name: Shellcheck
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@2.0.0
+      env:
+        SHELLCHECK_OPTS: -x # allow outside sources

--- a/base58/contrib/test_vars.sh
+++ b/base58/contrib/test_vars.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
 
 # Test all these features with "std" enabled.
 FEATURES_WITH_STD=""

--- a/bitcoin/contrib/test_vars.sh
+++ b/bitcoin/contrib/test_vars.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
 
 # Test all these features with "std" enabled.
 FEATURES_WITH_STD="rand-std serde secp-recovery bitcoinconsensus-std base64 ordered"

--- a/bitcoin/embedded/scripts/env.sh
+++ b/bitcoin/embedded/scripts/env.sh
@@ -1,2 +1,4 @@
+# we don't want shebangs in env.sh, disable shellcheck warning
+# shellcheck disable=SC2148
 export RUSTFLAGS="-C link-arg=-Tlink.x"
 export CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER="qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"

--- a/contrib/crates.sh
+++ b/contrib/crates.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
 
 # Crates in this workspace to test (note "fuzz" is only built not tested).
 CRATES=("base58" "bitcoin" "fuzz" "hashes" "internals" "io" "units")

--- a/contrib/gen_label_config.sh
+++ b/contrib/gen_label_config.sh
@@ -20,7 +20,7 @@ fi
 
 excluded_crates="fuzz|dep_test"
 
-CRATES="`cd "$SCAN_DIR" && cargo metadata --no-deps --format-version 1 | jq -j -r '.packages | map(.manifest_path | rtrimstr("/Cargo.toml") | ltrimstr("'$PWD'/")) | join(" ")'`"
+CRATES="$(cd "$SCAN_DIR" && cargo metadata --no-deps --format-version 1 | jq -j -r '.packages | map(.manifest_path | rtrimstr("/Cargo.toml") | ltrimstr("'"$PWD"'/")) | join(" ")')"
 
 for crate in $CRATES;
 do
@@ -29,7 +29,9 @@ do
 		continue
 	fi
 
-	echo "C-$crate:" >> "$config"
-	echo "  - changed-files:" >> "$config"
-	echo "    - any-glob-to-any-file: $crate/**" >> "$config"
+	{
+		echo "C-$crate:"
+		echo "  - changed-files:"
+		echo "    - any-glob-to-any-file: $crate/**"
+	} >> "$config"
 done

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -28,7 +28,7 @@ main () {
 # preparation for releasing the crate.
 release_changes() {
     local crate=$1
-    git log --patch --reverse master.. -- $crate/Cargo.toml | grep version
+    git log --patch --reverse master.. -- "$crate"/Cargo.toml | grep version
 }
 
 # Do a dry run publish to crates.io using the correct package name for crate ($1).
@@ -47,4 +47,4 @@ publish_dry_run() {
 #
 # Main script.
 #
-main $@
+main "$@"

--- a/contrib/test_vars.sh
+++ b/contrib/test_vars.sh
@@ -4,6 +4,8 @@
 #
 # Not to be confused with the per crate `test_vars.sh` used by
 # `rust-bitcoin-maintainer-tools-run_task.sh`.
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
 
-CRATES="`cargo metadata --no-deps --format-version 1 | jq -j -r '.packages | map(.manifest_path | rtrimstr("/Cargo.toml") | ltrimstr("'$PWD'/")) | join(" ")'`"
+CRATES="$(cargo metadata --no-deps --format-version 1 | jq -j -r '.packages | map(.manifest_path | rtrimstr("/Cargo.toml") | ltrimstr("'"$PWD"'/")) | join(" ")')"
 DEPS="recent minimal"

--- a/fuzz/cycle.sh
+++ b/fuzz/cycle.sh
@@ -8,7 +8,8 @@
 set -euo pipefail
 
 REPO_DIR=$(git rev-parse --show-toplevel)
-# shellcheck source=./fuzz-util.sh
+# can't find the file because of the ENV var
+# shellcheck source=/dev/null
 source "$REPO_DIR/fuzz/fuzz-util.sh"
 
 while :

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -3,7 +3,8 @@ set -euox pipefail
 
 REPO_DIR=$(git rev-parse --show-toplevel)
 
-# shellcheck source=./fuzz-util.sh
+# can't find the file because of the ENV var
+# shellcheck source=/dev/null
 source "$REPO_DIR/fuzz/fuzz-util.sh"
 
 # Check that input files are correct Windows file names

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 REPO_DIR=$(git rev-parse --show-toplevel)
 
-# shellcheck source=./fuzz-util.sh
+# can't find the file because of the ENV var
+# shellcheck source=/dev/null
 source "$REPO_DIR/fuzz/fuzz-util.sh"
 
 # 1. Generate fuzz/Cargo.toml

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -21,11 +21,13 @@ exec 1>&2
 # Cross platform projects tend to avoid non-ASCII filenames; prevent
 # them from being added to the repository. We exploit the fact that the
 # printable range starts at the space character and ends with tilde.
+# disable the check to quoting the $(...) command
+# shellcheck disable=SC2046
 if [ "$allownonascii" != "true" ] &&
 	# Note that the use of brackets around a tr range is ok here, (it's
 	# even required, for portability to Solaris 10's /usr/bin/tr), since
 	# the square bracket bytes happen to fall in the designated range.
-	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	test $(git diff --cached --name-only --diff-filter=A -z "$against" |
 	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
 then
 	cat <<\EOF
@@ -43,7 +45,9 @@ EOF
 fi
 
 # If there are whitespace errors, print the offending file names and fail.
-git diff-index --check --cached $against -- || exit 1
+git diff-index --check --cached "$against" -- || exit 1
 
 # Check that code lints cleanly.
+# disable the check to quoting the $(...) command
+# shellcheck disable=SC2046
 cargo +$(cat ./nightly-version) clippy --workspace --all-targets --all-features -- --deny warnings || exit 1

--- a/hashes/contrib/test_vars.sh
+++ b/hashes/contrib/test_vars.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
 
 # Test all these features with "std" enabled.
 FEATURES_WITH_STD="io serde small-hash schemars"

--- a/hashes/embedded/scripts/env.sh
+++ b/hashes/embedded/scripts/env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
-
+# we don't want shebangs in env.sh, disable shellcheck warning
+# shellcheck disable=SC2148
 export RUSTFLAGS="-C link-arg=-Tlink.x"
 export CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER="qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"

--- a/internals/contrib/test_vars.sh
+++ b/internals/contrib/test_vars.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
 
 # Test all these features with "std" enabled.
 FEATURES_WITH_STD="serde"

--- a/io/contrib/test_vars.sh
+++ b/io/contrib/test_vars.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
 
 # Test all these features with "std" enabled.
 FEATURES_WITH_STD=""

--- a/units/contrib/test_vars.sh
+++ b/units/contrib/test_vars.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
 
 # Test all these features with "std" enabled.
 FEATURES_WITH_STD="serde"


### PR DESCRIPTION
Closes #2739.

I am proposing that we use this GitHub Shellcheck action:
[`ludeeus/action-shellcheck`](https://github.com/ludeeus/action-shellcheck)
since it has most stars (and eyes on it).

I also did all fixes that I could find with

```bash
shellcheck **/*.sh
```

If I've missed any please let me know.