### PR TITLE
bip32: add From<&'a [u32]> for DerivationPath

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -7543,6 +7543,7 @@ pub fn bitcoin::bip32::DerivationPath::from(numbers: &'a [bitcoin::bip32::ChildN
 pub fn bitcoin::bip32::DerivationPath::from(numbers: alloc::vec::Vec<bitcoin::bip32::ChildNumber>) -> Self
 pub fn bitcoin::bip32::DerivationPath::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::bip32::ChildNumber>
 pub fn bitcoin::bip32::DerivationPath::from_str(path: &str) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::DerivationPath::from_u32_slice(numbers: &[u32]) -> Self
 pub fn bitcoin::bip32::DerivationPath::hardened_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
 pub fn bitcoin::bip32::DerivationPath::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::bip32::DerivationPath::index(&self, index: I) -> &Self::Output

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -7196,6 +7196,7 @@ pub fn bitcoin::bip32::DerivationPath::from(numbers: &'a [bitcoin::bip32::ChildN
 pub fn bitcoin::bip32::DerivationPath::from(numbers: alloc::vec::Vec<bitcoin::bip32::ChildNumber>) -> Self
 pub fn bitcoin::bip32::DerivationPath::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::bip32::ChildNumber>
 pub fn bitcoin::bip32::DerivationPath::from_str(path: &str) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::DerivationPath::from_u32_slice(numbers: &[u32]) -> Self
 pub fn bitcoin::bip32::DerivationPath::hardened_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
 pub fn bitcoin::bip32::DerivationPath::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::bip32::DerivationPath::index(&self, index: I) -> &Self::Output

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -6559,6 +6559,7 @@ pub fn bitcoin::bip32::DerivationPath::from(numbers: &'a [bitcoin::bip32::ChildN
 pub fn bitcoin::bip32::DerivationPath::from(numbers: alloc::vec::Vec<bitcoin::bip32::ChildNumber>) -> Self
 pub fn bitcoin::bip32::DerivationPath::from_iter<T>(iter: T) -> Self where T: core::iter::traits::collect::IntoIterator<Item = bitcoin::bip32::ChildNumber>
 pub fn bitcoin::bip32::DerivationPath::from_str(path: &str) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
+pub fn bitcoin::bip32::DerivationPath::from_u32_slice(numbers: &[u32]) -> Self
 pub fn bitcoin::bip32::DerivationPath::hardened_children(&self) -> bitcoin::bip32::DerivationPathIterator<'_>
 pub fn bitcoin::bip32::DerivationPath::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::bip32::DerivationPath::index(&self, index: I) -> &Self::Output

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -453,6 +453,19 @@ impl DerivationPath {
     /// assert_eq!(path.to_u32_vec(), vec![84 + HARDENED, HARDENED, HARDENED, 0, 1]);
     /// ```
     pub fn to_u32_vec(&self) -> Vec<u32> { self.into_iter().map(|&el| el.into()).collect() }
+
+    /// Creates a derivation path from a slice of u32s.
+    /// ```
+    /// use bitcoin::bip32::DerivationPath;
+    ///
+    /// const HARDENED: u32 = 0x80000000;
+    /// let expected = vec![84 + HARDENED, HARDENED, HARDENED, 0, 1];
+    /// let path = DerivationPath::from_u32_slice(expected.as_slice());
+    /// assert_eq!(path.to_u32_vec(), expected);
+    /// ```
+    pub fn from_u32_slice(numbers: &[u32]) -> Self {
+        numbers.iter().map(|&n| ChildNumber::from(n)).collect()
+    }
 }
 
 impl fmt::Display for DerivationPath {


### PR DESCRIPTION
ChildNumber already has a `From<u32>` impl, but converting `&[u32]` to a `DerivationPath` was still difficult.