### PR TITLE
Update PushBytes::read_scriptint(x) to x.read_scriptint()

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -19,7 +19,6 @@ use crate::consensus::{encode, Decodable, Encodable, Params};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::pow::{CompactTarget, Target, Work};
 use crate::prelude::*;
-use crate::script::PushBytes;
 use crate::{merkle_tree, VarInt};
 
 hashes::hash_newtype! {
@@ -381,7 +380,7 @@ impl Block {
         match push.map_err(|_| Bip34Error::NotPresent)? {
             script::Instruction::PushBytes(b) => {
                 // Check that the number is encoded in the minimal way.
-                let h = PushBytes::read_scriptint(b)
+                let h = b.read_scriptint()
                     .map_err(|_e| Bip34Error::UnexpectedPush(b.as_bytes().to_vec()))?;
                 if h < 0 {
                     Err(Bip34Error::NegativeHeight)

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -76,7 +76,7 @@ impl<'a> Instruction<'a> {
                     _ => None,
                 }
             }
-            Instruction::PushBytes(bytes) => match PushBytes::read_scriptint(bytes) {
+            Instruction::PushBytes(bytes) => match bytes.read_scriptint() {
                 Ok(v) => Some(v),
                 _ => None,
             },

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -23,7 +23,7 @@ fn do_test(data: &[u8]) {
                     // reserialized as numbers. (For -1 through 16, this will use special ops; for
                     // others it'll just reserialize them as pushes.)
                     if bytes.len() == 1 && bytes[0] != 0x80 && bytes[0] != 0x00 {
-                        if let Ok(num) = script::PushBytes::read_scriptint(bytes) {
+                        if let Ok(num) = bytes.read_scriptint() {
                             b = b.push_int(num);
                         } else {
                             b = b.push_slice(bytes);


### PR DESCRIPTION
Fixes #2849 

There were a few other usages of PushBytes::read_scriptint(_) in the tests such as [this](https://github.com/rust-bitcoin/rust-bitcoin/blob/406e3486ab4c0bee059ed6442dde0cd60ee4277f/bitcoin/src/blockdata/script/tests.rs#L315), but they couldn't be updated as cleanly as the changes in this PR. I wasn't sure if the intention of this issue was to fix those as well, but I can update this PR if needed