### PR TITLE
hashes: Add type alias'

### DIFF
--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -1,4 +1,13 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
 #[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
 #[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
 #[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::GeneralHash>(_)
 #[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
@@ -1006,6 +1015,7 @@ pub mod bitcoin_hashes::sha512
 pub mod bitcoin_hashes::sha512_256
 pub mod bitcoin_hashes::siphash24
 pub struct bitcoin_hashes::FromSliceError
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::hkdf::MaxLengthError
@@ -1028,6 +1038,11 @@ pub trait bitcoin_hashes::sha256t::Tag
 pub type bitcoin_hashes::GeneralHash::Engine: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
 pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
 pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
 pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::error::HexToArrayError

--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -1,4 +1,13 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
 #[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
 #[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
 #[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::GeneralHash>(_)
 #[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
@@ -847,6 +856,7 @@ pub mod bitcoin_hashes::sha512
 pub mod bitcoin_hashes::sha512_256
 pub mod bitcoin_hashes::siphash24
 pub struct bitcoin_hashes::FromSliceError
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::hkdf::MaxLengthError
@@ -868,6 +878,11 @@ pub trait bitcoin_hashes::sha256t::Tag
 pub type bitcoin_hashes::GeneralHash::Engine: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
 pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
 pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
 pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::error::HexToArrayError

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -1,4 +1,13 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
 #[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
 #[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
 #[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::GeneralHash>(_)
 #[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
@@ -846,6 +855,7 @@ pub mod bitcoin_hashes::sha512
 pub mod bitcoin_hashes::sha512_256
 pub mod bitcoin_hashes::siphash24
 pub struct bitcoin_hashes::FromSliceError
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::GeneralHash>
 pub struct bitcoin_hashes::hkdf::MaxLengthError
@@ -867,6 +877,11 @@ pub trait bitcoin_hashes::sha256t::Tag
 pub type bitcoin_hashes::GeneralHash::Engine: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::Hash::Bytes: hex_conservative::parse::FromHex + core::marker::Copy
 pub type bitcoin_hashes::HashEngine::MidState
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
 pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
 pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::error::HexToArrayError

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -126,7 +126,12 @@ pub mod siphash24;
 
 use core::{convert, fmt, hash};
 
-pub use hmac::{Hmac, HmacEngine};
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    hkdf::Hkdf,
+    hmac::{Hmac, HmacEngine},
+};
 
 /// A hashing engine which bytes can be serialized into.
 pub trait HashEngine: Clone + Default {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -12,25 +12,25 @@
 //! Hashing a single byte slice or a string:
 //!
 //! ```rust
-//! use bitcoin_hashes::{sha256, GeneralHash as _};
+//! use bitcoin_hashes::Sha256;
 //!
 //! let bytes = [0u8; 5];
-//! let hash_of_bytes = sha256::Hash::hash(&bytes);
-//! let hash_of_string = sha256::Hash::hash("some string".as_bytes());
+//! let hash_of_bytes = Sha256::hash(&bytes);
+//! let hash_of_string = Sha256::hash("some string".as_bytes());
 //! ```
 //!
 //!
 //! Hashing content from a reader:
 //!
 //! ```rust
-//! use bitcoin_hashes::{sha256, GeneralHash as _};
+//! use bitcoin_hashes::Sha256;
 //!
 //! #[cfg(std)]
 //! # fn main() -> std::io::Result<()> {
 //! let mut reader: &[u8] = b"hello"; // in real code, this could be a `File` or `TcpStream`
-//! let mut engine = sha256::HashEngine::default();
+//! let mut engine = Sha256::engine();
 //! std::io::copy(&mut reader, &mut engine)?;
-//! let hash = sha256::Hash::from_engine(engine);
+//! let hash = Sha256::from_engine(engine);
 //! # Ok(())
 //! # }
 //!
@@ -39,10 +39,10 @@
 //! ```
 //!
 //!
-//! Hashing content by [`std::io::Write`] on HashEngine:
+//! Hashing content by [`std::io::Write`] on `HashEngine`:
 //!
 //! ```rust
-//! use bitcoin_hashes::{sha256, Hash as _};
+//! use bitcoin_hashes::Sha256;
 //! use std::io::Write;
 //!
 //! #[cfg(std)]
@@ -50,11 +50,11 @@
 //! let mut part1: &[u8] = b"hello";
 //! let mut part2: &[u8] = b" ";
 //! let mut part3: &[u8] = b"world";
-//! let mut engine = sha256::HashEngine::default();
+//! let mut engine = Sha256::engine();
 //! engine.write_all(part1)?;
 //! engine.write_all(part2)?;
 //! engine.write_all(part3)?;
-//! let hash = sha256::Hash::from_engine(engine);
+//! let hash = Sha256::from_engine(engine);
 //! # Ok(())
 //! # }
 //!
@@ -132,6 +132,57 @@ pub use self::{
     hkdf::Hkdf,
     hmac::{Hmac, HmacEngine},
 };
+
+/// SHA-1: Alias for the [`sha1::Hash`] hash type.
+#[doc(inline)]
+pub use sha1::Hash as Sha1;
+
+/// SHA-256: Alias for the [`sha256::Hash`] hash type.
+#[doc(inline)]
+pub use sha256::Hash as Sha256;
+
+/// SHA-384: Alias for the [`sha384::Hash`] hash type.
+#[doc(inline)]
+pub use sha384::Hash as Sha384;
+
+/// SHA-512: Alias for the [`sha512::Hash`] hash type.
+#[doc(inline)]
+pub use sha512::Hash as Sha512;
+
+/// SHA-512-256: Alias for the [`sha512_256::Hash`] hash type.
+#[doc(inline)]
+pub use sha512_256::Hash as Sha512_256;
+
+/// RIPEMD-160: Alias for the [`ripemd160::Hash`] hash type.
+#[doc(inline)]
+pub use ripemd160::Hash as Ripemd160;
+
+/// SipHash-2-4: Alias for the [`siphash24::Hash`] hash type.
+#[doc(inline)]
+pub use siphash24::Hash as Siphash24;
+
+/// HASH-160: Alias for the [`hash160::Hash`] hash type.
+#[doc(inline)]
+pub use hash160::Hash as Hash160;
+
+/// Double SHA-256: Alias for the [`sha256d::Hash`] hash type.
+#[doc(inline)]
+pub use sha256d::Hash as Sha256d;
+
+/// Tagged SHA-256: Type alias for the [`sha256t::Hash`] hash type.
+pub type Sha256t<T> = sha256t::Hash<T>;
+
+/// HMAC-SHA-256: Type alias for the [`Hmac<Sha256>`] type.
+pub type HmacSha256 = Hmac<sha256::Hash>;
+
+/// HMAC-SHA-512: Type alias for the [`Hmac<Sha512>`] type.
+pub type HmacSha512 = Hmac<sha512::Hash>;
+
+/// HKDF-HMAC-SHA-256: Type alias for the [`Hkdf<Sha256>`] type.
+pub type HkdfSha256 = Hkdf<sha256::Hash>;
+
+/// HKDF-HMAC-SHA-512: Type alias for the [`Hkdf<Sha512>`] type.
+pub type HkdfSha512 = Hkdf<sha512::Hash>;
 
 /// A hashing engine which bytes can be serialized into.
 pub trait HashEngine: Clone + Default {


### PR DESCRIPTION
In an effort to make the `hashes` crate more ergonomic to use add a bunch of type alias' to the crate root.
    
We intentionally do not rename the `foo::Hash` types so that uses have a choice of either using the module path to differentiate or to use the alias.
    
Update the crate level docs to use the alias' because they are more terse with no loss of clarity.

