### PR TITLE
bitcoin: Document rand features

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -16,12 +16,14 @@ exclude = ["tests", "contrib"]
 [features]
 default = [ "std", "secp-recovery" ]
 std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "secp256k1/std", "units/std"]
-rand-std = ["secp256k1/rand-std", "std"]
-rand = ["secp256k1/rand"]
 serde = ["actual-serde", "hashes/serde", "secp256k1/serde", "internals/serde", "units/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
+
+# These features are additive but in typical usage you just want to pick one, ether std or no-std.
+rand-std = ["secp256k1/rand-std", "std"]
+rand = ["secp256k1/rand"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The "rand" and "rand-std" feature are unusual in that one typically only uses one of them, document this.

No logic changes.

(Pulled out of #3756.)