### PR TITLE
Create empty `bitcoin-receive` crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -90,6 +90,10 @@ name = "bitcoin-io"
 version = "0.1.2"
 
 [[package]]
+name = "bitcoin-receive"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-units"
 version = "0.1.1"
 dependencies = [

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -89,6 +89,10 @@ name = "bitcoin-io"
 version = "0.1.2"
 
 [[package]]
+name = "bitcoin-receive"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-units"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["bitcoin", "hashes", "internals", "fuzz", "io", "units", "base58"]
+members = ["bitcoin", "hashes", "internals", "fuzz", "io", "units", "base58", "receive"]
 resolver = "2"
 
 [patch.crates-io.base58ck]
@@ -16,6 +16,9 @@ path = "internals"
 
 [patch.crates-io.bitcoin-io]
 path = "io"
+
+[patch.crates-io.bitcoin-receive]
+path = "receive"
 
 [patch.crates-io.bitcoin-units]
 path = "units"

--- a/receive/CHANGELOG.md
+++ b/receive/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.0.0 - Initial dummy release
+
+- Empty crate to reserve the name on crates.io

--- a/receive/Cargo.toml
+++ b/receive/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bitcoin-receive"
+version = "0.0.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+description = "Support for receiving bitcoin - a.k.a. bitcoin addresses"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "types"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.56.1"
+exclude = ["tests", "contrib"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]
+
+[dev-dependencies]

--- a/receive/README.md
+++ b/receive/README.md
@@ -1,0 +1,7 @@
+# Bitcoin Receive
+
+Types and logic required to receive bitcoin - i.e., bitcoin addresses.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with any combination of features on **Rust 1.56.1**.

--- a/receive/contrib/test_vars.sh
+++ b/receive/contrib/test_vars.sh
@@ -4,5 +4,11 @@
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 
-# Crates in this workspace to test (note "fuzz" is only built not tested).
-CRATES=("base58" "bitcoin" "fuzz" "hashes" "internals" "io" "units" "receive")
+# Test all these features with "std" enabled.
+FEATURES_WITH_STD=""
+
+# Test all these features without "std" enabled.
+FEATURES_WITHOUT_STD=""
+
+# Run these examples.
+EXAMPLES=""

--- a/receive/src/lib.rs
+++ b/receive/src/lib.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! # Bitcoin Receive
+//!
+//! Types and logic required to receive bitcoin - i.e., bitcoin addresses.
+
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// Coding conventions.
+#![warn(missing_docs)]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;


### PR DESCRIPTION
We intend on splitting the address types and logic out into a separate crate. In preparation for doing so, and so that we can grab the name on crates.io, add an empty crate `bitcoin-receive`.

Tie it in to the CI infrastructure.