### PR TITLE
fix ServiceFlags::remove

### DIFF
--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -110,7 +110,7 @@ impl ServiceFlags {
     ///
     /// Returns itself.
     pub fn remove(&mut self, other: ServiceFlags) -> ServiceFlags {
-        self.0 ^= other.0;
+        self.0 &= !other.0;
         *self
     }
 


### PR DESCRIPTION
Contrary to the documentation and the method name, this function does an XOR operation, if there are no flags in `self`, flags from `other` are added.

What should happen to the core::ops::BitXor{,Assign} implementations? I did not touch them because it would break current API usage and would require a minor version bump (on 0.x.y versions).