### PR TITLE
Fix fuzz script

### DIFF
--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -10,7 +10,7 @@ source "$REPO_DIR/fuzz/fuzz-util.sh"
 # Check that input files are correct Windows file names
 checkWindowsFiles
 
-if [ "$1" == "" ]; then
+if [ -z "${1:-}" ]; then
   targetFiles="$(listTargetFiles)"
 else
   targetFiles=fuzz_targets/"$1".rs


### PR DESCRIPTION
Currently the `fuzz.sh` script fails with "unbound variable" if called without any arguments, this has gone undetected since we added `set -euox pipefail` because in CI we always call it with an argument.

Use chatGPT to fix the bug.

Fix: #2924