### PR TITLE
Fix rustdoc header format

### DIFF
--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -389,12 +389,12 @@ impl TaprootBuilder {
     /// example, [(3, S1), (2, S2), (5, S3)] would construct a [`TapTree`] that has optimal
     /// satisfaction weight when probability for S1 is 30%, S2 is 20% and S3 is 50%.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// - When the optimal Huffman Tree has a depth more than 128.
     /// - If the provided list of script weights is empty.
     ///
-    /// # Edge Cases:
+    /// # Edge Cases
     ///
     /// If the script weight calculations overflow, a sub-optimal tree may be generated. This should
     /// not happen unless you are dealing with billions of branches with weights close to 2^32.
@@ -467,7 +467,7 @@ impl TaprootBuilder {
     /// Converts the builder into a [`NodeInfo`] if the builder is a full tree with possibly
     /// hidden nodes
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// [`IncompleteBuilderError::NotFinalized`] if the builder is not finalized. The builder
     /// can be restored by calling [`IncompleteBuilderError::into_builder`]


### PR DESCRIPTION
By convention rustdoc headers should not include a colon.

Removed colon from rustdoc headers.