### PR TITLE
Improve docs on private `Witness` fields

### DIFF
--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -28,8 +28,12 @@ use crate::{Script, VarInt};
 /// [segwit upgrade]: <https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki>
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Witness {
-    /// Contains the witness `Vec<Vec<u8>>` serialization without the initial varint indicating the
-    /// number of elements (which is stored in `witness_elements`).
+    /// Contains the witness `Vec<Vec<u8>>` serialization.
+    ///
+    /// Does not include the initial varint indicating the number of elements, instead this is
+    /// stored stored in `witness_elements`. Concatenated onto the end of `content` is the index
+    /// area, this is a `4 * witness_elements` bytes area which stores the index of the start of
+    /// each witness item.
     content: Vec<u8>,
 
     /// The number of elements in the witness.
@@ -38,8 +42,10 @@ pub struct Witness {
     /// like [`Witness::push`] don't have to shift the entire array.
     witness_elements: usize,
 
-    /// This is the valid index pointing to the beginning of the index area. This area is 4 *
-    /// stack_size bytes at the end of the content vector which stores the indices of each item.
+    /// This is the valid index pointing to the beginning of the index area.
+    ///
+    /// Said another way, this is the total length of all witness elements serialized (without the
+    /// element count but with their sizes serialized as compact size).
     indices_start: usize,
 }
 


### PR DESCRIPTION
The `Witness` type is a reasonable complex data structure, make an effort to clarify its structure in the docs on the private fields.

Private docs only.

(Original idea pulled out of #2133.)