### PR TITLE
Remove `bech32` dependency from `blockdata`

### DIFF
--- a/api/bitcoin/all-features.txt
+++ b/api/bitcoin/all-features.txt
@@ -1838,7 +1838,6 @@ impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromErr
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::ParseError
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::FromStrError
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::TryFromInstructionError
-impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bech32::primitives::gf32::Fe32
 impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bitcoin::blockdata::opcodes::Opcode
 impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::InputsIndexError
 impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::OutputsIndexError
@@ -1984,7 +1983,6 @@ impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::trans
 impl core::convert::TryFrom<alloc::string::String> for bitcoin::p2p::message::CommandString
 impl core::convert::TryFrom<alloc::vec::Vec<bitcoin::taproot::TapNodeHash>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 impl core::convert::TryFrom<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::PushBytesBuf
-impl core::convert::TryFrom<bech32::primitives::gf32::Fe32> for bitcoin::blockdata::script::witness_version::WitnessVersion
 impl core::convert::TryFrom<bitcoin::PublicKey> for bitcoin::CompressedPublicKey
 impl core::convert::TryFrom<bitcoin::blockdata::constants::ChainHash> for bitcoin::network::Network
 impl core::convert::TryFrom<bitcoin::blockdata::opcodes::Opcode> for bitcoin::blockdata::script::witness_version::WitnessVersion
@@ -6985,7 +6983,6 @@ pub fn alloc::vec::Vec<u8>::consensus_decode_from_finite_reader<R: bitcoin_io::B
 pub fn alloc::vec::Vec<u8>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn alloc::vec::Vec<u8>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
 pub fn alloc::vec::Vec<u8>::from(value: bitcoin::blockdata::script::PushBytesBuf) -> Self
-pub fn bech32::primitives::gf32::Fe32::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> Self
 pub fn bitcoin::CompressedPublicKey::clone(&self) -> bitcoin::CompressedPublicKey
 pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::cmp::Ordering
 pub fn bitcoin::CompressedPublicKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
