### PR TITLE
pow: Fix off-by-one error

### DIFF
--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1589,6 +1589,14 @@ mod tests {
         assert_eq!(got, val);
     }
 
+    #[test]
+    fn u256_from_hex_32_characters_long() {
+        let hex = "a69b455cd41bb662a69b4555deadbeef";
+        let want = U256(0x00, 0xA69B_455C_D41B_B662_A69B_4555_DEAD_BEEF);
+        let got = U256::from_unprefixed_hex(hex).expect("failed to parse hex");
+        assert_eq!(got, want);
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn u256_serde() {

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -434,7 +434,7 @@ impl U256 {
 
     // Caller to ensure `s` does not contain a prefix.
     fn from_hex_internal(s: &str) -> Result<Self, ParseIntError> {
-        let (high, low) = if s.len() < 32 {
+        let (high, low) = if s.len() <= 32 {
             let low = parse::hex_u128(s)?;
             (0, low)
         } else {


### PR DESCRIPTION
This is a backport of the 2 patches in #2834, grammar mistakes in the commit log and all.

Note, one difference, we call `hex_u128` instead of `hex_u128_unchecked` because the unchecked version does not exist in `v0.32`.