### PR TITLE
Create empty `bitcoin-addresses` crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -69,6 +69,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-addresses"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -68,6 +68,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-addresses"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
-members = ["base58", "bitcoin", "fuzz", "hashes", "internals", "io", "units"]
+members = ["addresses", "base58", "bitcoin", "fuzz", "hashes", "internals", "io", "units"]
 resolver = "2"
+
+[patch.crates-io.bitcoin-addresses]
+path = "addresses"
 
 [patch.crates-io.base58ck]
 path = "base58"

--- a/addresses/CHANGELOG.md
+++ b/addresses/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.0.0 - Initial dummy release
+
+- Empty crate to reserve the name on crates.io

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bitcoin-addresses"
+version = "0.0.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+description = "Bitcoin address"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "types"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.56.1"
+exclude = ["tests", "contrib"]
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
+[dependencies]
+
+[dev-dependencies]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/addresses/README.md
+++ b/addresses/README.md
@@ -1,0 +1,7 @@
+# Bitcoin Receive
+
+Types and logic required to receive bitcoin - i.e., bitcoin addresses.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with any combination of features on **Rust 1.56.1**.

--- a/addresses/contrib/test_vars.sh
+++ b/addresses/contrib/test_vars.sh
@@ -4,5 +4,11 @@
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 
-# Crates in this workspace to test (note "fuzz" is only built not tested).
-CRATES=("addresses" "base58" "bitcoin" "fuzz" "hashes" "internals" "io" "units")
+# Test all these features with "std" enabled.
+FEATURES_WITH_STD=""
+
+# Test all these features without "std" enabled.
+FEATURES_WITHOUT_STD=""
+
+# Run these examples.
+EXAMPLES=""

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! # Bitcoin Addresses
+//!
+//! Bitcoin addresses do not appear on chain; rather, they are conventions used by Bitcoin (wallet)
+//! software to communicate where coins should be sent and are based on the output type e.g., P2WPKH.
+//!
+//! ref: <https://sprovoost.nl/2022/11/10/what-is-a-bitcoin-address/>
+
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// Coding conventions.
+#![warn(missing_docs)]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;


### PR DESCRIPTION
We intend on splitting the address types and logic out into a separate crate. In preparation for doing so, and so that we can grab the name on crates.io, add an empty crate `bitcoin-addresses`.

Tie it in to the CI infrastructure excluding the `check-api` infrastructure because that is in flux.