### PR TITLE
Pass hash types by value

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -7323,15 +7323,15 @@ pub fn bitcoin::bip158::BitStreamWriter<'a, W>::new(writer: &'a mut W) -> bitcoi
 pub fn bitcoin::bip158::BitStreamWriter<'a, W>::write(&mut self, data: u64, nbits: u8) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::BlockFilter::clone(&self) -> bitcoin::bip158::BlockFilter
 pub fn bitcoin::bip158::BlockFilter::eq(&self, other: &bitcoin::bip158::BlockFilter) -> bool
-pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::BlockFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
-pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
 pub fn bitcoin::bip158::BlockFilter::new(content: &[u8]) -> bitcoin::bip158::BlockFilter
 pub fn bitcoin::bip158::BlockFilter::new_script_filter<M, S>(block: &bitcoin::blockdata::block::Block, script_for_coin: M) -> core::result::Result<bitcoin::bip158::BlockFilter, bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
 pub fn bitcoin::bip158::BlockFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
 pub fn bitcoin::bip158::BlockFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
-pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: &bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
+pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_element(&mut self, data: &[u8])
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_input_scripts<M, S>(&mut self, script_for_coin: M) -> core::result::Result<(), bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_output_scripts(&mut self)
@@ -7356,7 +7356,7 @@ pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core
 pub fn bitcoin::bip158::FilterHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHash, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin::bip158::FilterHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
-pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
@@ -7614,7 +7614,7 @@ pub fn bitcoin::blockdata::block::Block::check_witness_commitment(&self) -> bool
 pub fn bitcoin::blockdata::block::Block::clone(&self) -> bitcoin::blockdata::block::Block
 pub fn bitcoin::blockdata::block::Block::coinbase(&self) -> core::option::Option<&bitcoin::blockdata::transaction::Transaction>
 pub fn bitcoin::blockdata::block::Block::compute_merkle_root(&self) -> core::option::Option<bitcoin::merkle_tree::TxMerkleNode>
-pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: &bitcoin::merkle_tree::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: bitcoin::merkle_tree::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::Block::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::Block::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::Block::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
@@ -8193,12 +8193,12 @@ pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::
 pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: bitcoin::PublicKey) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: bitcoin::blockdata::script::ScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: &bitcoin::WPubkeyHash) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: &bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: bitcoin::blockdata::script::WScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_witness_program(witness_program: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::p2wpkh_script_code(wpkh: bitcoin::WPubkeyHash) -> bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -6987,15 +6987,15 @@ pub fn bitcoin::bip158::BitStreamWriter<'a, W>::new(writer: &'a mut W) -> bitcoi
 pub fn bitcoin::bip158::BitStreamWriter<'a, W>::write(&mut self, data: u64, nbits: u8) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::BlockFilter::clone(&self) -> bitcoin::bip158::BlockFilter
 pub fn bitcoin::bip158::BlockFilter::eq(&self, other: &bitcoin::bip158::BlockFilter) -> bool
-pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::BlockFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
-pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
 pub fn bitcoin::bip158::BlockFilter::new(content: &[u8]) -> bitcoin::bip158::BlockFilter
 pub fn bitcoin::bip158::BlockFilter::new_script_filter<M, S>(block: &bitcoin::blockdata::block::Block, script_for_coin: M) -> core::result::Result<bitcoin::bip158::BlockFilter, bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
 pub fn bitcoin::bip158::BlockFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
 pub fn bitcoin::bip158::BlockFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
-pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: &bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
+pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_element(&mut self, data: &[u8])
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_input_scripts<M, S>(&mut self, script_for_coin: M) -> core::result::Result<(), bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_output_scripts(&mut self)
@@ -7019,7 +7019,7 @@ pub fn bitcoin::bip158::FilterHash::consensus_decode<R: bitcoin_io::BufRead + co
 pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::FilterHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
-pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
@@ -7257,7 +7257,7 @@ pub fn bitcoin::blockdata::block::Block::check_witness_commitment(&self) -> bool
 pub fn bitcoin::blockdata::block::Block::clone(&self) -> bitcoin::blockdata::block::Block
 pub fn bitcoin::blockdata::block::Block::coinbase(&self) -> core::option::Option<&bitcoin::blockdata::transaction::Transaction>
 pub fn bitcoin::blockdata::block::Block::compute_merkle_root(&self) -> core::option::Option<bitcoin::merkle_tree::TxMerkleNode>
-pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: &bitcoin::merkle_tree::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: bitcoin::merkle_tree::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::Block::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::Block::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::Block::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
@@ -7811,12 +7811,12 @@ pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::
 pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: bitcoin::PublicKey) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: bitcoin::blockdata::script::ScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: &bitcoin::WPubkeyHash) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: &bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: bitcoin::blockdata::script::WScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_witness_program(witness_program: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::p2wpkh_script_code(wpkh: bitcoin::WPubkeyHash) -> bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -6351,15 +6351,15 @@ pub fn bitcoin::bip158::BitStreamWriter<'a, W>::new(writer: &'a mut W) -> bitcoi
 pub fn bitcoin::bip158::BitStreamWriter<'a, W>::write(&mut self, data: u64, nbits: u8) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::BlockFilter::clone(&self) -> bitcoin::bip158::BlockFilter
 pub fn bitcoin::bip158::BlockFilter::eq(&self, other: &bitcoin::bip158::BlockFilter) -> bool
-pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::BlockFilter::filter_header(&self, previous_filter_header: bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::BlockFilter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
-pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: &bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_all<I>(&self, block_hash: bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
+pub fn bitcoin::bip158::BlockFilter::match_any<I>(&self, block_hash: bitcoin::blockdata::block::BlockHash, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>
 pub fn bitcoin::bip158::BlockFilter::new(content: &[u8]) -> bitcoin::bip158::BlockFilter
 pub fn bitcoin::bip158::BlockFilter::new_script_filter<M, S>(block: &bitcoin::blockdata::block::Block, script_for_coin: M) -> core::result::Result<bitcoin::bip158::BlockFilter, bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
 pub fn bitcoin::bip158::BlockFilterReader::match_all<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
 pub fn bitcoin::bip158::BlockFilterReader::match_any<I, R>(&self, reader: &mut R, query: I) -> core::result::Result<bool, bitcoin::bip158::Error> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<[u8]>, R: bitcoin_io::BufRead + core::marker::Sized
-pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: &bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
+pub fn bitcoin::bip158::BlockFilterReader::new(block_hash: bitcoin::blockdata::block::BlockHash) -> bitcoin::bip158::BlockFilterReader
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_element(&mut self, data: &[u8])
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_input_scripts<M, S>(&mut self, script_for_coin: M) -> core::result::Result<(), bitcoin::bip158::Error> where M: core::ops::function::Fn(&bitcoin::blockdata::transaction::OutPoint) -> core::result::Result<S, bitcoin::bip158::Error>, S: core::borrow::Borrow<bitcoin::blockdata::script::Script>
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::add_output_scripts(&mut self)
@@ -6382,7 +6382,7 @@ pub fn bitcoin::bip158::FilterHash::consensus_decode<R: bitcoin_io::BufRead + co
 pub fn bitcoin::bip158::FilterHash::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn bitcoin::bip158::FilterHash::engine() -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Engine
 pub fn bitcoin::bip158::FilterHash::eq(&self, other: &bitcoin::bip158::FilterHash) -> bool
-pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: &bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHash::filter_header(&self, previous_filter_header: bitcoin::bip158::FilterHeader) -> bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin::bip158::FilterHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
@@ -6618,7 +6618,7 @@ pub fn bitcoin::blockdata::block::Block::check_witness_commitment(&self) -> bool
 pub fn bitcoin::blockdata::block::Block::clone(&self) -> bitcoin::blockdata::block::Block
 pub fn bitcoin::blockdata::block::Block::coinbase(&self) -> core::option::Option<&bitcoin::blockdata::transaction::Transaction>
 pub fn bitcoin::blockdata::block::Block::compute_merkle_root(&self) -> core::option::Option<bitcoin::merkle_tree::TxMerkleNode>
-pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: &bitcoin::merkle_tree::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::Block::compute_witness_commitment(witness_root: bitcoin::merkle_tree::WitnessMerkleNode, witness_reserved_value: &[u8]) -> bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::Block::consensus_decode<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::Block::consensus_decode_from_finite_reader<R: bitcoin_io::BufRead + core::marker::Sized>(r: &mut R) -> core::result::Result<bitcoin::blockdata::block::Block, bitcoin::consensus::encode::Error>
 pub fn bitcoin::blockdata::block::Block::consensus_encode<R: bitcoin_io::Write + core::marker::Sized>(&self, r: &mut R) -> core::result::Result<usize, bitcoin_io::error::Error>
@@ -7166,12 +7166,12 @@ pub fn bitcoin::blockdata::script::ScriptBuf::into_boxed_script(self) -> alloc::
 pub fn bitcoin::blockdata::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
 pub fn bitcoin::blockdata::script::ScriptBuf::new_op_return<T: core::convert::AsRef<bitcoin::blockdata::script::PushBytes>>(data: T) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pk(pubkey: bitcoin::PublicKey) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: &bitcoin::PubkeyHash) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: &bitcoin::blockdata::script::ScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2pkh(pubkey_hash: bitcoin::PubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2sh(script_hash: bitcoin::blockdata::script::ScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr<C: secp256k1::context::Verification>(secp: &secp256k1::Secp256k1<C>, internal_key: bitcoin::key::UntweakedPublicKey, merkle_root: core::option::Option<bitcoin::taproot::TapNodeHash>) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_p2tr_tweaked(output_key: bitcoin::key::TweakedPublicKey) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: &bitcoin::WPubkeyHash) -> Self
-pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: &bitcoin::blockdata::script::WScriptHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wpkh(pubkey_hash: bitcoin::WPubkeyHash) -> Self
+pub fn bitcoin::blockdata::script::ScriptBuf::new_p2wsh(script_hash: bitcoin::blockdata::script::WScriptHash) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::new_witness_program(witness_program: &bitcoin::blockdata::script::witness_program::WitnessProgram) -> Self
 pub fn bitcoin::blockdata::script::ScriptBuf::p2wpkh_script_code(wpkh: bitcoin::WPubkeyHash) -> bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::blockdata::script::ScriptBuf::partial_cmp(&self, other: &bitcoin::blockdata::script::Script) -> core::option::Option<core::cmp::Ordering>

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -163,7 +163,7 @@ fn main() {
     // The change output is locked to a key controlled by us.
     let change = TxOut {
         value: CHANGE_AMOUNT,
-        script_pubkey: ScriptBuf::new_p2wpkh(&pk_change.wpubkey_hash()), // Change comes back to us.
+        script_pubkey: ScriptBuf::new_p2wpkh(pk_change.wpubkey_hash()), // Change comes back to us.
     };
 
     // The transaction we want to sign and broadcast.
@@ -196,14 +196,14 @@ fn main() {
     psbt.inputs = vec![
         Input {
             witness_utxo: Some(utxos[0].clone()),
-            redeem_script: Some(ScriptBuf::new_p2wpkh(&wpkhs[0])),
+            redeem_script: Some(ScriptBuf::new_p2wpkh(wpkhs[0])),
             bip32_derivation: bip32_derivations[0].clone(),
             sighash_type: Some(ty),
             ..Default::default()
         },
         Input {
             witness_utxo: Some(utxos[1].clone()),
-            redeem_script: Some(ScriptBuf::new_p2wpkh(&wpkhs[1])),
+            redeem_script: Some(ScriptBuf::new_p2wpkh(wpkhs[1])),
             bip32_derivation: bip32_derivations[1].clone(),
             sighash_type: Some(ty),
             ..Default::default()

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -206,7 +206,7 @@ impl WatchOnly {
         let pk = self.input_xpub.to_pub();
         let wpkh = pk.wpubkey_hash();
 
-        let redeem_script = ScriptBuf::new_p2wpkh(&wpkh);
+        let redeem_script = ScriptBuf::new_p2wpkh(wpkh);
         input.redeem_script = Some(redeem_script);
 
         let fingerprint = self.master_fingerprint;

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -37,7 +37,7 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, value: u64) {
     let pk = CompressedPublicKey::from_slice(pk_bytes).expect("failed to parse pubkey");
     let wpkh = pk.wpubkey_hash();
     println!("Script pubkey hash: {:x}", wpkh);
-    let spk = ScriptBuf::new_p2wpkh(&wpkh);
+    let spk = ScriptBuf::new_p2wpkh(wpkh);
 
     let mut cache = sighash::SighashCache::new(&tx);
     let sighash = cache

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Get an unspent output that is locked to the key above that we control.
     // In a real application these would come from the chain.
-    let (dummy_out_point, dummy_utxo) = dummy_unspent_transaction_output(&wpkh);
+    let (dummy_out_point, dummy_utxo) = dummy_unspent_transaction_output(wpkh);
 
     // The input for the transaction we are constructing.
     let input = TxIn {
@@ -44,7 +44,7 @@ fn main() {
     // The change output is locked to a key controlled by us.
     let change = TxOut {
         value: CHANGE_AMOUNT,
-        script_pubkey: ScriptBuf::new_p2wpkh(&wpkh), // Change comes back to us.
+        script_pubkey: ScriptBuf::new_p2wpkh(wpkh), // Change comes back to us.
     };
 
     // The transaction we want to sign and broadcast.
@@ -115,7 +115,7 @@ fn receivers_address() -> Address {
 ///
 /// This output is locked to keys that we control, in a real application this would be a valid
 /// output taken from a transaction that appears in the chain.
-fn dummy_unspent_transaction_output(wpkh: &WPubkeyHash) -> (OutPoint, TxOut) {
+fn dummy_unspent_transaction_output(wpkh: WPubkeyHash) -> (OutPoint, TxOut) {
     let script_pubkey = ScriptBuf::new_p2wpkh(wpkh);
 
     let out_point = OutPoint {

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -599,8 +599,8 @@ impl Address {
     pub fn script_pubkey(&self) -> ScriptBuf {
         use AddressInner::*;
         match self.0 {
-            P2pkh { ref hash, network: _ } => ScriptBuf::new_p2pkh(hash),
-            P2sh { ref hash, network: _ } => ScriptBuf::new_p2sh(hash),
+            P2pkh { hash, network: _ } => ScriptBuf::new_p2pkh(hash),
+            P2sh { hash, network: _ } => ScriptBuf::new_p2sh(hash),
             Segwit { ref program, hrp: _ } => {
                 let prog = program.program();
                 let version = program.version();
@@ -650,7 +650,7 @@ impl Address {
 
         (*pubkey_hash.as_byte_array() == *payload)
             || (xonly_pubkey.serialize() == *payload)
-            || (*segwit_redeem_hash(&pubkey_hash).as_byte_array() == *payload)
+            || (*segwit_redeem_hash(pubkey_hash).as_byte_array() == *payload)
     }
 
     /// Returns true if the supplied xonly public key can be used to derive the address.
@@ -878,7 +878,7 @@ impl FromStr for Address<NetworkUnchecked> {
 }
 
 /// Convert a byte array of a pubkey hash into a segwit redeem hash
-fn segwit_redeem_hash(pubkey_hash: &PubkeyHash) -> crate::hashes::hash160::Hash {
+fn segwit_redeem_hash(pubkey_hash: PubkeyHash) -> crate::hashes::hash160::Hash {
     let mut sha_engine = sha256::Hash::engine();
     sha_engine.input(&[0, 20]);
     sha_engine.input(pubkey_hash.as_ref());

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -114,7 +114,7 @@ pub struct BlockFilter {
 
 impl FilterHash {
     /// Computes the filter header from a filter hash and previous filter header.
-    pub fn filter_header(&self, previous_filter_header: &FilterHeader) -> FilterHeader {
+    pub fn filter_header(&self, previous_filter_header: FilterHeader) -> FilterHeader {
         let mut header_data = [0u8; 64];
         header_data[0..32].copy_from_slice(&self[..]);
         header_data[32..64].copy_from_slice(&previous_filter_header[..]);
@@ -145,13 +145,13 @@ impl BlockFilter {
     /// Computes this filter's ID in a chain of filters (see [BIP 157]).
     ///
     /// [BIP 157]: <https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki#Filter_Headers>
-    pub fn filter_header(&self, previous_filter_header: &FilterHeader) -> FilterHeader {
+    pub fn filter_header(&self, previous_filter_header: FilterHeader) -> FilterHeader {
         let filter_hash = FilterHash::hash(self.content.as_slice());
         filter_hash.filter_header(previous_filter_header)
     }
 
     /// Returns true if any query matches against this [`BlockFilter`].
-    pub fn match_any<I>(&self, block_hash: &BlockHash, query: I) -> Result<bool, Error>
+    pub fn match_any<I>(&self, block_hash: BlockHash, query: I) -> Result<bool, Error>
     where
         I: Iterator,
         I::Item: Borrow<[u8]>,
@@ -161,7 +161,7 @@ impl BlockFilter {
     }
 
     /// Returns true if all queries match against this [`BlockFilter`].
-    pub fn match_all<I>(&self, block_hash: &BlockHash, query: I) -> Result<bool, Error>
+    pub fn match_all<I>(&self, block_hash: BlockHash, query: I) -> Result<bool, Error>
     where
         I: Iterator,
         I::Item: Borrow<[u8]>,
@@ -234,7 +234,7 @@ pub struct BlockFilterReader {
 
 impl BlockFilterReader {
     /// Creates a new [`BlockFilterReader`] from `block_hash`.
-    pub fn new(block_hash: &BlockHash) -> BlockFilterReader {
+    pub fn new(block_hash: BlockHash) -> BlockFilterReader {
         let block_hash_as_int = block_hash.to_byte_array();
         let k0 = u64::from_le_bytes(block_hash_as_int[0..8].try_into().expect("8 byte slice"));
         let k1 = u64::from_le_bytes(block_hash_as_int[8..16].try_into().expect("8 byte slice"));
@@ -614,7 +614,7 @@ mod test {
             let block_hash = &block.block_hash();
             assert!(filter
                 .match_all(
-                    block_hash,
+                    *block_hash,
                     &mut txmap.iter().filter_map(|(_, s)| if !s.is_empty() {
                         Some(s.as_bytes())
                     } else {
@@ -627,12 +627,12 @@ mod test {
                 let query = [script];
                 if !script.is_empty() {
                     assert!(filter
-                        .match_any(block_hash, &mut query.iter().map(|s| s.as_bytes()))
+                        .match_any(*block_hash, &mut query.iter().map(|s| s.as_bytes()))
                         .unwrap());
                 }
             }
 
-            assert_eq!(filter_header, filter.filter_header(&previous_filter_header));
+            assert_eq!(filter_header, filter.filter_header(previous_filter_header));
         }
     }
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -270,7 +270,7 @@ impl Block {
             if witness_vec.len() == 1 && witness_vec[0].len() == 32 {
                 if let Some(witness_root) = self.witness_root() {
                     return commitment
-                        == Self::compute_witness_commitment(&witness_root, witness_vec[0]);
+                        == Self::compute_witness_commitment(witness_root, witness_vec[0]);
                 }
             }
         }
@@ -286,7 +286,7 @@ impl Block {
 
     /// Computes the witness commitment for the block's transaction list.
     pub fn compute_witness_commitment(
-        witness_root: &WitnessMerkleNode,
+        witness_root: WitnessMerkleNode,
         witness_reserved_value: &[u8],
     ) -> WitnessCommitment {
         let mut encoder = WitnessCommitment::engine();

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -153,7 +153,7 @@ impl Script {
     /// script").
     #[inline]
     pub fn to_p2wsh(&self) -> Result<ScriptBuf, WitnessScriptSizeError> {
-        self.wscript_hash().map(|hash| ScriptBuf::new_p2wsh(&hash))
+        self.wscript_hash().map(ScriptBuf::new_p2wsh)
     }
 
     /// Computes P2TR output with a given internal key and a single script spending path equal to
@@ -383,7 +383,7 @@ impl Script {
 
     /// Computes the P2SH output corresponding to this redeem script.
     pub fn to_p2sh(&self) -> Result<ScriptBuf, RedeemScriptSizeError> {
-        self.script_hash().map(|hash| ScriptBuf::new_p2sh(&hash))
+        self.script_hash().map(ScriptBuf::new_p2sh)
     }
 
     /// Returns the script code used for spending a P2WPKH output if this script is a script pubkey

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -81,7 +81,7 @@ impl ScriptBuf {
     }
 
     /// Generates P2PKH-type of scriptPubkey.
-    pub fn new_p2pkh(pubkey_hash: &PubkeyHash) -> Self {
+    pub fn new_p2pkh(pubkey_hash: PubkeyHash) -> Self {
         Builder::new()
             .push_opcode(OP_DUP)
             .push_opcode(OP_HASH160)
@@ -92,7 +92,7 @@ impl ScriptBuf {
     }
 
     /// Generates P2SH-type of scriptPubkey with a given hash of the redeem script.
-    pub fn new_p2sh(script_hash: &ScriptHash) -> Self {
+    pub fn new_p2sh(script_hash: ScriptHash) -> Self {
         Builder::new()
             .push_opcode(OP_HASH160)
             .push_slice(script_hash)
@@ -101,13 +101,13 @@ impl ScriptBuf {
     }
 
     /// Generates P2WPKH-type of scriptPubkey.
-    pub fn new_p2wpkh(pubkey_hash: &WPubkeyHash) -> Self {
+    pub fn new_p2wpkh(pubkey_hash: WPubkeyHash) -> Self {
         // pubkey hash is 20 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
         ScriptBuf::new_witness_program_unchecked(WitnessVersion::V0, pubkey_hash)
     }
 
     /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
-    pub fn new_p2wsh(script_hash: &WScriptHash) -> Self {
+    pub fn new_p2wsh(script_hash: WScriptHash) -> Self {
         // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
         ScriptBuf::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
     }

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -204,19 +204,19 @@ fn script_generators() {
     assert!(ScriptBuf::new_p2pk(pubkey).is_p2pk());
 
     let pubkey_hash = PubkeyHash::hash(&pubkey.inner.serialize());
-    assert!(ScriptBuf::new_p2pkh(&pubkey_hash).is_p2pkh());
+    assert!(ScriptBuf::new_p2pkh(pubkey_hash).is_p2pkh());
 
     let wpubkey_hash = WPubkeyHash::hash(&pubkey.inner.serialize());
-    assert!(ScriptBuf::new_p2wpkh(&wpubkey_hash).is_p2wpkh());
+    assert!(ScriptBuf::new_p2wpkh(wpubkey_hash).is_p2wpkh());
 
     let script = Builder::new().push_opcode(OP_NUMEQUAL).push_verify().into_script();
     let script_hash = script.script_hash().expect("script is less than 520 bytes");
-    let p2sh = ScriptBuf::new_p2sh(&script_hash);
+    let p2sh = ScriptBuf::new_p2sh(script_hash);
     assert!(p2sh.is_p2sh());
     assert_eq!(script.to_p2sh().unwrap(), p2sh);
 
     let wscript_hash = script.wscript_hash().expect("script is less than 10,000 bytes");
-    let p2wsh = ScriptBuf::new_p2wsh(&wscript_hash);
+    let p2wsh = ScriptBuf::new_p2wsh(wscript_hash);
     assert!(p2wsh.is_p2wsh());
     assert_eq!(script.to_p2wsh().unwrap(), p2wsh);
 

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -2271,7 +2271,7 @@ mod tests {
         // First input we can spend. See comment above on key_map for why we use defaults here.
         let txout_wpkh = TxOut {
             value: Amount::from_sat(10),
-            script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::hash(&pk.to_bytes())),
+            script_pubkey: ScriptBuf::new_p2wpkh(WPubkeyHash::hash(&pk.to_bytes())),
         };
         psbt.inputs[0].witness_utxo = Some(txout_wpkh);
 


### PR DESCRIPTION
We should pass `Copy` types by value not by reference. Pass the hash types by value.

Second step in the pass-copy-types-by-value work, pulled out of #2404.