### PR TITLE
Enable getting the witness program from an address

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -7129,6 +7129,7 @@ pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bit
 pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
 pub fn bitcoin::address::Address::script_pubkey(&self) -> bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::address::Address::to_qr_uri(&self) -> alloc::string::String
+pub fn bitcoin::address::Address::witness_program(&self) -> core::option::Option<bitcoin::blockdata::script::witness_program::WitnessProgram>
 pub fn bitcoin::address::Address<N>::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin::address::Address<V>::as_unchecked(&self) -> &bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
 pub fn bitcoin::address::Address<V>::clone(&self) -> bitcoin::address::Address<V>

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -6797,6 +6797,7 @@ pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bit
 pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
 pub fn bitcoin::address::Address::script_pubkey(&self) -> bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::address::Address::to_qr_uri(&self) -> alloc::string::String
+pub fn bitcoin::address::Address::witness_program(&self) -> core::option::Option<bitcoin::blockdata::script::witness_program::WitnessProgram>
 pub fn bitcoin::address::Address<V>::as_unchecked(&self) -> &bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
 pub fn bitcoin::address::Address<V>::clone(&self) -> bitcoin::address::Address<V>
 pub fn bitcoin::address::Address<V>::cmp(&self, other: &bitcoin::address::Address<V>) -> core::cmp::Ordering

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -6164,6 +6164,7 @@ pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bit
 pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
 pub fn bitcoin::address::Address::script_pubkey(&self) -> bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::address::Address::to_qr_uri(&self) -> alloc::string::String
+pub fn bitcoin::address::Address::witness_program(&self) -> core::option::Option<bitcoin::blockdata::script::witness_program::WitnessProgram>
 pub fn bitcoin::address::Address<V>::as_unchecked(&self) -> &bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
 pub fn bitcoin::address::Address<V>::clone(&self) -> bitcoin::address::Address<V>
 pub fn bitcoin::address::Address<V>::cmp(&self, other: &bitcoin::address::Address<V>) -> core::cmp::Ordering

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -490,6 +490,16 @@ impl Address {
         }
     }
 
+    /// Gets the witness program for this address if this is a segwit address.
+    pub fn witness_program(&self) -> Option<WitnessProgram> {
+        use AddressInner::*;
+
+        match self.0 {
+            Segwit { ref program, hrp: _ } => Some(*program),
+            _ => None,
+        }
+    }
+
     /// Checks whether or not the address is following Bitcoin standardness rules when
     /// *spending* from this address. *NOT* to be called by senders.
     ///


### PR DESCRIPTION
We have getters for the pubkey hash and script hash but we forgot one for the witness program - add it.
 
Done as part of fixing #2784, this is an additive change and is expected to be backported to `v0.32`