### PR TITLE
Release tracking PR: `units v0.1.2`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -92,7 +92,7 @@ version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitcoin-internals",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -91,7 +91,7 @@ version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitcoin-internals",
  "serde",

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.2 - 2024-07-01
+
+* Remove enable of `alloc` feature in the `internals` dependency.
+
+Note, the bug fixed by this release was introduced in
+[#2655](https://github.com/rust-bitcoin/rust-bitcoin/pull/2655) and
+was incorrect because we have an `alloc` feature that enables
+`internals/alloc`.
+
+`v0.1.1` will be yanked for this reason.
+
 # 0.1.1 - 2024-04-04
 
 * Enable "alloc" feature for `internals` dependency - enables caching

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
+internals = { package = "bitcoin-internals", version = "0.3.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
 

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
Backport the fix in #2942 in preparation for release of `units v0.1.1` (and yank of `v0.1.1`).

