### PR TITLE
Removed spare line at end of headers in units crate

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1745,7 +1745,7 @@ pub mod serde {
     pub mod as_sat {
         //! Serialize and deserialize [`Amount`](crate::Amount) as real numbers denominated in satoshi.
         //! Use with `#[serde(with = "amount::serde::as_sat")]`.
-        //!
+
         use serde::{Deserializer, Serializer};
 
         use super::private;


### PR DESCRIPTION
Some of the headers had a //! at the end but most didn't. They have all been removed in units/src/ to make the files consistent