### PR TITLE
p2p: Cleanup test imports

### DIFF
--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -303,13 +303,12 @@ impl ToSocketAddrs for AddrV2Message {
 #[cfg(test)]
 mod test {
     use core::str::FromStr;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    use std::net::IpAddr;
 
     use hex::{test_hex_unwrap as hex, FromHex};
 
-    use super::{AddrV2, AddrV2Message, Address};
+    use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::p2p::ServiceFlags;
 
     #[test]
     fn serialize_address_test() {

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -536,11 +536,8 @@ impl Decodable for RawNetworkMessage {
 mod test {
     use std::net::Ipv4Addr;
 
-    use hashes::sha256d::Hash;
-    use hashes::Hash as HashTrait;
     use hex::test_hex_unwrap as hex;
 
-    use super::message_network::{Reject, RejectReason, VersionMessage};
     use super::*;
     use crate::bip152::BlockTransactionsRequest;
     use crate::blockdata::block::Block;
@@ -554,9 +551,10 @@ mod test {
     use crate::p2p::message_filter::{
         CFCheckpt, CFHeaders, CFilter, GetCFCheckpt, GetCFHeaders, GetCFilters,
     };
+    use crate::p2p::message_network::{Reject, RejectReason, VersionMessage};
     use crate::p2p::ServiceFlags;
 
-    fn hash(slice: [u8; 32]) -> Hash { Hash::from_slice(&slice).unwrap() }
+    fn hash(slice: [u8; 32]) -> sha256d::Hash { sha256d::Hash::from_slice(&slice).unwrap() }
 
     #[test]
     fn full_round_ser_der_raw_network_message_test() {

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -147,9 +147,8 @@ mod tests {
     use hashes::Hash;
     use hex::test_hex_unwrap as hex;
 
-    use super::{GetBlocksMessage, GetHeadersMessage};
+    use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::BlockHash;
 
     #[test]
     fn getblocks_message_test() {

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -148,12 +148,10 @@ impl_consensus_encoding!(Reject, message, ccode, reason, hash);
 
 #[cfg(test)]
 mod tests {
-    use hashes::sha256d;
     use hex::test_hex_unwrap as hex;
 
-    use super::{Reject, RejectReason, VersionMessage};
+    use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::p2p::ServiceFlags;
 
     #[test]
     fn version_message_test() {


### PR DESCRIPTION
Clean up the test imports in the `p2p` module:

- Use `use super::*` as is conventional.
- Use `sha256d::Hash` as is conventional.

Refactor, no logic changes.