### PR TITLE
Header change from arguments to parameters

### DIFF
--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -13,7 +13,7 @@ use hex_lit::hex;
 
 /// Computes segwit sighash for a transaction input that spends a p2wpkh output with "witness_v0_keyhash" scriptPubKey.type
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `raw_tx` - spending tx hex
 /// * `inp_idx` - spending tx input index
@@ -52,7 +52,7 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, value: u64) {
 
 /// Computes sighash for a legacy multisig transaction input that spends either a p2sh or a p2ms output.
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `raw_tx` - spending tx hex
 /// * `inp_idx` - spending tx input inde
@@ -98,7 +98,7 @@ fn compute_sighash_legacy(raw_tx: &[u8], inp_idx: usize, script_pubkey_bytes_opt
 
 /// Computes sighash for a segwit multisig transaction input that spends a p2wsh output with "witness_v0_scripthash" scriptPubKey.type
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `raw_tx` - spending tx hex
 /// * `inp_idx` - spending tx input index

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1303,7 +1303,7 @@ impl From<&Transaction> for Wtxid {
 /// a [`TxOut`] when adding another [`TxOut`] to the transaction.  This happens when the new
 /// [`TxOut`] added causes the output length `VarInt` to increase its encoding length.
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `fee_rate` - the fee rate of the transaction being created.
 /// * `satisfaction_weight` - satisfied spending conditions weight.
@@ -1322,7 +1322,7 @@ pub fn effective_value(
 /// This function computes the weight of a transaction which is not fully known. All that is needed
 /// is the lengths of scripts and witness elements.
 ///
-/// # Arguments
+/// # Parameters
 ///
 /// * `inputs` - an iterator which returns `InputWeightPrediction` for each input of the
 ///   to-be-constructed transaction.

--- a/internals/src/error/parse_error.rs
+++ b/internals/src/error/parse_error.rs
@@ -9,7 +9,7 @@
 /// The resulting type is public, conditionally implements `std::error::Error` and has a private
 /// `new()` method for convenience.
 ///
-/// ## Parameters
+/// # Parameters
 ///
 /// * `name` - the name of the error type
 /// * `source` - the type of the source type


### PR DESCRIPTION
In a few cases a function header documents the parameters of the following function under the heading "Arguments", this has been changed to "Parameters".  

Since the description is at the level of the function definition and not where it is being called parameters seems the more accurate term.