### PR TITLE
doc: fix "lazy line continuations" in markdown

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -232,7 +232,7 @@ impl WatchOnly {
 
         let sigs: Vec<_> = psbt.inputs[0].partial_sigs.values().collect();
         let mut script_witness: Witness = Witness::new();
-        script_witness.push(&sigs[0].to_vec());
+        script_witness.push(sigs[0].serialize());
         script_witness.push(self.input_xpub.to_pub().to_bytes());
 
         psbt.inputs[0].final_script_witness = Some(script_witness);

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -295,8 +295,8 @@ impl From<Network> for KnownHrp {
 /// ```
 ///
 /// 2. `Debug` on `Address<NetworkUnchecked>` does not produce clean address but address wrapped by
-/// an indicator that its network has not been checked. This is to encourage programmer to properly
-/// check the network and use `Display` in user-facing context.
+///    an indicator that its network has not been checked. This is to encourage programmer to properly
+///    check the network and use `Display` in user-facing context.
 ///
 /// ```
 /// # use std::str::FromStr;

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -798,19 +798,16 @@ impl TapTweak for UntweakedKeypair {
     type TweakedAux = TweakedKeypair;
     type TweakedKey = TweakedKeypair;
 
-    /// Tweaks private and public keys within an untweaked [`Keypair`] with corresponding public key
-    /// value and optional script tree merkle root.
+    /// Applies a Taproot tweak to both keys within the keypair.
     ///
-    /// This is done by tweaking private key within the pair using the equation q = p + H(P|c), where
-    ///  * q is the tweaked private key
-    ///  * p is the internal private key
-    ///  * H is the hash function
-    ///  * c is the commitment data
-    /// The public key is generated from a private key by multiplying with generator point, Q = qG.
+    /// If `merkle_root` is provided, produces a Taproot key that can be spent by any
+    /// of the script paths committed to by the root. If it is not provided, produces
+    /// a Taproot key which can [provably only be spent via
+    /// keyspend](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-23).
     ///
     /// # Returns
     ///
-    /// The tweaked key and its parity.
+    /// The tweaked keypair.
     fn tap_tweak<C: Verification>(
         self,
         secp: &Secp256k1<C>,

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -886,8 +886,8 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
     /// # Warning
     ///
     /// - Does NOT attempt to support OP_CODESEPARATOR. In general this would require evaluating
-    /// `script_pubkey` to determine which separators get evaluated and which don't, which we don't
-    /// have the information to determine.
+    ///   `script_pubkey` to determine which separators get evaluated and which don't, which we don't
+    ///   have the information to determine.
     /// - Does NOT handle the sighash single bug (see "Return type" section)
     ///
     /// # Returns

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -191,6 +191,7 @@ impl Decodable for MerkleBlock {
 ///  - uint256[]  hashes in depth-first order (<= 32*N bytes)
 ///  - varint     number of bytes of flag bits (1-3 bytes)
 ///  - byte[]     flag bits, packed per 8 in a byte, least significant bit first (<= 2*N-1 bits)
+///
 /// The size constraints follow from this.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct PartialMerkleTree {

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -452,8 +452,8 @@ fn finalize_psbt(mut psbt: Psbt) -> Psbt {
         let sigs: Vec<_> = psbt.inputs[1].partial_sigs.values().collect();
         let mut script_witness = Witness::new();
         script_witness.push([]); // Push 0x00 to the stack.
-        script_witness.push(&sigs[1].to_vec());
-        script_witness.push(&sigs[0].to_vec());
+        script_witness.push(sigs[1].serialize());
+        script_witness.push(sigs[0].serialize());
         script_witness.push(psbt.inputs[1].witness_script.clone().unwrap().as_bytes());
 
         script_witness


### PR DESCRIPTION
Rust nightly as of 2024-05-27 has a new lint which detects list items which are continued by a non-indented line. Markdown treats these as single list items, which they sometimes are, but sometimes we intended them to be on a separate line.
    
Also changes the docs for `UntweakedKeypair::tap_tweak` because the existing ones were overly technical and out-of-date.

Also fixes a minor "no need to create a vec then dereference it" lint in the examples.

