### PR TITLE
Add inherent functions to hashes

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -6876,6 +6876,7 @@ pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &m
 pub fn bitcoin::EcdsaSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
 pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
@@ -6884,20 +6885,25 @@ pub fn bitcoin::LegacySighash::borrow(&self) -> &[u8]
 pub fn bitcoin::LegacySighash::clone(&self) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::cmp(&self, other: &bitcoin::LegacySighash) -> core::cmp::Ordering
 pub fn bitcoin::LegacySighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::LegacySighash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::LegacySighash::engine() -> Self::Engine
+pub fn bitcoin::LegacySighash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
 pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::LegacySighash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::LegacySighash::from_str(s: &str) -> core::result::Result<bitcoin::LegacySighash, Self::Err>
+pub fn bitcoin::LegacySighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::LegacySighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::LegacySighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::LegacySighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::LegacySighash::partial_cmp(&self, other: &bitcoin::LegacySighash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::LegacySighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::LegacySighash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::LegacySighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::LegacySighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::MerkleBlock::clone(&self) -> bitcoin::MerkleBlock
@@ -6925,6 +6931,7 @@ pub fn bitcoin::PrivateKey::serialize<S: serde::ser::Serializer>(&self, s: S) ->
 pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
 pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -6934,7 +6941,7 @@ pub fn bitcoin::PubkeyHash::borrow(&self) -> &[u8]
 pub fn bitcoin::PubkeyHash::clone(&self) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::cmp(&self, other: &bitcoin::PubkeyHash) -> core::cmp::Ordering
 pub fn bitcoin::PubkeyHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PubkeyHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::PubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::PubkeyHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::PubkeyHash::eq(&self, other: &bitcoin::PubkeyHash) -> bool
 pub fn bitcoin::PubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::PubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
@@ -6942,16 +6949,21 @@ pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::PubkeyHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::PubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::PubkeyHash, Self::Err>
+pub fn bitcoin::PubkeyHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::PubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PubkeyHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::PubkeyHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::PubkeyHash::partial_cmp(&self, other: &bitcoin::PubkeyHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::PubkeyHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::PubkeyHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::PubkeyHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::PubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PublicKey::clone(&self) -> bitcoin::PublicKey
@@ -6978,6 +6990,7 @@ pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, se
 pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPublicKeyError>
 pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
 pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
@@ -6986,23 +6999,29 @@ pub fn bitcoin::SegwitV0Sighash::borrow(&self) -> &[u8]
 pub fn bitcoin::SegwitV0Sighash::clone(&self) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::cmp::Ordering
 pub fn bitcoin::SegwitV0Sighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::SegwitV0Sighash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
+pub fn bitcoin::SegwitV0Sighash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
 pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::SegwitV0Sighash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::SegwitV0Sighash::from_str(s: &str) -> core::result::Result<bitcoin::SegwitV0Sighash, Self::Err>
+pub fn bitcoin::SegwitV0Sighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::SegwitV0Sighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::SegwitV0Sighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::SegwitV0Sighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub fn bitcoin::TapSighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
@@ -7011,20 +7030,25 @@ pub fn bitcoin::TapSighash::borrow(&self) -> &[u8]
 pub fn bitcoin::TapSighash::clone(&self) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::cmp(&self, other: &bitcoin::TapSighash) -> core::cmp::Ordering
 pub fn bitcoin::TapSighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::TapSighash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::TapSighash::engine() -> Self::Engine
+pub fn bitcoin::TapSighash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
 pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::TapSighash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::TapSighash::from_str(s: &str) -> core::result::Result<bitcoin::TapSighash, Self::Err>
+pub fn bitcoin::TapSighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::TapSighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::TapSighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::TapSighash::partial_cmp(&self, other: &bitcoin::TapSighash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::TapSighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::TapSighash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::TapSighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::TapSighash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighashTag::clone(&self) -> bitcoin::TapSighashTag
@@ -7046,6 +7070,7 @@ pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut
 pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::TapSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -7055,22 +7080,27 @@ pub fn bitcoin::WPubkeyHash::borrow(&self) -> &[u8]
 pub fn bitcoin::WPubkeyHash::clone(&self) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::cmp(&self, other: &bitcoin::WPubkeyHash) -> core::cmp::Ordering
 pub fn bitcoin::WPubkeyHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::WPubkeyHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::WPubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::WPubkeyHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::WPubkeyHash::eq(&self, other: &bitcoin::WPubkeyHash) -> bool
 pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::WPubkeyHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::WPubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::WPubkeyHash, Self::Err>
+pub fn bitcoin::WPubkeyHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::WPubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::WPubkeyHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::WPubkeyHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::WPubkeyHash::partial_cmp(&self, other: &bitcoin::WPubkeyHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::WPubkeyHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::WPubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bitcoin::address::AddressType>
@@ -7299,6 +7329,7 @@ pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
 pub fn bitcoin::bip158::Error::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin::bip158::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
@@ -7309,24 +7340,30 @@ pub fn bitcoin::bip158::FilterHash::cmp(&self, other: &bitcoin::bip158::FilterHa
 pub fn bitcoin::bip158::FilterHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::FilterHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::bip158::FilterHash::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
 pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip158::FilterHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip158::FilterHash::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHash, Self::Err>
+pub fn bitcoin::bip158::FilterHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip158::FilterHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::bip158::FilterHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
@@ -7337,20 +7374,25 @@ pub fn bitcoin::bip158::FilterHeader::cmp(&self, other: &bitcoin::bip158::Filter
 pub fn bitcoin::bip158::FilterHeader::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::bip158::FilterHeader::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::FilterHeader::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHeader, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHeader::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
 pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip158::FilterHeader::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip158::FilterHeader::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHeader, Self::Err>
+pub fn bitcoin::bip158::FilterHeader::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip158::FilterHeader::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHeader::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip158::FilterHeader::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip158::FilterHeader::partial_cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::bip158::FilterHeader::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::GcsFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
@@ -7478,6 +7520,7 @@ pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::eq(&self, other: &bitcoi
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::invalid_base58_payload_length(&self) -> usize
 pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
@@ -7486,22 +7529,27 @@ pub fn bitcoin::bip32::XKeyIdentifier::borrow(&self) -> &[u8]
 pub fn bitcoin::bip32::XKeyIdentifier::clone(&self) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::cmp::Ordering
 pub fn bitcoin::bip32::XKeyIdentifier::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::bip32::XKeyIdentifier::engine() -> Self::Engine
+pub fn bitcoin::bip32::XKeyIdentifier::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip32::XKeyIdentifier::eq(&self, other: &bitcoin::bip32::XKeyIdentifier) -> bool
 pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip32::XKeyIdentifier::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip32::XKeyIdentifier::from_str(s: &str) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, Self::Err>
+pub fn bitcoin::bip32::XKeyIdentifier::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::XKeyIdentifier::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip32::XKeyIdentifier::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip32::XKeyIdentifier::partial_cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::bip32::XKeyIdentifier::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::Xpriv::clone(&self) -> bitcoin::bip32::Xpriv
@@ -7564,6 +7612,7 @@ pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
 pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
 pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
@@ -7574,7 +7623,7 @@ pub fn bitcoin::blockdata::block::BlockHash::cmp(&self, other: &bitcoin::blockda
 pub fn bitcoin::blockdata::block::BlockHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::BlockHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::blockdata::block::BlockHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::BlockHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::blockdata::block::BlockHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::BlockHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::BlockHash::eq(&self, other: &bitcoin::blockdata::block::BlockHash) -> bool
 pub fn bitcoin::blockdata::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::BlockHash::from(block: &bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
@@ -7582,16 +7631,21 @@ pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::blo
 pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::BlockHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::BlockHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::BlockHash, Self::Err>
+pub fn bitcoin::blockdata::block::BlockHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::BlockHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::BlockHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::BlockHash::partial_cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::BlockHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::Header::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
@@ -7612,6 +7666,7 @@ pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
 pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
 pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
 pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -7622,21 +7677,26 @@ pub fn bitcoin::blockdata::block::TxMerkleNode::cmp(&self, other: &bitcoin::bloc
 pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::blockdata::block::TxMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> bool
 pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::TxMerkleNode::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::TxMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::TxMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::ValidationError::clone(&self) -> bitcoin::blockdata::block::ValidationError
@@ -7658,6 +7718,7 @@ pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::b
 pub fn bitcoin::blockdata::block::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
 pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
@@ -7666,23 +7727,29 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::block::WitnessCommitment::clone(&self) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::block::WitnessCommitment::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
 pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::WitnessCommitment::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -7693,21 +7760,26 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::cmp(&self, other: &bitcoin:
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> bool
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::constants::ChainHash::as_byte_array(&self) -> &[u8; 32]
@@ -8191,6 +8263,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
 pub fn bitcoin::blockdata::script::ScriptBuf::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
@@ -8200,26 +8273,32 @@ pub fn bitcoin::blockdata::script::ScriptHash::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::script::ScriptHash::clone(&self) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::script::ScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::blockdata::script::ScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::ScriptHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::script::ScriptHash::eq(&self, other: &bitcoin::blockdata::script::ScriptHash) -> bool
 pub fn bitcoin::blockdata::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::script::ScriptHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::script::ScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::ScriptHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::script::ScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
@@ -8229,23 +8308,28 @@ pub fn bitcoin::blockdata::script::WScriptHash::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::script::WScriptHash::clone(&self) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::script::WScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::blockdata::script::WScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::WScriptHash::engine() -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::script::WScriptHash::eq(&self, other: &bitcoin::blockdata::script::WScriptHash) -> bool
 pub fn bitcoin::blockdata::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::script::WScriptHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::script::WScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::WScriptHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::WScriptHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::script::WScriptHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::script::WScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::script::WScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::to_raw_hash(self) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::read_scriptbool(v: &[u8]) -> bool
@@ -8431,6 +8515,7 @@ pub fn bitcoin::blockdata::transaction::TxOut::serialize<__S>(&self, __serialize
 pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
 pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
@@ -8441,22 +8526,27 @@ pub fn bitcoin::blockdata::transaction::Txid::cmp(&self, other: &bitcoin::blockd
 pub fn bitcoin::blockdata::transaction::Txid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::transaction::Txid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::blockdata::transaction::Txid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::transaction::Txid, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::blockdata::transaction::Txid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Txid::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::transaction::Txid::eq(&self, other: &bitcoin::blockdata::transaction::Txid) -> bool
 pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::transaction::Txid::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::transaction::Txid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Txid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Txid::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Txid::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::transaction::Txid::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::transaction::Txid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::transaction::Txid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Version::clone(&self) -> bitcoin::blockdata::transaction::Version
@@ -8472,6 +8562,7 @@ pub fn bitcoin::blockdata::transaction::Version::non_standard(version: i32) -> b
 pub fn bitcoin::blockdata::transaction::Version::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::transaction::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
@@ -8482,22 +8573,27 @@ pub fn bitcoin::blockdata::transaction::Wtxid::cmp(&self, other: &bitcoin::block
 pub fn bitcoin::blockdata::transaction::Wtxid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::transaction::Wtxid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::blockdata::transaction::Wtxid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::transaction::Wtxid::eq(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> bool
 pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::transaction::Wtxid::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::transaction::Wtxid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Wtxid::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Wtxid::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::transaction::Wtxid::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::transaction::Wtxid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::transaction::Wtxid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::effective_value(fee_rate: bitcoin_units::fee_rate::FeeRate, satisfaction_weight: bitcoin_units::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
@@ -9501,6 +9597,7 @@ pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &m
 pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapLeaf::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
@@ -9511,22 +9608,27 @@ pub fn bitcoin::taproot::TapLeafHash::cmp(&self, other: &bitcoin::taproot::TapLe
 pub fn bitcoin::taproot::TapLeafHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::taproot::TapLeafHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::taproot::TapLeafHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapLeafHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::taproot::TapLeafHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapLeafHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLeafHash) -> bool
 pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapLeafHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapLeafHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapLeafHash, Self::Err>
+pub fn bitcoin::taproot::TapLeafHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapLeafHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapLeafHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafTag::clone(&self) -> bitcoin::taproot::TapLeafTag
@@ -9537,6 +9639,7 @@ pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeaf
 pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
@@ -9546,25 +9649,30 @@ pub fn bitcoin::taproot::TapNodeHash::borrow(&self) -> &[u8]
 pub fn bitcoin::taproot::TapNodeHash::clone(&self) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::cmp::Ordering
 pub fn bitcoin::taproot::TapNodeHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapNodeHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::taproot::TapNodeHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapNodeHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapNodeHash::eq(&self, other: &bitcoin::taproot::TapNodeHash) -> bool
 pub fn bitcoin::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapNodeHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapNodeHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapNodeHash, Self::Err>
+pub fn bitcoin::taproot::TapNodeHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapNodeHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapNodeHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapNodeHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapTree::clone(&self) -> bitcoin::taproot::TapTree
@@ -9580,6 +9688,7 @@ pub fn bitcoin::taproot::TapTree::serialize<__S>(&self, __serializer: __S) -> co
 pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
@@ -9588,23 +9697,28 @@ pub fn bitcoin::taproot::TapTweakHash::borrow(&self) -> &[u8]
 pub fn bitcoin::taproot::TapTweakHash::clone(&self) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::cmp::Ordering
 pub fn bitcoin::taproot::TapTweakHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapTweakHash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin::taproot::TapTweakHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapTweakHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapTweakHash::eq(&self, other: &bitcoin::taproot::TapTweakHash) -> bool
 pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapTweakHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapTweakHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapTweakHash, Self::Err>
+pub fn bitcoin::taproot::TapTweakHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapTweakHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapTweakHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::to_scalar(self) -> secp256k1::scalar::Scalar

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -6566,6 +6566,7 @@ pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self
 pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
 pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
@@ -6573,18 +6574,23 @@ pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8]
 pub fn bitcoin::LegacySighash::borrow(&self) -> &[u8]
 pub fn bitcoin::LegacySighash::clone(&self) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::cmp(&self, other: &bitcoin::LegacySighash) -> core::cmp::Ordering
-pub fn bitcoin::LegacySighash::engine() -> Self::Engine
+pub fn bitcoin::LegacySighash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
 pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::LegacySighash::from_str(s: &str) -> core::result::Result<bitcoin::LegacySighash, Self::Err>
+pub fn bitcoin::LegacySighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::LegacySighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::LegacySighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::LegacySighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::LegacySighash::partial_cmp(&self, other: &bitcoin::LegacySighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::LegacySighash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::LegacySighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::LegacySighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::MerkleBlock::clone(&self) -> bitcoin::MerkleBlock
@@ -6609,6 +6615,7 @@ pub fn bitcoin::PrivateKey::public_key<C: secp256k1::context::Signing>(&self, se
 pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
 pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -6617,7 +6624,7 @@ pub fn bitcoin::PubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBy
 pub fn bitcoin::PubkeyHash::borrow(&self) -> &[u8]
 pub fn bitcoin::PubkeyHash::clone(&self) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::cmp(&self, other: &bitcoin::PubkeyHash) -> core::cmp::Ordering
-pub fn bitcoin::PubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::PubkeyHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::PubkeyHash::eq(&self, other: &bitcoin::PubkeyHash) -> bool
 pub fn bitcoin::PubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::PubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
@@ -6625,14 +6632,19 @@ pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::PubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::PubkeyHash, Self::Err>
+pub fn bitcoin::PubkeyHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::PubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PubkeyHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::PubkeyHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::PubkeyHash::partial_cmp(&self, other: &bitcoin::PubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::PubkeyHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::PubkeyHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::PubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PublicKey::clone(&self) -> bitcoin::PublicKey
@@ -6657,6 +6669,7 @@ pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, se
 pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPublicKeyError>
 pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
 pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
@@ -6664,21 +6677,27 @@ pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8]
 pub fn bitcoin::SegwitV0Sighash::borrow(&self) -> &[u8]
 pub fn bitcoin::SegwitV0Sighash::clone(&self) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::cmp::Ordering
-pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
+pub fn bitcoin::SegwitV0Sighash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
 pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::SegwitV0Sighash::from_str(s: &str) -> core::result::Result<bitcoin::SegwitV0Sighash, Self::Err>
+pub fn bitcoin::SegwitV0Sighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::SegwitV0Sighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::SegwitV0Sighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub fn bitcoin::TapSighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
@@ -6686,18 +6705,23 @@ pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8]
 pub fn bitcoin::TapSighash::borrow(&self) -> &[u8]
 pub fn bitcoin::TapSighash::clone(&self) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::cmp(&self, other: &bitcoin::TapSighash) -> core::cmp::Ordering
-pub fn bitcoin::TapSighash::engine() -> Self::Engine
+pub fn bitcoin::TapSighash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
 pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::TapSighash::from_str(s: &str) -> core::result::Result<bitcoin::TapSighash, Self::Err>
+pub fn bitcoin::TapSighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::TapSighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::TapSighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::TapSighash::partial_cmp(&self, other: &bitcoin::TapSighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::TapSighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::TapSighash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighashTag::clone(&self) -> bitcoin::TapSighashTag
@@ -6717,6 +6741,7 @@ pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, 
 pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -6725,20 +6750,25 @@ pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushB
 pub fn bitcoin::WPubkeyHash::borrow(&self) -> &[u8]
 pub fn bitcoin::WPubkeyHash::clone(&self) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::cmp(&self, other: &bitcoin::WPubkeyHash) -> core::cmp::Ordering
-pub fn bitcoin::WPubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::WPubkeyHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::WPubkeyHash::eq(&self, other: &bitcoin::WPubkeyHash) -> bool
 pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::WPubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::WPubkeyHash, Self::Err>
+pub fn bitcoin::WPubkeyHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::WPubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::WPubkeyHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::WPubkeyHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::WPubkeyHash::partial_cmp(&self, other: &bitcoin::WPubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::WPubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bitcoin::address::AddressType>
@@ -6963,6 +6993,7 @@ pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
 pub fn bitcoin::bip158::Error::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin::bip158::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
@@ -6972,22 +7003,28 @@ pub fn bitcoin::bip158::FilterHash::clone(&self) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::cmp::Ordering
 pub fn bitcoin::bip158::FilterHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::bip158::FilterHash::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
 pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip158::FilterHash::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHash, Self::Err>
+pub fn bitcoin::bip158::FilterHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip158::FilterHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
@@ -6997,18 +7034,23 @@ pub fn bitcoin::bip158::FilterHeader::clone(&self) -> bitcoin::bip158::FilterHea
 pub fn bitcoin::bip158::FilterHeader::cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::cmp::Ordering
 pub fn bitcoin::bip158::FilterHeader::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::bip158::FilterHeader::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHeader::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
 pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip158::FilterHeader::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHeader, Self::Err>
+pub fn bitcoin::bip158::FilterHeader::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip158::FilterHeader::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHeader::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip158::FilterHeader::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip158::FilterHeader::partial_cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::GcsFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
@@ -7128,6 +7170,7 @@ pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::eq(&self, other: &bitcoi
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::invalid_base58_payload_length(&self) -> usize
 pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
@@ -7135,20 +7178,25 @@ pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8]
 pub fn bitcoin::bip32::XKeyIdentifier::borrow(&self) -> &[u8]
 pub fn bitcoin::bip32::XKeyIdentifier::clone(&self) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::cmp::Ordering
-pub fn bitcoin::bip32::XKeyIdentifier::engine() -> Self::Engine
+pub fn bitcoin::bip32::XKeyIdentifier::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip32::XKeyIdentifier::eq(&self, other: &bitcoin::bip32::XKeyIdentifier) -> bool
 pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip32::XKeyIdentifier::from_str(s: &str) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, Self::Err>
+pub fn bitcoin::bip32::XKeyIdentifier::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::XKeyIdentifier::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip32::XKeyIdentifier::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip32::XKeyIdentifier::partial_cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::Xpriv::clone(&self) -> bitcoin::bip32::Xpriv
@@ -7205,6 +7253,7 @@ pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
 pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
 pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
@@ -7214,7 +7263,7 @@ pub fn bitcoin::blockdata::block::BlockHash::clone(&self) -> bitcoin::blockdata:
 pub fn bitcoin::blockdata::block::BlockHash::cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::block::BlockHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::BlockHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::block::BlockHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::BlockHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::BlockHash::eq(&self, other: &bitcoin::blockdata::block::BlockHash) -> bool
 pub fn bitcoin::blockdata::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::BlockHash::from(block: &bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
@@ -7222,14 +7271,19 @@ pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::blo
 pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::BlockHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::BlockHash, Self::Err>
+pub fn bitcoin::blockdata::block::BlockHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::BlockHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::BlockHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::BlockHash::partial_cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::Header::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
@@ -7248,6 +7302,7 @@ pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
 pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
 pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
 pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -7257,19 +7312,24 @@ pub fn bitcoin::blockdata::block::TxMerkleNode::clone(&self) -> bitcoin::blockda
 pub fn bitcoin::blockdata::block::TxMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> bool
 pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::TxMerkleNode::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::TxMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::ValidationError::clone(&self) -> bitcoin::blockdata::block::ValidationError
@@ -7289,6 +7349,7 @@ pub fn bitcoin::blockdata::block::Version::is_signalling_soft_fork(&self, bit: u
 pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
 pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
@@ -7296,21 +7357,27 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8]
 pub fn bitcoin::blockdata::block::WitnessCommitment::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::block::WitnessCommitment::clone(&self) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::cmp::Ordering
-pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
 pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -7320,19 +7387,24 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::clone(&self) -> bitcoin::bl
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> bool
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::constants::ChainHash::as_byte_array(&self) -> &[u8; 32]
@@ -7802,6 +7874,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::reserve_exact(&mut self, additiona
 pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
 pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
@@ -7810,24 +7883,30 @@ pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &bitcoin::blockd
 pub fn bitcoin::blockdata::script::ScriptHash::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::script::ScriptHash::clone(&self) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::cmp::Ordering
-pub fn bitcoin::blockdata::script::ScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::ScriptHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::script::ScriptHash::eq(&self, other: &bitcoin::blockdata::script::ScriptHash) -> bool
 pub fn bitcoin::blockdata::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::script::ScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::ScriptHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
@@ -7836,21 +7915,26 @@ pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &bitcoin::block
 pub fn bitcoin::blockdata::script::WScriptHash::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::script::WScriptHash::clone(&self) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::cmp::Ordering
-pub fn bitcoin::blockdata::script::WScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::WScriptHash::engine() -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::script::WScriptHash::eq(&self, other: &bitcoin::blockdata::script::WScriptHash) -> bool
 pub fn bitcoin::blockdata::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::script::WScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::WScriptHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::WScriptHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::script::WScriptHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::script::WScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::to_raw_hash(self) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::read_scriptbool(v: &[u8]) -> bool
@@ -8024,6 +8108,7 @@ pub fn bitcoin::blockdata::transaction::TxOut::partial_cmp(&self, other: &bitcoi
 pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
 pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
@@ -8033,20 +8118,25 @@ pub fn bitcoin::blockdata::transaction::Txid::clone(&self) -> bitcoin::blockdata
 pub fn bitcoin::blockdata::transaction::Txid::cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::transaction::Txid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::transaction::Txid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::transaction::Txid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Txid::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::transaction::Txid::eq(&self, other: &bitcoin::blockdata::transaction::Txid) -> bool
 pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::transaction::Txid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Txid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Txid::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Txid::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::transaction::Txid::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::transaction::Txid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Version::clone(&self) -> bitcoin::blockdata::transaction::Version
@@ -8060,6 +8150,7 @@ pub fn bitcoin::blockdata::transaction::Version::is_standard(&self) -> bool
 pub fn bitcoin::blockdata::transaction::Version::non_standard(version: i32) -> bitcoin::blockdata::transaction::Version
 pub fn bitcoin::blockdata::transaction::Version::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
@@ -8069,20 +8160,25 @@ pub fn bitcoin::blockdata::transaction::Wtxid::clone(&self) -> bitcoin::blockdat
 pub fn bitcoin::blockdata::transaction::Wtxid::cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::transaction::Wtxid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::transaction::Wtxid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::transaction::Wtxid::eq(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> bool
 pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::transaction::Wtxid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Wtxid::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Wtxid::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::transaction::Wtxid::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::transaction::Wtxid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::effective_value(fee_rate: bitcoin_units::fee_rate::FeeRate, satisfaction_weight: bitcoin_units::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
@@ -8998,6 +9094,7 @@ pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
@@ -9007,20 +9104,25 @@ pub fn bitcoin::taproot::TapLeafHash::clone(&self) -> bitcoin::taproot::TapLeafH
 pub fn bitcoin::taproot::TapLeafHash::cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::cmp::Ordering
 pub fn bitcoin::taproot::TapLeafHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::taproot::TapLeafHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::taproot::TapLeafHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapLeafHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLeafHash) -> bool
 pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapLeafHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapLeafHash, Self::Err>
+pub fn bitcoin::taproot::TapLeafHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapLeafHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafTag::clone(&self) -> bitcoin::taproot::TapLeafTag
@@ -9031,6 +9133,7 @@ pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeaf
 pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
@@ -9039,23 +9142,28 @@ pub fn bitcoin::taproot::TapNodeHash::assume_hidden(hash: [u8; 32]) -> bitcoin::
 pub fn bitcoin::taproot::TapNodeHash::borrow(&self) -> &[u8]
 pub fn bitcoin::taproot::TapNodeHash::clone(&self) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::cmp::Ordering
-pub fn bitcoin::taproot::TapNodeHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapNodeHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapNodeHash::eq(&self, other: &bitcoin::taproot::TapNodeHash) -> bool
 pub fn bitcoin::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapNodeHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapNodeHash, Self::Err>
+pub fn bitcoin::taproot::TapNodeHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapNodeHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapNodeHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapTree::clone(&self) -> bitcoin::taproot::TapTree
@@ -9069,6 +9177,7 @@ pub fn bitcoin::taproot::TapTree::script_leaves(&self) -> bitcoin::taproot::Scri
 pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
@@ -9076,21 +9185,26 @@ pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8]
 pub fn bitcoin::taproot::TapTweakHash::borrow(&self) -> &[u8]
 pub fn bitcoin::taproot::TapTweakHash::clone(&self) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::cmp::Ordering
-pub fn bitcoin::taproot::TapTweakHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapTweakHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapTweakHash::eq(&self, other: &bitcoin::taproot::TapTweakHash) -> bool
 pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapTweakHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapTweakHash, Self::Err>
+pub fn bitcoin::taproot::TapTweakHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapTweakHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::to_scalar(self) -> secp256k1::scalar::Scalar

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -5937,6 +5937,7 @@ pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self
 pub fn bitcoin::EcdsaSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::EcdsaSighashType::to_u32(self) -> u32
 pub fn bitcoin::LegacySighash::all_zeros() -> Self
+pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::LegacySighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::LegacySighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8; 32]
@@ -5944,18 +5945,23 @@ pub fn bitcoin::LegacySighash::as_ref(&self) -> &[u8]
 pub fn bitcoin::LegacySighash::borrow(&self) -> &[u8]
 pub fn bitcoin::LegacySighash::clone(&self) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::cmp(&self, other: &bitcoin::LegacySighash) -> core::cmp::Ordering
-pub fn bitcoin::LegacySighash::engine() -> Self::Engine
+pub fn bitcoin::LegacySighash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::LegacySighash::eq(&self, other: &bitcoin::LegacySighash) -> bool
 pub fn bitcoin::LegacySighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::LegacySighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::LegacySighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::LegacySighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::LegacySighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::LegacySighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::LegacySighash::from_str(s: &str) -> core::result::Result<bitcoin::LegacySighash, Self::Err>
+pub fn bitcoin::LegacySighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::LegacySighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::LegacySighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::LegacySighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::LegacySighash::partial_cmp(&self, other: &bitcoin::LegacySighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::LegacySighash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::LegacySighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::LegacySighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::MerkleBlock::clone(&self) -> bitcoin::MerkleBlock
@@ -5980,6 +5986,7 @@ pub fn bitcoin::PrivateKey::public_key<C: secp256k1::context::Signing>(&self, se
 pub fn bitcoin::PrivateKey::to_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::PrivateKey::to_wif(self) -> alloc::string::String
 pub fn bitcoin::PubkeyHash::all_zeros() -> Self
+pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::PubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::PubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -5988,7 +5995,7 @@ pub fn bitcoin::PubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushBy
 pub fn bitcoin::PubkeyHash::borrow(&self) -> &[u8]
 pub fn bitcoin::PubkeyHash::clone(&self) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::cmp(&self, other: &bitcoin::PubkeyHash) -> core::cmp::Ordering
-pub fn bitcoin::PubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::PubkeyHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::PubkeyHash::eq(&self, other: &bitcoin::PubkeyHash) -> bool
 pub fn bitcoin::PubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::PubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
@@ -5996,14 +6003,19 @@ pub fn bitcoin::PubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: &bitcoin::PublicKey) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::PubkeyHash::from(key: bitcoin::PublicKey) -> bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::PubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::PubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::PubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::PubkeyHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::PubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::PubkeyHash, Self::Err>
+pub fn bitcoin::PubkeyHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::PubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::PubkeyHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::PubkeyHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::PubkeyHash::partial_cmp(&self, other: &bitcoin::PubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::PubkeyHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::PubkeyHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::PubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::PublicKey::clone(&self) -> bitcoin::PublicKey
@@ -6028,6 +6040,7 @@ pub fn bitcoin::PublicKey::verify<C: secp256k1::context::Verification>(&self, se
 pub fn bitcoin::PublicKey::wpubkey_hash(&self) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin::key::UncompressedPublicKeyError>
 pub fn bitcoin::PublicKey::write_into<W: bitcoin_io::Write + core::marker::Sized>(&self, writer: &mut W) -> core::result::Result<(), bitcoin_io::error::Error>
 pub fn bitcoin::SegwitV0Sighash::all_zeros() -> Self
+pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8; 32]
@@ -6035,21 +6048,27 @@ pub fn bitcoin::SegwitV0Sighash::as_ref(&self) -> &[u8]
 pub fn bitcoin::SegwitV0Sighash::borrow(&self) -> &[u8]
 pub fn bitcoin::SegwitV0Sighash::clone(&self) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::cmp::Ordering
-pub fn bitcoin::SegwitV0Sighash::engine() -> Self::Engine
+pub fn bitcoin::SegwitV0Sighash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::SegwitV0Sighash::eq(&self, other: &bitcoin::SegwitV0Sighash) -> bool
 pub fn bitcoin::SegwitV0Sighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::SegwitV0Sighash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::SegwitV0Sighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::SegwitV0Sighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::SegwitV0Sighash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::SegwitV0Sighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::SegwitV0Sighash::from_str(s: &str) -> core::result::Result<bitcoin::SegwitV0Sighash, Self::Err>
+pub fn bitcoin::SegwitV0Sighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::SegwitV0Sighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::SegwitV0Sighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::SegwitV0Sighash::partial_cmp(&self, other: &bitcoin::SegwitV0Sighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::SegwitV0Sighash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::TapSighash::all_zeros() -> Self
+pub fn bitcoin::TapSighash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::TapSighash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::TapSighash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8; 32]
@@ -6057,18 +6076,23 @@ pub fn bitcoin::TapSighash::as_ref(&self) -> &[u8]
 pub fn bitcoin::TapSighash::borrow(&self) -> &[u8]
 pub fn bitcoin::TapSighash::clone(&self) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::cmp(&self, other: &bitcoin::TapSighash) -> core::cmp::Ordering
-pub fn bitcoin::TapSighash::engine() -> Self::Engine
+pub fn bitcoin::TapSighash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::TapSighash::eq(&self, other: &bitcoin::TapSighash) -> bool
 pub fn bitcoin::TapSighash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::TapSighash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
+pub fn bitcoin::TapSighash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::TapSighash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::TapSighash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::TapSighash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>) -> bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::TapSighash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::TapSighash::from_str(s: &str) -> core::result::Result<bitcoin::TapSighash, Self::Err>
+pub fn bitcoin::TapSighash::hash(data: &[u8]) -> Self
 pub fn bitcoin::TapSighash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::TapSighash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::TapSighash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::TapSighash::partial_cmp(&self, other: &bitcoin::TapSighash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::TapSighash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::TapSighash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::TapSighash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::TapSighashTag>
 pub fn bitcoin::TapSighashTag::clone(&self) -> bitcoin::TapSighashTag
@@ -6088,6 +6112,7 @@ pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, 
 pub fn bitcoin::TapSighashType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::TapSighashType::partial_cmp(&self, other: &bitcoin::TapSighashType) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::WPubkeyHash::all_zeros() -> Self
+pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::WPubkeyHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::WPubkeyHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &[u8; 20]
@@ -6096,20 +6121,25 @@ pub fn bitcoin::WPubkeyHash::as_ref(&self) -> &bitcoin::blockdata::script::PushB
 pub fn bitcoin::WPubkeyHash::borrow(&self) -> &[u8]
 pub fn bitcoin::WPubkeyHash::clone(&self) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::cmp(&self, other: &bitcoin::WPubkeyHash) -> core::cmp::Ordering
-pub fn bitcoin::WPubkeyHash::engine() -> Self::Engine
+pub fn bitcoin::WPubkeyHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::WPubkeyHash::eq(&self, other: &bitcoin::WPubkeyHash) -> bool
 pub fn bitcoin::WPubkeyHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::WPubkeyHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from(key: &bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::WPubkeyHash::from(key: bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::WPubkeyHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::WPubkeyHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::WPubkeyHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::WPubkeyHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::WPubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::WPubkeyHash, Self::Err>
+pub fn bitcoin::WPubkeyHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::WPubkeyHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::WPubkeyHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::WPubkeyHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::WPubkeyHash::partial_cmp(&self, other: &bitcoin::WPubkeyHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::WPubkeyHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::WPubkeyHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bitcoin::address::AddressType>
@@ -6326,6 +6356,7 @@ pub fn bitcoin::bip158::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn bitcoin::bip158::Error::from(io: bitcoin_io::error::Error) -> Self
 pub fn bitcoin::bip158::Error::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin::bip158::FilterHash::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHash::as_ref(&self) -> &[u8; 32]
@@ -6335,22 +6366,28 @@ pub fn bitcoin::bip158::FilterHash::clone(&self) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::cmp::Ordering
 pub fn bitcoin::bip158::FilterHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::bip158::FilterHash::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
 pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip158::FilterHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip158::FilterHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip158::FilterHash::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHash, Self::Err>
+pub fn bitcoin::bip158::FilterHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip158::FilterHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip158::FilterHash::partial_cmp(&self, other: &bitcoin::bip158::FilterHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::all_zeros() -> Self
+pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::FilterHeader::as_ref(&self) -> &[u8; 32]
@@ -6360,18 +6397,23 @@ pub fn bitcoin::bip158::FilterHeader::clone(&self) -> bitcoin::bip158::FilterHea
 pub fn bitcoin::bip158::FilterHeader::cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::cmp::Ordering
 pub fn bitcoin::bip158::FilterHeader::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::bip158::FilterHeader::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::bip158::FilterHeader::engine() -> Self::Engine
+pub fn bitcoin::bip158::FilterHeader::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHeader::eq(&self, other: &bitcoin::bip158::FilterHeader) -> bool
 pub fn bitcoin::bip158::FilterHeader::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHeader::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip158::FilterHeader::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip158::FilterHeader::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip158::FilterHeader::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip158::FilterHeader, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip158::FilterHeader::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHeader, Self::Err>
+pub fn bitcoin::bip158::FilterHeader::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip158::FilterHeader::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip158::FilterHeader::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip158::FilterHeader::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip158::FilterHeader::partial_cmp(&self, other: &bitcoin::bip158::FilterHeader) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip158::FilterHeader::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip158::FilterHeader::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::bip158::GcsFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
@@ -6490,6 +6532,7 @@ pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::eq(&self, other: &bitcoi
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::invalid_base58_payload_length(&self) -> usize
 pub fn bitcoin::bip32::XKeyIdentifier::all_zeros() -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8; 20]
@@ -6497,20 +6540,25 @@ pub fn bitcoin::bip32::XKeyIdentifier::as_ref(&self) -> &[u8]
 pub fn bitcoin::bip32::XKeyIdentifier::borrow(&self) -> &[u8]
 pub fn bitcoin::bip32::XKeyIdentifier::clone(&self) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::cmp::Ordering
-pub fn bitcoin::bip32::XKeyIdentifier::engine() -> Self::Engine
+pub fn bitcoin::bip32::XKeyIdentifier::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip32::XKeyIdentifier::eq(&self, other: &bitcoin::bip32::XKeyIdentifier) -> bool
 pub fn bitcoin::bip32::XKeyIdentifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip32::XKeyIdentifier::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: &bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(key: bitcoin::bip32::Xpub) -> bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::bip32::XKeyIdentifier::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::bip32::XKeyIdentifier::from_str(s: &str) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, Self::Err>
+pub fn bitcoin::bip32::XKeyIdentifier::hash(data: &[u8]) -> Self
 pub fn bitcoin::bip32::XKeyIdentifier::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::bip32::XKeyIdentifier::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::bip32::XKeyIdentifier::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::bip32::XKeyIdentifier::partial_cmp(&self, other: &bitcoin::bip32::XKeyIdentifier) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::bip32::XKeyIdentifier::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::bip32::Xpriv::clone(&self) -> bitcoin::bip32::Xpriv
@@ -6566,6 +6614,7 @@ pub fn bitcoin::blockdata::block::Block::total_size(&self) -> usize
 pub fn bitcoin::blockdata::block::Block::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::block::Block::witness_root(&self) -> core::option::Option<bitcoin::blockdata::block::WitnessMerkleNode>
 pub fn bitcoin::blockdata::block::BlockHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::BlockHash::as_ref(&self) -> &[u8; 32]
@@ -6575,7 +6624,7 @@ pub fn bitcoin::blockdata::block::BlockHash::clone(&self) -> bitcoin::blockdata:
 pub fn bitcoin::blockdata::block::BlockHash::cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::block::BlockHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::BlockHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::block::BlockHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::BlockHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::BlockHash::eq(&self, other: &bitcoin::blockdata::block::BlockHash) -> bool
 pub fn bitcoin::blockdata::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::BlockHash::from(block: &bitcoin::blockdata::block::Block) -> bitcoin::blockdata::block::BlockHash
@@ -6583,14 +6632,19 @@ pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::blo
 pub fn bitcoin::blockdata::block::BlockHash::from(header: &bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(header: bitcoin::blockdata::block::Header) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::BlockHash::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::BlockHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::BlockHash, Self::Err>
+pub fn bitcoin::blockdata::block::BlockHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::BlockHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::BlockHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::BlockHash::partial_cmp(&self, other: &bitcoin::blockdata::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::BlockHash::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::Header::block_hash(&self) -> bitcoin::blockdata::block::BlockHash
@@ -6609,6 +6663,7 @@ pub fn bitcoin::blockdata::block::Header::target(&self) -> bitcoin::pow::Target
 pub fn bitcoin::blockdata::block::Header::validate_pow(&self, required_target: bitcoin::pow::Target) -> core::result::Result<bitcoin::blockdata::block::BlockHash, bitcoin::blockdata::block::ValidationError>
 pub fn bitcoin::blockdata::block::Header::work(&self) -> bitcoin::pow::Work
 pub fn bitcoin::blockdata::block::TxMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -6618,19 +6673,24 @@ pub fn bitcoin::blockdata::block::TxMerkleNode::clone(&self) -> bitcoin::blockda
 pub fn bitcoin::blockdata::block::TxMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::TxMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::TxMerkleNode::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::TxMerkleNode::eq(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> bool
 pub fn bitcoin::blockdata::block::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(txid: bitcoin::blockdata::transaction::Txid) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::TxMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::TxMerkleNode::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::TxMerkleNode::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::TxMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::TxMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::ValidationError::clone(&self) -> bitcoin::blockdata::block::ValidationError
@@ -6649,6 +6709,7 @@ pub fn bitcoin::blockdata::block::Version::is_signalling_soft_fork(&self, bit: u
 pub fn bitcoin::blockdata::block::Version::partial_cmp(&self, other: &bitcoin::blockdata::block::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::block::Version::to_consensus(self) -> i32
 pub fn bitcoin::blockdata::block::WitnessCommitment::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
@@ -6656,21 +6717,27 @@ pub fn bitcoin::blockdata::block::WitnessCommitment::as_ref(&self) -> &[u8]
 pub fn bitcoin::blockdata::block::WitnessCommitment::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::block::WitnessCommitment::clone(&self) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::cmp::Ordering
-pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessCommitment::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::WitnessCommitment::eq(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> bool
 pub fn bitcoin::blockdata::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessCommitment::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessCommitment::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessCommitment::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::all_zeros() -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -6680,19 +6747,24 @@ pub fn bitcoin::blockdata::block::WitnessMerkleNode::clone(&self) -> bitcoin::bl
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> Self::Engine
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::eq(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> bool
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(wtxid: bitcoin::blockdata::transaction::Wtxid) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, Self::Err>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin::blockdata::block::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::constants::ChainHash::as_byte_array(&self) -> &[u8; 32]
@@ -7157,6 +7229,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::reserve_exact(&mut self, additiona
 pub fn bitcoin::blockdata::script::ScriptBuf::scan_and_push_verify(&mut self)
 pub fn bitcoin::blockdata::script::ScriptBuf::with_capacity(capacity: usize) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &[u8; 20]
@@ -7165,24 +7238,30 @@ pub fn bitcoin::blockdata::script::ScriptHash::as_ref(&self) -> &bitcoin::blockd
 pub fn bitcoin::blockdata::script::ScriptHash::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::script::ScriptHash::clone(&self) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::cmp::Ordering
-pub fn bitcoin::blockdata::script::ScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::ScriptHash::engine() -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::script::ScriptHash::eq(&self, other: &bitcoin::blockdata::script::ScriptHash) -> bool
 pub fn bitcoin::blockdata::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::script::ScriptHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::script::ScriptHash::from_engine(e: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_raw_hash(inner: bitcoin_hashes::hash160::Hash) -> bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::script::ScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::ScriptHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::ScriptHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::script::ScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::ScriptHash::to_raw_hash(self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::all_zeros() -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &[u8; 32]
@@ -7191,21 +7270,26 @@ pub fn bitcoin::blockdata::script::WScriptHash::as_ref(&self) -> &bitcoin::block
 pub fn bitcoin::blockdata::script::WScriptHash::borrow(&self) -> &[u8]
 pub fn bitcoin::blockdata::script::WScriptHash::clone(&self) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::cmp::Ordering
-pub fn bitcoin::blockdata::script::WScriptHash::engine() -> Self::Engine
+pub fn bitcoin::blockdata::script::WScriptHash::engine() -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::script::WScriptHash::eq(&self, other: &bitcoin::blockdata::script::WScriptHash) -> bool
 pub fn bitcoin::blockdata::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::script::WScriptHash::from(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::Script) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: &bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(script: bitcoin::blockdata::script::ScriptBuf) -> bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::script::WScriptHash::from_engine(e: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_raw_hash(inner: bitcoin_hashes::sha256::Hash) -> bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::script::WScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, Self::Err>
+pub fn bitcoin::blockdata::script::WScriptHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::script::WScriptHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::script::WScriptHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::script::WScriptHash::partial_cmp(&self, other: &bitcoin::blockdata::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::script::WScriptHash::to_raw_hash(self) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin::blockdata::script::read_scriptbool(v: &[u8]) -> bool
@@ -7369,6 +7453,7 @@ pub fn bitcoin::blockdata::transaction::TxOut::partial_cmp(&self, other: &bitcoi
 pub fn bitcoin::blockdata::transaction::TxOut::size(&self) -> usize
 pub fn bitcoin::blockdata::transaction::TxOut::weight(&self) -> bitcoin_units::weight::Weight
 pub fn bitcoin::blockdata::transaction::Txid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Txid::as_ref(&self) -> &[u8; 32]
@@ -7378,20 +7463,25 @@ pub fn bitcoin::blockdata::transaction::Txid::clone(&self) -> bitcoin::blockdata
 pub fn bitcoin::blockdata::transaction::Txid::cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::transaction::Txid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::transaction::Txid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::transaction::Txid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Txid::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::transaction::Txid::eq(&self, other: &bitcoin::blockdata::transaction::Txid) -> bool
 pub fn bitcoin::blockdata::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Txid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Txid, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::transaction::Txid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Txid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Txid::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Txid::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::transaction::Txid::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::transaction::Txid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::transaction::Txid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Version::clone(&self) -> bitcoin::blockdata::transaction::Version
@@ -7405,6 +7495,7 @@ pub fn bitcoin::blockdata::transaction::Version::is_standard(&self) -> bool
 pub fn bitcoin::blockdata::transaction::Version::non_standard(version: i32) -> bitcoin::blockdata::transaction::Version
 pub fn bitcoin::blockdata::transaction::Version::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Version) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::transaction::Wtxid::all_zeros() -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::as_raw_hash(&self) -> &bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
@@ -7414,20 +7505,25 @@ pub fn bitcoin::blockdata::transaction::Wtxid::clone(&self) -> bitcoin::blockdat
 pub fn bitcoin::blockdata::transaction::Wtxid::cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::cmp::Ordering
 pub fn bitcoin::blockdata::transaction::Wtxid::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::transaction::Wtxid::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> Self::Engine
+pub fn bitcoin::blockdata::transaction::Wtxid::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::blockdata::transaction::Wtxid::eq(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> bool
 pub fn bitcoin::blockdata::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::blockdata::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: &bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(tx: bitcoin::blockdata::transaction::Transaction) -> bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::blockdata::transaction::Wtxid::from_engine(e: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_raw_hash(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::blockdata::transaction::Wtxid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, Self::Err>
+pub fn bitcoin::blockdata::transaction::Wtxid::hash(data: &[u8]) -> Self
 pub fn bitcoin::blockdata::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::blockdata::transaction::Wtxid::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::blockdata::transaction::Wtxid::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::blockdata::transaction::Wtxid::partial_cmp(&self, other: &bitcoin::blockdata::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::blockdata::transaction::Wtxid::to_raw_hash(self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin::blockdata::transaction::effective_value(fee_rate: bitcoin_units::fee_rate::FeeRate, satisfaction_weight: bitcoin_units::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
@@ -8109,6 +8205,7 @@ pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeaf::partial_cmp(&self, other: &bitcoin::taproot::TapLeaf) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapLeafHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
@@ -8118,20 +8215,25 @@ pub fn bitcoin::taproot::TapLeafHash::clone(&self) -> bitcoin::taproot::TapLeafH
 pub fn bitcoin::taproot::TapLeafHash::cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::cmp::Ordering
 pub fn bitcoin::taproot::TapLeafHash::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 pub fn bitcoin::taproot::TapLeafHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
-pub fn bitcoin::taproot::TapLeafHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapLeafHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapLeafHash::eq(&self, other: &bitcoin::taproot::TapLeafHash) -> bool
 pub fn bitcoin::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from(script_path: bitcoin::sighash::ScriptPath<'s>) -> bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapLeafHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapLeafHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapLeafHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapLeafHash, Self::Err>
+pub fn bitcoin::taproot::TapLeafHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapLeafHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapLeafHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapLeafHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapLeafTag>
 pub fn bitcoin::taproot::TapLeafTag::clone(&self) -> bitcoin::taproot::TapLeafTag
@@ -8142,6 +8244,7 @@ pub fn bitcoin::taproot::TapLeafTag::eq(&self, other: &bitcoin::taproot::TapLeaf
 pub fn bitcoin::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::taproot::TapNodeHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
@@ -8150,23 +8253,28 @@ pub fn bitcoin::taproot::TapNodeHash::assume_hidden(hash: [u8; 32]) -> bitcoin::
 pub fn bitcoin::taproot::TapNodeHash::borrow(&self) -> &[u8]
 pub fn bitcoin::taproot::TapNodeHash::clone(&self) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::cmp::Ordering
-pub fn bitcoin::taproot::TapNodeHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapNodeHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapNodeHash::eq(&self, other: &bitcoin::taproot::TapNodeHash) -> bool
 pub fn bitcoin::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: &bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::LeafNode) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(leaf: bitcoin::taproot::TapLeafHash) -> bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapNodeHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapNodeHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_node_hashes(a: bitcoin::taproot::TapNodeHash, b: bitcoin::taproot::TapNodeHash) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_script(script: &bitcoin::blockdata::script::Script, ver: bitcoin::taproot::LeafVersion) -> bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapNodeHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapNodeHash, Self::Err>
+pub fn bitcoin::taproot::TapNodeHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapNodeHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapNodeHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapNodeHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapBranchTag>
 pub fn bitcoin::taproot::TapTree::clone(&self) -> bitcoin::taproot::TapTree
@@ -8180,6 +8288,7 @@ pub fn bitcoin::taproot::TapTree::script_leaves(&self) -> bitcoin::taproot::Scri
 pub fn bitcoin::taproot::TapTree::try_from(builder: bitcoin::taproot::TaprootBuilder) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTree::try_from(node_info: bitcoin::taproot::NodeInfo) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::taproot::TapTweakHash::all_zeros() -> Self
+pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::as_raw_hash(&self) -> &bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
@@ -8187,21 +8296,26 @@ pub fn bitcoin::taproot::TapTweakHash::as_ref(&self) -> &[u8]
 pub fn bitcoin::taproot::TapTweakHash::borrow(&self) -> &[u8]
 pub fn bitcoin::taproot::TapTweakHash::clone(&self) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::cmp::Ordering
-pub fn bitcoin::taproot::TapTweakHash::engine() -> Self::Engine
+pub fn bitcoin::taproot::TapTweakHash::engine() -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::taproot::TapTweakHash::eq(&self, other: &bitcoin::taproot::TapTweakHash) -> bool
 pub fn bitcoin::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: &bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(spend_info: bitcoin::taproot::TaprootSpendInfo) -> bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub fn bitcoin::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
-pub fn bitcoin::taproot::TapTweakHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine) -> Self
+pub fn bitcoin::taproot::TapTweakHash::from_engine(e: <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Engine) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_key_and_tweak(internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_raw_hash(inner: bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>) -> bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin::taproot::TapTweakHash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapTweakHash, Self::Err>
+pub fn bitcoin::taproot::TapTweakHash::hash(data: &[u8]) -> Self
 pub fn bitcoin::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin::taproot::TapTweakHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin::taproot::TapTweakHash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
 pub fn bitcoin::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin::taproot::TapTweakHash::to_raw_hash(self) -> bitcoin_hashes::sha256t::Hash<bitcoin::taproot::TapTweakTag>
 pub fn bitcoin::taproot::TapTweakHash::to_scalar(self) -> secp256k1::scalar::Scalar

--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -534,9 +534,46 @@ pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
 pub const bitcoin_hashes::siphash24::Hash::LEN: usize
 pub const bitcoin_hashes::siphash24::Hash::N: usize
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
 pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
 pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
 pub const fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
 pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
 pub extern crate bitcoin_hashes::hex
@@ -567,7 +604,7 @@ pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::hash160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hash160::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
 pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -577,7 +614,9 @@ pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::Has
 pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::hash160::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::hash160::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
@@ -628,7 +667,7 @@ pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
 pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::ripemd160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
 pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
 pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -638,7 +677,9 @@ pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160
 pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::ripemd160::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::ripemd160::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
@@ -665,7 +706,7 @@ pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha1::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha1::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
 pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
 pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -675,7 +716,9 @@ pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngi
 pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha1::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha1::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
@@ -699,7 +742,7 @@ pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
 pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -709,8 +752,10 @@ pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
@@ -743,7 +788,6 @@ pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, st
 pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256::Midstate::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
@@ -752,7 +796,7 @@ pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha256d::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256d::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
 pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -762,7 +806,9 @@ pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::Has
 pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256d::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256d::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
@@ -771,6 +817,7 @@ pub fn bitcoin_hashes::sha256d::Hash::serialize<S: serde::ser::Serializer>(&self
 pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
@@ -778,23 +825,27 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
 pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256t::Hash<T>::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256t::Hash<T>::schema_name() -> alloc::string::String
 pub fn bitcoin_hashes::sha256t::Hash<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
@@ -804,7 +855,7 @@ pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha384::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha384::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::sha384::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
 pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
 pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -814,7 +865,9 @@ pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha384::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha384::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha384::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha384::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha384::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
@@ -834,7 +887,7 @@ pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha512::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
 pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
 pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -844,7 +897,9 @@ pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha512::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha512::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
@@ -868,7 +923,7 @@ pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
 pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha512_256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
 pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
 pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -878,7 +933,9 @@ pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_2
 pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha512_256::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha512_256::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
@@ -899,7 +956,7 @@ pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::siphash24::Hash, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -911,7 +968,9 @@ pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::R
 pub fn bitcoin_hashes::siphash24::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
 pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output

--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -462,9 +462,46 @@ pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
 pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
 pub const bitcoin_hashes::siphash24::Hash::LEN: usize
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
 pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
 pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
 pub const fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
 pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
 pub extern crate bitcoin_hashes::hex
@@ -493,7 +530,7 @@ pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
 pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -502,7 +539,9 @@ pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
@@ -540,7 +579,7 @@ pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
 pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
 pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
 pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -549,7 +588,9 @@ pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Sel
 pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
 pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
@@ -565,7 +606,7 @@ pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
 pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
 pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -574,7 +615,9 @@ pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
@@ -590,7 +633,7 @@ pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
 pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -599,8 +642,10 @@ pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
@@ -623,7 +668,6 @@ pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Resu
 pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
@@ -631,7 +675,7 @@ pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
 pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -640,31 +684,38 @@ pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
-pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
 pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
@@ -673,7 +724,7 @@ pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha384::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
 pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
 pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -682,7 +733,9 @@ pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
 pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha384::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha384::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha384::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> Self::Bytes
@@ -698,7 +751,7 @@ pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
 pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
 pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -707,7 +760,9 @@ pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
 pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
@@ -723,7 +778,7 @@ pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
 pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
 pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
 pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -732,7 +787,9 @@ pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Se
 pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
 pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
@@ -749,7 +806,7 @@ pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
 pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -760,7 +817,9 @@ pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::si
 pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
 pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -462,9 +462,46 @@ pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
 pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
 pub const bitcoin_hashes::siphash24::Hash::LEN: usize
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
 pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) -> Self
 pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha512::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512_256::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::siphash24::Hash::all_zeros() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
 pub const fn bitcoin_hashes::siphash24::HashEngine::new() -> bitcoin_hashes::siphash24::HashEngine
 pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
 pub extern crate bitcoin_hashes::hex
@@ -493,7 +530,7 @@ pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::hash160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
 pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -502,7 +539,9 @@ pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::hash160::Hash
 pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
@@ -539,7 +578,7 @@ pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
 pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::ripemd160::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
 pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
 pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -548,7 +587,9 @@ pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Sel
 pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
 pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
@@ -564,7 +605,7 @@ pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha1::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
 pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
 pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -573,7 +614,9 @@ pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
 pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
@@ -589,7 +632,7 @@ pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
 pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -598,8 +641,10 @@ pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
@@ -622,7 +667,6 @@ pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Resu
 pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin_hashes::sha256d::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
@@ -630,7 +674,7 @@ pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha256d::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
 pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -639,31 +683,38 @@ pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin_hashes::sha256t::Hash<T>::all_zeros() -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
 pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
 pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
-pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
 pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
 pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha384::Hash::all_zeros() -> Self
 pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
@@ -672,7 +723,7 @@ pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha384::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
 pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
 pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -681,7 +732,9 @@ pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
 pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha384::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha384::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha384::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> Self::Bytes
@@ -697,7 +750,7 @@ pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha512::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
 pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
 pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -706,7 +759,9 @@ pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
 pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
@@ -722,7 +777,7 @@ pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
 pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::sha512_256::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
 pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
 pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -731,7 +786,9 @@ pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Se
 pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
 pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
 pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
@@ -748,7 +805,7 @@ pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
 pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
-pub fn bitcoin_hashes::siphash24::Hash::engine() -> Self::Engine
+pub fn bitcoin_hashes::siphash24::Hash::engine() -> bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
@@ -759,7 +816,9 @@ pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::si
 pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::FromSliceError>
 pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash(data: &[u8]) -> Self
 pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
 pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
 pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -35,7 +35,7 @@ use core::{fmt, str};
 #[cfg(feature = "std")]
 pub use std::{string::String, vec::Vec};
 
-use hashes::{sha256d, Hash};
+use hashes::sha256d;
 
 use crate::error::{IncorrectChecksumError, TooShortError};
 

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -26,7 +26,6 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
-use bitcoin::hashes::Hash;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
 use bitcoin::secp256k1::{Secp256k1, Signing};

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -4,7 +4,6 @@
 
 use std::str::FromStr;
 
-use bitcoin::hashes::Hash;
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -4,7 +4,6 @@
 
 use std::str::FromStr;
 
-use bitcoin::hashes::Hash;
 use bitcoin::key::{Keypair, TapTweak, TweakedKeypair, UntweakedPublicKey};
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing, Verification};

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -24,7 +24,6 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
-use bitcoin::hashes::Hash;
 use bitcoin::key::UntweakedPublicKey;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -33,7 +33,7 @@ use core::marker::PhantomData;
 use core::str::FromStr;
 
 use bech32::primitives::hrp::Hrp;
-use hashes::{sha256, Hash, HashEngine};
+use hashes::{sha256, HashEngine};
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 
 use crate::blockdata::constants::{

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -8,7 +8,7 @@ use core::{convert, fmt, mem};
 #[cfg(feature = "std")]
 use std::error;
 
-use hashes::{sha256, siphash24, Hash};
+use hashes::{sha256, siphash24};
 use internals::impl_array_newtype;
 use io::{BufRead, Write};
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -40,7 +40,7 @@
 use core::cmp::{self, Ordering};
 use core::fmt::{self, Display, Formatter};
 
-use hashes::{sha256d, siphash24, Hash};
+use hashes::{sha256d, siphash24};
 use internals::write_err;
 use io::{BufRead, Write};
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -9,7 +9,7 @@
 
 use core::fmt;
 
-use hashes::{sha256d, Hash, HashEngine};
+use hashes::{sha256d, HashEngine};
 use io::{BufRead, Write};
 
 use super::Weight;

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -6,7 +6,7 @@
 //! consensus code. In particular, it defines the genesis block and its
 //! single transaction.
 
-use hashes::{sha256d, Hash};
+use hashes::sha256d;
 use internals::impl_array_newtype;
 
 use crate::blockdata::block::{self, Block};

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -5,7 +5,6 @@ use core::ops::{
     Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
-use hashes::Hash;
 use secp256k1::{Secp256k1, Verification};
 
 use super::PushBytes;

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -2,7 +2,6 @@
 
 use core::str::FromStr;
 
-use hashes::Hash;
 use hex_lit::hex;
 
 use super::*;

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -9,7 +9,6 @@
 
 use core::fmt;
 
-use hashes::Hash as _;
 use internals::array_vec::ArrayVec;
 use secp256k1::{Secp256k1, Verification};
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -12,7 +12,7 @@
 
 use core::{cmp, fmt, str};
 
-use hashes::{sha256d, Hash};
+use hashes::sha256d;
 use internals::write_err;
 use io::{BufRead, Write};
 use units::parse::{self, PrefixedHexError, UnprefixedHexError};

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -9,7 +9,7 @@ use core::fmt::{self, Write as _};
 use core::ops;
 use core::str::FromStr;
 
-use hashes::{hash160, Hash};
+use hashes::hash160;
 use hex::{FromHex, HexToArrayError};
 use internals::array_vec::ArrayVec;
 use internals::write_err;

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -13,7 +13,7 @@
 
 use core::{fmt, str};
 
-use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype, Hash};
+use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype};
 use internals::write_err;
 use io::Write;
 

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -13,7 +13,6 @@ pub use crate::{
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hashes::Hash;
     use crate::{
         LegacySighash, PubkeyHash, ScriptHash, SegwitV0Sighash, TapSighash, WPubkeyHash,
         WScriptHash, XKeyIdentifier,

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -185,7 +185,6 @@ macro_rules! impl_hashencode {
 
         impl $crate::consensus::Decodable for $hashtype {
             fn consensus_decode<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
-                use $crate::hashes::Hash;
                 Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode(r)?))
             }
         }
@@ -199,14 +198,12 @@ macro_rules! impl_asref_push_bytes {
         $(
             impl AsRef<$crate::blockdata::script::PushBytes> for $hashtype {
                 fn as_ref(&self) -> &$crate::blockdata::script::PushBytes {
-                    use $crate::hashes::Hash;
                     self.as_byte_array().into()
                 }
             }
 
             impl From<$hashtype> for $crate::blockdata::script::PushBytesBuf {
                 fn from(hash: $hashtype) -> Self {
-                    use $crate::hashes::Hash;
                     hash.as_byte_array().into()
                 }
             }

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -40,7 +40,6 @@
 
 use core::fmt;
 
-use hashes::Hash;
 use io::{BufRead, Write};
 
 use self::MerkleBlockError::*;

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -7,7 +7,7 @@
 
 use core::{fmt, iter};
 
-use hashes::{sha256d, Hash};
+use hashes::sha256d;
 use io::{BufRead, Write};
 
 use crate::blockdata::{block, transaction};

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -5,7 +5,7 @@
 //! This module describes network messages which are used for passing
 //! Bitcoin data (blocks and transactions) around.
 
-use hashes::{sha256d, Hash as _};
+use hashes::sha256d;
 use io::{BufRead, Write};
 
 use crate::blockdata::block::BlockHash;
@@ -144,7 +144,6 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {
-    use hashes::Hash;
     use hex::test_hex_unwrap as hex;
 
     use super::*;

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -217,7 +217,6 @@ impl Target {
     /// to the target.
     #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_met_by(&self, hash: BlockHash) -> bool {
-        use hashes::Hash;
         let hash = U256::from_le_bytes(hash.to_byte_array());
         hash <= self.0
     }
@@ -1784,8 +1783,6 @@ mod tests {
 
     #[test]
     fn compact_target_from_upwards_difficulty_adjustment_using_headers() {
-        use hashes::Hash;
-
         use crate::block::Version;
         use crate::constants::genesis_block;
         use crate::TxMerkleNode;
@@ -1809,8 +1806,6 @@ mod tests {
 
     #[test]
     fn compact_target_from_downwards_difficulty_adjustment_using_headers() {
-        use hashes::Hash;
-
         use crate::block::Version;
         use crate::TxMerkleNode;
         let params = Params::new(crate::Network::Signet);
@@ -1895,8 +1890,6 @@ mod tests {
     #[test]
     fn target_is_met_by_for_target_equals_hash() {
         use std::str::FromStr;
-
-        use hashes::Hash;
 
         let hash =
             BlockHash::from_str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1205,7 +1205,7 @@ pub use self::display_from_str::PsbtParseError;
 
 #[cfg(test)]
 mod tests {
-    use hashes::{hash160, ripemd160, sha256, Hash};
+    use hashes::{hash160, ripemd160, sha256};
     use hex::{test_hex_unwrap as hex, FromHex};
     #[cfg(feature = "rand-std")]
     use secp256k1::{All, SecretKey};

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -5,7 +5,7 @@
 //! Traits to serialize PSBT values to and from raw bytes
 //! according to the BIP-174 specification.
 
-use hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use hashes::{hash160, ripemd160, sha256, sha256d};
 use secp256k1::XOnlyPublicKey;
 
 use super::map::{Input, Map, Output, PsbtSighashType};

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -5,7 +5,7 @@
 //! This module provides signature related functions including secp256k1 signature recovery when
 //! library is used with the `secp-recovery` feature.
 
-use hashes::{sha256d, Hash, HashEngine};
+use hashes::{sha256d, HashEngine};
 
 use crate::consensus::{encode, Encodable};
 
@@ -21,7 +21,7 @@ pub const BITCOIN_SIGNED_MSG_PREFIX: &[u8] = b"\x18Bitcoin Signed Message:\n";
 mod message_signing {
     use core::fmt;
 
-    use hashes::{sha256d, Hash};
+    use hashes::sha256d;
     use internals::write_err;
     use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -11,7 +11,7 @@ use core::cmp::Reverse;
 use core::fmt;
 use core::iter::FusedIterator;
 
-use hashes::{sha256t_hash_newtype, Hash, HashEngine};
+use hashes::{sha256t_hash_newtype, HashEngine};
 use internals::write_err;
 use io::Write;
 use secp256k1::{Scalar, Secp256k1};

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -30,7 +30,7 @@ use bitcoin::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
 use bitcoin::blockdata::locktime::{absolute, relative};
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::consensus::encode::deserialize;
-use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::hex::FromHex;
 use bitcoin::psbt::raw::{self, Key, Pair, ProprietaryKey};
 use bitcoin::psbt::{Input, Output, Psbt, PsbtSighashType};

--- a/fuzz/fuzz_targets/hashes/ripemd160.rs
+++ b/fuzz/fuzz_targets/hashes/ripemd160.rs
@@ -1,4 +1,4 @@
-use bitcoin::hashes::{ripemd160, Hash, HashEngine};
+use bitcoin::hashes::{ripemd160, HashEngine};
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/hashes/sha1.rs
+++ b/fuzz/fuzz_targets/hashes/sha1.rs
@@ -1,4 +1,4 @@
-use bitcoin::hashes::{sha1, Hash, HashEngine};
+use bitcoin::hashes::{sha1, HashEngine};
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/hashes/sha256.rs
+++ b/fuzz/fuzz_targets/hashes/sha256.rs
@@ -1,4 +1,4 @@
-use bitcoin::hashes::{sha256, Hash, HashEngine};
+use bitcoin::hashes::{sha256, HashEngine};
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/hashes/sha512.rs
+++ b/fuzz/fuzz_targets/hashes/sha512.rs
@@ -1,4 +1,4 @@
-use bitcoin::hashes::{sha512, Hash, HashEngine};
+use bitcoin::hashes::{sha512, HashEngine};
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/hashes/sha512_256.rs
+++ b/fuzz/fuzz_targets/hashes/sha512_256.rs
@@ -1,4 +1,4 @@
-use bitcoin::hashes::{sha512_256, Hash, HashEngine};
+use bitcoin::hashes::{sha512_256, HashEngine};
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -21,8 +21,6 @@ crate::internal_macros::hash_type! {
 type HashEngine = sha256::HashEngine;
 
 fn from_engine(e: HashEngine) -> Hash {
-    use crate::Hash as _;
-
     let sha2 = sha256::Hash::from_engine(e);
     let rmd = ripemd160::Hash::hash(&sha2[..]);
 
@@ -92,7 +90,7 @@ mod tests {
     fn ripemd_serde() {
         use serde_test::{assert_tokens, Configure, Token};
 
-        use crate::{hash160, Hash};
+        use crate::hash160;
 
         #[rustfmt::skip]
         static HASH_BYTES: [u8; 20] = [

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -249,7 +249,7 @@ impl std::error::Error for FromSliceError {}
 
 #[cfg(test)]
 mod tests {
-    use crate::{sha256d, Hash};
+    use crate::sha256d;
 
     hash_newtype! {
         /// A test newtype

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -412,7 +412,7 @@ mod tests {
     fn test() {
         use std::convert::TryFrom;
 
-        use crate::{ripemd160, Hash, HashEngine};
+        use crate::{ripemd160, HashEngine};
 
         #[derive(Clone)]
         struct Test {
@@ -507,7 +507,7 @@ mod tests {
     fn ripemd_serde() {
         use serde_test::{assert_tokens, Configure, Token};
 
-        use crate::{ripemd160, Hash};
+        use crate::ripemd160;
 
         #[rustfmt::skip]
         static HASH_BYTES: [u8; 20] = [

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test() {
-        use crate::{sha1, Hash, HashEngine};
+        use crate::{sha1, HashEngine};
 
         #[derive(Clone)]
         struct Test {
@@ -199,7 +199,7 @@ mod tests {
     fn sha1_serde() {
         use serde_test::{assert_tokens, Configure, Token};
 
-        use crate::{sha1, Hash};
+        use crate::sha1;
 
         #[rustfmt::skip]
         static HASH_BYTES: [u8; 20] = [

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -154,7 +154,7 @@ impl Midstate {
     }
 
     /// Unwraps the [`Midstate`] and returns the underlying byte array.
-    pub fn to_byte_array(self) -> [u8; 32] { self.0 }
+    pub const fn to_byte_array(self) -> [u8; 32] { self.0 }
 
     /// Creates midstate for tagged hashes.
     ///
@@ -815,7 +815,7 @@ impl HashEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{sha256, Hash as _, HashEngine};
+    use crate::{sha256, HashEngine};
 
     #[test]
     #[cfg(feature = "alloc")]

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -16,8 +16,6 @@ crate::internal_macros::hash_type! {
 type HashEngine = sha256::HashEngine;
 
 fn from_engine(e: sha256::HashEngine) -> Hash {
-    use crate::Hash as _;
-
     let sha2 = sha256::Hash::from_engine(e);
     let sha2d = sha256::Hash::hash(&sha2[..]);
 
@@ -28,7 +26,7 @@ fn from_engine(e: sha256::HashEngine) -> Hash {
 
 #[cfg(test)]
 mod tests {
-    use crate::{sha256d, Hash as _};
+    use crate::sha256d;
 
     #[test]
     #[cfg(feature = "alloc")]

--- a/hashes/src/sha384.rs
+++ b/hashes/src/sha384.rs
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test() {
-        use crate::{sha384, Hash, HashEngine};
+        use crate::{sha384, HashEngine};
 
         #[derive(Clone)]
         struct Test {

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test() {
-        use crate::{sha512, Hash, HashEngine};
+        use crate::{sha512, HashEngine};
 
         #[derive(Clone)]
         struct Test {
@@ -386,7 +386,7 @@ mod tests {
     fn sha512_serde() {
         use serde_test::{assert_tokens, Configure, Token};
 
-        use crate::{sha512, Hash};
+        use crate::sha512;
 
         #[rustfmt::skip]
         static HASH_BYTES: [u8; 64] = [

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -57,7 +57,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test() {
-        use crate::{sha512_256, Hash, HashEngine};
+        use crate::{sha512_256, HashEngine};
 
         #[derive(Clone)]
         struct Test {

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -6,7 +6,7 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, mem, ptr};
 
-use crate::{FromSliceError, Hash as _, HashEngine as _};
+use crate::{FromSliceError, HashEngine as _};
 
 crate::internal_macros::hash_type! {
     64,


### PR DESCRIPTION
Currently we have a trait `Hash` that is required for `Hmac`, `Hkdf`, and other use cases. However, it is unegonomic for users who just want to do a simple hash to have to import the trait.
    
Add inherent functions to all hash types including those created with the new wrapper type macros.
    
This patch introduces some duplicate code but we are trying to make progress in the hashes API re-write. We can come back and de-dublicate later.

Includes making `to_byte_array`,`from_byte_array`, `as_byte_array`, and `all_zeros` const where easily possible.
 

