### PR TITLE
Add API for extracting the inner payload of `RawNetworkMessage`

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -8931,6 +8931,7 @@ pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_decode_from_finite_re
 pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::p2p::message::RawNetworkMessage::eq(&self, other: &bitcoin::p2p::message::RawNetworkMessage) -> bool
 pub fn bitcoin::p2p::message::RawNetworkMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::RawNetworkMessage::into_payload(self) -> bitcoin::p2p::message::NetworkMessage
 pub fn bitcoin::p2p::message::RawNetworkMessage::magic(&self) -> &bitcoin::p2p::Magic
 pub fn bitcoin::p2p::message::RawNetworkMessage::new(magic: bitcoin::p2p::Magic, payload: bitcoin::p2p::message::NetworkMessage) -> Self
 pub fn bitcoin::p2p::message::RawNetworkMessage::payload(&self) -> &bitcoin::p2p::message::NetworkMessage

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -8465,6 +8465,7 @@ pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_decode_from_finite_re
 pub fn bitcoin::p2p::message::RawNetworkMessage::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::p2p::message::RawNetworkMessage::eq(&self, other: &bitcoin::p2p::message::RawNetworkMessage) -> bool
 pub fn bitcoin::p2p::message::RawNetworkMessage::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin::p2p::message::RawNetworkMessage::into_payload(self) -> bitcoin::p2p::message::NetworkMessage
 pub fn bitcoin::p2p::message::RawNetworkMessage::magic(&self) -> &bitcoin::p2p::Magic
 pub fn bitcoin::p2p::message::RawNetworkMessage::new(magic: bitcoin::p2p::Magic, payload: bitcoin::p2p::message::NetworkMessage) -> Self
 pub fn bitcoin::p2p::message::RawNetworkMessage::payload(&self) -> &bitcoin::p2p::message::NetworkMessage

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -310,6 +310,11 @@ impl RawNetworkMessage {
         Self { magic, payload, payload_len, checksum }
     }
 
+    /// Consumes the [RawNetworkMessage] instance and returns the inner payload.
+    pub fn into_payload(self) -> NetworkMessage {
+        self.payload
+    }
+
     /// The actual message data
     pub fn payload(&self) -> &NetworkMessage { &self.payload }
 


### PR DESCRIPTION
I'd like to take out the `payload` of `RawNetworkMessage` and then send it to the actual network message processor, but find there is no way to do it. This commit adds such an API to expose all the inner parts (UPD: so that I don't have to do an unnecessary clone to obtain the owned value of `payload`).