### PR TITLE
Remove unnecessary braces

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -55,11 +55,9 @@ use crate::taproot::TapNodeHash;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use self::{
-    error::{
+pub use self::error::{
         FromScriptError, InvalidBase58PayloadLengthError, InvalidLegacyPrefixError, LegacyAddressTooLongError,
-        NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError
-    },
+        NetworkValidationError, ParseError, UnknownAddressTypeError, UnknownHrpError,
 };
 
 /// The different types of addresses.


### PR DESCRIPTION
Remove the unnecessary braces to eliminate the rust-analyzer warning,.

This is trivial, but it causes rust-analyzer to constantly flag a warning, and a simple change removes it.  

I also added a comma at the end, again trivial but as someone who speaks Rust as a second language I have read this is what is normally done and I only mention it to get feedback on if that is correct or not.