### PR TITLE
Enable getting the witness program from an address

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -490,6 +490,16 @@ impl Address {
         }
     }
 
+    /// Gets the witness program for this address if this is a segwit address.
+    pub fn witness_program(&self) -> Option<WitnessProgram> {
+        use AddressInner::*;
+
+        match self.0 {
+            Segwit { ref program, hrp: _ } => Some(*program),
+            _ => None,
+        }
+    }
+
     /// Checks whether or not the address is following Bitcoin standardness rules when
     /// *spending* from this address. *NOT* to be called by senders.
     ///


### PR DESCRIPTION
We have getters for the pubkey hash and script hash but we forgot one for the witness program - add it.

This is a backport of #2796 without the update to api files which don't exist yet on this release branch.