### PR TITLE
just: Add command just update-api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,12 +200,7 @@ All PRs that change the public API of `rust-bitcoin` must include a patch to
 the `api/` text files. This should be a separate, final patch to the PR
 that is the diff created by running `./contrib/check-for-api-changes.sh`.
 
-Or use `just`:
-
-```bash
-just check-api
-git commit -a -m 'api: Run just check-api'
-```
+Or use `just update-api`.
 
 ### Policy
 

--- a/justfile
+++ b/justfile
@@ -40,3 +40,7 @@ update-lock-files:
 # Check for API changes.
 check-api:
  contrib/check-for-api-changes.sh
+
+# Check for API changes and commit changes if index is dirty.
+update-api:
+ contrib/check-for-api-changes.sh  && git commit -a -m 'api: Run just check-api' -n


### PR DESCRIPTION
After checking the api one almost always wants to commit the changes, add a `just` command to do so.