### PR TITLE
Remove usage of blockdata from paths

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -5,8 +5,8 @@ use core::fmt;
 use internals::write_err;
 
 use crate::address::{Address, NetworkUnchecked};
-use crate::blockdata::script::{witness_program, witness_version};
 use crate::prelude::*;
+use crate::script::{witness_program, witness_version};
 use crate::Network;
 
 /// Error while generating address from script.

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -36,21 +36,21 @@ use bech32::primitives::hrp::Hrp;
 use hashes::{sha256, HashEngine};
 use secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 
-use crate::blockdata::constants::{
+use crate::consensus::Params;
+use crate::constants::{
     PUBKEY_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST, SCRIPT_ADDRESS_PREFIX_MAIN,
     SCRIPT_ADDRESS_PREFIX_TEST,
 };
-use crate::blockdata::script::witness_program::WitnessProgram;
-use crate::blockdata::script::witness_version::WitnessVersion;
-use crate::blockdata::script::{
-    self, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
-};
-use crate::consensus::Params;
 use crate::crypto::key::{
     CompressedPublicKey, PubkeyHash, PublicKey, TweakedPublicKey, UntweakedPublicKey,
 };
 use crate::network::{Network, NetworkKind};
 use crate::prelude::*;
+use crate::script::witness_program::WitnessProgram;
+use crate::script::witness_version::WitnessVersion;
+use crate::script::{
+    self, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
+};
 use crate::taproot::TapNodeHash;
 
 #[rustfmt::skip]                // Keep public re-exports separate.

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -374,11 +374,13 @@ mod test {
     use hex::FromHex;
 
     use super::*;
-    use crate::blockdata::locktime::absolute;
-    use crate::blockdata::transaction;
     use crate::consensus::encode::{deserialize, serialize};
+    use crate::locktime::absolute;
     use crate::merkle_tree::TxMerkleNode;
-    use crate::{Amount, CompactTarget, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Txid, Witness};
+    use crate::{
+        transaction, Amount, CompactTarget, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Txid,
+        Witness,
+    };
 
     fn dummy_tx(nonce: &[u8]) -> Transaction {
         Transaction {

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -44,13 +44,13 @@ use hashes::{sha256d, siphash24};
 use internals::write_err;
 use io::{BufRead, Write};
 
-use crate::blockdata::block::{Block, BlockHash};
-use crate::blockdata::script::Script;
-use crate::blockdata::transaction::OutPoint;
+use crate::block::{Block, BlockHash};
 use crate::consensus::encode::VarInt;
 use crate::consensus::{Decodable, Encodable};
 use crate::internal_macros::impl_hashencode;
 use crate::prelude::*;
+use crate::script::Script;
+use crate::transaction::OutPoint;
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845
 const P: u8 = 19;

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -13,14 +13,13 @@ use hashes::{sha256d, HashEngine};
 use io::{BufRead, Write};
 
 use super::Weight;
-use crate::blockdata::script;
-use crate::blockdata::transaction::{Transaction, Wtxid};
 use crate::consensus::{encode, Decodable, Encodable, Params};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::merkle_tree::{MerkleNode as _, TxMerkleNode, WitnessMerkleNode};
 use crate::pow::{CompactTarget, Target, Work};
 use crate::prelude::*;
-use crate::VarInt;
+use crate::transaction::{Transaction, Wtxid};
+use crate::{script, VarInt};
 
 hashes::hash_newtype! {
     /// A bitcoin block hash.
@@ -367,7 +366,8 @@ impl Block {
         match push.map_err(|_| Bip34Error::NotPresent)? {
             script::Instruction::PushBytes(b) => {
                 // Check that the number is encoded in the minimal way.
-                let h = b.read_scriptint()
+                let h = b
+                    .read_scriptint()
                     .map_err(|_e| Bip34Error::UnexpectedPush(b.as_bytes().to_vec()))?;
                 if h < 0 {
                     Err(Bip34Error::NegativeHeight)

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -9,17 +9,16 @@
 use hashes::sha256d;
 use internals::impl_array_newtype;
 
-use crate::blockdata::block::{self, Block};
-use crate::blockdata::locktime::absolute;
-use crate::blockdata::opcodes::all::*;
-use crate::blockdata::script;
-use crate::blockdata::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut};
-use crate::blockdata::witness::Witness;
+use crate::block::{self, Block};
 use crate::consensus::Params;
 use crate::internal_macros::impl_array_newtype_stringify;
+use crate::locktime::absolute;
 use crate::network::Network;
+use crate::opcodes::all::*;
 use crate::pow::CompactTarget;
-use crate::{Amount, BlockHash};
+use crate::transaction::{self, OutPoint, Sequence, Transaction, TxIn, TxOut};
+use crate::witness::Witness;
+use crate::{script, Amount, BlockHash};
 
 /// How many seconds between blocks we expect on average.
 pub const TARGET_BLOCK_SPACING: u32 = 600;

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -33,8 +33,8 @@ pub mod fee_rate {
         fn fee_convenience_functions_agree() {
             use hex::test_hex_unwrap as hex;
 
-            use crate::blockdata::transaction::Transaction;
             use crate::consensus::Decodable;
+            use crate::transaction::Transaction;
 
             const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -8,23 +8,23 @@ use core::ops::{
 use secp256k1::{Secp256k1, Verification};
 
 use super::PushBytes;
-use crate::blockdata::fee_rate::FeeRate;
-use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::{self, Opcode};
-use crate::blockdata::script::witness_version::WitnessVersion;
-use crate::blockdata::script::{
+use crate::consensus::Encodable;
+use crate::key::{PublicKey, UntweakedPublicKey, WPubkeyHash};
+use crate::opcodes::all::*;
+use crate::opcodes::{self, Opcode};
+use crate::policy::DUST_RELAY_TX_FEE;
+use crate::prelude::*;
+use crate::script::witness_version::WitnessVersion;
+use crate::script::{
     bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions,
     RedeemScriptSizeError, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
 };
-use crate::consensus::Encodable;
-use crate::key::{PublicKey, UntweakedPublicKey, WPubkeyHash};
-use crate::policy::DUST_RELAY_TX_FEE;
-use crate::prelude::*;
 use crate::taproot::{LeafVersion, TapLeafHash, TapNodeHash};
+use crate::FeeRate;
 
 /// Bitcoin script slice.
 ///
-/// *[See also the `bitcoin::blockdata::script` module](crate::blockdata::script).*
+/// *[See also the `bitcoin::script` module](crate::script).*
 ///
 /// `Script` is a script slice, the most primitive script type. It's usually seen in its borrowed
 /// form `&Script`. It is always encoded as a series of bytes representing the opcodes and data
@@ -368,7 +368,7 @@ impl Script {
     )]
     #[inline]
     pub fn is_provably_unspendable(&self) -> bool {
-        use crate::blockdata::opcodes::Class::{IllegalOp, ReturnOp};
+        use crate::opcodes::Class::{IllegalOp, ReturnOp};
 
         match self.0.first() {
             Some(b) => {
@@ -685,7 +685,7 @@ delegate_index!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blockdata::script::witness_program::WitnessProgram;
+    use crate::script::witness_program::WitnessProgram;
 
     #[test]
     fn shortest_witness_program() {

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -4,13 +4,13 @@ use core::fmt;
 
 use secp256k1::XOnlyPublicKey;
 
-use crate::blockdata::locktime::absolute;
-use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::{self, Opcode};
-use crate::blockdata::script::{opcode_to_verify, write_scriptint, PushBytes, Script, ScriptBuf};
-use crate::blockdata::transaction::Sequence;
 use crate::key::PublicKey;
+use crate::locktime::absolute;
+use crate::opcodes::all::*;
+use crate::opcodes::{self, Opcode};
 use crate::prelude::*;
+use crate::script::{opcode_to_verify, write_scriptint, PushBytes, Script, ScriptBuf};
+use crate::transaction::Sequence;
 
 /// An Object which can be used to construct a script piece by piece.
 #[derive(PartialEq, Eq, Clone)]

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use crate::blockdata::opcodes::{self, Opcode};
-use crate::blockdata::script::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
+use crate::opcodes::{self, Opcode};
+use crate::script::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
 
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -67,11 +67,11 @@ use core::ops::{Deref, DerefMut};
 use hashes::{hash160, sha256};
 use io::{BufRead, Write};
 
-use crate::blockdata::constants::{MAX_REDEEM_SCRIPT_SIZE, MAX_WITNESS_SCRIPT_SIZE};
-use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::{self, Opcode};
 use crate::consensus::{encode, Decodable, Encodable};
+use crate::constants::{MAX_REDEEM_SCRIPT_SIZE, MAX_WITNESS_SCRIPT_SIZE};
 use crate::internal_macros::impl_asref_push_bytes;
+use crate::opcodes::all::*;
+use crate::opcodes::{self, Opcode};
 use crate::prelude::*;
 use crate::OutPoint;
 

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -6,17 +6,17 @@ use core::ops::Deref;
 use hex::FromHex;
 use secp256k1::{Secp256k1, Verification};
 
-use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::{self, Opcode};
-use crate::blockdata::script::witness_program::WitnessProgram;
-use crate::blockdata::script::witness_version::WitnessVersion;
-use crate::blockdata::script::{
-    opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash,
-};
 use crate::key::{
     PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
 };
+use crate::opcodes::all::*;
+use crate::opcodes::{self, Opcode};
 use crate::prelude::*;
+use crate::script::witness_program::WitnessProgram;
+use crate::script::witness_version::WitnessVersion;
+use crate::script::{
+    opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash,
+};
 use crate::taproot::TapNodeHash;
 
 /// An owned, growable script.

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -19,10 +19,9 @@ mod primitive {
     };
 
     use super::PushBytesError;
-    use crate::blockdata::script::Error;
     #[allow(unused)]
     use crate::prelude::*;
-    use crate::script::scriptint_parse;
+    use crate::script::{scriptint_parse, Error};
 
     #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
     fn check_limit(_: usize) -> Result<(), PushBytesError> { Ok(()) }

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -12,9 +12,9 @@ use core::fmt;
 use internals::array_vec::ArrayVec;
 use secp256k1::{Secp256k1, Verification};
 
-use crate::blockdata::script::witness_version::WitnessVersion;
-use crate::blockdata::script::{PushBytes, Script, WScriptHash, WitnessScriptSizeError};
 use crate::crypto::key::{CompressedPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
+use crate::script::witness_version::WitnessVersion;
+use crate::script::{PushBytes, Script, WScriptHash, WitnessScriptSizeError};
 use crate::taproot::TapNodeHash;
 
 /// The minimum byte size of a segregated witness program.

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -14,9 +14,9 @@ use bech32::Fe32;
 use internals::write_err;
 use units::{parse, ParseIntError};
 
-use crate::blockdata::opcodes::all::*;
-use crate::blockdata::opcodes::Opcode;
-use crate::blockdata::script::Instruction;
+use crate::opcodes::all::*;
+use crate::opcodes::Opcode;
+use crate::script::Instruction;
 
 /// Version of the segregated witness program.
 ///

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -18,17 +18,16 @@ use io::{BufRead, Write};
 use units::parse::{self, PrefixedHexError, UnprefixedHexError};
 
 use super::Weight;
-use crate::blockdata::locktime::absolute::{self, Height, Time};
-use crate::blockdata::locktime::relative::{self, TimeOverflowError};
-use crate::blockdata::script::{Script, ScriptBuf};
-use crate::blockdata::witness::Witness;
-use crate::blockdata::FeeRate;
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
+use crate::locktime::absolute::{self, Height, Time};
+use crate::locktime::relative::{self, TimeOverflowError};
 use crate::prelude::*;
+use crate::script::{Script, ScriptBuf};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
-use crate::{Amount, SignedAmount, VarInt};
+use crate::witness::Witness;
+use crate::{Amount, FeeRate, SignedAmount, VarInt};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[cfg(feature = "bitcoinconsensus")]
@@ -1618,8 +1617,8 @@ mod tests {
     use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::*;
-    use crate::blockdata::constants::WITNESS_SCALE_FACTOR;
     use crate::consensus::encode::{deserialize, serialize};
+    use crate::constants::WITNESS_SCALE_FACTOR;
     use crate::sighash::EcdsaSighashType;
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
@@ -1729,7 +1728,7 @@ mod tests {
 
     #[test]
     fn is_coinbase() {
-        use crate::blockdata::constants;
+        use crate::constants;
         use crate::network::Network;
 
         let genesis = constants::genesis_block(Network::Bitcoin);
@@ -2030,7 +2029,7 @@ mod tests {
     fn transaction_verify() {
         use std::collections::HashMap;
 
-        use crate::blockdata::witness::Witness;
+        use crate::witness::Witness;
 
         // a random recent segwit transaction from blockchain using both old and segwit inputs
         let mut spending: Transaction = deserialize(hex!("020000000001031cfbc8f54fbfa4a33a30068841371f80dbfe166211242213188428f437445c91000000006a47304402206fbcec8d2d2e740d824d3d36cc345b37d9f65d665a99f5bd5c9e8d42270a03a8022013959632492332200c2908459547bf8dbf97c65ab1a28dec377d6f1d41d3d63e012103d7279dfb90ce17fe139ba60a7c41ddf605b25e1c07a4ddcb9dfef4e7d6710f48feffffff476222484f5e35b3f0e43f65fc76e21d8be7818dd6a989c160b1e5039b7835fc00000000171600140914414d3c94af70ac7e25407b0689e0baa10c77feffffffa83d954a62568bbc99cc644c62eb7383d7c2a2563041a0aeb891a6a4055895570000000017160014795d04cc2d4f31480d9a3710993fbd80d04301dffeffffff06fef72f000000000017a91476fd7035cd26f1a32a5ab979e056713aac25796887a5000f00000000001976a914b8332d502a529571c6af4be66399cd33379071c588ac3fda0500000000001976a914fc1d692f8de10ae33295f090bea5fe49527d975c88ac522e1b00000000001976a914808406b54d1044c429ac54c0e189b0d8061667e088ac6eb68501000000001976a914dfab6085f3a8fb3e6710206a5a959313c5618f4d88acbba20000000000001976a914eb3026552d7e3f3073457d0bee5d4757de48160d88ac0002483045022100bee24b63212939d33d513e767bc79300051f7a0d433c3fcf1e0e3bf03b9eb1d70220588dc45a9ce3a939103b4459ce47500b64e23ab118dfc03c9caa7d6bfc32b9c601210354fd80328da0f9ae6eef2b3a81f74f9a6f66761fadf96f1d1d22b1fd6845876402483045022100e29c7e3a5efc10da6269e5fc20b6a1cb8beb92130cc52c67e46ef40aaa5cac5f0220644dd1b049727d991aece98a105563416e10a5ac4221abac7d16931842d5c322012103960b87412d6e169f30e12106bdf70122aabb9eb61f455518322a18b920a4dfa887d30700")

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -394,7 +394,7 @@ impl Witness {
     /// This does not guarantee that this represents a P2TR [`Witness`]. It
     /// merely gets the second to last or third to last element depending on
     /// the first byte of the last element being equal to 0x50. See
-    /// [Script::is_p2tr](crate::blockdata::script::Script::is_p2tr) to
+    /// [Script::is_p2tr](crate::script::Script::is_p2tr) to
     /// check whether this is actually a Taproot witness.
     pub fn tapscript(&self) -> Option<&Script> {
         let len = self.len();

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -23,8 +23,7 @@ use io::{BufRead, Cursor, Read, Write};
 
 use crate::bip152::{PrefilledTransaction, ShortId};
 use crate::bip158::{FilterHash, FilterHeader};
-use crate::blockdata::block::{self, BlockHash};
-use crate::blockdata::transaction::{Transaction, TxIn, TxOut};
+use crate::block::{self, BlockHash};
 use crate::consensus::{DecodeError, IterReader};
 use crate::merkle_tree::TxMerkleNode;
 #[cfg(feature = "std")]
@@ -34,6 +33,7 @@ use crate::p2p::{
 };
 use crate::prelude::*;
 use crate::taproot::TapLeafHash;
+use crate::transaction::{Transaction, TxIn, TxOut};
 
 /// Encoding error.
 #[derive(Debug)]

--- a/bitcoin/src/consensus/validation.rs
+++ b/bitcoin/src/consensus/validation.rs
@@ -9,11 +9,11 @@ use core::fmt;
 use internals::write_err;
 
 use crate::amount::Amount;
-use crate::blockdata::script::Script;
-use crate::blockdata::transaction::{OutPoint, Transaction, TxOut};
 #[cfg(doc)]
 use crate::consensus;
 use crate::consensus::encode;
+use crate::script::Script;
+use crate::transaction::{OutPoint, Transaction, TxOut};
 
 /// Verifies spend of an input script.
 ///

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -15,11 +15,11 @@ use internals::array_vec::ArrayVec;
 use internals::write_err;
 use io::{Read, Write};
 
-use crate::blockdata::script::ScriptBuf;
 use crate::crypto::ecdsa;
 use crate::internal_macros::impl_asref_push_bytes;
 use crate::network::NetworkKind;
 use crate::prelude::*;
+use crate::script::ScriptBuf;
 use crate::taproot::{TapNodeHash, TapTweakHash};
 
 #[rustfmt::skip]                // Keep public re-exports separate.

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -17,10 +17,10 @@ use hashes::{hash_newtype, sha256, sha256d, sha256t_hash_newtype};
 use internals::write_err;
 use io::Write;
 
-use crate::blockdata::witness::Witness;
 use crate::consensus::{encode, Encodable};
 use crate::prelude::*;
 use crate::taproot::{LeafVersion, TapLeafHash, TAPROOT_ANNEX_PREFIX};
+use crate::witness::Witness;
 use crate::{transaction, Amount, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut};
 
 /// Used for signature hash for invalid use of SIGHASH_SINGLE.
@@ -1453,8 +1453,8 @@ mod tests {
     use hex::{test_hex_unwrap as hex, FromHex};
 
     use super::*;
-    use crate::blockdata::locktime::absolute;
     use crate::consensus::deserialize;
+    use crate::locktime::absolute;
 
     extern crate serde_json;
 

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -196,13 +196,13 @@ pub(crate) use impl_hashencode;
 macro_rules! impl_asref_push_bytes {
     ($($hashtype:ident),*) => {
         $(
-            impl AsRef<$crate::blockdata::script::PushBytes> for $hashtype {
-                fn as_ref(&self) -> &$crate::blockdata::script::PushBytes {
+            impl AsRef<$crate::script::PushBytes> for $hashtype {
+                fn as_ref(&self) -> &$crate::script::PushBytes {
                     self.as_byte_array().into()
                 }
             }
 
-            impl From<$hashtype> for $crate::blockdata::script::PushBytesBuf {
+            impl From<$hashtype> for $crate::script::PushBytesBuf {
                 fn from(hash: $hashtype) -> Self {
                     hash.as_byte_array().into()
                 }

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -14,12 +14,12 @@ use core::fmt;
 use io::{BufRead, Write};
 
 use self::MerkleBlockError::*;
-use crate::blockdata::block::{self, Block};
-use crate::blockdata::transaction::{Transaction, Txid};
-use crate::blockdata::weight::Weight;
+use crate::block::{self, Block};
 use crate::consensus::encode::{self, Decodable, Encodable, MAX_VEC_SIZE};
 use crate::merkle_tree::{MerkleNode as _, TxMerkleNode};
 use crate::prelude::*;
+use crate::transaction::{Transaction, Txid};
+use crate::Weight;
 
 /// Data structure that represents a block header paired to a partial merkle tree.
 ///

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -121,7 +121,7 @@ impl MerkleNode for WitnessMerkleNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blockdata::block::Block;
+    use crate::block::Block;
     use crate::consensus::encode::deserialize;
 
     #[test]

--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -149,7 +149,7 @@ impl Network {
     ///
     /// ```rust
     /// use bitcoin::Network;
-    /// use bitcoin::blockdata::constants::ChainHash;
+    /// use bitcoin::constants::ChainHash;
     ///
     /// let network = Network::Bitcoin;
     /// assert_eq!(network.chain_hash(), ChainHash::BITCOIN);
@@ -162,7 +162,7 @@ impl Network {
     ///
     /// ```rust
     /// use bitcoin::Network;
-    /// use bitcoin::blockdata::constants::ChainHash;
+    /// use bitcoin::constants::ChainHash;
     ///
     /// assert_eq!(Ok(Network::Bitcoin), Network::try_from(ChainHash::BITCOIN));
     /// ```

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -10,7 +10,6 @@ use core::{fmt, iter};
 use hashes::sha256d;
 use io::{BufRead, Write};
 
-use crate::blockdata::{block, transaction};
 use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, VarInt};
 use crate::merkle_tree::MerkleBlock;
 use crate::p2p::address::{AddrV2Message, Address};
@@ -19,6 +18,7 @@ use crate::p2p::{
     Magic,
 };
 use crate::prelude::*;
+use crate::{block, transaction};
 
 /// The maximum number of [super::message_blockdata::Inventory] items in an `inv` message.
 ///
@@ -544,9 +544,7 @@ mod test {
 
     use super::*;
     use crate::bip152::BlockTransactionsRequest;
-    use crate::blockdata::block::Block;
-    use crate::blockdata::script::ScriptBuf;
-    use crate::blockdata::transaction::Transaction;
+    use crate::block::Block;
     use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
     use crate::p2p::address::AddrV2;
     use crate::p2p::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};
@@ -557,6 +555,8 @@ mod test {
     };
     use crate::p2p::message_network::{Reject, RejectReason, VersionMessage};
     use crate::p2p::ServiceFlags;
+    use crate::script::ScriptBuf;
+    use crate::transaction::Transaction;
 
     fn hash(slice: [u8; 32]) -> sha256d::Hash { sha256d::Hash::from_slice(&slice).unwrap() }
 

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -8,11 +8,11 @@
 use hashes::sha256d;
 use io::{BufRead, Write};
 
-use crate::blockdata::block::BlockHash;
-use crate::blockdata::transaction::{Txid, Wtxid};
+use crate::block::BlockHash;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::internal_macros::impl_consensus_encoding;
 use crate::p2p;
+use crate::transaction::{Txid, Wtxid};
 
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]

--- a/bitcoin/src/p2p/message_filter.rs
+++ b/bitcoin/src/p2p/message_filter.rs
@@ -7,7 +7,7 @@
 use units::BlockHeight;
 
 use crate::bip158::{FilterHash, FilterHeader};
-use crate::blockdata::block::BlockHash;
+use crate::block::BlockHash;
 use crate::internal_macros::impl_consensus_encoding;
 
 /// getcfilters message

--- a/bitcoin/src/policy.rs
+++ b/bitcoin/src/policy.rs
@@ -13,7 +13,7 @@
 
 use core::cmp;
 
-use super::blockdata::constants::{MAX_BLOCK_SIGOPS_COST, WITNESS_SCALE_FACTOR};
+use super::constants::{MAX_BLOCK_SIGOPS_COST, WITNESS_SCALE_FACTOR};
 
 /// Maximum weight of a transaction for it to be relayed by most nodes on the network
 pub const MAX_STANDARD_TX_WEIGHT: u32 = 400_000;

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -14,8 +14,7 @@ use io::{BufRead, Write};
 use mutagen::mutate;
 use units::parse::{self, ParseIntError, PrefixedHexError, UnprefixedHexError};
 
-use crate::block::Header;
-use crate::blockdata::block::BlockHash;
+use crate::block::{BlockHash, Header};
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::consensus::Params;
 
@@ -251,7 +250,7 @@ impl Target {
     /// Panics if `self` is zero (divide by zero).
     ///
     /// [max]: Target::max
-    /// [target]: crate::blockdata::block::Header::target
+    /// [target]: crate::block::Header::target
     #[cfg_attr(all(test, mutate), mutate)]
     pub fn difficulty(&self, params: impl AsRef<Params>) -> u128 {
         // Panic here may be eaiser to debug than during the actual division.

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -5,10 +5,10 @@ use core::fmt;
 use internals::write_err;
 
 use crate::bip32::Xpub;
-use crate::blockdata::transaction::Transaction;
 use crate::consensus::encode;
 use crate::prelude::*;
 use crate::psbt::raw;
+use crate::transaction::Transaction;
 
 /// Enum for marking psbt hash error.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -3,12 +3,12 @@
 use io::{BufRead, Cursor, Read};
 
 use crate::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
-use crate::blockdata::transaction::Transaction;
 use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::consensus::{encode, Decodable};
 use crate::prelude::*;
 use crate::psbt::map::Map;
 use crate::psbt::{raw, Error, Psbt};
+use crate::transaction::Transaction;
 
 /// Type: Unsigned Transaction PSBT_GLOBAL_UNSIGNED_TX = 0x00
 const PSBT_GLOBAL_UNSIGNED_TX: u8 = 0x00;

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -7,20 +7,20 @@ use hashes::{hash160, ripemd160, sha256, sha256d};
 use secp256k1::XOnlyPublicKey;
 
 use crate::bip32::KeySource;
-use crate::blockdata::script::ScriptBuf;
-use crate::blockdata::transaction::{Transaction, TxOut};
-use crate::blockdata::witness::Witness;
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
 use crate::prelude::*;
 use crate::psbt::map::Map;
 use crate::psbt::serialize::Deserialize;
 use crate::psbt::{self, error, raw, Error};
+use crate::script::ScriptBuf;
 use crate::sighash::{
     EcdsaSighashType, InvalidSighashTypeError, NonStandardSighashTypeError, SighashTypeParseError,
     TapSighashType,
 };
 use crate::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapNodeHash};
+use crate::transaction::{Transaction, TxOut};
+use crate::witness::Witness;
 
 /// Type: Non-Witness UTXO PSBT_IN_NON_WITNESS_UTXO = 0x00
 const PSBT_IN_NON_WITNESS_UTXO: u8 = 0x00;

--- a/bitcoin/src/psbt/map/output.rs
+++ b/bitcoin/src/psbt/map/output.rs
@@ -3,10 +3,10 @@
 use secp256k1::XOnlyPublicKey;
 
 use crate::bip32::KeySource;
-use crate::blockdata::script::ScriptBuf;
 use crate::prelude::*;
 use crate::psbt::map::Map;
 use crate::psbt::{raw, Error};
+use crate::script::ScriptBuf;
 use crate::taproot::{TapLeafHash, TapTree};
 
 /// Type: Redeem ScriptBuf PSBT_OUT_REDEEM_SCRIPT = 0x00

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -21,12 +21,12 @@ use internals::write_err;
 use secp256k1::{Keypair, Message, Secp256k1, Signing, Verification};
 
 use crate::bip32::{self, KeySource, Xpriv, Xpub};
-use crate::blockdata::transaction::{self, Transaction, TxOut};
 use crate::crypto::key::{PrivateKey, PublicKey};
 use crate::crypto::{ecdsa, taproot};
 use crate::key::{TapTweak, XOnlyPublicKey};
 use crate::prelude::*;
 use crate::sighash::{self, EcdsaSighashType, Prevouts, SighashCache};
+use crate::transaction::{self, Transaction, TxOut};
 use crate::{Amount, FeeRate, TapLeafHash, TapSighashType};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -1212,12 +1212,12 @@ mod tests {
 
     use super::*;
     use crate::bip32::ChildNumber;
-    use crate::blockdata::locktime::absolute;
-    use crate::blockdata::script::ScriptBuf;
-    use crate::blockdata::transaction::{self, OutPoint, Sequence, TxIn};
-    use crate::blockdata::witness::Witness;
+    use crate::locktime::absolute;
     use crate::network::NetworkKind;
     use crate::psbt::serialize::{Deserialize, Serialize};
+    use crate::script::ScriptBuf;
+    use crate::transaction::{self, OutPoint, Sequence, TxIn};
+    use crate::witness::Witness;
 
     #[track_caller]
     pub fn hex_psbt(s: &str) -> Result<Psbt, crate::psbt::error::Error> {

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -10,17 +10,17 @@ use secp256k1::XOnlyPublicKey;
 
 use super::map::{Input, Map, Output, PsbtSighashType};
 use crate::bip32::{ChildNumber, Fingerprint, KeySource};
-use crate::blockdata::script::ScriptBuf;
-use crate::blockdata::transaction::{Transaction, TxOut};
-use crate::blockdata::witness::Witness;
 use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
 use crate::prelude::*;
 use crate::psbt::{Error, Psbt};
+use crate::script::ScriptBuf;
 use crate::taproot::{
     ControlBlock, LeafVersion, TapLeafHash, TapNodeHash, TapTree, TaprootBuilder,
 };
+use crate::transaction::{Transaction, TxOut};
+use crate::witness::Witness;
 use crate::VarInt;
 /// A trait for serializing a value as raw data for insertion into PSBT
 /// key-value maps.

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -5,16 +5,15 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::bip32::{Fingerprint, IntoDerivationPath, KeySource, Xpriv, Xpub};
-use bitcoin::blockdata::opcodes::OP_0;
-use bitcoin::blockdata::{script, transaction};
 use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
+use bitcoin::opcodes::OP_0;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::script::PushBytes;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{
-    absolute, Amount, Denomination, NetworkKind, OutPoint, PrivateKey, PublicKey, ScriptBuf,
-    Sequence, Transaction, TxIn, TxOut, Witness,
+    absolute, script, transaction, Amount, Denomination, NetworkKind, OutPoint, PrivateKey,
+    PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
 
 #[track_caller]

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -27,15 +27,15 @@ use std::str::FromStr;
 
 use bincode::serialize;
 use bitcoin::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
-use bitcoin::blockdata::locktime::{absolute, relative};
-use bitcoin::blockdata::witness::Witness;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::hex::FromHex;
+use bitcoin::locktime::{absolute, relative};
 use bitcoin::psbt::raw::{self, Key, Pair, ProprietaryKey};
 use bitcoin::psbt::{Input, Output, Psbt, PsbtSighashType};
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapTree, TaprootBuilder};
+use bitcoin::witness::Witness;
 use bitcoin::{
     ecdsa, transaction, Address, Amount, Block, NetworkKind, OutPoint, PrivateKey, PublicKey,
     ScriptBuf, Sequence, Target, Transaction, TxIn, TxOut, Txid, Work,

--- a/bitcoin/tests/serde_opcodes.rs
+++ b/bitcoin/tests/serde_opcodes.rs
@@ -9,7 +9,7 @@ extern crate serde_json;
 macro_rules! test_opcodes {
     ($($op:ident),* $(,)+) => {
         $(
-            let op = bitcoin::blockdata::opcodes::all::$op;
+            let op = bitcoin::opcodes::all::$op;
             let want = concat!("\"", stringify!($op), "\"");
             let got = ::serde_json::to_string(&op).unwrap();
             assert_eq!(got, want);

--- a/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
@@ -1,7 +1,7 @@
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
-    let block_result: Result<bitcoin::blockdata::block::Block, _> =
+    let block_result: Result<bitcoin::block::Block, _> =
         bitcoin::consensus::encode::deserialize(data);
 
     match block_result {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -1,7 +1,6 @@
 use bitcoin::address::Address;
-use bitcoin::blockdata::script;
 use bitcoin::consensus::encode;
-use bitcoin::Network;
+use bitcoin::{script, Network};
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
@@ -1,7 +1,7 @@
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
-    let tx_result: Result<bitcoin::blockdata::transaction::Transaction, _> =
+    let tx_result: Result<bitcoin::transaction::Transaction, _> =
         bitcoin::consensus::encode::deserialize(data);
     match tx_result {
         Err(_) => {}
@@ -11,7 +11,7 @@ fn do_test(data: &[u8]) {
             let len = ser.len();
             let calculated_weight = tx.weight().to_wu() as usize;
             for input in &mut tx.input {
-                input.witness = bitcoin::blockdata::witness::Witness::default();
+                input.witness = bitcoin::witness::Witness::default();
             }
             let no_witness_len = bitcoin::consensus::encode::serialize(&tx).len();
             // For 0-input transactions, `no_witness_len` will be incorrect because

--- a/fuzz/fuzz_targets/bitcoin/deserialize_witness.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_witness.rs
@@ -1,5 +1,5 @@
-use bitcoin::blockdata::witness::Witness;
 use bitcoin::consensus::{deserialize, serialize};
+use bitcoin::witness::Witness;
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/outpoint_string.rs
+++ b/fuzz/fuzz_targets/bitcoin/outpoint_string.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use bitcoin::blockdata::transaction::OutPoint;
 use bitcoin::consensus::encode;
+use bitcoin::transaction::OutPoint;
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {


### PR DESCRIPTION
the `blockdata` directory is code organisation thing, all the types/modules are re-exported from other places. In preparation for, and to make easier, the `primitives` crate smashing work - remove all explicit usage of `blockdata`.

Note that the few instances remain as they seem required e.g.,

  `pub(in crate::blockdata::script)`

Refactor only, no logic changes.

Done as part of #2883