### PR TITLE
Revert "bug fix" (actually a bug) from #2655

### DIFF
--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -18,7 +18,7 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
+internals = { package = "bitcoin-internals", version = "0.3.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
 


### PR DESCRIPTION
In a2b019f82 it was claimed that losing the input string without alloc is a bug. It is not, because allowing no-alloc is desired and there's no way to have the input string otherwise so we just accept it'll be missing and modify the messages accordingly. The commit that forced alloc was also horribly misleading since it kept the `alloc` feature but it makes this one easier.

Note that input string is still present by default in all configurations except for no-alloc.

I think we should also backport this and release fixed `units` because of the misleading `alloc` feature in them. Although it's not urgent. The only crate I know of that is kinda broken by it is `ln_types` which is already broken by depending on old `bitcoin`.