@@ -8323,12 +8320,10 @@ pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::fmt(&self, f
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_fe(self) -> bech32::primitives::gf32::Fe32
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_num(self) -> u8
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(instruction: bitcoin::blockdata::script::Instruction<'_>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(opcode: bitcoin::blockdata::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
-pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(value: bech32::primitives::gf32::Fe32) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::clone(&self) -> bitcoin::blockdata::transaction::IndexOutOfBoundsError
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::eq(&self, other: &bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> bool

--- a/api/bitcoin/default-features.txt
+++ b/api/bitcoin/default-features.txt
@@ -1798,7 +1798,6 @@ impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromErr
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::ParseError
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::FromStrError
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::TryFromInstructionError
-impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bech32::primitives::gf32::Fe32
 impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bitcoin::blockdata::opcodes::Opcode
 impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::InputsIndexError
 impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::OutputsIndexError
@@ -1941,7 +1940,6 @@ impl core::convert::TryFrom<alloc::string::String> for bitcoin::blockdata::trans
 impl core::convert::TryFrom<alloc::string::String> for bitcoin::p2p::message::CommandString
 impl core::convert::TryFrom<alloc::vec::Vec<bitcoin::taproot::TapNodeHash>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 impl core::convert::TryFrom<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::PushBytesBuf
-impl core::convert::TryFrom<bech32::primitives::gf32::Fe32> for bitcoin::blockdata::script::witness_version::WitnessVersion
 impl core::convert::TryFrom<bitcoin::PublicKey> for bitcoin::CompressedPublicKey
 impl core::convert::TryFrom<bitcoin::blockdata::constants::ChainHash> for bitcoin::network::Network
 impl core::convert::TryFrom<bitcoin::blockdata::opcodes::Opcode> for bitcoin::blockdata::script::witness_version::WitnessVersion
@@ -6679,7 +6677,6 @@ pub fn alloc::vec::Vec<u8>::consensus_decode_from_finite_reader<R: bitcoin_io::B
 pub fn alloc::vec::Vec<u8>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn alloc::vec::Vec<u8>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
 pub fn alloc::vec::Vec<u8>::from(value: bitcoin::blockdata::script::PushBytesBuf) -> Self
-pub fn bech32::primitives::gf32::Fe32::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> Self
 pub fn bitcoin::CompressedPublicKey::clone(&self) -> bitcoin::CompressedPublicKey
 pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::cmp::Ordering
 pub fn bitcoin::CompressedPublicKey::eq(&self, other: &bitcoin::CompressedPublicKey) -> bool
@@ -7934,12 +7931,10 @@ pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::fmt(&self, f
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_fe(self) -> bech32::primitives::gf32::Fe32
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_num(self) -> u8
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(instruction: bitcoin::blockdata::script::Instruction<'_>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(opcode: bitcoin::blockdata::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
-pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(value: bech32::primitives::gf32::Fe32) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::clone(&self) -> bitcoin::blockdata::transaction::IndexOutOfBoundsError
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::eq(&self, other: &bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> bool

--- a/api/bitcoin/no-features.txt
+++ b/api/bitcoin/no-features.txt
@@ -1634,7 +1634,6 @@ impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromErr
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::address::error::ParseError
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::FromStrError
 impl core::convert::From<bitcoin::blockdata::script::witness_version::TryFromError> for bitcoin::blockdata::script::witness_version::TryFromInstructionError
-impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bech32::primitives::gf32::Fe32
 impl core::convert::From<bitcoin::blockdata::script::witness_version::WitnessVersion> for bitcoin::blockdata::opcodes::Opcode
 impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::InputsIndexError
 impl core::convert::From<bitcoin::blockdata::transaction::IndexOutOfBoundsError> for bitcoin::blockdata::transaction::OutputsIndexError
@@ -1767,7 +1766,6 @@ impl core::convert::TryFrom<&bitcoin::blockdata::script::ScriptBuf> for bitcoin:
 impl core::convert::TryFrom<alloc::boxed::Box<[bitcoin::taproot::TapNodeHash]>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 impl core::convert::TryFrom<alloc::vec::Vec<bitcoin::taproot::TapNodeHash>> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 impl core::convert::TryFrom<alloc::vec::Vec<u8>> for bitcoin::blockdata::script::PushBytesBuf
-impl core::convert::TryFrom<bech32::primitives::gf32::Fe32> for bitcoin::blockdata::script::witness_version::WitnessVersion
 impl core::convert::TryFrom<bitcoin::PublicKey> for bitcoin::CompressedPublicKey
 impl core::convert::TryFrom<bitcoin::blockdata::constants::ChainHash> for bitcoin::network::Network
 impl core::convert::TryFrom<bitcoin::blockdata::opcodes::Opcode> for bitcoin::blockdata::script::witness_version::WitnessVersion
@@ -6049,7 +6047,6 @@ pub fn alloc::vec::Vec<u8>::consensus_decode_from_finite_reader<R: bitcoin_io::B
 pub fn alloc::vec::Vec<u8>::consensus_encode<W: bitcoin_io::Write + core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
 pub fn alloc::vec::Vec<u8>::from(v: bitcoin::blockdata::script::ScriptBuf) -> Self
 pub fn alloc::vec::Vec<u8>::from(value: bitcoin::blockdata::script::PushBytesBuf) -> Self
-pub fn bech32::primitives::gf32::Fe32::from(version: bitcoin::blockdata::script::witness_version::WitnessVersion) -> Self
 pub fn bitcoin::CompressedPublicKey::clone(&self) -> bitcoin::CompressedPublicKey
 pub fn bitcoin::CompressedPublicKey::cmp(&self, other: &bitcoin::CompressedPublicKey) -> core::cmp::Ordering
 pub fn bitcoin::CompressedPublicKey::eq(&self, other: &bitcoin::CompressedPublicKey) -> bool
@@ -7286,12 +7283,10 @@ pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::fmt(&self, f
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin::blockdata::script::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_fe(self) -> bech32::primitives::gf32::Fe32
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::to_num(self) -> u8
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(instruction: bitcoin::blockdata::script::Instruction<'_>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(opcode: bitcoin::blockdata::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
-pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::try_from(value: bech32::primitives::gf32::Fe32) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin::blockdata::script::write_scriptint(out: &mut [u8; 8], n: i64) -> usize
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::clone(&self) -> bitcoin::blockdata::transaction::IndexOutOfBoundsError
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::eq(&self, other: &bitcoin::blockdata::transaction::IndexOutOfBoundsError) -> bool

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -10,7 +10,6 @@
 use core::fmt;
 use core::str::FromStr;
 
-use bech32::Fe32;
 use internals::write_err;
 use units::{parse, ParseIntError};
 
@@ -71,11 +70,6 @@ impl WitnessVersion {
     /// version in bitcoin script. Thus, there is no function to directly convert witness version
     /// into a byte since the conversion requires context (bitcoin script or just a version number).
     pub fn to_num(self) -> u8 { self as u8 }
-
-    /// Converts this witness version to a GF32 field element.
-    pub fn to_fe(self) -> Fe32 {
-        Fe32::try_from(self.to_num()).expect("0-16 are valid fe32 values")
-    }
 }
 
 /// Prints [`WitnessVersion`] number (from 0 to 16) as integer, without any prefix or suffix.
@@ -90,12 +84,6 @@ impl FromStr for WitnessVersion {
         let version: u8 = parse::int(s)?;
         Ok(WitnessVersion::try_from(version)?)
     }
-}
-
-impl TryFrom<bech32::Fe32> for WitnessVersion {
-    type Error = TryFromError;
-
-    fn try_from(value: Fe32) -> Result<Self, Self::Error> { Self::try_from(value.to_u8()) }
 }
 
 impl TryFrom<u8> for WitnessVersion {
@@ -150,10 +138,6 @@ impl<'a> TryFrom<Instruction<'a>> for WitnessVersion {
             Instruction::PushBytes(_) => Err(TryFromInstructionError::DataPush),
         }
     }
-}
-
-impl From<WitnessVersion> for Fe32 {
-    fn from(version: WitnessVersion) -> Self { version.to_fe() }
 }
 
 impl From<WitnessVersion> for Opcode {


### PR DESCRIPTION
We have a single usage of the `bech32` crate inside the `blockdata` module, to convert a `WitnessVersion` to a `Fe32`. We then have a single call site where we use the conversion in the `address` module.
    
This code was written without thinking to hard about the introduced dependency on `bech32`, in hindsite it shouldn't have been added.
    
In preparation for splitting a bunch of code in `blockdata` out into the `primitives` crate remove the `bech32` stuff from the `witness_version` module.
