### PR TITLE
api: Run just check-api

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -7228,7 +7228,8 @@ pub fn bitcoin::bip152::PrefilledTransaction::eq(&self, other: &bitcoin::bip152:
 pub fn bitcoin::bip152::PrefilledTransaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip152::PrefilledTransaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::bip152::PrefilledTransaction::partial_cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_byte_array(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8; 6]
 pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip152::ShortId::as_mut_ptr(&mut self) -> *mut u8
@@ -7250,6 +7251,7 @@ pub fn bitcoin::bip152::ShortId::eq(&self, other: &bitcoin::bip152::ShortId) -> 
 pub fn bitcoin::bip152::ShortId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip152::ShortId::from(data: &'a [u8; 6]) -> Self
 pub fn bitcoin::bip152::ShortId::from(data: [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from_byte_array(bytes: [u8; 6]) -> Self
 pub fn bitcoin::bip152::ShortId::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip152::ShortId::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip152::ShortId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -7258,7 +7260,7 @@ pub fn bitcoin::bip152::ShortId::is_empty(&self) -> bool
 pub fn bitcoin::bip152::ShortId::len(&self) -> usize
 pub fn bitcoin::bip152::ShortId::partial_cmp(&self, other: &bitcoin::bip152::ShortId) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::bip152::ShortId::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin::bip152::ShortId::to_bytes(self) -> [u8; 6]
+pub fn bitcoin::bip152::ShortId::to_byte_array(self) -> [u8; 6]
 pub fn bitcoin::bip152::ShortId::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip152::ShortId::with_siphash_keys<T: core::convert::AsRef<[u8]>>(txid: &T, siphash_keys: (u64, u64)) -> bitcoin::bip152::ShortId
 pub fn bitcoin::bip152::TxIndexOutOfRangeError::clone(&self) -> bitcoin::bip152::TxIndexOutOfRangeError
@@ -7352,7 +7354,8 @@ pub fn bitcoin::bip158::GcsFilterReader::new(k0: u64, k1: u64, m: u64, p: u8) ->
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::add_element(&mut self, element: &[u8])
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::new(writer: &'a mut W, k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterWriter<'a, W>
-pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_byte_array(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8; 32]
 pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip32::ChainCode::as_mut_ptr(&mut self) -> *mut u8
@@ -7370,6 +7373,7 @@ pub fn bitcoin::bip32::ChainCode::eq(&self, other: &bitcoin::bip32::ChainCode) -
 pub fn bitcoin::bip32::ChainCode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::ChainCode::from(data: &'a [u8; 32]) -> Self
 pub fn bitcoin::bip32::ChainCode::from(data: [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin::bip32::ChainCode::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip32::ChainCode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip32::ChainCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -7378,7 +7382,7 @@ pub fn bitcoin::bip32::ChainCode::is_empty(&self) -> bool
 pub fn bitcoin::bip32::ChainCode::len(&self) -> usize
 pub fn bitcoin::bip32::ChainCode::partial_cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::bip32::ChainCode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin::bip32::ChainCode::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::bip32::ChainCode::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin::bip32::ChainCode::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip32::ChildNumber::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
 pub fn bitcoin::bip32::ChildNumber::clone(&self) -> bitcoin::bip32::ChildNumber
@@ -7432,7 +7436,8 @@ pub fn bitcoin::bip32::Error::from(e: secp256k1::Error) -> bitcoin::bip32::Error
 pub fn bitcoin::bip32::Error::from(err: base58ck::error::Error) -> Self
 pub fn bitcoin::bip32::Error::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin::bip32::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_byte_array(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8; 4]
 pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip32::Fingerprint::as_mut_ptr(&mut self) -> *mut u8
@@ -7451,6 +7456,7 @@ pub fn bitcoin::bip32::Fingerprint::eq(&self, other: &bitcoin::bip32::Fingerprin
 pub fn bitcoin::bip32::Fingerprint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::Fingerprint::from(data: &'a [u8; 4]) -> Self
 pub fn bitcoin::bip32::Fingerprint::from(data: [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from_byte_array(bytes: [u8; 4]) -> Self
 pub fn bitcoin::bip32::Fingerprint::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip32::Fingerprint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip32::Fingerprint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -7459,7 +7465,7 @@ pub fn bitcoin::bip32::Fingerprint::is_empty(&self) -> bool
 pub fn bitcoin::bip32::Fingerprint::len(&self) -> usize
 pub fn bitcoin::bip32::Fingerprint::partial_cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::bip32::Fingerprint::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin::bip32::Fingerprint::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::to_byte_array(self) -> [u8; 4]
 pub fn bitcoin::bip32::Fingerprint::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip32::IntoDerivationPath::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::clone(&self) -> bitcoin::bip32::InvalidBase58PayloadLengthError
@@ -7699,7 +7705,8 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_byte_array(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8; 32]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut_ptr(&mut self) -> *mut u8
@@ -7717,6 +7724,7 @@ pub fn bitcoin::blockdata::constants::ChainHash::eq(&self, other: &bitcoin::bloc
 pub fn bitcoin::blockdata::constants::ChainHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::constants::ChainHash::from(data: &'a [u8; 32]) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from(data: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from_genesis_block_hash(block_hash: bitcoin::blockdata::block::BlockHash) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::blockdata::constants::ChainHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
@@ -7726,7 +7734,7 @@ pub fn bitcoin::blockdata::constants::ChainHash::is_empty(&self) -> bool
 pub fn bitcoin::blockdata::constants::ChainHash::len(&self) -> usize
 pub fn bitcoin::blockdata::constants::ChainHash::partial_cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::constants::ChainHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin::blockdata::constants::ChainHash::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin::blockdata::constants::ChainHash::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::constants::ChainHash::using_genesis_block(params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> Self
 pub fn bitcoin::blockdata::constants::genesis_block(params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> bitcoin::blockdata::block::Block
@@ -8520,6 +8528,7 @@ pub fn bitcoin::blockdata::witness::Witness::second_to_last(&self) -> core::opti
 pub fn bitcoin::blockdata::witness::Witness::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin::blockdata::witness::Witness::size(&self) -> usize
 pub fn bitcoin::blockdata::witness::Witness::tapscript(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::witness::Witness::to_bytes(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
 pub fn bitcoin::blockdata::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
 pub fn bitcoin::consensus::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::consensus::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
@@ -8684,6 +8693,7 @@ pub fn bitcoin::ecdsa::Signature::serialize(&self) -> bitcoin::ecdsa::Serialized
 pub fn bitcoin::ecdsa::Signature::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin::ecdsa::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
 pub fn bitcoin::ecdsa::Signature::sighash_all(signature: secp256k1::ecdsa::Signature) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::ecdsa::Signature::to_vec(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::key::FromSliceError::clone(&self) -> bitcoin::key::FromSliceError
 pub fn bitcoin::key::FromSliceError::eq(&self, other: &bitcoin::key::FromSliceError) -> bool
@@ -9464,6 +9474,7 @@ pub fn bitcoin::taproot::Signature::partial_cmp(&self, other: &bitcoin::taproot:
 pub fn bitcoin::taproot::Signature::serialize(self) -> bitcoin::taproot::serialized_signature::SerializedSignature
 pub fn bitcoin::taproot::Signature::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin::taproot::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::taproot::Signature::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::taproot::Signature::to_vec(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::taproot::Signature::try_from(value: &'a bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::Signature::try_from(value: bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -6894,7 +6894,8 @@ pub fn bitcoin::bip152::PrefilledTransaction::eq(&self, other: &bitcoin::bip152:
 pub fn bitcoin::bip152::PrefilledTransaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip152::PrefilledTransaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::bip152::PrefilledTransaction::partial_cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_byte_array(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8; 6]
 pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip152::ShortId::as_mut_ptr(&mut self) -> *mut u8
@@ -6915,6 +6916,7 @@ pub fn bitcoin::bip152::ShortId::eq(&self, other: &bitcoin::bip152::ShortId) -> 
 pub fn bitcoin::bip152::ShortId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip152::ShortId::from(data: &'a [u8; 6]) -> Self
 pub fn bitcoin::bip152::ShortId::from(data: [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from_byte_array(bytes: [u8; 6]) -> Self
 pub fn bitcoin::bip152::ShortId::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip152::ShortId::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip152::ShortId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6922,7 +6924,7 @@ pub fn bitcoin::bip152::ShortId::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip152::ShortId::is_empty(&self) -> bool
 pub fn bitcoin::bip152::ShortId::len(&self) -> usize
 pub fn bitcoin::bip152::ShortId::partial_cmp(&self, other: &bitcoin::bip152::ShortId) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip152::ShortId::to_bytes(self) -> [u8; 6]
+pub fn bitcoin::bip152::ShortId::to_byte_array(self) -> [u8; 6]
 pub fn bitcoin::bip152::ShortId::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip152::ShortId::with_siphash_keys<T: core::convert::AsRef<[u8]>>(txid: &T, siphash_keys: (u64, u64)) -> bitcoin::bip152::ShortId
 pub fn bitcoin::bip152::TxIndexOutOfRangeError::clone(&self) -> bitcoin::bip152::TxIndexOutOfRangeError
@@ -7010,7 +7012,8 @@ pub fn bitcoin::bip158::GcsFilterReader::new(k0: u64, k1: u64, m: u64, p: u8) ->
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::add_element(&mut self, element: &[u8])
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::new(writer: &'a mut W, k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterWriter<'a, W>
-pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_byte_array(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8; 32]
 pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip32::ChainCode::as_mut_ptr(&mut self) -> *mut u8
@@ -7027,6 +7030,7 @@ pub fn bitcoin::bip32::ChainCode::eq(&self, other: &bitcoin::bip32::ChainCode) -
 pub fn bitcoin::bip32::ChainCode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::ChainCode::from(data: &'a [u8; 32]) -> Self
 pub fn bitcoin::bip32::ChainCode::from(data: [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin::bip32::ChainCode::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip32::ChainCode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip32::ChainCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -7034,7 +7038,7 @@ pub fn bitcoin::bip32::ChainCode::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip32::ChainCode::is_empty(&self) -> bool
 pub fn bitcoin::bip32::ChainCode::len(&self) -> usize
 pub fn bitcoin::bip32::ChainCode::partial_cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip32::ChainCode::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::bip32::ChainCode::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin::bip32::ChainCode::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip32::ChildNumber::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
 pub fn bitcoin::bip32::ChildNumber::clone(&self) -> bitcoin::bip32::ChildNumber
@@ -7084,7 +7088,8 @@ pub fn bitcoin::bip32::Error::from(e: secp256k1::Error) -> bitcoin::bip32::Error
 pub fn bitcoin::bip32::Error::from(err: base58ck::error::Error) -> Self
 pub fn bitcoin::bip32::Error::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin::bip32::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_byte_array(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8; 4]
 pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip32::Fingerprint::as_mut_ptr(&mut self) -> *mut u8
@@ -7102,6 +7107,7 @@ pub fn bitcoin::bip32::Fingerprint::eq(&self, other: &bitcoin::bip32::Fingerprin
 pub fn bitcoin::bip32::Fingerprint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::Fingerprint::from(data: &'a [u8; 4]) -> Self
 pub fn bitcoin::bip32::Fingerprint::from(data: [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from_byte_array(bytes: [u8; 4]) -> Self
 pub fn bitcoin::bip32::Fingerprint::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip32::Fingerprint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip32::Fingerprint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -7109,7 +7115,7 @@ pub fn bitcoin::bip32::Fingerprint::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip32::Fingerprint::is_empty(&self) -> bool
 pub fn bitcoin::bip32::Fingerprint::len(&self) -> usize
 pub fn bitcoin::bip32::Fingerprint::partial_cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip32::Fingerprint::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::to_byte_array(self) -> [u8; 4]
 pub fn bitcoin::bip32::Fingerprint::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip32::IntoDerivationPath::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::clone(&self) -> bitcoin::bip32::InvalidBase58PayloadLengthError
@@ -7324,7 +7330,8 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_byte_array(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8; 32]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut_ptr(&mut self) -> *mut u8
@@ -7341,6 +7348,7 @@ pub fn bitcoin::blockdata::constants::ChainHash::eq(&self, other: &bitcoin::bloc
 pub fn bitcoin::blockdata::constants::ChainHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::constants::ChainHash::from(data: &'a [u8; 32]) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from(data: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from_genesis_block_hash(block_hash: bitcoin::blockdata::block::BlockHash) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::blockdata::constants::ChainHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
@@ -7349,7 +7357,7 @@ pub fn bitcoin::blockdata::constants::ChainHash::index(&self, index: I) -> &Self
 pub fn bitcoin::blockdata::constants::ChainHash::is_empty(&self) -> bool
 pub fn bitcoin::blockdata::constants::ChainHash::len(&self) -> usize
 pub fn bitcoin::blockdata::constants::ChainHash::partial_cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::blockdata::constants::ChainHash::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin::blockdata::constants::ChainHash::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::constants::ChainHash::using_genesis_block(params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> Self
 pub fn bitcoin::blockdata::constants::genesis_block(params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> bitcoin::blockdata::block::Block
@@ -8103,6 +8111,7 @@ pub fn bitcoin::blockdata::witness::Witness::push_ecdsa_signature(&mut self, sig
 pub fn bitcoin::blockdata::witness::Witness::second_to_last(&self) -> core::option::Option<&[u8]>
 pub fn bitcoin::blockdata::witness::Witness::size(&self) -> usize
 pub fn bitcoin::blockdata::witness::Witness::tapscript(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::witness::Witness::to_bytes(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
 pub fn bitcoin::blockdata::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
 pub fn bitcoin::consensus::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::consensus::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
@@ -8226,6 +8235,7 @@ pub fn bitcoin::ecdsa::Signature::hash<__H: core::hash::Hasher>(&self, state: &m
 pub fn bitcoin::ecdsa::Signature::serialize(&self) -> bitcoin::ecdsa::SerializedSignature
 pub fn bitcoin::ecdsa::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
 pub fn bitcoin::ecdsa::Signature::sighash_all(signature: secp256k1::ecdsa::Signature) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::ecdsa::Signature::to_vec(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::key::FromSliceError::clone(&self) -> bitcoin::key::FromSliceError
 pub fn bitcoin::key::FromSliceError::eq(&self, other: &bitcoin::key::FromSliceError) -> bool
@@ -8963,6 +8973,7 @@ pub fn bitcoin::taproot::Signature::hash<__H: core::hash::Hasher>(&self, state: 
 pub fn bitcoin::taproot::Signature::partial_cmp(&self, other: &bitcoin::taproot::Signature) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::Signature::serialize(self) -> bitcoin::taproot::serialized_signature::SerializedSignature
 pub fn bitcoin::taproot::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::taproot::Signature::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::taproot::Signature::to_vec(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::taproot::Signature::try_from(value: &'a bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::Signature::try_from(value: bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -6259,7 +6259,8 @@ pub fn bitcoin::bip152::PrefilledTransaction::eq(&self, other: &bitcoin::bip152:
 pub fn bitcoin::bip152::PrefilledTransaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip152::PrefilledTransaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::bip152::PrefilledTransaction::partial_cmp(&self, other: &bitcoin::bip152::PrefilledTransaction) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_byte_array(&self) -> &[u8; 6]
+pub fn bitcoin::bip152::ShortId::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8; 6]
 pub fn bitcoin::bip152::ShortId::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip152::ShortId::as_mut_ptr(&mut self) -> *mut u8
@@ -6280,6 +6281,7 @@ pub fn bitcoin::bip152::ShortId::eq(&self, other: &bitcoin::bip152::ShortId) -> 
 pub fn bitcoin::bip152::ShortId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip152::ShortId::from(data: &'a [u8; 6]) -> Self
 pub fn bitcoin::bip152::ShortId::from(data: [u8; 6]) -> Self
+pub fn bitcoin::bip152::ShortId::from_byte_array(bytes: [u8; 6]) -> Self
 pub fn bitcoin::bip152::ShortId::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip152::ShortId::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip152::ShortId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6287,7 +6289,7 @@ pub fn bitcoin::bip152::ShortId::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip152::ShortId::is_empty(&self) -> bool
 pub fn bitcoin::bip152::ShortId::len(&self) -> usize
 pub fn bitcoin::bip152::ShortId::partial_cmp(&self, other: &bitcoin::bip152::ShortId) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip152::ShortId::to_bytes(self) -> [u8; 6]
+pub fn bitcoin::bip152::ShortId::to_byte_array(self) -> [u8; 6]
 pub fn bitcoin::bip152::ShortId::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip152::ShortId::with_siphash_keys<T: core::convert::AsRef<[u8]>>(txid: &T, siphash_keys: (u64, u64)) -> bitcoin::bip152::ShortId
 pub fn bitcoin::bip152::TxIndexOutOfRangeError::clone(&self) -> bitcoin::bip152::TxIndexOutOfRangeError
@@ -6373,7 +6375,8 @@ pub fn bitcoin::bip158::GcsFilterReader::new(k0: u64, k1: u64, m: u64, p: u8) ->
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::add_element(&mut self, element: &[u8])
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::finish(&mut self) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::new(writer: &'a mut W, k0: u64, k1: u64, m: u64, p: u8) -> bitcoin::bip158::GcsFilterWriter<'a, W>
-pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_byte_array(&self) -> &[u8; 32]
+pub fn bitcoin::bip32::ChainCode::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8; 32]
 pub fn bitcoin::bip32::ChainCode::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip32::ChainCode::as_mut_ptr(&mut self) -> *mut u8
@@ -6390,6 +6393,7 @@ pub fn bitcoin::bip32::ChainCode::eq(&self, other: &bitcoin::bip32::ChainCode) -
 pub fn bitcoin::bip32::ChainCode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::ChainCode::from(data: &'a [u8; 32]) -> Self
 pub fn bitcoin::bip32::ChainCode::from(data: [u8; 32]) -> Self
+pub fn bitcoin::bip32::ChainCode::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin::bip32::ChainCode::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip32::ChainCode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip32::ChainCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6397,7 +6401,7 @@ pub fn bitcoin::bip32::ChainCode::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip32::ChainCode::is_empty(&self) -> bool
 pub fn bitcoin::bip32::ChainCode::len(&self) -> usize
 pub fn bitcoin::bip32::ChainCode::partial_cmp(&self, other: &bitcoin::bip32::ChainCode) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip32::ChainCode::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::bip32::ChainCode::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin::bip32::ChainCode::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip32::ChildNumber::as_ref(&self) -> &[bitcoin::bip32::ChildNumber]
 pub fn bitcoin::bip32::ChildNumber::clone(&self) -> bitcoin::bip32::ChildNumber
@@ -6446,7 +6450,8 @@ pub fn bitcoin::bip32::Error::from(e: bitcoin::bip32::InvalidBase58PayloadLength
 pub fn bitcoin::bip32::Error::from(e: secp256k1::Error) -> bitcoin::bip32::Error
 pub fn bitcoin::bip32::Error::from(err: base58ck::error::Error) -> Self
 pub fn bitcoin::bip32::Error::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_byte_array(&self) -> &[u8; 4]
+pub fn bitcoin::bip32::Fingerprint::as_bytes(&self) -> &[u8]
 pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8; 4]
 pub fn bitcoin::bip32::Fingerprint::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::bip32::Fingerprint::as_mut_ptr(&mut self) -> *mut u8
@@ -6464,6 +6469,7 @@ pub fn bitcoin::bip32::Fingerprint::eq(&self, other: &bitcoin::bip32::Fingerprin
 pub fn bitcoin::bip32::Fingerprint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::Fingerprint::from(data: &'a [u8; 4]) -> Self
 pub fn bitcoin::bip32::Fingerprint::from(data: [u8; 4]) -> Self
+pub fn bitcoin::bip32::Fingerprint::from_byte_array(bytes: [u8; 4]) -> Self
 pub fn bitcoin::bip32::Fingerprint::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::bip32::Fingerprint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::bip32::Fingerprint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6471,7 +6477,7 @@ pub fn bitcoin::bip32::Fingerprint::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip32::Fingerprint::is_empty(&self) -> bool
 pub fn bitcoin::bip32::Fingerprint::len(&self) -> usize
 pub fn bitcoin::bip32::Fingerprint::partial_cmp(&self, other: &bitcoin::bip32::Fingerprint) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::bip32::Fingerprint::to_bytes(self) -> [u8; 4]
+pub fn bitcoin::bip32::Fingerprint::to_byte_array(self) -> [u8; 4]
 pub fn bitcoin::bip32::Fingerprint::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::bip32::IntoDerivationPath::into_derivation_path(self) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::clone(&self) -> bitcoin::bip32::InvalidBase58PayloadLengthError
@@ -6684,7 +6690,8 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
-pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_byte_array(&self) -> &[u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::as_bytes(&self) -> &[u8]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8; 32]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin::blockdata::constants::ChainHash::as_mut_ptr(&mut self) -> *mut u8
@@ -6701,6 +6708,7 @@ pub fn bitcoin::blockdata::constants::ChainHash::eq(&self, other: &bitcoin::bloc
 pub fn bitcoin::blockdata::constants::ChainHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::constants::ChainHash::from(data: &'a [u8; 32]) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from(data: [u8; 32]) -> Self
+pub fn bitcoin::blockdata::constants::ChainHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from_genesis_block_hash(block_hash: bitcoin::blockdata::block::BlockHash) -> Self
 pub fn bitcoin::blockdata::constants::ChainHash::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::HexToArrayError>
 pub fn bitcoin::blockdata::constants::ChainHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
@@ -6709,7 +6717,7 @@ pub fn bitcoin::blockdata::constants::ChainHash::index(&self, index: I) -> &Self
 pub fn bitcoin::blockdata::constants::ChainHash::is_empty(&self) -> bool
 pub fn bitcoin::blockdata::constants::ChainHash::len(&self) -> usize
 pub fn bitcoin::blockdata::constants::ChainHash::partial_cmp(&self, other: &bitcoin::blockdata::constants::ChainHash) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::blockdata::constants::ChainHash::to_bytes(self) -> [u8; 32]
+pub fn bitcoin::blockdata::constants::ChainHash::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin::blockdata::constants::ChainHash::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::constants::ChainHash::using_genesis_block(params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> Self
 pub fn bitcoin::blockdata::constants::genesis_block(params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> bitcoin::blockdata::block::Block
@@ -7448,6 +7456,7 @@ pub fn bitcoin::blockdata::witness::Witness::push_ecdsa_signature(&mut self, sig
 pub fn bitcoin::blockdata::witness::Witness::second_to_last(&self) -> core::option::Option<&[u8]>
 pub fn bitcoin::blockdata::witness::Witness::size(&self) -> usize
 pub fn bitcoin::blockdata::witness::Witness::tapscript(&self) -> core::option::Option<&bitcoin::blockdata::script::Script>
+pub fn bitcoin::blockdata::witness::Witness::to_bytes(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
 pub fn bitcoin::blockdata::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
 pub fn bitcoin::consensus::Decodable::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::consensus::Decodable::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(reader: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
@@ -7567,6 +7576,7 @@ pub fn bitcoin::ecdsa::Signature::hash<__H: core::hash::Hasher>(&self, state: &m
 pub fn bitcoin::ecdsa::Signature::serialize(&self) -> bitcoin::ecdsa::SerializedSignature
 pub fn bitcoin::ecdsa::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
 pub fn bitcoin::ecdsa::Signature::sighash_all(signature: secp256k1::ecdsa::Signature) -> bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::ecdsa::Signature::to_vec(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::key::FromSliceError::clone(&self) -> bitcoin::key::FromSliceError
 pub fn bitcoin::key::FromSliceError::eq(&self, other: &bitcoin::key::FromSliceError) -> bool
@@ -8075,6 +8085,7 @@ pub fn bitcoin::taproot::Signature::hash<__H: core::hash::Hasher>(&self, state: 
 pub fn bitcoin::taproot::Signature::partial_cmp(&self, other: &bitcoin::taproot::Signature) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::Signature::serialize(self) -> bitcoin::taproot::serialized_signature::SerializedSignature
 pub fn bitcoin::taproot::Signature::serialize_to_writer<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
+pub fn bitcoin::taproot::Signature::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::taproot::Signature::to_vec(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::taproot::Signature::try_from(value: &'a bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::Signature::try_from(value: bitcoin::taproot::serialized_signature::SerializedSignature) -> core::result::Result<Self, Self::Error>

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1,4 +1,3 @@
-#[non_exhaustive] pub enum bitcoin_units::ParseAmountError
 #[non_exhaustive] pub enum bitcoin_units::amount::Denomination
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseAmountError
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
@@ -557,11 +556,6 @@ impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::Tim
 impl<'de> serde::de::Deserialize<'de> for bitcoin_units::weight::Weight
 impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::Amount>
 impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::SignedAmount>
-pub bitcoin_units::ParseAmountError::InputTooLarge(bitcoin_units::amount::InputTooLargeError)
-pub bitcoin_units::ParseAmountError::InvalidCharacter(bitcoin_units::amount::InvalidCharacterError)
-pub bitcoin_units::ParseAmountError::MissingDigits(bitcoin_units::amount::MissingDigitsError)
-pub bitcoin_units::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
-pub bitcoin_units::ParseAmountError::TooPrecise(bitcoin_units::amount::TooPreciseError)
 pub bitcoin_units::amount::Denomination::Bit
 pub bitcoin_units::amount::Denomination::Bitcoin
 pub bitcoin_units::amount::Denomination::CentiBitcoin

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1,4 +1,3 @@
-#[non_exhaustive] pub enum bitcoin_units::ParseAmountError
 #[non_exhaustive] pub enum bitcoin_units::amount::Denomination
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseAmountError
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
@@ -520,11 +519,6 @@ impl core::str::traits::FromStr for bitcoin_units::weight::Weight
 impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::weight::Weight> for bitcoin_units::weight::Weight
 impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::Amount>
 impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::SignedAmount>
-pub bitcoin_units::ParseAmountError::InputTooLarge(bitcoin_units::amount::InputTooLargeError)
-pub bitcoin_units::ParseAmountError::InvalidCharacter(bitcoin_units::amount::InvalidCharacterError)
-pub bitcoin_units::ParseAmountError::MissingDigits(bitcoin_units::amount::MissingDigitsError)
-pub bitcoin_units::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
-pub bitcoin_units::ParseAmountError::TooPrecise(bitcoin_units::amount::TooPreciseError)
 pub bitcoin_units::amount::Denomination::Bit
 pub bitcoin_units::amount::Denomination::Bitcoin
 pub bitcoin_units::amount::Denomination::CentiBitcoin

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1,4 +1,3 @@
-#[non_exhaustive] pub enum bitcoin_units::ParseAmountError
 #[non_exhaustive] pub enum bitcoin_units::amount::Denomination
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseAmountError
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
@@ -245,11 +244,6 @@ impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
 impl core::str::traits::FromStr for bitcoin_units::amount::SignedAmount
 impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::Amount>
 impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::SignedAmount>
-pub bitcoin_units::ParseAmountError::InputTooLarge(bitcoin_units::amount::InputTooLargeError)
-pub bitcoin_units::ParseAmountError::InvalidCharacter(bitcoin_units::amount::InvalidCharacterError)
-pub bitcoin_units::ParseAmountError::MissingDigits(bitcoin_units::amount::MissingDigitsError)
-pub bitcoin_units::ParseAmountError::OutOfRange(bitcoin_units::amount::OutOfRangeError)
-pub bitcoin_units::ParseAmountError::TooPrecise(bitcoin_units::amount::TooPreciseError)
 pub bitcoin_units::amount::Denomination::Bit
 pub bitcoin_units::amount::Denomination::Bitcoin
 pub bitcoin_units::amount::Denomination::CentiBitcoin


### PR DESCRIPTION
During a bunch of merges the `api/` files have gotten out of sync.

Run `just check-api`, no other changes.