### PR TITLE
Fix rustdoc header format

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -3,7 +3,6 @@
 //! BIP152 Compact Blocks
 //!
 //! Implementation of compact blocks data structure and algorithms.
-//!
 
 use core::{convert, fmt, mem};
 #[cfg(feature = "std")]

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -36,7 +36,6 @@
 //!   // get this block
 //! }
 //!  ```
-//!
 
 use core::cmp::{self, Ordering};
 use core::fmt::{self, Display, Formatter};

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -4,7 +4,6 @@
 //!
 //! Implementation of BIP32 hierarchical deterministic wallets, as defined
 //! at <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>.
-//!
 
 use core::ops::Index;
 use core::str::FromStr;

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -6,7 +6,6 @@
 //! which commits to an earlier block to form the blockchain. This
 //! module describes structures and functions needed to describe
 //! these blocks and the blockchain.
-//!
 
 use core::fmt;
 

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -5,7 +5,6 @@
 //! This module provides various constants relating to the blockchain and
 //! consensus code. In particular, it defines the genesis block and its
 //! single transaction.
-//!
 
 use hashes::{sha256d, Hash};
 use hex_lit::hex;

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -4,7 +4,6 @@
 //!
 //! There are two types of lock time: lock-by-blockheight and lock-by-blocktime, distinguished by
 //! whether `LockTime < LOCKTIME_THRESHOLD`.
-//!
 
 use core::cmp::Ordering;
 use core::fmt;

--- a/bitcoin/src/blockdata/locktime/mod.rs
+++ b/bitcoin/src/blockdata/locktime/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! Provides absolute and relative locktimes.
-//!
 
 pub mod absolute;
 pub mod relative;

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -4,7 +4,6 @@
 //!
 //! There are two types of lock time: lock-by-blockheight and lock-by-blocktime, distinguished by
 //! whether bit 22 of the `u32` consensus value is set.
-//!
 
 #[cfg(feature = "ordered")]
 use core::cmp::Ordering;

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -4,7 +4,6 @@
 //!
 //! This module defines structures and functions for storing the blocks and
 //! transactions which make up the Bitcoin system.
-//!
 
 pub mod block;
 pub mod constants;

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -4,7 +4,6 @@
 //!
 //! Bitcoin's script uses a stack-based assembly language. This module defines
 //! all of the opcodes for that language.
-//!
 
 #![allow(non_camel_case_types)]
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -9,7 +9,6 @@
 //! signatures ensures that coins cannot be spent by unauthorized parties.
 //!
 //! This module provides the structures and functions needed to support transactions.
-//!
 
 use core::{cmp, fmt, str};
 

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -3,7 +3,6 @@
 //! Witness
 //!
 //! This module contains the [`Witness`] struct and related methods to operate on it
-//!
 
 use core::fmt;
 use core::ops::Index;

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -13,7 +13,6 @@
 //! course, but has some critical differences from the network format e.g.,
 //! scripts come with an opcode decode, hashes are big-endian, numbers are
 //! typically big-endian decimals, etc.)
-//!
 
 use core::{fmt, mem};
 

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -4,7 +4,6 @@
 //!
 //! This module defines structures, functions, and traits that are needed to
 //! conform to Bitcoin consensus.
-//!
 
 pub mod encode;
 pub mod params;

--- a/bitcoin/src/crypto/mod.rs
+++ b/bitcoin/src/crypto/mod.rs
@@ -3,7 +3,6 @@
 //! Cryptography
 //!
 //! Cryptography related functionality: keys and signatures.
-//!
 
 pub mod ecdsa;
 pub mod key;

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -3,7 +3,6 @@
 //! Bitcoin taproot keys.
 //!
 //! This module provides taproot keys used in Bitcoin (including reexporting secp256k1 keys).
-//!
 
 use core::fmt;
 

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -3,7 +3,6 @@
 //! Internal macros.
 //!
 //! Macros meant to be used inside the Rust Bitcoin library.
-//!
 
 macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -4,7 +4,6 @@
 //!
 //! This module defines the structures and functions needed to encode
 //! network addresses in Bitcoin messages.
-//!
 
 use core::{fmt, iter};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -4,7 +4,6 @@
 //!
 //! This module defines the `NetworkMessage` and `RawNetworkMessage` types that
 //! are used for (de)serializing Bitcoin objects for transmission on the network.
-//!
 
 use core::{fmt, iter};
 

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -4,7 +4,6 @@
 //!
 //! This module describes network messages which are used for passing
 //! Bitcoin data (blocks and transactions) around.
