### PR TITLE
Use concrete type for all_zeros call

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -468,7 +468,7 @@ mod test {
             {
                 // test serialization
                 let raw: Vec<u8> = serialize(&BlockTransactionsRequest {
-                    block_hash: Hash::all_zeros(),
+                    block_hash: BlockHash::all_zeros(),
                     indexes: testcase.1,
                 });
                 let mut expected_raw: Vec<u8> = [0u8; 32].to_vec();
@@ -491,7 +491,7 @@ mod test {
     #[should_panic] // 'attempt to add with overflow' in consensus_encode()
     fn test_getblocktx_panic_when_encoding_u64_max() {
         serialize(&BlockTransactionsRequest {
-            block_hash: Hash::all_zeros(),
+            block_hash: BlockHash::all_zeros(),
             indexes: vec![u64::MAX],
         });
     }

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -21,7 +21,7 @@ use crate::consensus::Params;
 use crate::internal_macros::impl_bytes_newtype;
 use crate::network::Network;
 use crate::pow::CompactTarget;
-use crate::Amount;
+use crate::{Amount, BlockHash};
 
 /// How many seconds between blocks we expect on average.
 pub const TARGET_BLOCK_SPACING: u32 = 600;
@@ -93,7 +93,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Bitcoin => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1231006505,
                 bits: CompactTarget::from_consensus(0x1d00ffff),
@@ -104,7 +104,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Testnet => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1296688602,
                 bits: CompactTarget::from_consensus(0x1d00ffff),
@@ -115,7 +115,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Signet => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1598918400,
                 bits: CompactTarget::from_consensus(0x1e0377ae),
@@ -126,7 +126,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
         Network::Regtest => Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: Hash::all_zeros(),
+                prev_blockhash: BlockHash::all_zeros(),
                 merkle_root,
                 time: 1296688602,
                 bits: CompactTarget::from_consensus(0x207fffff),
@@ -200,6 +200,7 @@ mod test {
     use super::*;
     use crate::consensus::encode::serialize;
     use crate::consensus::params;
+    use crate::Txid;
 
     #[test]
     fn bitcoin_genesis_first_transaction() {
@@ -207,7 +208,7 @@ mod test {
 
         assert_eq!(gen.version, transaction::Version::ONE);
         assert_eq!(gen.input.len(), 1);
-        assert_eq!(gen.input[0].previous_output.txid, Hash::all_zeros());
+        assert_eq!(gen.input[0].previous_output.txid, Txid::all_zeros());
         assert_eq!(gen.input[0].previous_output.vout, 0xFFFFFFFF);
         assert_eq!(serialize(&gen.input[0].script_sig),
                    hex!("4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"));
@@ -242,7 +243,7 @@ mod test {
         let gen = genesis_block(&params::MAINNET);
 
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
@@ -261,7 +262,7 @@ mod test {
     fn testnet_genesis_full_block() {
         let gen = genesis_block(&params::TESTNET);
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
@@ -279,7 +280,7 @@ mod test {
     fn signet_genesis_full_block() {
         let gen = genesis_block(&params::SIGNET);
         assert_eq!(gen.header.version, block::Version::ONE);
-        assert_eq!(gen.header.prev_blockhash, Hash::all_zeros());
+        assert_eq!(gen.header.prev_blockhash, BlockHash::all_zeros());
         assert_eq!(
             gen.header.merkle_root.to_string(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -84,7 +84,7 @@ impl OutPoint {
     ///
     /// This value is used for coinbase transactions because they don't have any previous outputs.
     #[inline]
-    pub fn null() -> OutPoint { OutPoint { txid: Hash::all_zeros(), vout: u32::MAX } }
+    pub fn null() -> OutPoint { OutPoint { txid: Txid::all_zeros(), vout: u32::MAX } }
 
     /// Checks if an `OutPoint` is "null".
     ///

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -127,7 +127,7 @@ mod tests {
 
         let hashes_iter = block.txdata.iter().map(|obj| obj.compute_txid().to_raw_hash());
 
-        let mut hashes_array: [sha256d::Hash; 15] = [Hash::all_zeros(); 15];
+        let mut hashes_array = [sha256d::Hash::all_zeros(); 15];
         for (i, hash) in hashes_iter.clone().enumerate() {
             hashes_array[i] = hash;
         }

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -150,6 +150,7 @@ mod tests {
 
     use super::{GetBlocksMessage, GetHeadersMessage};
     use crate::consensus::encode::{deserialize, serialize};
+    use crate::BlockHash;
 
     #[test]
     fn getblocks_message_test() {
@@ -162,7 +163,7 @@ mod tests {
         assert_eq!(real_decode.version, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
-        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
+        assert_eq!(real_decode.stop_hash, BlockHash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
     }
@@ -178,7 +179,7 @@ mod tests {
         assert_eq!(real_decode.version, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
-        assert_eq!(real_decode.stop_hash, Hash::all_zeros());
+        assert_eq!(real_decode.stop_hash, BlockHash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
     }


### PR DESCRIPTION
Currently we use the `Hash` trait in a bunch of places to call `all_zeros`. We are attempting to improve the `hashes` API and this usage is both unnecessary and also hindering that effort.

Use the concrete type (e.g. `BlockHash`) instead of calling through the trait method.

Refactor only, no logic changes.