### PR TITLE
bitcoin: Update crate level docs

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 rust-version = "1.56.1"
 exclude = ["tests", "contrib"]
 
+# If you change features or optional dependencies in any way please update the "# Cargo features" section in lib.rs as well.
 [features]
 default = [ "std", "secp-recovery" ]
 std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "secp256k1/std", "units/std"]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -11,21 +11,21 @@
 //!
 //! See README.md for detailed documentation about development and supported environments.
 //!
-//! ## Available feature flags
+//! # Cargo features
 //!
-//! * `std` - the usual dependency on `std` (default).
-//! * `secp-recovery` - enables calculating public key from a signature and message.
-//! * `base64` - (dependency), enables encoding of PSBTs and message signatures.
-//! * `rand` - (dependency), makes it more convenient to generate random values.
-//! * `serde` - (dependency), implements `serde`-based serialization and
-//!                 deserialization.
+//! * `base64` (dependency) - enables encoding of PSBTs and message signatures.
+//! * `bitcoinconsensus` (dependency) - enables validating scripts and transactions.
+//! * `bitcoinconsensus-std` - same as `bitcoinconsensus` but also enables `std` here and in the
+//!                            `bitcoinconsensus` crate. Additionally, enables returning
+//!                            `bitcoinconsensus::Error` from `std::error::Error::source()`.
+//! * `default` - enables `std` and `secp-recovery`.
+//! * `ordered` (dependency) - adds implementations of `ArbitraryOrd` to some structs.
+//! * `rand` (transitive dependency) - makes it more convenient to generate random values.
+//! * `rand-std` - same as `rand` but also enables `std` here and in `secp256k1`.
+//! * `serde` (dependency) - implements `serde`-based serialization and deserialization.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
-//! * `bitcoinconsensus-std` - enables `std` in `bitcoinconsensus` and communicates it
-//!                            to this crate so it knows how to implement
-//!                            `std::error::Error`. At this time there's a hack to
-//!                            achieve the same without this feature but it could
-//!                            happen the implementations diverge one day.
-//! * `ordered` - (dependency), adds implementations of `ArbitraryOrdOrd` to some structs.
+//! * `secp-recovery` - enables calculating public key from a signature and message.
+//! * `std` - the usual dependency on `std`.
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -2,16 +2,14 @@
 
 //! # Rust Bitcoin Library
 //!
-//! This is a library that supports the Bitcoin network protocol and associated
-//! primitives. It is designed for Rust programs built to work with the Bitcoin
-//! network.
+//! This is a library that supports the Bitcoin network protocol and associated primitives. It is
+//! designed for Rust programs built to work with the Bitcoin network.
 //!
-//! Except for its dependency on libsecp256k1 (and optionally libbitcoinconsensus),
-//! this library is written entirely in Rust. It illustrates the benefits of
-//! strong type safety, including ownership and lifetime, for financial and/or cryptographic software.
+//! Except for its dependency on libsecp256k1 (and optionally libbitcoinconsensus), this library is
+//! written entirely in Rust. It illustrates the benefits of strong type safety, including ownership
+//! and lifetime, for financial and/or cryptographic software.
 //!
-//! See README.md for detailed documentation about development and supported
-//! environments.
+//! See README.md for detailed documentation about development and supported environments.
 //!
 //! ## Available feature flags
 //!


### PR DESCRIPTION
Update stale crate level docs in `bitcoin`. Done as two separate patches so the last one is trivial to review, whitespace only.