-//!
 
 use hashes::{sha256d, Hash as _};
 use io::{BufRead, Write};

--- a/bitcoin/src/p2p/message_bloom.rs
+++ b/bitcoin/src/p2p/message_bloom.rs
@@ -3,7 +3,6 @@
 //! Bitcoin Connection Bloom filtering network messages.
 //!
 //! This module describes BIP37 Connection Bloom filtering network messages.
-//!
 
 use io::{BufRead, Write};
 

--- a/bitcoin/src/p2p/message_compact_blocks.rs
+++ b/bitcoin/src/p2p/message_compact_blocks.rs
@@ -2,7 +2,6 @@
 
 //!
 //! BIP152  Compact Blocks network messages
-//!
 
 use crate::bip152;
 use crate::internal_macros::impl_consensus_encoding;

--- a/bitcoin/src/p2p/message_filter.rs
+++ b/bitcoin/src/p2p/message_filter.rs
@@ -3,7 +3,6 @@
 //! Bitcoin Client Side Block Filtering network messages.
 //!
 //! This module describes BIP157 Client Side Block Filtering network messages.
-//!
 
 use crate::bip158::{FilterHash, FilterHeader};
 use crate::blockdata::block::BlockHash;

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -4,7 +4,6 @@
 //!
 //! This module defines network messages which describe peers and their
 //! capabilities.
-//!
 
 use hashes::sha256d;
 use io::{BufRead, Write};

--- a/bitcoin/src/policy.rs
+++ b/bitcoin/src/policy.rs
@@ -10,7 +10,6 @@
 //! Bitcoin. As such they must not be relied upon as if they were consensus rules.
 //!
 //! These values were taken from bitcoind v0.21.1 (194b9b8792d9b0798fdb570b79fa51f1d1f5ebaf).
-//!
 
 use core::cmp;
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -4,7 +4,6 @@
 //!
 //! Provides the [`Work`] and [`Target`] types that are used in proof-of-work calculations. The
 //! functions here are designed to be fast, by that we mean it is safe to use them to check headers.
-//!
 
 use core::cmp;
 use core::fmt::{self, LowerHex, UpperHex};

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -5,7 +5,6 @@
 //! Implementation of BIP174 Partially Signed Bitcoin Transaction Format as
 //! defined at <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki>
 //! except we define PSBTs containing non-standard sighash types as invalid.
-//!
 
 #[macro_use]
 mod macros;

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -4,7 +4,6 @@
 //!
 //! Raw PSBT key-value pairs as defined at
 //! <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki>.
-//!
 
 use core::fmt;
 

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -4,7 +4,6 @@
 //!
 //! Traits to serialize PSBT values to and from raw bytes
 //! according to the BIP-174 specification.
-//!
 
 use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use secp256k1::XOnlyPublicKey;

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -3,7 +3,6 @@
 //! Bitcoin serde utilities.
 //!
 //! This module is for special serde serializations.
-//!
 
 pub(crate) struct SerializeBytesAsHex<'a>(pub(crate) &'a [u8]);
 

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -4,7 +4,6 @@
 //!
 //! This module provides signature related functions including secp256k1 signature recovery when
 //! library is used with the `secp-recovery` feature.
-//!
 
 use hashes::{sha256d, Hash, HashEngine};
 

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -392,12 +392,12 @@ impl TaprootBuilder {
     /// example, [(3, S1), (2, S2), (5, S3)] would construct a [`TapTree`] that has optimal
     /// satisfaction weight when probability for S1 is 30%, S2 is 20% and S3 is 50%.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// - When the optimal Huffman Tree has a depth more than 128.
     /// - If the provided list of script weights is empty.
     ///
-    /// # Edge Cases:
+    /// # Edge Cases
     ///
     /// If the script weight calculations overflow, a sub-optimal tree may be generated. This should
     /// not happen unless you are dealing with billions of branches with weights close to 2^32.

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -3,7 +3,6 @@
 //! Bitcoin Taproot.
 //!
 //! This module provides support for taproot tagged hashes.
-//!
 
 pub mod merkle_branch;
 pub mod serialized_signature;

--- a/bitcoin/src/test_macros.rs
+++ b/bitcoin/src/test_macros.rs
@@ -3,7 +3,6 @@
 //! Bitcoin serde macros.
 //!
 //! This module provides internal macros used for unit tests.
-//!
 
 #[cfg(feature = "serde")]
 macro_rules! serde_round_trip (


### PR DESCRIPTION
Fix rustdoc header format

By convention rustdoc headers should not include a colon.

Remove colon from rustdoc headers.