### PR TITLE
Pass keys by value

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -6851,7 +6851,7 @@ pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPubli
 pub fn bitcoin::CompressedPublicKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin::CompressedPublicKey::eq(&self, other: &bitcoin::CompressedPublicKey) -> bool
 pub fn bitcoin::CompressedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPublicKeyError>
+pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPublicKeyError>
 pub fn bitcoin::CompressedPublicKey::from_slice(data: &[u8]) -> core::result::Result<Self, secp256k1::Error>
 pub fn bitcoin::CompressedPublicKey::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::CompressedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6961,7 +6961,7 @@ pub fn bitcoin::PublicKey::eq(&self, other: &bitcoin::PublicKey) -> bool
 pub fn bitcoin::PublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::PublicKey::from(pk: secp256k1::key::PublicKey) -> bitcoin::PublicKey
 pub fn bitcoin::PublicKey::from(value: bitcoin::CompressedPublicKey) -> Self
-pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: bitcoin::PrivateKey) -> bitcoin::PublicKey
 pub fn bitcoin::PublicKey::from_slice(data: &[u8]) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::FromSliceError>
 pub fn bitcoin::PublicKey::from_str(s: &str) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::ParsePublicKeyError>
 pub fn bitcoin::PublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -7077,18 +7077,18 @@ pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bi
 pub fn bitcoin::address::Address::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::address::Address::from_script(script: &bitcoin::blockdata::script::Script, params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::FromScriptError>
 pub fn bitcoin::address::Address::from_witness_program(program: bitcoin::blockdata::script::witness_program::WitnessProgram, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: &bitcoin::PublicKey) -> bool
-pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: &secp256k1::key::XOnlyPublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: bitcoin::PublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: secp256k1::key::XOnlyPublicKey) -> bool
 pub fn bitcoin::address::Address::is_spend_standard(&self) -> bool
 pub fn bitcoin::address::Address::matches_script_pubkey(&self, script: &bitcoin::blockdata::script::Script) -> bool
 pub fn bitcoin::address::Address::p2pkh(pk: impl core::convert::Into<bitcoin::PubkeyHash>, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2sh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::P2shError>
 pub fn bitcoin::address::Address::p2sh_from_hash(hash: bitcoin::blockdata::script::ScriptHash, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::p2shwpkh(pk: &bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2shwpkh(pk: bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2shwsh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::p2wpkh(pk: &bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
+pub fn bitcoin::address::Address::p2wpkh(pk: bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
 pub fn bitcoin::address::Address::p2wsh(script: &bitcoin::blockdata::script::Script, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bitcoin::PubkeyHash>
 pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
@@ -7827,13 +7827,13 @@ pub fn bitcoin::blockdata::script::Builder::into_script(self) -> bitcoin::blockd
 pub fn bitcoin::blockdata::script::Builder::is_empty(&self) -> bool
 pub fn bitcoin::blockdata::script::Builder::len(&self) -> usize
 pub fn bitcoin::blockdata::script::Builder::push_int(self, data: i64) -> bitcoin::blockdata::script::Builder
-pub fn bitcoin::blockdata::script::Builder::push_key(self, key: &bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_key(self, key: bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_lock_time(self, lock_time: bitcoin::blockdata::locktime::absolute::LockTime) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_opcode(self, data: bitcoin::blockdata::opcodes::Opcode) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_sequence(self, sequence: bitcoin::blockdata::transaction::Sequence) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(self, data: T) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_verify(self) -> bitcoin::blockdata::script::Builder
-pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: &secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Bytes<'_>::next(&mut self) -> core::option::Option<Self::Item>
 pub fn bitcoin::blockdata::script::Bytes<'_>::next_back(&mut self) -> core::option::Option<Self::Item>
 pub fn bitcoin::blockdata::script::Bytes<'_>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
@@ -8170,7 +8170,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::hash<__H: core::hash::Hasher>(&sel
 pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin::blockdata::script::Script>
 pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: &bitcoin::PublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: bitcoin::PublicKey) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
@@ -8266,7 +8266,7 @@ pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wsh(&se
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::new(version: bitcoin::blockdata::script::witness_version::WitnessVersion, bytes: &[u8]) -> core::result::Result<Self, bitcoin::blockdata::script::witness_program::Error>
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
-pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wsh(script: &bitcoin::blockdata::script::Script) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::program(&self) -> &bitcoin::blockdata::script::PushBytes
@@ -8526,7 +8526,7 @@ pub fn bitcoin::blockdata::witness::Witness::last(&self) -> core::option::Option
 pub fn bitcoin::blockdata::witness::Witness::len(&self) -> usize
 pub fn bitcoin::blockdata::witness::Witness::nth(&self, index: usize) -> core::option::Option<&[u8]>
 pub fn bitcoin::blockdata::witness::Witness::p2tr_key_spend(signature: &bitcoin::taproot::Signature) -> bitcoin::blockdata::witness::Witness
-pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: &secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
 pub fn bitcoin::blockdata::witness::Witness::partial_cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
 pub fn bitcoin::blockdata::witness::Witness::push_ecdsa_signature(&mut self, signature: &bitcoin::ecdsa::Signature)

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -6544,7 +6544,7 @@ pub fn bitcoin::CompressedPublicKey::clone(&self) -> bitcoin::CompressedPublicKe
 pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::cmp::Ordering
 pub fn bitcoin::CompressedPublicKey::eq(&self, other: &bitcoin::CompressedPublicKey) -> bool
 pub fn bitcoin::CompressedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPublicKeyError>
+pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPublicKeyError>
 pub fn bitcoin::CompressedPublicKey::from_slice(data: &[u8]) -> core::result::Result<Self, secp256k1::Error>
 pub fn bitcoin::CompressedPublicKey::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::CompressedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6641,7 +6641,7 @@ pub fn bitcoin::PublicKey::eq(&self, other: &bitcoin::PublicKey) -> bool
 pub fn bitcoin::PublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::PublicKey::from(pk: secp256k1::key::PublicKey) -> bitcoin::PublicKey
 pub fn bitcoin::PublicKey::from(value: bitcoin::CompressedPublicKey) -> Self
-pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: bitcoin::PrivateKey) -> bitcoin::PublicKey
 pub fn bitcoin::PublicKey::from_slice(data: &[u8]) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::FromSliceError>
 pub fn bitcoin::PublicKey::from_str(s: &str) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::ParsePublicKeyError>
 pub fn bitcoin::PublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6745,18 +6745,18 @@ pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bi
 pub fn bitcoin::address::Address::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::address::Address::from_script(script: &bitcoin::blockdata::script::Script, params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::FromScriptError>
 pub fn bitcoin::address::Address::from_witness_program(program: bitcoin::blockdata::script::witness_program::WitnessProgram, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: &bitcoin::PublicKey) -> bool
-pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: &secp256k1::key::XOnlyPublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: bitcoin::PublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: secp256k1::key::XOnlyPublicKey) -> bool
 pub fn bitcoin::address::Address::is_spend_standard(&self) -> bool
 pub fn bitcoin::address::Address::matches_script_pubkey(&self, script: &bitcoin::blockdata::script::Script) -> bool
 pub fn bitcoin::address::Address::p2pkh(pk: impl core::convert::Into<bitcoin::PubkeyHash>, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2sh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::P2shError>
 pub fn bitcoin::address::Address::p2sh_from_hash(hash: bitcoin::blockdata::script::ScriptHash, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::p2shwpkh(pk: &bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2shwpkh(pk: bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2shwsh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::p2wpkh(pk: &bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
+pub fn bitcoin::address::Address::p2wpkh(pk: bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
 pub fn bitcoin::address::Address::p2wsh(script: &bitcoin::blockdata::script::Script, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bitcoin::PubkeyHash>
 pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
@@ -7443,13 +7443,13 @@ pub fn bitcoin::blockdata::script::Builder::into_script(self) -> bitcoin::blockd
 pub fn bitcoin::blockdata::script::Builder::is_empty(&self) -> bool
 pub fn bitcoin::blockdata::script::Builder::len(&self) -> usize
 pub fn bitcoin::blockdata::script::Builder::push_int(self, data: i64) -> bitcoin::blockdata::script::Builder
-pub fn bitcoin::blockdata::script::Builder::push_key(self, key: &bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_key(self, key: bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_lock_time(self, lock_time: bitcoin::blockdata::locktime::absolute::LockTime) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_opcode(self, data: bitcoin::blockdata::opcodes::Opcode) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_sequence(self, sequence: bitcoin::blockdata::transaction::Sequence) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(self, data: T) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_verify(self) -> bitcoin::blockdata::script::Builder
-pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: &secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Bytes<'_>::next(&mut self) -> core::option::Option<Self::Item>
 pub fn bitcoin::blockdata::script::Bytes<'_>::next_back(&mut self) -> core::option::Option<Self::Item>
 pub fn bitcoin::blockdata::script::Bytes<'_>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
@@ -7782,7 +7782,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::hash<__H: core::hash::Hasher>(&sel
 pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin::blockdata::script::Script>
 pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: &bitcoin::PublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: bitcoin::PublicKey) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
@@ -7871,7 +7871,7 @@ pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wsh(&se
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::new(version: bitcoin::blockdata::script::witness_version::WitnessVersion, bytes: &[u8]) -> core::result::Result<Self, bitcoin::blockdata::script::witness_program::Error>
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
-pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wsh(script: &bitcoin::blockdata::script::Script) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::program(&self) -> &bitcoin::blockdata::script::PushBytes
@@ -8110,7 +8110,7 @@ pub fn bitcoin::blockdata::witness::Witness::last(&self) -> core::option::Option
 pub fn bitcoin::blockdata::witness::Witness::len(&self) -> usize
 pub fn bitcoin::blockdata::witness::Witness::nth(&self, index: usize) -> core::option::Option<&[u8]>
 pub fn bitcoin::blockdata::witness::Witness::p2tr_key_spend(signature: &bitcoin::taproot::Signature) -> bitcoin::blockdata::witness::Witness
-pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: &secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
 pub fn bitcoin::blockdata::witness::Witness::partial_cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
 pub fn bitcoin::blockdata::witness::Witness::push_ecdsa_signature(&mut self, signature: &bitcoin::ecdsa::Signature)

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -5915,7 +5915,7 @@ pub fn bitcoin::CompressedPublicKey::clone(&self) -> bitcoin::CompressedPublicKe
 pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::cmp::Ordering
 pub fn bitcoin::CompressedPublicKey::eq(&self, other: &bitcoin::CompressedPublicKey) -> bool
 pub fn bitcoin::CompressedPublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPublicKeyError>
+pub fn bitcoin::CompressedPublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: bitcoin::PrivateKey) -> core::result::Result<Self, bitcoin::key::UncompressedPublicKeyError>
 pub fn bitcoin::CompressedPublicKey::from_slice(data: &[u8]) -> core::result::Result<Self, secp256k1::Error>
 pub fn bitcoin::CompressedPublicKey::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::CompressedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6012,7 +6012,7 @@ pub fn bitcoin::PublicKey::eq(&self, other: &bitcoin::PublicKey) -> bool
 pub fn bitcoin::PublicKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::PublicKey::from(pk: secp256k1::key::PublicKey) -> bitcoin::PublicKey
 pub fn bitcoin::PublicKey::from(value: bitcoin::CompressedPublicKey) -> Self
-pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: &bitcoin::PrivateKey) -> bitcoin::PublicKey
+pub fn bitcoin::PublicKey::from_private_key<C: secp256k1::context::Signing>(secp: &secp256k1::Secp256k1<C>, sk: bitcoin::PrivateKey) -> bitcoin::PublicKey
 pub fn bitcoin::PublicKey::from_slice(data: &[u8]) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::FromSliceError>
 pub fn bitcoin::PublicKey::from_str(s: &str) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::ParsePublicKeyError>
 pub fn bitcoin::PublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -6116,18 +6116,18 @@ pub fn bitcoin::address::Address::address_type(&self) -> core::option::Option<bi
 pub fn bitcoin::address::Address::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::address::Address::from_script(script: &bitcoin::blockdata::script::Script, params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::FromScriptError>
 pub fn bitcoin::address::Address::from_witness_program(program: bitcoin::blockdata::script::witness_program::WitnessProgram, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: &bitcoin::PublicKey) -> bool
-pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: &secp256k1::key::XOnlyPublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_pubkey(&self, pubkey: bitcoin::PublicKey) -> bool
+pub fn bitcoin::address::Address::is_related_to_xonly_pubkey(&self, xonly_pubkey: secp256k1::key::XOnlyPublicKey) -> bool
 pub fn bitcoin::address::Address::is_spend_standard(&self) -> bool
 pub fn bitcoin::address::Address::matches_script_pubkey(&self, script: &bitcoin::blockdata::script::Script) -> bool
 pub fn bitcoin::address::Address::p2pkh(pk: impl core::convert::Into<bitcoin::PubkeyHash>, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2sh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> core::result::Result<bitcoin::address::Address, bitcoin::address::error::P2shError>
 pub fn bitcoin::address::Address::p2sh_from_hash(hash: bitcoin::blockdata::script::ScriptHash, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::p2shwpkh(pk: &bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
+pub fn bitcoin::address::Address::p2shwpkh(pk: bitcoin::CompressedPublicKey, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2shwsh(script: &bitcoin::blockdata::script::Script, network: impl core::convert::Into<bitcoin::network::NetworkKind>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
-pub fn bitcoin::address::Address::p2wpkh(pk: &bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
+pub fn bitcoin::address::Address::p2wpkh(pk: bitcoin::CompressedPublicKey, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> Self
 pub fn bitcoin::address::Address::p2wsh(script: &bitcoin::blockdata::script::Script, hrp: impl core::convert::Into<bitcoin::address::KnownHrp>) -> bitcoin::address::Address
 pub fn bitcoin::address::Address::pubkey_hash(&self) -> core::option::Option<bitcoin::PubkeyHash>
 pub fn bitcoin::address::Address::script_hash(&self) -> core::option::Option<bitcoin::blockdata::script::ScriptHash>
@@ -6800,13 +6800,13 @@ pub fn bitcoin::blockdata::script::Builder::into_script(self) -> bitcoin::blockd
 pub fn bitcoin::blockdata::script::Builder::is_empty(&self) -> bool
 pub fn bitcoin::blockdata::script::Builder::len(&self) -> usize
 pub fn bitcoin::blockdata::script::Builder::push_int(self, data: i64) -> bitcoin::blockdata::script::Builder
-pub fn bitcoin::blockdata::script::Builder::push_key(self, key: &bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_key(self, key: bitcoin::PublicKey) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_lock_time(self, lock_time: bitcoin::blockdata::locktime::absolute::LockTime) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_opcode(self, data: bitcoin::blockdata::opcodes::Opcode) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_sequence(self, sequence: bitcoin::blockdata::transaction::Sequence) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_slice<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(self, data: T) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::push_verify(self) -> bitcoin::blockdata::script::Builder
-pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: &secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
+pub fn bitcoin::blockdata::script::Builder::push_x_only_key(self, x_only_key: secp256k1::key::XOnlyPublicKey) -> bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Bytes<'_>::next(&mut self) -> core::option::Option<Self::Item>
 pub fn bitcoin::blockdata::script::Bytes<'_>::next_back(&mut self) -> core::option::Option<Self::Item>
 pub fn bitcoin::blockdata::script::Bytes<'_>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
@@ -7137,7 +7137,7 @@ pub fn bitcoin::blockdata::script::ScriptBuf::hash<__H: core::hash::Hasher>(&sel
 pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin::blockdata::script::Script>
 pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: &bitcoin::PublicKey) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: bitcoin::PublicKey) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
@@ -7225,7 +7225,7 @@ pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::is_p2wsh(&se
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::new(version: bitcoin::blockdata::script::witness_version::WitnessVersion, bytes: &[u8]) -> core::result::Result<Self, bitcoin::blockdata::script::witness_program::Error>
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
-pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: &bitcoin::CompressedPublicKey) -> Self
+pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wpkh(pk: bitcoin::CompressedPublicKey) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::p2wsh(script: &bitcoin::blockdata::script::Script) -> Self
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::program(&self) -> &bitcoin::blockdata::script::PushBytes
@@ -7455,7 +7455,7 @@ pub fn bitcoin::blockdata::witness::Witness::last(&self) -> core::option::Option
 pub fn bitcoin::blockdata::witness::Witness::len(&self) -> usize
 pub fn bitcoin::blockdata::witness::Witness::nth(&self, index: usize) -> core::option::Option<&[u8]>
 pub fn bitcoin::blockdata::witness::Witness::p2tr_key_spend(signature: &bitcoin::taproot::Signature) -> bitcoin::blockdata::witness::Witness
-pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: &secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::p2wpkh(signature: &bitcoin::ecdsa::Signature, pubkey: secp256k1::key::PublicKey) -> bitcoin::blockdata::witness::Witness
 pub fn bitcoin::blockdata::witness::Witness::partial_cmp(&self, other: &bitcoin::blockdata::witness::Witness) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin::blockdata::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
 pub fn bitcoin::blockdata::witness::Witness::push_ecdsa_signature(&mut self, signature: &bitcoin::ecdsa::Signature)

--- a/bitcoin/embedded/src/main.rs
+++ b/bitcoin/embedded/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
 
     // Derive address
     let pubkey = pk.public_key(&secp).try_into().unwrap();
-    let address = Address::p2wpkh(&pubkey, Network::Bitcoin);
+    let address = Address::p2wpkh(pubkey, Network::Bitcoin);
     hprintln!("Address: {}", address).unwrap();
 
     assert_eq!(address.to_string(), "bc1qpx9t9pzzl4qsydmhyt6ctrxxjd4ep549np9993".to_string());

--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -50,6 +50,6 @@ fn main() {
     // manually creating indexes this time
     let zero = ChildNumber::from_normal_idx(0).unwrap();
     let public_key = xpub.derive_pub(&secp, &[zero, zero]).unwrap().public_key;
-    let address = Address::p2wpkh(&CompressedPublicKey(public_key), KnownHrp::Mainnet);
+    let address = Address::p2wpkh(CompressedPublicKey(public_key), KnownHrp::Mainnet);
     println!("First receiving address: {}", address);
 }

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -222,7 +222,7 @@ fn main() {
         .enumerate()
         .map(|(idx, input)| {
             let (_, sig) = input.partial_sigs.iter().next().expect("we have one sig");
-            Witness::p2wpkh(sig, &pk_inputs[idx].0)
+            Witness::p2wpkh(sig, pk_inputs[idx].0)
         })
         .collect();
     psbt.inputs.iter_mut().enumerate().for_each(|(idx, input)| {

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -259,7 +259,7 @@ impl WatchOnly {
         let derived = self.account_0_xpub.derive_pub(secp, &path)?;
 
         let pk = derived.to_pub();
-        let addr = Address::p2wpkh(&pk, NETWORK);
+        let addr = Address::p2wpkh(pk, NETWORK);
         let path = path.into_derivation_path()?;
 
         Ok((pk, addr, path))

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -76,7 +76,7 @@ fn main() {
     // Update the witness stack.
     let signature = bitcoin::ecdsa::Signature { signature, sighash_type };
     let pk = sk.public_key(&secp);
-    *sighasher.witness_mut(input_index).unwrap() = Witness::p2wpkh(&signature, &pk);
+    *sighasher.witness_mut(input_index).unwrap() = Witness::p2wpkh(&signature, pk);
 
     // Get the signed transaction.
     let tx = sighasher.into_transaction();

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -298,7 +298,7 @@ fn generate_bip86_key_spend_tx(
 
             let secret_key = master_xpriv.derive_priv(secp, &derivation_path).to_priv().inner;
             sign_psbt_taproot(
-                &secret_key,
+                secret_key,
                 input.tap_internal_key.unwrap(),
                 None,
                 input,
@@ -372,7 +372,7 @@ impl BenefactorWallet {
             .push_int(locktime.to_consensus_u32() as i64)
             .push_opcode(OP_CLTV)
             .push_opcode(OP_DROP)
-            .push_x_only_key(&beneficiary_key)
+            .push_x_only_key(beneficiary_key)
             .push_opcode(OP_CHECKSIG)
             .into_script()
     }
@@ -532,7 +532,7 @@ impl BenefactorWallet {
                 let secret_key =
                     self.master_xpriv.derive_priv(&self.secp, &derivation_path).to_priv().inner;
                 sign_psbt_taproot(
-                    &secret_key,
+                    secret_key,
                     spend_info.internal_key(),
                     None,
                     input,
@@ -664,7 +664,7 @@ impl BeneficiaryWallet {
                     sighash_type,
                 )?;
                 sign_psbt_taproot(
-                    &secret_key,
+                    secret_key,
                     *x_only_pubkey,
                     Some(*lh),
                     &mut psbt.inputs[0],
@@ -724,7 +724,7 @@ impl BeneficiaryWallet {
 
 // Calling this with `leaf_hash` = `None` will sign for key-spend
 fn sign_psbt_taproot(
-    secret_key: &secp256k1::SecretKey,
+    secret_key: secp256k1::SecretKey,
     pubkey: XOnlyPublicKey,
     leaf_hash: Option<TapLeafHash>,
     psbt_input: &mut psbt::Input,

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -421,7 +421,7 @@ impl Address {
     /// Creates a witness pay to public key address from a public key.
     ///
     /// This is the native segwit address type for an output redeemable with a single signature.
-    pub fn p2wpkh(pk: &CompressedPublicKey, hrp: impl Into<KnownHrp>) -> Self {
+    pub fn p2wpkh(pk: CompressedPublicKey, hrp: impl Into<KnownHrp>) -> Self {
         let program = WitnessProgram::p2wpkh(pk);
         Address::from_witness_program(program, hrp)
     }
@@ -429,7 +429,7 @@ impl Address {
     /// Creates a pay to script address that embeds a witness pay to public key.
     ///
     /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
-    pub fn p2shwpkh(pk: &CompressedPublicKey, network: impl Into<NetworkKind>) -> Address {
+    pub fn p2shwpkh(pk: CompressedPublicKey, network: impl Into<NetworkKind>) -> Address {
         let builder = script::Builder::new().push_int(0).push_slice(pk.wpubkey_hash());
         let script_hash = builder.as_script().script_hash();
         Address::p2sh_from_hash(script_hash, network)
@@ -628,7 +628,7 @@ impl Address {
     /// This is determined by directly comparing the address payload with either the
     /// hash of the given public key or the segwit redeem hash generated from the
     /// given key. For taproot addresses, the supplied key is assumed to be tweaked
-    pub fn is_related_to_pubkey(&self, pubkey: &PublicKey) -> bool {
+    pub fn is_related_to_pubkey(&self, pubkey: PublicKey) -> bool {
         let pubkey_hash = pubkey.pubkey_hash();
         let payload = self.payload_as_bytes();
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
@@ -642,7 +642,7 @@ impl Address {
     ///
     /// This will only work for Taproot addresses. The Public Key is
     /// assumed to have already been tweaked.
-    pub fn is_related_to_xonly_pubkey(&self, xonly_pubkey: &XOnlyPublicKey) -> bool {
+    pub fn is_related_to_xonly_pubkey(&self, xonly_pubkey: XOnlyPublicKey) -> bool {
         xonly_pubkey.serialize() == *self.payload_as_bytes()
     }
 
@@ -966,7 +966,7 @@ mod tests {
         let key = "033bc8c83c52df5712229a2f72206d90192366c36428cb0c12b6af98324d97bfbc"
             .parse::<CompressedPublicKey>()
             .unwrap();
-        let addr = Address::p2wpkh(&key, KnownHrp::Mainnet);
+        let addr = Address::p2wpkh(key, KnownHrp::Mainnet);
         assert_eq!(&addr.to_string(), "bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw");
         assert_eq!(addr.address_type(), Some(AddressType::P2wpkh));
         roundtrips(&addr, Bitcoin);
@@ -991,7 +991,7 @@ mod tests {
         let key = "026c468be64d22761c30cd2f12cbc7de255d592d7904b1bab07236897cc4c2e766"
             .parse::<CompressedPublicKey>()
             .unwrap();
-        let addr = Address::p2shwpkh(&key, NetworkKind::Main);
+        let addr = Address::p2shwpkh(key, NetworkKind::Main);
         assert_eq!(&addr.to_string(), "3QBRmWNqqBGme9er7fMkGqtZtp4gjMFxhE");
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
         roundtrips(&addr, Bitcoin);
@@ -1202,14 +1202,14 @@ mod tests {
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
         let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
 
-        let result = address.is_related_to_pubkey(&pubkey);
+        let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
         let unused_pubkey = PublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
-        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+        assert!(!address.is_related_to_pubkey(unused_pubkey))
     }
 
     #[test]
@@ -1223,14 +1223,14 @@ mod tests {
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
         let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
 
-        let result = address.is_related_to_pubkey(&pubkey);
+        let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
         let unused_pubkey = PublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
-        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+        assert!(!address.is_related_to_pubkey(unused_pubkey))
     }
 
     #[test]
@@ -1244,14 +1244,14 @@ mod tests {
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
         let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
 
-        let result = address.is_related_to_pubkey(&pubkey);
+        let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
         let unused_pubkey = PublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
-        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+        assert!(!address.is_related_to_pubkey(unused_pubkey))
     }
 
     #[test]
@@ -1265,14 +1265,14 @@ mod tests {
         let pubkey_string = "04e96e22004e3db93530de27ccddfdf1463975d2138ac018fc3e7ba1a2e5e0aad8e424d0b55e2436eb1d0dcd5cb2b8bcc6d53412c22f358de57803a6a655fbbd04";
         let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
 
-        let result = address.is_related_to_pubkey(&pubkey);
+        let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
         let unused_pubkey = PublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
-        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+        assert!(!address.is_related_to_pubkey(unused_pubkey))
     }
 
     #[test]
@@ -1291,14 +1291,14 @@ mod tests {
                 .expect("mainnet")
         );
 
-        let result = address.is_related_to_pubkey(&pubkey);
+        let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
         let unused_pubkey = PublicKey::from_str(
             "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
         )
         .expect("pubkey");
-        assert!(!address.is_related_to_pubkey(&unused_pubkey));
+        assert!(!address.is_related_to_pubkey(unused_pubkey));
     }
 
     #[test]
@@ -1317,7 +1317,7 @@ mod tests {
                 .expect("mainnet")
         );
 
-        let result = address.is_related_to_xonly_pubkey(&xonly_pubkey);
+        let result = address.is_related_to_xonly_pubkey(xonly_pubkey);
         assert!(result);
     }
 

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -64,7 +64,7 @@ impl Builder {
     }
 
     /// Adds instructions to push a public key onto the stack.
-    pub fn push_key(self, key: &PublicKey) -> Builder {
+    pub fn push_key(self, key: PublicKey) -> Builder {
         if key.compressed {
             self.push_slice(key.inner.serialize())
         } else {
@@ -73,7 +73,7 @@ impl Builder {
     }
 
     /// Adds instructions to push an XOnly public key onto the stack.
-    pub fn push_x_only_key(self, x_only_key: &XOnlyPublicKey) -> Builder {
+    pub fn push_x_only_key(self, x_only_key: XOnlyPublicKey) -> Builder {
         self.push_slice(x_only_key.serialize())
     }
 

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -76,7 +76,7 @@ impl ScriptBuf {
     pub fn builder() -> Builder { Builder::new() }
 
     /// Generates P2PK-type of scriptPubkey.
-    pub fn new_p2pk(pubkey: &PublicKey) -> Self {
+    pub fn new_p2pk(pubkey: PublicKey) -> Self {
         Builder::new().push_key(pubkey).push_opcode(OP_CHECKSIG).into_script()
     }
 

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -37,10 +37,10 @@ fn script() {
     // keys
     const KEYSTR1: &str = "21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";
     let key = PublicKey::from_str(&KEYSTR1[2..]).unwrap();
-    script = script.push_key(&key); comp.extend_from_slice(&hex!(KEYSTR1)); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_key(key); comp.extend_from_slice(&hex!(KEYSTR1)); assert_eq!(script.as_bytes(), &comp[..]);
     const KEYSTR2: &str = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
     let key = PublicKey::from_str(&KEYSTR2[2..]).unwrap();
-    script = script.push_key(&key); comp.extend_from_slice(&hex!(KEYSTR2)); assert_eq!(script.as_bytes(), &comp[..]);
+    script = script.push_key(key); comp.extend_from_slice(&hex!(KEYSTR2)); assert_eq!(script.as_bytes(), &comp[..]);
 
     // opcodes
     script = script.push_opcode(OP_CHECKSIG); comp.push(0xACu8); assert_eq!(script.as_bytes(), &comp[..]);
@@ -51,7 +51,7 @@ fn script() {
 fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
+    let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
     assert_eq!(actual.to_vec(), key.to_bytes());
 }
@@ -60,7 +60,7 @@ fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
 fn p2pk_pubkey_bytes_no_checksig_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let no_checksig = Script::builder().push_key(&key).into_script();
+    let no_checksig = Script::builder().push_key(key).into_script();
     assert_eq!(no_checksig.p2pk_pubkey_bytes(), None);
 }
 
@@ -81,7 +81,7 @@ fn p2pk_pubkey_bytes_no_key_returns_none() {
 fn p2pk_pubkey_bytes_different_op_code_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let different_op_code = Script::builder().push_key(&key).push_opcode(OP_NOP).into_script();
+    let different_op_code = Script::builder().push_key(key).push_opcode(OP_NOP).into_script();
     assert!(different_op_code.p2pk_pubkey_bytes().is_none());
 }
 
@@ -106,7 +106,7 @@ fn p2pk_pubkey_bytes_invalid_key_returns_some() {
 fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
     let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
     let key = PublicKey::from_str(compressed_key_str).unwrap();
-    let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
+    let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
     assert_eq!(actual.to_vec(), key.to_bytes());
 }
@@ -115,7 +115,7 @@ fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
 fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
+    let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_public_key().unwrap();
     assert_eq!(actual, key);
 }
@@ -124,7 +124,7 @@ fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
 fn p2pk_public_key_no_checksig_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let no_checksig = Script::builder().push_key(&key).into_script();
+    let no_checksig = Script::builder().push_key(key).into_script();
     assert_eq!(no_checksig.p2pk_public_key(), None);
 }
 
@@ -144,7 +144,7 @@ fn p2pk_public_key_no_key_returns_none() {
 fn p2pk_public_key_different_op_code_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let different_op_code = Script::builder().push_key(&key).push_opcode(OP_NOP).into_script();
+    let different_op_code = Script::builder().push_key(key).push_opcode(OP_NOP).into_script();
     assert!(different_op_code.p2pk_public_key().is_none());
 }
 
@@ -168,7 +168,7 @@ fn p2pk_public_key_invalid_key_returns_none() {
 fn p2pk_public_key_compressed_key_returns_some() {
     let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
     let key = PublicKey::from_str(compressed_key_str).unwrap();
-    let p2pk = Script::builder().push_key(&key).push_opcode(OP_CHECKSIG).into_script();
+    let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_public_key().unwrap();
     assert_eq!(actual, key);
 }
@@ -180,7 +180,7 @@ fn script_x_only_key() {
     // From: https://github.com/bitcoin-core/btcdeb/blob/e8c2750c4a4702768c52d15640ed03bf744d2601/doc/tapscript-example.md?plain=1#L43
     const KEYSTR: &str = "209997a497d964fc1a62885b05a51166a65a90df00492c8d7cf61d6accf54803be";
     let x_only_key = XOnlyPublicKey::from_str(&KEYSTR[2..]).unwrap();
-    let script = Builder::new().push_x_only_key(&x_only_key);
+    let script = Builder::new().push_x_only_key(x_only_key);
     assert_eq!(script.into_bytes(), &hex!(KEYSTR) as &[u8]);
 }
 
@@ -202,7 +202,7 @@ fn script_generators() {
     let pubkey =
         PublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e")
             .unwrap();
-    assert!(ScriptBuf::new_p2pk(&pubkey).is_p2pk());
+    assert!(ScriptBuf::new_p2pk(pubkey).is_p2pk());
 
     let pubkey_hash = PubkeyHash::hash(&pubkey.inner.serialize());
     assert!(ScriptBuf::new_p2pkh(&pubkey_hash).is_p2pkh());

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -72,7 +72,7 @@ impl WitnessProgram {
     }
 
     /// Creates a [`WitnessProgram`] from `pk` for a P2WPKH output.
-    pub fn p2wpkh(pk: &CompressedPublicKey) -> Self {
+    pub fn p2wpkh(pk: CompressedPublicKey) -> Self {
         let hash = pk.wpubkey_hash();
         WitnessProgram::new_p2wpkh(hash.to_byte_array())
     }

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -243,7 +243,7 @@ impl Witness {
     /// serialized public key. Also useful for spending a P2SH-P2WPKH output.
     ///
     /// It is expected that `pubkey` is related to the secret key used to create `signature`.
-    pub fn p2wpkh(signature: &ecdsa::Signature, pubkey: &secp256k1::PublicKey) -> Witness {
+    pub fn p2wpkh(signature: &ecdsa::Signature, pubkey: secp256k1::PublicKey) -> Witness {
         let mut witness = Witness::new();
         witness.push_slice(&signature.serialize());
         witness.push_slice(&pubkey.serialize());

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -194,7 +194,7 @@ impl PublicKey {
     /// Computes the public key as supposed to be used with this secret.
     pub fn from_private_key<C: secp256k1::Signing>(
         secp: &Secp256k1<C>,
-        sk: &PrivateKey,
+        sk: PrivateKey,
     ) -> PublicKey {
         sk.public_key(secp)
     }
@@ -327,7 +327,7 @@ impl CompressedPublicKey {
     /// Computes the public key as supposed to be used with this secret.
     pub fn from_private_key<C: secp256k1::Signing>(
         secp: &Secp256k1<C>,
-        sk: &PrivateKey,
+        sk: PrivateKey,
     ) -> Result<Self, UncompressedPublicKeyError> {
         sk.public_key(secp).try_into()
     }
@@ -1243,7 +1243,7 @@ mod tests {
 
         let s = Secp256k1::new();
         let sk = PrivateKey::from_str(KEY_WIF).unwrap();
-        let pk = PublicKey::from_private_key(&s, &sk);
+        let pk = PublicKey::from_private_key(&s, sk);
         let pk_u = PublicKey { inner: pk.inner, compressed: false };
 
         assert_tokens(&sk, &[Token::BorrowedStr(KEY_WIF)]);

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -2120,7 +2120,7 @@ mod tests {
 
         let sk = SecretKey::new(&mut thread_rng());
         let priv_key = PrivateKey::new(sk, NetworkKind::Test);
-        let pk = PublicKey::from_private_key(&secp, &priv_key);
+        let pk = PublicKey::from_private_key(&secp, priv_key);
 
         (priv_key, pk, secp)
     }

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -246,12 +246,12 @@ mod tests {
 
         let p2pkh = Address::p2pkh(pubkey, NetworkKind::Main);
         assert_eq!(signature2.is_signed_by_address(&secp, &p2pkh, msg_hash), Ok(true));
-        let p2wpkh = Address::p2wpkh(&pubkey, Network::Bitcoin);
+        let p2wpkh = Address::p2wpkh(pubkey, Network::Bitcoin);
         assert_eq!(
             signature2.is_signed_by_address(&secp, &p2wpkh, msg_hash),
             Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2wpkh))
         );
-        let p2shwpkh = Address::p2shwpkh(&pubkey, NetworkKind::Main);
+        let p2shwpkh = Address::p2shwpkh(pubkey, NetworkKind::Main);
         assert_eq!(
             signature2.is_signed_by_address(&secp, &p2shwpkh, msg_hash),
             Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2sh))


### PR DESCRIPTION
We should pass `Copy` types by value not by reference. Pass the key types by value.

This is patch 1 from #2404