### PR TITLE
Remove repetition from sha256t_hash_newtype macro

### DIFF
--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -36,14 +36,18 @@ sha256t_hash_newtype! {
     ///
     /// This is used for computing tapscript script spend hash.
     pub struct TapLeafHash(_);
+}
 
+sha256t_hash_newtype! {
     pub struct TapBranchTag = hash_str("TapBranch");
 
     /// Tagged hash used in taproot trees.
     ///
     /// See BIP-340 for tagging rules.
     pub struct TapNodeHash(_);
+}
 
+sha256t_hash_newtype! {
     pub struct TapTweakTag = hash_str("TapTweak");
 
     /// Taproot-tagged hash with tag \"TapTweak\".

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -112,8 +112,7 @@ fn from_engine<T: Tag>(e: sha256::HashEngine) -> Hash<T> {
 /// [`hash_newtype`]: crate::hash_newtype
 #[macro_export]
 macro_rules! sha256t_hash_newtype {
-    ($($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+); $(#[$($hash_attr:tt)*])* $hash_vis:vis struct $hash_name:ident($(#[$($field_attr:tt)*])* _);)+) => {
-        $(
+    ($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+); $(#[$($hash_attr:tt)*])* $hash_vis:vis struct $hash_name:ident($(#[$($field_attr:tt)*])* _);) => {
         $crate::sha256t_hash_newtype_tag!($tag_vis, $tag, stringify!($hash_name), $(#[$($tag_attr)*])*);
 
         impl $crate::sha256t::Tag for $tag {
@@ -130,7 +129,6 @@ macro_rules! sha256t_hash_newtype {
             $(#[$($hash_attr)*])*
             $hash_vis struct $hash_name($(#[$($field_attr)*])* $crate::sha256t::Hash<$tag>);
         }
-        )+
     }
 }
 


### PR DESCRIPTION
The `sha256t_hash_newtype` macro is hard to reason about because we allow repetition so which tag goes with which type is slightly obscure.

Remove repetition and call the macro three times.

Internal change in `bitcoin`, API change in `hashes`.

Fix #2811