### PR TITLE
Remove wildcard imports

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use internals::write_err;
 
 use crate::address::{Address, NetworkUnchecked};
-use crate::prelude::*;
+use crate::prelude::String;
 use crate::script::{witness_program, witness_version};
 use crate::Network;
 

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -45,7 +45,7 @@ use crate::crypto::key::{
     CompressedPublicKey, PubkeyHash, PublicKey, TweakedPublicKey, UntweakedPublicKey,
 };
 use crate::network::{Network, NetworkKind};
-use crate::prelude::*;
+use crate::prelude::{String, ToOwned};
 use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -14,7 +14,7 @@ use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable, VarInt};
 use crate::internal_macros::{impl_array_newtype_stringify, impl_consensus_encoding};
-use crate::prelude::*;
+use crate::prelude::Vec;
 use crate::{block, Block, BlockHash, Transaction};
 
 /// A BIP-152 error

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -48,7 +48,7 @@ use crate::block::{Block, BlockHash};
 use crate::consensus::encode::VarInt;
 use crate::consensus::{Decodable, Encodable};
 use crate::internal_macros::impl_hashencode;
-use crate::prelude::*;
+use crate::prelude::{Borrow, BTreeSet, Vec};
 use crate::script::Script;
 use crate::transaction::OutPoint;
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -16,7 +16,7 @@ use secp256k1::{Secp256k1, XOnlyPublicKey};
 use crate::crypto::key::{CompressedPublicKey, Keypair, PrivateKey};
 use crate::internal_macros::impl_array_newtype_stringify;
 use crate::network::NetworkKind;
-use crate::prelude::*;
+use crate::prelude::{Vec, String};
 
 /// Version bytes for extended public keys on the Bitcoin network.
 const VERSION_BYTES_MAINNET_PUBLIC: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -17,7 +17,7 @@ use crate::consensus::{encode, Decodable, Encodable, Params};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::merkle_tree::{MerkleNode as _, TxMerkleNode, WitnessMerkleNode};
 use crate::pow::{CompactTarget, Target, Work};
-use crate::prelude::*;
+use crate::prelude::Vec;
 use crate::transaction::{Transaction, Wtxid};
 use crate::{script, VarInt};
 

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -12,7 +12,7 @@ use core::fmt;
 use internals::debug_from_display;
 
 #[cfg(feature = "serde")]
-use crate::prelude::*;
+use crate::prelude::ToString;
 
 /// A script Opcode.
 ///

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -13,7 +13,7 @@ use crate::key::{PublicKey, UntweakedPublicKey, WPubkeyHash};
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::policy::DUST_RELAY_TX_FEE;
-use crate::prelude::*;
+use crate::prelude::{Box, DisplayHex, sink, String, ToOwned, Vec};
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{
     bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions,

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -8,7 +8,7 @@ use crate::key::PublicKey;
 use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
-use crate::prelude::*;
+use crate::prelude::Vec;
 use crate::script::{opcode_to_verify, write_scriptint, PushBytes, Script, ScriptBuf};
 use crate::transaction::Sequence;
 

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -72,7 +72,7 @@ use crate::constants::{MAX_REDEEM_SCRIPT_SIZE, MAX_WITNESS_SCRIPT_SIZE};
 use crate::internal_macros::impl_asref_push_bytes;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
-use crate::prelude::*;
+use crate::prelude::{Borrow, BorrowMut, Box, Cow, DisplayHex, ToOwned, Vec};
 use crate::OutPoint;
 
 #[rustfmt::skip]                // Keep public re-exports separate.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -11,7 +11,7 @@ use crate::key::{
 };
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
-use crate::prelude::*;
+use crate::prelude::{Box, Vec};
 use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -4,8 +4,7 @@
 
 use core::ops::{Deref, DerefMut};
 
-#[allow(unused)]
-use crate::prelude::*;
+use crate::prelude::{Borrow, BorrowMut};
 use crate::script;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -20,8 +19,7 @@ mod primitive {
     };
 
     use super::PushBytesError;
