### PR TITLE
Run schemars test from extra_tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,8 +8,7 @@ The minimal/recent lock files are handled by CI (`rust.yml`).
 
 ## Jobs
 
-Run from `rust.yml` unless stated otherwise. Total 21 jobs but
-`Prepare` is quick and must be run first anyway.
+Run from `rust.yml` unless stated otherwise.
 
 0.  `Prepare`
 1.  `Stable - minimal`
@@ -24,11 +23,10 @@ Run from `rust.yml` unless stated otherwise. Total 21 jobs but
 10. `Bench`
 11. `ASAN`
 12. `WASM`
-13. `schemars`
-14. `Arch32bit`
-15. `Cross`
-16. `Embedded`
-17. `Kani`
-18. `Coveralls` - run by `coveralls.yml`
-19. `release` - run by `release.yml`
-20. `labeler` - run by `manage-pr.yml`
+13. `Arch32bit`
+14. `Cross`
+15. `Embedded`
+16. `Kani`
+17. `Coveralls` - run by `coveralls.yml`
+18. `release` - run by `release.yml`
+19. `labeler` - run by `manage-pr.yml`

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -292,20 +292,6 @@ jobs:
       - name: "Run wasm script"
         run: cd hashes && ./contrib/wasm.sh
 
-  Schemars:                     # hashes crate only.
-    name: Schemars - stable toolchain
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      # Note we do not use the recent lock file for schemars testing.
-    steps:
-      - name: "Checkout repo"
-        uses: actions/checkout@v4
-      - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@stable
-      - name: "Run schemars test"
-        run: cd hashes/extended_tests/schemars && cargo test
-
   Kani:
     name: Kani codegen - stable toolchain
     runs-on: ubuntu-20.04

--- a/hashes/contrib/extra_tests.sh
+++ b/hashes/contrib/extra_tests.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
-set -ex
+set -euox pipefail
 
 REPO_DIR=$(git rev-parse --show-toplevel)
 
-if [ "$DO_SCHEMARS_TESTS" = true ]; then
-    pushd "$REPO_DIR/hashes/extended_tests/schemars" > /dev/null
-    cargo test
-    popd > /dev/null
-fi
+pushd "$REPO_DIR/hashes/extended_tests/schemars" > /dev/null
+cargo test
+popd > /dev/null


### PR DESCRIPTION
We have a mechanism to run additional custom tests by way of the `extra_tests.sh` script in each crate.

Remove the CI job and run the schemars test using `extra_tests.sh`. This patch changes the test coverage because currently the schemars test is only run with a stable toolchain but with this patch applied it runs with stable, MSRV, and nightly.

Fix: #2787