### PR TITLE
Make Address:p2sh_from_hash public

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -384,8 +384,13 @@ impl Address {
         Ok(Address::p2sh_from_hash(hash, network))
     }
 
-    // This is intentionally not public so we enforce script length checks.
-    fn p2sh_from_hash(hash: ScriptHash, network: impl Into<NetworkKind>) -> Address {
+    /// Creates a pay to script hash P2SH address from a script hash.
+    ///
+    /// # Warning
+    ///
+    /// The `hash` pre-image (redeem script) must not exceed 520 bytes in length
+    /// otherwise outputs created from the returned address will be un-spendable.
+    pub fn p2sh_from_hash(hash: ScriptHash, network: impl Into<NetworkKind>) -> Address {
         Self(AddressInner::P2sh { hash, network: network.into() }, PhantomData)
     }
 


### PR DESCRIPTION
We previously made this function Private and added a comment that doing so was somehow better to remove the footgun of hashing the wrong length script. However in hindsight this was a bad idea and users want the functionality.

Make the `Address:p2sh_from_hash` public and document it as we do for `Address::p2sh`.

This is a backport of patch 1 from #2795, patch 2 is an update to api files which don't exist on the `\0.32.x` release branch.