### PR TITLE
fuzz: switch from serde_cbor to cborium

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ bitcoin = { path = "../bitcoin", features = [ "serde" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"
-serde_cbor = "0.9"
+ciborium = "0.2"
 
 [[bin]]
 name = "bitcoin_deserialize_address"

--- a/fuzz/fuzz_targets/hashes/cbor.rs
+++ b/fuzz/fuzz_targets/hashes/cbor.rs
@@ -16,8 +16,9 @@ struct Main {
 }
 
 fn do_test(data: &[u8]) {
-    if let Ok(m) = serde_cbor::from_slice::<Main>(data) {
-        let vec = serde_cbor::to_vec(&m).unwrap();
+    if let Ok(m) = ciborium::from_reader::<Main, _>(data) {
+        let mut vec = Vec::new();
+        ciborium::into_writer(&m, &mut vec).unwrap();
         assert_eq!(data, &vec[..]);
     }
 }


### PR DESCRIPTION
We were using an outdated CBOR crate for MSRV reasons. But in our fuzz tests we have already given up on MSRV compatibility, and the outdated crate was causing us problems. So replace it.

In general, I am suspicious of this decode-then-reencode test. CBOR has some ambiguity in integer encoding. But empirically it has seemed to work for a long time, and updating the crate seems to tighten the decoder enough to get it working again, so we'll keep it for now.

Fixes #2801