### PR TITLE
CI: Remove shebang from non-executable scripts

### DIFF
--- a/base58/contrib/test_vars.sh
+++ b/base58/contrib/test_vars.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 

--- a/bitcoin/contrib/test_vars.sh
+++ b/bitcoin/contrib/test_vars.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 

--- a/contrib/crates.sh
+++ b/contrib/crates.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 

--- a/contrib/test_vars.sh
+++ b/contrib/test_vars.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
 #
 # Used by labeler.yaml
 #

--- a/hashes/contrib/test_vars.sh
+++ b/hashes/contrib/test_vars.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 

--- a/internals/contrib/test_vars.sh
+++ b/internals/contrib/test_vars.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 

--- a/io/contrib/test_vars.sh
+++ b/io/contrib/test_vars.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 

--- a/units/contrib/test_vars.sh
+++ b/units/contrib/test_vars.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 


### PR DESCRIPTION
Some of our CI shell scripts are meant only to be sourced and not run directly however they include an initial shebang line, implying that they should be run.

Remove the shebang line from `crates.sh` and the various `test_vars.sh` scripts. Add a `shellcheck` directive to inhibit the no-shebang warning.

Please note, the issue mentions the following in the discussion thread and it is _not_ implemented here. 

> It would be good also to find a way to detect whether the script is being run directly, and to print an error message. I'm sure this is a common thing and we can find a stackexchange post telling us how to do it.

I don't see an immediate way to do this because CI is run using `run_task.sh` which is not in this repo. And since one can still run a script without the shebang (by doing eg, `bash script.sh`) the lack of shebang is only an indicator of how we are using the script. 

Fix: #2764