### PR TITLE
Release tracking PR: `v0.32.1`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "base58ck",
  "base64",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "base58ck",
  "base64",

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.32.1 - 2024-05-29
+
+Fix things we broke/removed from the `Address` API in the last release.
+
+- Enable getting the witness program from an address [#2804](https://github.com/rust-bitcoin/rust-bitcoin/pull/2804)
+- Make `Address:p2sh_from_hash` public [#2806](https://github.com/rust-bitcoin/rust-bitcoin/pull/2806)
+- Add an `AddressData` type [#2810](https://github.com/rust-bitcoin/rust-bitcoin/pull/2810)
+
+If you are looking for the `address::Payload` type we removed in `v0.32.0` then the `AddressData` type
+might be what you are after.
+
 # 0.32.0 - 2024-04-23
 
 - Bump MSRV to Rust 1.56.1 [#2188](https://github.com/rust-bitcoin/rust-bitcoin/pull/2188)

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
In preparation for doing a point release add a changelog entry and bump the version.
    
Note that the changelog risks being lost because this patch is going to go in via the `0.32.x` branch and will not exist on master.
 
Close: #2784 
