### PR TITLE
Introduce `ToU64` trait

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -9,7 +9,7 @@ use core::{convert, fmt, mem};
 use std::error;
 
 use hashes::{sha256, siphash24};
-use internals::impl_array_newtype;
+use internals::{impl_array_newtype, ToU64 as _};
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable, VarInt};
@@ -287,7 +287,7 @@ impl Encodable for BlockTransactionsRequest {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = self.block_hash.consensus_encode(w)?;
         // Manually encode indexes because they are differentially encoded VarInts.
-        len += VarInt(self.indexes.len() as u64).consensus_encode(w)?;
+        len += VarInt(self.indexes.len().to_u64()).consensus_encode(w)?;
         let mut last_idx = 0;
         for idx in &self.indexes {
             len += VarInt(*idx - last_idx).consensus_encode(w)?;
@@ -383,7 +383,7 @@ impl BlockTransactions {
             transactions: {
                 let mut txs = Vec::with_capacity(request.indexes.len());
                 for idx in &request.indexes {
-                    if *idx >= block.txdata.len() as u64 {
+                    if *idx >= block.txdata.len().to_u64() {
                         return Err(TxIndexOutOfRangeError(*idx));
                     }
                     txs.push(block.txdata[*idx as usize].clone());

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -41,7 +41,7 @@ use core::cmp::{self, Ordering};
 use core::fmt;
 
 use hashes::{sha256d, siphash24, HashEngine as _};
-use internals::write_err;
+use internals::{write_err, ToU64 as _};
 use io::{BufRead, Write};
 
 use crate::block::{Block, BlockHash};
@@ -387,7 +387,7 @@ impl<'a, W: Write> GcsFilterWriter<'a, W> {
 
     /// Writes the filter to the wrapped writer.
     pub fn finish(&mut self) -> Result<usize, io::Error> {
-        let nm = self.elements.len() as u64 * self.m;
+        let nm = self.elements.len().to_u64() * self.m;
 
         // map hashes to [0, n_elements * M)
         let mut mapped: Vec<_> = self

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -480,6 +480,7 @@ impl std::error::Error for ValidationError {
 #[cfg(test)]
 mod tests {
     use hex::{test_hex_unwrap as hex, FromHex};
+    use internals::ToU64 as _;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
@@ -540,7 +541,7 @@ mod tests {
         assert_eq!(real_decode.base_size(), some_block.len());
         assert_eq!(
             real_decode.weight(),
-            Weight::from_non_witness_data_size(some_block.len() as u64)
+            Weight::from_non_witness_data_size(some_block.len().to_u64())
         );
 
         // should be also ok for a non-witness block as commitment is optional in that case

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -25,6 +25,8 @@ pub mod fee_rate {
 
     #[cfg(test)]
     mod tests {
+        use internals::ToU64 as _;
+
         use super::*;
 
         #[test]
@@ -41,7 +43,7 @@ pub mod fee_rate {
 
             let rate = FeeRate::from_sat_per_vb(1).expect("1 sat/byte is valid");
 
-            assert_eq!(rate.fee_vb(tx.vsize() as u64), rate.fee_wu(tx.weight()));
+            assert_eq!(rate.fee_vb(tx.vsize().to_u64()), rate.fee_wu(tx.weight()));
         }
     }
 }

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -5,6 +5,8 @@ use core::ops::{
     Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
+use internals::ToU64 as _;
+
 use super::witness_version::WitnessVersion;
 use super::{
     bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions, PushBytes,
@@ -399,11 +401,11 @@ impl Script {
             } else if self.is_witness_program() {
                 32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
                     8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+                    self.consensus_encode(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
             } else {
                 32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
                     8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+                    self.consensus_encode(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
             })
             .expect("dust_relay_fee or script length should not be absurdly large")
             / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -4,6 +4,7 @@
 use core::ops::Deref;
 
 use hex::FromHex;
+use internals::ToU64 as _;
 
 use super::{opcode_to_verify, Builder, Instruction, PushBytes, Script};
 use crate::opcodes::all::*;
@@ -100,7 +101,7 @@ impl ScriptBuf {
     /// Pushes the slice without reserving
     fn push_slice_no_opt(&mut self, data: &PushBytes) {
         // Start with a PUSH opcode
-        match data.len() as u64 {
+        match data.len().to_u64() {
             n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {
                 self.0.push(n as u8);
             }

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -33,7 +33,9 @@ macro_rules! impl_consensus_encoding {
             fn consensus_decode<R: $crate::io::BufRead + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$thing, $crate::consensus::encode::Error> {
-                let mut r = r.take($crate::consensus::encode::MAX_VEC_SIZE as u64);
+                use internals::ToU64 as _;
+
+                let mut r = r.take($crate::consensus::encode::MAX_VEC_SIZE.to_u64());
                 Ok($thing {
                     $($field: $crate::consensus::Decodable::consensus_decode(&mut r)?),+
                 })

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -11,6 +11,7 @@
 
 use core::fmt;
 
+use internals::ToU64 as _;
 use io::{BufRead, Write};
 
 use self::MerkleBlockError::*;
@@ -245,7 +246,7 @@ impl PartialMerkleTree {
             return Err(NoTransactions);
         };
         // check for excessively high numbers of transactions
-        if self.num_transactions as u64 > Weight::MAX_BLOCK / Weight::MIN_TRANSACTION {
+        if self.num_transactions.to_u64() > Weight::MAX_BLOCK / Weight::MIN_TRANSACTION {
             return Err(TooManyTransactions);
         }
         // there can never be more hashes provided than one for every txid

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -8,6 +8,7 @@
 use core::{fmt, iter};
 
 use hashes::sha256d;
+use internals::ToU64 as _;
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, VarInt};
@@ -426,7 +427,7 @@ impl Decodable for HeaderDeserializationWrapper {
 
     #[inline]
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
+        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE.to_u64()))
     }
 }
 
@@ -531,7 +532,7 @@ impl Decodable for RawNetworkMessage {
 
     #[inline]
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
+        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE.to_u64()))
     }
 }
 

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
+use internals::ToU64 as _;
 use io::{BufRead, Cursor, Read};
 
 use crate::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
@@ -71,7 +72,7 @@ impl Map for Psbt {
 
 impl Psbt {
     pub(crate) fn decode_global<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
-        let mut r = r.take(MAX_VEC_SIZE as u64);
+        let mut r = r.take(MAX_VEC_SIZE.to_u64());
         let mut tx: Option<Transaction> = None;
         let mut version: Option<u32> = None;
         let mut unknowns: BTreeMap<raw::Key, Vec<u8>> = Default::default();
@@ -100,7 +101,7 @@ impl Psbt {
                                         lock_time: Decodable::consensus_decode(&mut decoder)?,
                                     });
 
-                                    if decoder.position() != vlen as u64 {
+                                    if decoder.position() != vlen.to_u64() {
                                         return Err(Error::PartialDataConsumption);
                                     }
                                 } else {

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -7,6 +7,7 @@
 
 use core::fmt;
 
+use internals::ToU64 as _;
 use io::{BufRead, Write};
 
 use super::serialize::{Deserialize, Serialize};
@@ -80,7 +81,7 @@ impl Key {
 
         let key_byte_size: u64 = byte_size - 1;
 
-        if key_byte_size > MAX_VEC_SIZE as u64 {
+        if key_byte_size > MAX_VEC_SIZE.to_u64() {
             return Err(encode::Error::OversizedVectorAllocation {
                 requested: key_byte_size as usize,
                 max: MAX_VEC_SIZE,

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -35,3 +35,28 @@ mod parse;
 #[cfg(feature = "serde")]
 #[macro_use]
 pub mod serde;
+
+/// A conversion trait for unsigned integer types smaller than or equal to 64-bits.
+///
+/// This trait exists because [`usize`] doesn't implement `Into<u64>`. We only support 32 and 64 bit
+/// architectures because of consensus code so we can infallibly do the conversion.
+pub trait ToU64 {
+    /// Converts unsigned integer type to a [`u64`].
+    fn to_u64(self) -> u64;
+}
+
+macro_rules! impl_to_u64 {
+    ($($ty:ident),*) => {
+        $(
+            impl ToU64 for $ty { fn to_u64(self) -> u64 { self.into() } }
+        )*
+    }
+}
+impl_to_u64!(u8, u16, u32, u64);
+
+impl ToU64 for usize {
+    fn to_u64(self) -> u64 {
+        crate::const_assert!(core::mem::size_of::<usize>() <= 8);
+        self as u64
+    }
+}


### PR DESCRIPTION
The idea for this was pulled out of Steven's work in #2133 

We already explicitly do not support 16 bit machines.

Also, because Rust supports `u182`s one cannot infallibly convert from a `usize` to a `u64`. This is unergonomic and results in a ton of casts.

We can instead limit our code to running only on machines where `usize` is less that or equal to 64 bits then the infallible conversion is possible.

Since 128 bit machines are not a thing yet this does not in reality introduce any limitations on the library.

Add a "private" trait to the `internals` crate to do infallible conversion to a `u64` from `usize`.

Implement it for all unsigned integers smaller than `u64` as well so we have the option to use the trait instead of `u32::from(foo)`.
