### PR TITLE
units: Do not enable `alloc` unconditionally in the `internals` dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -91,7 +91,7 @@ version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitcoin-internals",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -90,7 +90,7 @@ version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitcoin-internals",
  "serde",

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.2 - 2024-07-01
+
+* Remove enable of `alloc` feature in the `internals` dependency.
+
+Note, the bug fixed by this release was introduced in
+[#2655](https://github.com/rust-bitcoin/rust-bitcoin/pull/2655) and
+was incorrect because we have an `alloc` feature that enables
+`internals/alloc`.
+
+`v0.1.1` will be yanked for this reason.
+
 # 0.1.1 - 2024-04-04
 
 * Enable "alloc" feature for `internals` dependency - enables caching

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
+internals = { package = "bitcoin-internals", version = "0.3.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
 

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
In #2655 I introduced a bug whereby we unconditionally enabled the `alloc` feature of `internals` from within the `units` crate.

- Patch 1: Removes the feature
- Pach 2: Prepares for release, changelog, version bump, and lock file update

This cannot be released from `master`, currently we do not have a release branch (eg `units-0.1.x`) like we do for `0.32.x`. We do have a tag `units-0.1.1`. 

I _think_ this should be merged into `master` then backported to a new branch that should be created by checking out the latest `units` tagged release. I'm not sure about patch 2, in the past I have done release tracking PRs straight to a release branch but that results in the changelog getting lost?

(EDIT: I created the new branch `units-0.1.x` and used that as the base branch for #2943.)

Fix: #2940