### PR TITLE
 Make 'use core::fmt' calls consistent

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -38,7 +38,7 @@
 //!  ```
 
 use core::cmp::{self, Ordering};
-use core::fmt::{self, Display, Formatter};
+use core::fmt;
 
 use hashes::{sha256d, siphash24};
 use internals::write_err;
@@ -78,8 +78,8 @@ pub enum Error {
 
 internals::impl_from_infallible!(Error);
 
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         use Error::*;
 
         match *self {

--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -19,7 +19,6 @@
 //! ```
 
 use core::fmt;
-use core::fmt::Display;
 use core::str::FromStr;
 
 use internals::write_err;
@@ -279,7 +278,7 @@ impl fmt::Display for Network {
 #[non_exhaustive]
 pub struct UnknownChainHashError(ChainHash);
 
-impl Display for UnknownChainHashError {
+impl fmt::Display for UnknownChainHashError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "unknown chain hash: {}", self.0)
     }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -6,7 +6,7 @@
 //! functions here are designed to be fast, by that we mean it is safe to use them to check headers.
 
 use core::cmp;
-use core::fmt::{self, LowerHex, UpperHex};
+use core::fmt;
 use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 
 use io::{BufRead, Write};
@@ -465,14 +465,14 @@ impl Decodable for CompactTarget {
     }
 }
 
-impl LowerHex for CompactTarget {
+impl fmt::LowerHex for CompactTarget {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { LowerHex::fmt(&self.0, f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
 
-impl UpperHex for CompactTarget {
+impl fmt::UpperHex for CompactTarget {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { UpperHex::fmt(&self.0, f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
 }
 
 /// Big-endian 256 bit integer type.
@@ -976,7 +976,7 @@ impl fmt::Debug for U256 {
 }
 
 macro_rules! impl_hex {
-    ($hex:ident, $case:expr) => {
+    ($hex:path, $case:expr) => {
         impl $hex for U256 {
             fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
                 hex::fmt_hex_exact!(f, 32, &self.to_be_bytes(), $case)
@@ -984,8 +984,8 @@ macro_rules! impl_hex {
         }
     };
 }
-impl_hex!(LowerHex, hex::Case::Lower);
-impl_hex!(UpperHex, hex::Case::Upper);
+impl_hex!(fmt::LowerHex, hex::Case::Lower);
+impl_hex!(fmt::UpperHex, hex::Case::Upper);
 
 #[cfg(feature = "serde")]
 impl crate::serde::Serialize for U256 {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1141,7 +1141,7 @@ impl std::error::Error for IndexOutOfBoundsError {
 
 #[cfg(feature = "base64")]
 mod display_from_str {
-    use core::fmt::{self, Display, Formatter};
+    use core::fmt;
     use core::str::FromStr;
 
     use base64::display::Base64Display;
@@ -1162,8 +1162,8 @@ mod display_from_str {
 
     internals::impl_from_infallible!(PsbtParseError);
 
-    impl Display for PsbtParseError {
-        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    impl fmt::Display for PsbtParseError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             use self::PsbtParseError::*;
 
             match *self {
@@ -1185,8 +1185,8 @@ mod display_from_str {
         }
     }
 
-    impl Display for Psbt {
-        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    impl fmt::Display for Psbt {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{}", Base64Display::new(&self.serialize(), &BASE64_STANDARD))
         }
     }

--- a/io/src/error.rs
+++ b/io/src/error.rs
@@ -1,6 +1,6 @@
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;
-use core::fmt::{Debug, Display, Formatter};
+use core::fmt;
 
 /// The `io` crate error type.
 #[derive(Debug)]
@@ -10,7 +10,7 @@ pub struct Error {
     #[cfg(feature = "std")]
     error: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
     #[cfg(all(feature = "alloc", not(feature = "std")))]
-    error: Option<Box<dyn Debug + Send + Sync + 'static>>,
+    error: Option<Box<dyn fmt::Debug + Send + Sync + 'static>>,
 }
 
 impl Error {
@@ -40,7 +40,7 @@ impl Error {
 
     /// Returns a reference to this error.
     #[cfg(all(feature = "alloc", not(feature = "std")))]
-    pub fn get_ref(&self) -> Option<&(dyn Debug + Send + Sync + 'static)> { self.error.as_deref() }
+    pub fn get_ref(&self) -> Option<&(dyn fmt::Debug + Send + Sync + 'static)> { self.error.as_deref() }
 }
 
 impl From<ErrorKind> for Error {
@@ -53,8 +53,8 @@ impl From<ErrorKind> for Error {
     }
 }
 
-impl Display for Error {
-    fn fmt(&self, fmt: &mut Formatter) -> core::result::Result<(), core::fmt::Error> {
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
         fmt.write_fmt(format_args!("I/O Error: {}", self.kind.description()))?;
         #[cfg(any(feature = "alloc", feature = "std"))]
         if let Some(e) = &self.error {
@@ -189,17 +189,17 @@ define_errorkind!(
 mod sealed {
     use alloc::boxed::Box;
     use alloc::string::String;
-    use core::fmt::Debug;
+    use core::fmt;
 
     pub trait IntoBoxDynDebug {
-        fn into(self) -> Box<dyn Debug + Send + Sync + 'static>;
+        fn into(self) -> Box<dyn fmt::Debug + Send + Sync + 'static>;
     }
 
     impl IntoBoxDynDebug for &str {
-        fn into(self) -> Box<dyn Debug + Send + Sync + 'static> { Box::new(String::from(self)) }
+        fn into(self) -> Box<dyn fmt::Debug + Send + Sync + 'static> { Box::new(String::from(self)) }
     }
 
     impl IntoBoxDynDebug for String {
-        fn into(self) -> Box<dyn Debug + Send + Sync + 'static> { Box::new(self) }
+        fn into(self) -> Box<dyn fmt::Debug + Send + Sync + 'static> { Box::new(self) }
     }
 }


### PR DESCRIPTION
I started taking a look at #2869 and looked for everything that was implementing the `Display` trait:

```rust
impl fmt::Display for _
``` 

but found some places where the imports weren't consistent:
```rust
impl Display for _
``` 

There were only a few instances of the latter, so I went ahead and cleaned those up before starting #2869 

I started pulling this thread when I saw the same thing was happening for `fmt::Debug` and `fmt::Formatter` so I updated the rest of the `use core::fmt::*` statements with a few exceptions:

- No updates to `use core::fmt::*` if it was being called from within a function since I felt like the function scope was small enough to not cause confusion 
- No updates to `use core::fmt::{self, Write as _};`