### PR TITLE
Removed spare line at end of headers in internals crate

### DIFF
--- a/internals/src/error.rs
+++ b/internals/src/error.rs
@@ -3,7 +3,6 @@
 //! # Error
 //!
 //! Error handling macros and helpers.
-//!
 
 pub mod input_string;
 mod parse_error;

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -4,7 +4,6 @@
 //!
 //! This crate is only meant to be used internally by crates in the
 //! [rust-bitcoin](https://github.com/rust-bitcoin) ecosystem.
-//!
 
 #![no_std]
 // Experimental features we need.

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! Various macros used by the Rust Bitcoin ecosystem.
-//!
 
 /// Implements standard array methods for a given wrapper type.
 #[macro_export]


### PR DESCRIPTION
Some of the headers had a //! at the end but most didn't. They have all been removed in internals/src/ to make the files consistent