### PR TITLE
Link to std::error::Error

### DIFF
--- a/internals/src/error/parse_error.rs
+++ b/internals/src/error/parse_error.rs
@@ -6,7 +6,7 @@
 /// [`InputString`](super::InputString), the type of `source` is specified as the second argument
 /// to the macro.
 ///
-/// The resulting type is public, conditionally implements `std::error::Error` and has a private
+/// The resulting type is public, conditionally implements [`std::error::Error`] and has a private
 /// `new()` method for convenience.
 ///
 /// # Parameters


### PR DESCRIPTION
In #2521 I removed the link from `std::error::Error` with the claim that it broke no-std builds. However there are a ton of other places where we link to `std::` types.

I have no idea where the breakage was, I assume it existed and I was sane at the time, CI on this patch will tell us.

Close: #2571