### PR TITLE
Deprecate `to_vec` in favour of `to_bytes`

### DIFF
--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -284,7 +284,11 @@ impl Witness {
     }
 
     /// Convenience method to create an array of byte-arrays from this witness.
-    pub fn to_vec(&self) -> Vec<Vec<u8>> { self.iter().map(|s| s.to_vec()).collect() }
+    pub fn to_bytes(&self) -> Vec<Vec<u8>> { self.iter().map(|s| s.to_vec()).collect() }
+
+    /// Convenience method to create an array of byte-arrays from this witness.
+    #[deprecated(since = "TBD", note = "Use to_bytes instead")]
+    pub fn to_vec(&self) -> Vec<Vec<u8>> { self.to_bytes() }
 
     /// Returns `true` if the witness contains no element.
     pub fn is_empty(&self) -> bool { self.witness_elements == 0 }

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -57,7 +57,7 @@ impl Signature {
     ///
     /// Note: this performs an extra heap allocation, you might prefer the
     /// [`serialize`](Self::serialize) method instead.
-    pub fn to_vec(self) -> Vec<u8> {
+    pub fn to_bytes(self) -> Vec<u8> {
         self.signature
             .serialize_der()
             .iter()
@@ -65,6 +65,10 @@ impl Signature {
             .chain(iter::once(self.sighash_type as u8))
             .collect()
     }
+
+    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) into `Vec`.
+    #[deprecated(since = "TBD", note = "Use to_bytes instead")]
+    pub fn to_vec(self) -> Vec<u8> { self.to_bytes() }
 
     /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) to a `writer`.
     #[inline]

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -47,7 +47,7 @@ impl Signature {
     /// Serialize Signature
     ///
     /// Note: this allocates on the heap, prefer [`serialize`](Self::serialize) if vec is not needed.
-    pub fn to_vec(self) -> Vec<u8> {
+    pub fn to_bytes(self) -> Vec<u8> {
         let mut ser_sig = self.signature.as_ref().to_vec();
         if self.sighash_type == TapSighashType::Default {
             // default sighash type, don't add extra sighash byte
@@ -56,6 +56,10 @@ impl Signature {
         }
         ser_sig
     }
+
+    /// Serialize Signature
+    #[deprecated(since = "TBD", note = "Use to_bytes instead")]
+    pub fn to_vec(self) -> Vec<u8> { self.to_bytes() }
 
     /// Serializes the signature to `writer`.
     #[inline]


### PR DESCRIPTION
Currently we have to method names for the same thing "copy this object into a vector". The library is easier to use if we are uniform and just use one.

Elect to use `to_bytes`, for context see discussion in PR #2585.