### PR TITLE
Implement GetKey for Vec<Xpriv>

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -817,6 +817,7 @@ impl GetKey for $set<Xpriv> {
         }
     }
 }}}
+impl_get_key_for_set!(Vec);
 impl_get_key_for_set!(BTreeSet);
 #[cfg(feature = "std")]
 impl_get_key_for_set!(HashSet);


### PR DESCRIPTION
It appears that the `BTreeSet<Xpriv>`/`HashSet<Xpriv>` sets currently implementing `GetKey` cannot actually be constructed, because `Xpriv` does not implement `Ord` nor `Hash`. (And that the rust-bitcoin code referencing these sets should not even compile? yet evidently it does :eyes: )

This PR adds support for `Vec<Xpriv>` to enable signing with multiple `Xpriv`s, but does not address the issue with the existing sets.

The added test case demonstrates the issue:

```rust
error[E0277]: the trait bound `bip32::Xpriv: std::hash::Hash` is not satisfied
    --> bitcoin/src/psbt/mod.rs:2301:24
     |
2301 |         HashSet::new().insert(xpriv.clone());
     |                        ^^^^^^ the trait `std::hash::Hash` is not implemented for `bip32::Xpriv`
     |
note: required by a bound in `std::collections::HashSet::<T, S>::insert`
    --> /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/collections/hash/set.rs:888:5

error[E0277]: the trait bound `bip32::Xpriv: Ord` is not satisfied
    --> bitcoin/src/psbt/mod.rs:2302:25
     |
2302 |         BTreeSet::new().insert(xpriv.clone());
     |                         ^^^^^^ the trait `Ord` is not implemented for `bip32::Xpriv`
     |
note: required by a bound in `std::collections::BTreeSet::<T, A>::insert`
    --> /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/collections/btree/set.rs:899:5

```