### PR TITLE
Replace deprecated associated function call

### DIFF
--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -153,7 +153,7 @@ impl Deserialize for secp256k1::PublicKey {
 }
 
 impl Serialize for ecdsa::Signature {
-    fn serialize(&self) -> Vec<u8> { self.to_vec() }
+    fn serialize(&self) -> Vec<u8> { self.to_bytes() }
 }
 
 impl Deserialize for ecdsa::Signature {
@@ -247,7 +247,7 @@ impl Deserialize for XOnlyPublicKey {
 }
 
 impl Serialize for taproot::Signature {
-    fn serialize(&self) -> Vec<u8> { self.to_vec() }
+    fn serialize(&self) -> Vec<u8> { self.to_bytes() }
 }
 
 impl Deserialize for taproot::Signature {


### PR DESCRIPTION
Looks like compiler wants `to_bytes` instead of `to_vec` I guess since this is an FFI call to a Vec<u8>

```
warning: use of deprecated associated function `crypto::ecdsa::Signature::to_vec`: Use to_bytes instead
   --> bitcoin/src/psbt/serialize.rs:156:43
    |
156 |     fn serialize(&self) -> Vec<u8> { self.to_vec() }
    |                                           ^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated associated function `crypto::taproot::Signature::to_vec`: Use to_bytes instead
   --> bitcoin/src/psbt/serialize.rs:250:43
    |
250 |     fn serialize(&self) -> Vec<u8> { self.to_vec() }
    |                                           ^^^^^^

warning: `bitcoin` (lib) generated 2 warnings
```