### PR TITLE
Removed spare line at end of headers in hashes crate

### DIFF
--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -6,7 +6,6 @@
 // contents here as CC0.
 
 //! HASH160 (SHA256 then RIPEMD160) implementation.
-//!
 
 use core::ops::Index;
 use core::slice::SliceIndex;

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -6,7 +6,6 @@
 // contents here as CC0.
 
 //! Hash-based Message Authentication Code (HMAC).
-//!
 
 use core::{convert, fmt, str};
 

--- a/hashes/src/impls.rs
+++ b/hashes/src/impls.rs
@@ -3,7 +3,6 @@
 //! `std` / `io` Impls.
 //!
 //! Implementations of traits defined in `std` / `io` and not in `core`.
-//!
 
 use bitcoin_io::impl_write;
 

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! RIPEMD160 implementation.
-//!
 
 use core::cmp;
 use core::ops::Index;

--- a/hashes/src/serde_macros.rs
+++ b/hashes/src/serde_macros.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! Macros for serde trait implementations, and supporting code.
-//!
 
 /// Functions used by serde impls of all hashes.
 #[cfg(feature = "serde")]

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! SHA1 implementation.
-//!
 
 use core::cmp;
 use core::ops::Index;

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! SHA256 implementation.
-//!
 
 #[cfg(all(feature = "std", target_arch = "x86"))]
 use core::arch::x86::*;

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! SHA256d implementation (double SHA256).
-//!
 
 use core::ops::Index;
 use core::slice::SliceIndex;

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! SHA256t implementation (tagged SHA256).
-//!
 
 use core::cmp;
 use core::marker::PhantomData;

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! SHA512 implementation.
-//!
 
 use core::cmp;
 use core::ops::Index;

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! SipHash 2-4 implementation.
-//!
 
 use core::ops::Index;
 use core::slice::SliceIndex;


### PR DESCRIPTION
Some of the headers had a //! spare line at the end but most didn't. They have all been removed in hashes/src/ to make the files consistent