### PR TITLE
Remove `InvalidInternalKey` variant from `TaprootBuilderError`

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -5633,7 +5633,6 @@ pub bitcoin::taproot::Signature::signature: secp256k1::schnorr::Signature
 pub bitcoin::taproot::TapLeaf::Hidden(bitcoin::taproot::TapNodeHash)
 pub bitcoin::taproot::TapLeaf::Script(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)
 pub bitcoin::taproot::TaprootBuilderError::EmptyTree
-pub bitcoin::taproot::TaprootBuilderError::InvalidInternalKey(secp256k1::Error)
 pub bitcoin::taproot::TaprootBuilderError::InvalidMerkleTreeDepth(usize)
 pub bitcoin::taproot::TaprootBuilderError::NodeNotInDfsOrder
 pub bitcoin::taproot::TaprootBuilderError::OverCompleteTree

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -5353,7 +5353,6 @@ pub bitcoin::taproot::Signature::signature: secp256k1::schnorr::Signature
 pub bitcoin::taproot::TapLeaf::Hidden(bitcoin::taproot::TapNodeHash)
 pub bitcoin::taproot::TapLeaf::Script(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)
 pub bitcoin::taproot::TaprootBuilderError::EmptyTree
-pub bitcoin::taproot::TaprootBuilderError::InvalidInternalKey(secp256k1::Error)
 pub bitcoin::taproot::TaprootBuilderError::InvalidMerkleTreeDepth(usize)
 pub bitcoin::taproot::TaprootBuilderError::NodeNotInDfsOrder
 pub bitcoin::taproot::TaprootBuilderError::OverCompleteTree

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -4736,7 +4736,6 @@ pub bitcoin::taproot::Signature::signature: secp256k1::schnorr::Signature
 pub bitcoin::taproot::TapLeaf::Hidden(bitcoin::taproot::TapNodeHash)
 pub bitcoin::taproot::TapLeaf::Script(bitcoin::blockdata::script::ScriptBuf, bitcoin::taproot::LeafVersion)
 pub bitcoin::taproot::TaprootBuilderError::EmptyTree
-pub bitcoin::taproot::TaprootBuilderError::InvalidInternalKey(secp256k1::Error)
 pub bitcoin::taproot::TaprootBuilderError::InvalidMerkleTreeDepth(usize)
 pub bitcoin::taproot::TaprootBuilderError::NodeNotInDfsOrder
 pub bitcoin::taproot::TaprootBuilderError::OverCompleteTree

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1337,8 +1337,6 @@ pub enum TaprootBuilderError {
     NodeNotInDfsOrder,
     /// Two nodes at depth 0 are not allowed.
     OverCompleteTree,
-    /// Invalid taproot internal key.
-    InvalidInternalKey(secp256k1::Error),
     /// Called finalize on a empty tree.
     EmptyTree,
 }
@@ -1365,9 +1363,6 @@ impl fmt::Display for TaprootBuilderError {
                 "Attempted to create a tree with two nodes at depth 0. There must\
                 only be a exactly one node at depth 0",
             ),
-            InvalidInternalKey(ref e) => {
-                write_err!(f, "invalid internal x-only key"; e)
-            }
             EmptyTree => {
                 write!(f, "Called finalize on an empty tree")
             }
@@ -1381,7 +1376,6 @@ impl std::error::Error for TaprootBuilderError {
         use TaprootBuilderError::*;
 
         match self {
-            InvalidInternalKey(e) => Some(e),
             InvalidMerkleTreeDepth(_) | NodeNotInDfsOrder | OverCompleteTree | EmptyTree => None,
         }
     }


### PR DESCRIPTION
This variant is unused, remove it.

Done as part of #2883.