### PR TITLE
Document installation of cargo-public-api

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -317,6 +317,6 @@ jobs:
         with:
           toolchain: ${{ needs.Prepare.outputs.nightly_version }}
       - name: "Install cargo-public-api"
-        run: cargo install cargo-public-api@0.35.0 --locked
+        run: cargo install --locked cargo-public-api@0.35.0
       - name: "Run API checker script"
         run: ./contrib/check-for-api-changes.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,15 @@ just check-api
 git commit -a -m 'api: Run just check-api'
 ```
 
+Please note, we pin the version in CI, you'll need to install cargo-public-api using:
+
+```bash
+cargo install --locked cargo-public-api@0.35.0
+```
+
+Tip: If you get a strangely noisy diff, on `master` check that `just check-api` runs without
+dirtying the index.
+
 ### Policy
 
 We have various `rust-bitcoin` specific coding styles and conventions that are


### PR DESCRIPTION
Installing `cargo-public-api` without using `--locked` leads to a version that creates spurious changes when checking the public api even though the version may still be `v0.35.0`, this is surprising to say the least.

Add documentation to help devs navigate the tool installation. While we are at it move the `--locked` flag so that the CI command and docs use the same command incantation.