-    #[allow(unused)]
-    use crate::prelude::*;
+    use crate::prelude::{ToOwned, Vec};
 
     #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
     fn check_limit(_: usize) -> Result<(), PushBytesError> { Ok(()) }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -22,7 +22,7 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::locktime::absolute::{self, Height, Time};
 use crate::locktime::relative::{self, TimeOverflowError};
-use crate::prelude::*;
+use crate::prelude::{Borrow, Vec};
 use crate::script::{Script, ScriptBuf};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -12,7 +12,7 @@ use io::{BufRead, Write};
 use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::crypto::ecdsa;
-use crate::prelude::*;
+use crate::prelude::Vec;
 use crate::taproot::{self, TAPROOT_ANNEX_PREFIX};
 use crate::{Script, VarInt};
 
@@ -561,6 +561,7 @@ mod test {
     use crate::consensus::{deserialize, serialize};
     use crate::sighash::EcdsaSighashType;
     use crate::Transaction;
+    use crate::hex::DisplayHex;
 
     fn append_u32_vec(mut v: Vec<u8>, n: &[u32]) -> Vec<u8> {
         for &num in n {

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -31,7 +31,7 @@ use crate::p2p::{
     address::{AddrV2Message, Address},
     message_blockdata::Inventory,
 };
-use crate::prelude::*;
+use crate::prelude::{Box, Cow, DisplayHex, rc, String, sync, Vec};
 use crate::taproot::TapLeafHash;
 use crate::transaction::{Transaction, TxIn, TxOut};
 

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -11,7 +11,7 @@ use hex::FromHex;
 use internals::write_err;
 use io::Write;
 
-use crate::prelude::*;
+use crate::prelude::{DisplayHex, Vec};
 use crate::script::PushBytes;
 use crate::sighash::{EcdsaSighashType, NonStandardSighashTypeError};
 

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -18,7 +18,7 @@ use io::{Read, Write};
 use crate::crypto::ecdsa;
 use crate::internal_macros::impl_asref_push_bytes;
 use crate::network::NetworkKind;
-use crate::prelude::*;
+use crate::prelude::{DisplayHex,  String, Vec};
 use crate::script::ScriptBuf;
 use crate::taproot::{TapNodeHash, TapTweakHash};
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -18,7 +18,7 @@ use internals::write_err;
 use io::Write;
 
 use crate::consensus::{encode, Encodable};
-use crate::prelude::*;
+use crate::prelude::{Borrow, BorrowMut, String, ToOwned, Vec};
 use crate::taproot::{LeafVersion, TapLeafHash, TAPROOT_ANNEX_PREFIX};
 use crate::witness::Witness;
 use crate::{transaction, Amount, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut};

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -9,7 +9,7 @@ use core::fmt;
 use internals::write_err;
 use io::Write;
 
-use crate::prelude::*;
+use crate::prelude::Vec;
 use crate::sighash::{InvalidSighashTypeError, TapSighashType};
 use crate::taproot::serialized_signature::{self, SerializedSignature};
 

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -17,7 +17,7 @@ use self::MerkleBlockError::*;
 use crate::block::{self, Block};
 use crate::consensus::encode::{self, Decodable, Encodable, MAX_VEC_SIZE};
 use crate::merkle_tree::{MerkleNode as _, TxMerkleNode};
-use crate::prelude::*;
+use crate::prelude::Vec;
 use crate::transaction::{Transaction, Txid};
 use crate::Weight;
 
@@ -512,7 +512,7 @@ mod tests {
     use super::*;
     use crate::consensus::encode;
     use crate::hash_types::Txid;
-    use crate::hex::{test_hex_unwrap as hex, FromHex};
+    use crate::hex::{test_hex_unwrap as hex, FromHex, DisplayHex};
 
     #[cfg(feature = "rand-std")]
     macro_rules! pmt_tests {

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -19,7 +19,7 @@ mod block;
 use hashes::{sha256d, HashEngine as _};
 
 use crate::internal_macros::impl_hashencode;
-use crate::prelude::*;
+use crate::prelude::Vec;
 use crate::{Txid, Wtxid};
 
 #[rustfmt::skip]

--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use crate::consensus::Params;
 use crate::constants::ChainHash;
 use crate::p2p::Magic;
-use crate::prelude::*;
+use crate::prelude::{String, ToOwned};
 
 /// What kind of network we are on.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -17,7 +17,7 @@ use crate::p2p::{
     message_blockdata, message_bloom, message_compact_blocks, message_filter, message_network,
     Magic,
 };
-use crate::prelude::*;
+use crate::prelude::{Box, Cow, String, ToOwned, Vec};
 use crate::{block, transaction};
 
 /// The maximum number of [super::message_blockdata::Inventory] items in an `inv` message.

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -13,7 +13,7 @@ use crate::internal_macros::impl_consensus_encoding;
 use crate::p2p;
 use crate::p2p::address::Address;
 use crate::p2p::ServiceFlags;
-use crate::prelude::*;
+use crate::prelude::{Cow, String};
 
 /// Some simple messages
 

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -29,7 +29,7 @@ use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::consensus::Params;
-use crate::prelude::*;
+use crate::prelude::{Borrow, BorrowMut, String, ToOwned};
 use crate::Network;
 
 #[rustfmt::skip]

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -6,7 +6,7 @@ use internals::write_err;
 
 use crate::bip32::Xpub;
 use crate::consensus::encode;
-use crate::prelude::*;
+use crate::prelude::Box;
 use crate::psbt::raw;
 use crate::transaction::Transaction;
 

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -5,7 +5,7 @@ use io::{BufRead, Cursor, Read};
 use crate::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
 use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::consensus::{encode, Decodable};
-use crate::prelude::*;
+use crate::prelude::{BTreeMap, btree_map, Vec};
 use crate::psbt::map::Map;
 use crate::psbt::{raw, Error, Psbt};
 use crate::transaction::Transaction;

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -9,7 +9,7 @@ use secp256k1::XOnlyPublicKey;
 use crate::bip32::KeySource;
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
-use crate::prelude::*;
+use crate::prelude::{Borrow, Box, BTreeMap, btree_map, ToOwned, Vec};
 use crate::psbt::map::Map;
 use crate::psbt::serialize::Deserialize;
 use crate::psbt::{self, error, raw, Error};

--- a/bitcoin/src/psbt/map/mod.rs
+++ b/bitcoin/src/psbt/map/mod.rs
@@ -4,7 +4,7 @@ mod global;
 mod input;
 mod output;
 
-use crate::prelude::*;
+use crate::prelude::Vec;
 use crate::psbt::raw;
 use crate::psbt::serialize::Serialize;
 

--- a/bitcoin/src/psbt/map/output.rs
+++ b/bitcoin/src/psbt/map/output.rs
@@ -3,7 +3,7 @@
 use secp256k1::XOnlyPublicKey;
 
 use crate::bip32::KeySource;
-use crate::prelude::*;
+use crate::prelude::{BTreeMap, btree_map,  Vec};
 use crate::psbt::map::Map;
 use crate::psbt::{raw, Error};
 use crate::script::ScriptBuf;

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -24,7 +24,7 @@ use crate::bip32::{self, KeySource, Xpriv, Xpub};
 use crate::crypto::key::{PrivateKey, PublicKey};
 use crate::crypto::{ecdsa, taproot};
 use crate::key::{TapTweak, XOnlyPublicKey};
-use crate::prelude::*;
+use crate::prelude::{Borrow, Box, BTreeMap, BTreeSet, btree_map, Vec};
 use crate::sighash::{self, EcdsaSighashType, Prevouts, SighashCache};
 use crate::transaction::{self, Transaction, TxOut};
 use crate::{Amount, FeeRate, TapLeafHash, TapSighashType};

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -13,7 +13,7 @@ use super::serialize::{Deserialize, Serialize};
 use crate::consensus::encode::{
     self, deserialize, serialize, Decodable, Encodable, ReadExt, VarInt, WriteExt, MAX_VEC_SIZE,
 };
-use crate::prelude::*;
+use crate::prelude::{DisplayHex, Vec};
 use crate::psbt::Error;
 
 /// A PSBT key in its raw byte form.

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -13,7 +13,7 @@ use crate::bip32::{ChildNumber, Fingerprint, KeySource};
 use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
-use crate::prelude::*;
+use crate::prelude::{DisplayHex, String, Vec};
 use crate::psbt::{Error, Psbt};
 use crate::script::ScriptBuf;
 use crate::taproot::{

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -25,7 +25,7 @@ pub mod btreemap_byte_values {
 
     use hex::FromHex;
 
-    use crate::prelude::*;
+    use crate::prelude::BTreeMap;
 
     pub fn serialize<S, T>(v: &BTreeMap<T, Vec<u8>>, s: S) -> Result<S::Ok, S::Error>
     where
@@ -92,7 +92,7 @@ pub mod btreemap_as_seq {
 
     // NOTE: This module can be exactly copied to use with HashMap.
 
-    use crate::prelude::*;
+    use crate::prelude::BTreeMap;
 
     pub fn serialize<S, T, U>(v: &BTreeMap<T, U>, s: S) -> Result<S::Ok, S::Error>
     where
@@ -162,7 +162,7 @@ pub mod btreemap_as_seq_byte_values {
 
     // NOTE: This module can be exactly copied to use with HashMap.
 
-    use crate::prelude::*;
+    use crate::prelude::BTreeMap;
 
     /// A custom key-value pair type that serialized the bytes as hex.
     #[derive(Debug, Deserialize)]

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -165,7 +165,7 @@ mod message_signing {
         use base64::prelude::{Engine as _, BASE64_STANDARD};
 
         use super::*;
-        use crate::prelude::*;
+        use crate::prelude::String;
 
         impl MessageSignature {
             /// Convert a signature from base64 encoding.

--- a/bitcoin/src/taproot/merkle_branch.rs
+++ b/bitcoin/src/taproot/merkle_branch.rs
@@ -8,7 +8,7 @@ use super::{
     TapNodeHash, TaprootBuilderError, TaprootError, TAPROOT_CONTROL_MAX_NODE_COUNT,
     TAPROOT_CONTROL_NODE_SIZE,
 };
-use crate::prelude::*;
+use crate::prelude::{Borrow, BorrowMut, Box, Vec};
 
 /// The merkle proof for inclusion of a tree in a taptree hash.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -18,7 +18,7 @@ use secp256k1::{Scalar, Secp256k1};
 
 use crate::consensus::Encodable;
 use crate::crypto::key::{TapTweak, TweakedPublicKey, UntweakedPublicKey, XOnlyPublicKey};
-use crate::prelude::*;
+use crate::prelude::{BinaryHeap, BTreeMap, BTreeSet, Vec};
 use crate::{Script, ScriptBuf};
 
 // Re-export these so downstream only has to use one `taproot` module.
@@ -1454,7 +1454,7 @@ mod test {
 
     use hashes::sha256;
     use hashes::sha256t::Tag;
-    use hex::FromHex;
+    use hex::{FromHex, DisplayHex};
     use secp256k1::VerifyOnly;
 
     use super::*;

--- a/hashes/src/hkdf.rs
+++ b/hashes/src/hkdf.rs
@@ -102,7 +102,7 @@ impl<T: GeneralHash> Hkdf<T> {
 #[cfg(test)]
 #[cfg(feature = "alloc")]
 mod tests {
-    use hex::prelude::*;
+    use hex::prelude::{FromHex, DisplayHex};
 
     use super::*;
     use crate::sha256;

--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -10,7 +10,7 @@ use internals::write_err;
 use crate::parse;
 use crate::parse::ParseIntError;
 #[cfg(feature = "alloc")]
-use crate::prelude::*;
+use crate::prelude::{Box, String};
 
 /// The Threshold for deciding whether a lock time value is a height or a time (see [Bitcoin Core]).
 ///


### PR DESCRIPTION
This patch replaces  `prelude::*` wildcard imports with the types actually used.  In a couple of cases `DisplayHex` was previously imported by the wildcard but was only used in the test module, an additional import was added to the test module instead of at the top where it causes an unused import warning.

Close: #2875