### PR TITLE
Remove repetition for hash_newtype

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -59,11 +59,13 @@ const M: u64 = 784931;
 hashes::hash_newtype! {
     /// Filter hash, as defined in BIP-157.
     pub struct FilterHash(sha256d::Hash);
+}
+impl_hashencode!(FilterHash);
+
+hashes::hash_newtype! {
     /// Filter header, as defined in BIP-157.
     pub struct FilterHeader(sha256d::Hash);
 }
-
-impl_hashencode!(FilterHash);
 impl_hashencode!(FilterHeader);
 
 /// Errors for blockfilter.

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -25,16 +25,25 @@ use crate::{merkle_tree, VarInt};
 hashes::hash_newtype! {
     /// A bitcoin block hash.
     pub struct BlockHash(sha256d::Hash);
+}
+impl_hashencode!(BlockHash);
+
+hashes::hash_newtype! {
     /// A hash of the Merkle tree branch or root for transactions.
     pub struct TxMerkleNode(sha256d::Hash);
+}
+impl_hashencode!(TxMerkleNode);
+
+hashes::hash_newtype! {
     /// A hash corresponding to the Merkle tree root for witness data.
     pub struct WitnessMerkleNode(sha256d::Hash);
+}
+impl_hashencode!(WitnessMerkleNode);
+
+hashes::hash_newtype! {
     /// A hash corresponding to the witness structure commitment in the coinbase transaction.
     pub struct WitnessCommitment(sha256d::Hash);
 }
-impl_hashencode!(BlockHash);
-impl_hashencode!(TxMerkleNode);
-impl_hashencode!(WitnessMerkleNode);
 
 impl From<Txid> for TxMerkleNode {
     fn from(txid: Txid) -> Self { Self::from_byte_array(txid.to_byte_array()) }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -87,10 +87,14 @@ pub use self::{
 hashes::hash_newtype! {
     /// A hash of Bitcoin Script bytecode.
     pub struct ScriptHash(hash160::Hash);
+}
+impl_asref_push_bytes!(ScriptHash);
+
+hashes::hash_newtype! {
     /// SegWit version of a Bitcoin Script bytecode hash.
     pub struct WScriptHash(sha256::Hash);
 }
-impl_asref_push_bytes!(ScriptHash, WScriptHash);
+impl_asref_push_bytes!(WScriptHash);
 
 impl From<ScriptBuf> for ScriptHash {
     fn from(script: ScriptBuf) -> ScriptHash { script.script_hash() }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -43,11 +43,13 @@ hashes::hash_newtype! {
     /// serialized in reverse byte order when converted to a hex string via [`std::fmt::Display`]
     /// trait operations. See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
     pub struct Txid(sha256d::Hash);
+}
+impl_hashencode!(Txid);
 
+hashes::hash_newtype! {
     /// A bitcoin witness transaction ID.
     pub struct Wtxid(sha256d::Hash);
 }
-impl_hashencode!(Txid);
 impl_hashencode!(Wtxid);
 
 /// The marker MUST be a 1-byte zero value: 0x00. (BIP-141)

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -256,10 +256,14 @@ impl FromStr for PublicKey {
 hashes::hash_newtype! {
     /// A hash of a public key.
     pub struct PubkeyHash(hash160::Hash);
+}
+impl_asref_push_bytes!(PubkeyHash);
+
+hashes::hash_newtype! {
     /// SegWit version of a public key hash.
     pub struct WPubkeyHash(hash160::Hash);
 }
-impl_asref_push_bytes!(PubkeyHash, WPubkeyHash);
+impl_asref_push_bytes!(WPubkeyHash);
 
 impl From<PublicKey> for PubkeyHash {
     fn from(key: PublicKey) -> PubkeyHash { key.pubkey_hash() }

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -13,7 +13,7 @@
 
 use core::{fmt, str};
 
-use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype};
+use hashes::{sha256, sha256d, sha256t_hash_newtype};
 use internals::write_err;
 use io::Write;
 
@@ -42,17 +42,18 @@ macro_rules! impl_message_from_hash {
     };
 }
 
-hash_newtype! {
+hashes::hash_newtype! {
     /// Hash of a transaction according to the legacy signature algorithm.
     #[hash_newtype(forward)]
     pub struct LegacySighash(sha256d::Hash);
+}
+impl_message_from_hash!(LegacySighash);
 
+hashes::hash_newtype! {
     /// Hash of a transaction according to the segwit version 0 signature algorithm.
     #[hash_newtype(forward)]
     pub struct SegwitV0Sighash(sha256d::Hash);
 }
-
-impl_message_from_hash!(LegacySighash);
 impl_message_from_hash!(SegwitV0Sighash);
 
 sha256t_hash_newtype! {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -254,7 +254,9 @@ mod tests {
     hash_newtype! {
         /// A test newtype
         struct TestNewtype(sha256d::Hash);
+    }
 
+    hash_newtype! {
         /// A test newtype
         struct TestNewtype2(sha256d::Hash);
     }

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -178,8 +178,7 @@ macro_rules! engine_input_impl(
 // may be composed of multiple token trees - that's the point of "double repetition".
 #[macro_export]
 macro_rules! hash_newtype {
-    ($($(#[$($type_attrs:tt)*])* $type_vis:vis struct $newtype:ident($(#[$field_attrs:tt])* $field_vis:vis $hash:path);)+) => {
-        $(
+    ($(#[$($type_attrs:tt)*])* $type_vis:vis struct $newtype:ident($(#[$field_attrs:tt])* $field_vis:vis $hash:path);) => {
         $($crate::hash_newtype_known_attrs!(#[ $($type_attrs)* ]);)*
 
         $crate::hash_newtype_struct! {
@@ -340,7 +339,6 @@ macro_rules! hash_newtype {
                 &self.0[index]
             }
         }
-        )+
     };
 }
 


### PR DESCRIPTION
Macros are hard enough to work on and read without adding the additional complexity from repetition. Also, since the macro call site is [hopefully] write-once-read-often code making the call site as quick to read as possible is beneficial.
    
The changes in this patch are subjective, I'd argue that the real benefit is in the future when we work more on refactoring and improving the macro.
