### PR TITLE
CI: Pin cargo-public-api version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -317,6 +317,6 @@ jobs:
         with:
           toolchain: ${{ needs.Prepare.outputs.nightly_version }}
       - name: "Install cargo-public-api"
-        run: cargo install --locked cargo-public-api
+        run: cargo install cargo-public-api@0.35.0 --locked
       - name: "Run API checker script"
         run: ./contrib/check-for-api-changes.sh


### PR DESCRIPTION
So that updates don't break our CI setup used a specific version of `cargo-public-api`, this means we will have to update it manually periodically though.

For now, since the latest release just broke us, use the release from a month ago.