### PR TITLE
Support Testnet4 Network

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -194,7 +194,7 @@ impl fmt::Display for AddressInner {
 pub enum KnownHrp {
     /// The main Bitcoin network.
     Mainnet,
-    /// The test networks, testnet (testnet3), and signet.
+    /// The test networks, testnet (testnet3), testnet4, and signet.
     Testnets,
     /// The regtest network.
     Regtest,
@@ -720,6 +720,7 @@ impl Address<NetworkUnchecked> {
     ///
     /// let address: Address<NetworkUnchecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse().unwrap();
     /// assert!(address.is_valid_for_network(Network::Bitcoin));
+    /// assert_eq!(address.is_valid_for_network(Network::Testnet(TestnetVersion::V4)), false);
     /// ```
     pub fn is_valid_for_network(&self, n: Network) -> bool {
         use AddressInner::*;
@@ -887,8 +888,8 @@ mod tests {
     use hex_lit::hex;
 
     use super::*;
-    use crate::network::params;
     use crate::network::Network::{Bitcoin, Testnet};
+    use crate::network::{params, TestnetVersion};
     use crate::script::ScriptBufExt as _;
 
     fn roundtrips(addr: &Address, network: Network) {
@@ -941,7 +942,7 @@ mod tests {
         let addr = Address::p2pkh(key, NetworkKind::Test);
         assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
         assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
-        roundtrips(&addr, Testnet(crate::TestnetVersion::V3));
+        roundtrips(&addr, Testnet(TestnetVersion::V3));
     }
 
     #[test]
@@ -964,7 +965,7 @@ mod tests {
         let addr = Address::p2sh(&script, NetworkKind::Test).unwrap();
         assert_eq!(&addr.to_string(), "2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr");
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
-        roundtrips(&addr, Testnet(crate::TestnetVersion::V3));
+        roundtrips(&addr, Testnet(TestnetVersion::V3));
     }
 
     #[test]
@@ -1281,7 +1282,7 @@ mod tests {
         let address = address_string
             .parse::<Address<_>>()
             .expect("address")
-            .require_network(Network::Testnet(crate::TestnetVersion::V3))
+            .require_network(Network::Testnet(TestnetVersion::V3))
             .expect("testnet");
 
         let pubkey_string = "04e96e22004e3db93530de27ccddfdf1463975d2138ac018fc3e7ba1a2e5e0aad8e424d0b55e2436eb1d0dcd5cb2b8bcc6d53412c22f358de57803a6a655fbbd04";

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -194,7 +194,7 @@ impl fmt::Display for AddressInner {
 pub enum KnownHrp {
     /// The main Bitcoin network.
     Mainnet,
-    /// The test networks, testnet and signet.
+    /// The test networks, testnet (testnet3), and signet.
     Testnets,
     /// The regtest network.
     Regtest,
@@ -207,7 +207,7 @@ impl KnownHrp {
 
         match network {
             Bitcoin => Self::Mainnet,
-            Testnet | Signet => Self::Testnets,
+            Testnet(_) | Signet => Self::Testnets,
             Regtest => Self::Regtest,
         }
     }
@@ -708,11 +708,11 @@ impl Address<NetworkUnchecked> {
     /// network a simple comparison is not enough anymore. Instead this function can be used.
     ///
     /// ```rust
-    /// use bitcoin::{Address, Network};
+    /// use bitcoin::{Address, Network, TestnetVersion};
     /// use bitcoin::address::NetworkUnchecked;
     ///
     /// let address: Address<NetworkUnchecked> = "2N83imGV3gPwBzKJQvWJ7cRUY2SpUyU6A5e".parse().unwrap();
-    /// assert!(address.is_valid_for_network(Network::Testnet));
+    /// assert!(address.is_valid_for_network(Network::Testnet(TestnetVersion::V3)));
     /// assert!(address.is_valid_for_network(Network::Regtest));
     /// assert!(address.is_valid_for_network(Network::Signet));
     ///
@@ -720,7 +720,6 @@ impl Address<NetworkUnchecked> {
     ///
     /// let address: Address<NetworkUnchecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse().unwrap();
     /// assert!(address.is_valid_for_network(Network::Bitcoin));
-    /// assert_eq!(address.is_valid_for_network(Network::Testnet), false);
     /// ```
     pub fn is_valid_for_network(&self, n: Network) -> bool {
         use AddressInner::*;
@@ -942,7 +941,7 @@ mod tests {
         let addr = Address::p2pkh(key, NetworkKind::Test);
         assert_eq!(&addr.to_string(), "mqkhEMH6NCeYjFybv7pvFC22MFeaNT9AQC");
         assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
-        roundtrips(&addr, Testnet);
+        roundtrips(&addr, Testnet(crate::TestnetVersion::V3));
     }
 
     #[test]
@@ -965,7 +964,7 @@ mod tests {
         let addr = Address::p2sh(&script, NetworkKind::Test).unwrap();
         assert_eq!(&addr.to_string(), "2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr");
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
-        roundtrips(&addr, Testnet);
+        roundtrips(&addr, Testnet(crate::TestnetVersion::V3));
     }
 
     #[test]
@@ -1282,7 +1281,7 @@ mod tests {
         let address = address_string
             .parse::<Address<_>>()
             .expect("address")
-            .require_network(Network::Testnet)
+            .require_network(Network::Testnet(crate::TestnetVersion::V3))
             .expect("testnet");
 
         let pubkey_string = "04e96e22004e3db93530de27ccddfdf1463975d2138ac018fc3e7ba1a2e5e0aad8e424d0b55e2436eb1d0dcd5cb2b8bcc6d53412c22f358de57803a6a655fbbd04";

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -477,7 +477,7 @@ mod tests {
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::Network;
+    use crate::{Network, TestnetVersion};
 
     #[test]
     fn test_coinbase_and_bip34() {
@@ -546,7 +546,7 @@ mod tests {
     // Check testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
     #[test]
     fn segwit_block_test() {
-        let params = Params::new(Network::Testnet(crate::TestnetVersion::V3));
+        let params = Params::new(Network::Testnet(TestnetVersion::V3));
         let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw").to_vec();
 
         let decode: Result<Block, _> = deserialize(&segwit_block);

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -546,7 +546,7 @@ mod tests {
     // Check testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
     #[test]
     fn segwit_block_test() {
-        let params = Params::new(Network::Testnet);
+        let params = Params::new(Network::Testnet(crate::TestnetVersion::V3));
         let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw").to_vec();
 
         let decode: Result<Block, _> = deserialize(&segwit_block);

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -72,8 +72,11 @@ const GENESIS_OUTPUT_PK: [u8; 65] = [
     0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, 0x1d, 0x5f
 ];
 
+#[rustfmt::skip]
+const TESTNET4_GENESIS_OUTPUT_PK: [u8; 33] = [0x00; 33];
+
 /// Constructs and returns the coinbase (and only) transaction of the Bitcoin genesis block.
-fn bitcoin_genesis_tx() -> Transaction {
+fn bitcoin_genesis_tx(params: &Params) -> Transaction {
     // Base
     let mut ret = Transaction {
         version: transaction::Version::ONE,
@@ -82,21 +85,35 @@ fn bitcoin_genesis_tx() -> Transaction {
         output: vec![],
     };
 
-    // Inputs
-    let in_script = script::Builder::new()
-        .push_int_unchecked(486604799)
-        .push_int_non_minimal(4)
-        .push_slice(b"The Times 03/Jan/2009 Chancellor on brink of second bailout for banks")
-        .into_script();
+    let (in_script, out_script) = {
+        match params.network {
+            Network::Testnet(TestnetVersion::V4) => (
+                script::Builder::new()
+                .push_int_unchecked(486604799)
+                .push_int_non_minimal(4)
+                .push_slice(b"03/May/2024 000000000000000000001ebd58c244970b3aa9d783bb001011fbe8ea8e98e00e")
+                .into_script(),
+                script::Builder::new().push_slice(TESTNET4_GENESIS_OUTPUT_PK).push_opcode(OP_CHECKSIG).into_script(),
+
+            ),
+            _ => (
+                script::Builder::new()
+                .push_int_unchecked(486604799)
+                .push_int_non_minimal(4)
+                .push_slice(b"The Times 03/Jan/2009 Chancellor on brink of second bailout for banks")
+                .into_script(),
+                script::Builder::new().push_slice(GENESIS_OUTPUT_PK).push_opcode(OP_CHECKSIG).into_script(),
+            ),
+        }
+    };
+
     ret.input.push(TxIn {
         previous_output: OutPoint::COINBASE_PREVOUT,
         script_sig: in_script,
         sequence: Sequence::MAX,
         witness: Witness::default(),
     });
-    // Outputs
-    let out_script =
-        script::Builder::new().push_slice(GENESIS_OUTPUT_PK).push_opcode(OP_CHECKSIG).into_script();
+
     ret.output.push(TxOut { value: Amount::from_sat(50 * 100_000_000), script_pubkey: out_script });
 
     // end
@@ -105,12 +122,12 @@ fn bitcoin_genesis_tx() -> Transaction {
 
 /// Constructs and returns the genesis block.
 pub fn genesis_block(params: impl AsRef<Params>) -> Block {
-    let params_ref = params.as_ref();
-    let txdata = vec![bitcoin_genesis_tx()];
+    let params = params.as_ref();
+    let txdata = vec![bitcoin_genesis_tx(params)];
     let hash: sha256d::Hash = txdata[0].compute_txid().into();
     let merkle_root: crate::TxMerkleNode = hash.into();
 
-    match params_ref.network {
+    match params.network {
         Network::Bitcoin => Block {
             header: block::Header {
                 version: block::Version::ONE,
@@ -130,6 +147,17 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
                 time: 1296688602,
                 bits: CompactTarget::from_consensus(0x1d00ffff),
                 nonce: 414098458,
+            },
+            txdata,
+        },
+        Network::Testnet(TestnetVersion::V4) => Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
+                merkle_root,
+                time: 1714777860,
+                bits: CompactTarget::from_consensus(0x1d00ffff),
+                nonce: 393743547,
             },
             txdata,
         },
@@ -172,9 +200,20 @@ impl ChainHash {
         101, 225, 90, 8, 156, 104, 214, 25, 0, 0, 0, 0, 0,
     ]);
     /// `ChainHash` for testnet3 bitcoin.
+    #[deprecated(since = "0.33.0", note = "Use TESTNET3 instead")]
     pub const TESTNET: Self = Self([
         67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151,
         32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0,
+    ]);
+    /// `ChainHash` for testnet3 bitcoin.
+    pub const TESTNET3: Self = Self([
+        67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151,
+        32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0,
+    ]);
+    /// `ChainHash` for testnet4 bitcoin.
+    pub const TESTNET4: Self = Self([
+        67, 240, 139, 218, 176, 80, 227, 91, 86, 124, 134, 75, 145, 244, 127, 80, 174, 114, 90,
+        226, 222, 83, 188, 251, 186, 242, 132, 218, 0, 0, 0, 0,
     ]);
     /// `ChainHash` for signet bitcoin.
     pub const SIGNET: Self = Self([
@@ -194,7 +233,8 @@ impl ChainHash {
     pub fn using_genesis_block(params: impl AsRef<Params>) -> Self {
         match params.as_ref().network {
             Network::Bitcoin => Self::BITCOIN,
-            Network::Testnet(TestnetVersion::V3) => Self::TESTNET,
+            Network::Testnet(TestnetVersion::V3) => Self::TESTNET3,
+            Network::Testnet(TestnetVersion::V4) => Self::TESTNET4,
             Network::Signet => Self::SIGNET,
             Network::Regtest => Self::REGTEST,
         }
@@ -207,7 +247,8 @@ impl ChainHash {
     pub const fn using_genesis_block_const(network: Network) -> Self {
         match network {
             Network::Bitcoin => Self::BITCOIN,
-            Network::Testnet(TestnetVersion::V3) => Self::TESTNET,
+            Network::Testnet(TestnetVersion::V3) => Self::TESTNET3,
+            Network::Testnet(TestnetVersion::V4) => Self::TESTNET4,
             Network::Signet => Self::SIGNET,
             Network::Regtest => Self::REGTEST,
         }
@@ -230,7 +271,7 @@ mod test {
 
     #[test]
     fn bitcoin_genesis_first_transaction() {
-        let gen = bitcoin_genesis_tx();
+        let gen = bitcoin_genesis_tx(&Params::MAINNET);
 
         assert_eq!(gen.version, transaction::Version::ONE);
         assert_eq!(gen.input.len(), 1);
@@ -286,7 +327,7 @@ mod test {
 
     #[test]
     fn testnet_genesis_full_block() {
-        let gen = genesis_block(&params::TESTNET);
+        let gen = genesis_block(&params::TESTNET3);
         assert_eq!(gen.header.version, block::Version::ONE);
         assert_eq!(gen.header.prev_blockhash, BlockHash::GENESIS_PREVIOUS_BLOCK_HASH);
         assert_eq!(
@@ -341,6 +382,7 @@ mod test {
         match network {
             Network::Bitcoin => {},
             Network::Testnet(TestnetVersion::V3) => {},
+            Network::Testnet(TestnetVersion::V4) => {},
             Network::Signet => {},
             Network::Regtest => {},
             _ => panic!("update ChainHash::using_genesis_block and chain_hash_genesis_block with new variants"),
@@ -361,6 +403,7 @@ mod test {
     chain_hash_genesis_block! {
         mainnet_chain_hash_genesis_block, Network::Bitcoin;
         testnet_chain_hash_genesis_block, Network::Testnet(TestnetVersion::V3);
+        testnet4_chain_hash_genesis_block, Network::Testnet(TestnetVersion::V4);
         signet_chain_hash_genesis_block, Network::Signet;
         regtest_chain_hash_genesis_block, Network::Regtest;
     }

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -202,12 +202,12 @@ mod primitive {
         }
     }
 
-    // Sizes up to 73 to support all pubkey and signature sizes
+    // Sizes up to 76 to support all pubkey and signature sizes
     from_array! {
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
         48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
-        71, 72, 73,
+        71, 72, 73, 74, 75, 76
     }
 
     /// Owned, growable counterpart to `PushBytes`.

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -135,7 +135,7 @@ pub use crate::{
     crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, CompressedPublicKey, WPubkeyHash, XOnlyPublicKey},
     crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},
     merkle_tree::{MerkleBlock, TxMerkleNode, WitnessMerkleNode},
-    network::{Network, NetworkKind},
+    network::{Network, NetworkKind, TestnetVersion},
     network::params::{self, Params},
     pow::{CompactTarget, Target, Work},
     psbt::Psbt,

--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -3,7 +3,7 @@
 //! Bitcoin consensus parameters.
 //!
 //! This module provides a predefined set of parameters for different Bitcoin
-//! chains (such as mainnet, testnet).
+//! chains (such as mainnet, testnet, testnet4).
 //!
 //! # Custom Signets Example
 //!
@@ -128,8 +128,13 @@ pub struct Params {
 ///
 /// [using-statics-or-consts]: <https://doc.rust-lang.org/reference/items/static-items.html#using-statics-or-consts>
 pub static MAINNET: Params = Params::MAINNET;
-/// The testnet parameters.
-pub static TESTNET: Params = Params::TESTNET;
+/// The testnet3 parameters.
+#[deprecated(since = "0.33.0", note = "Use TESTNET3 instead")]
+pub static TESTNET: Params = Params::TESTNET3;
+/// The testnet3 parameters.
+pub static TESTNET3: Params = Params::TESTNET3;
+/// The testnet4 parameters.
+pub static TESTNET4: Params = Params::TESTNET4;
 /// The signet parameters.
 pub static SIGNET: Params = Params::SIGNET;
 /// The regtest parameters.
@@ -157,13 +162,48 @@ impl Params {
         no_pow_retargeting: false,
     };
 
-    /// The testnet parameters.
+    /// The testnet3 parameters.
+    #[deprecated(since = "0.33.0", note = "Use TESTNET3 instead")]
     pub const TESTNET: Params = Params {
         network: Network::Testnet(TestnetVersion::V3),
         bip16_time: 1333238400,                      // Apr 1 2012
         bip34_height: BlockHeight::from_u32(21111), // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
         bip65_height: BlockHeight::from_u32(581885), // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         bip66_height: BlockHeight::from_u32(330776), // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        rule_change_activation_threshold: BlockInterval::from_u32(1512), // 75%
+        miner_confirmation_window: BlockInterval::from_u32(2016),
+        pow_limit: Target::MAX_ATTAINABLE_TESTNET,
+        max_attainable_target: Target::MAX_ATTAINABLE_TESTNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: true,
+        no_pow_retargeting: false,
+    };
+
+    /// The testnet3 parameters.
+    pub const TESTNET3: Params = Params {
+        network: Network::Testnet(TestnetVersion::V3),
+        bip16_time: 1333238400,                      // Apr 1 2012
+        bip34_height: BlockHeight::from_u32(21111), // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
+        bip65_height: BlockHeight::from_u32(581885), // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+        bip66_height: BlockHeight::from_u32(330776), // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        rule_change_activation_threshold: BlockInterval::from_u32(1512), // 75%
+        miner_confirmation_window: BlockInterval::from_u32(2016),
+        pow_limit: Target::MAX_ATTAINABLE_TESTNET,
+        max_attainable_target: Target::MAX_ATTAINABLE_TESTNET,
+        pow_target_spacing: 10 * 60,            // 10 minutes.
+        pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+        allow_min_difficulty_blocks: true,
+        no_pow_retargeting: false,
+    };
+
+    /// The testnet4 parameters.
+    pub const TESTNET4: Params = Params {
+        network: Network::Testnet(TestnetVersion::V4),
+        bip16_time: 1333238400, // Apr 1 2012
+        bip34_height: BlockHeight::from_u32(1),
+        bip65_height: BlockHeight::from_u32(1),
+        bip66_height: BlockHeight::from_u32(1),
         rule_change_activation_threshold: BlockInterval::from_u32(1512), // 75%
         miner_confirmation_window: BlockInterval::from_u32(2016),
         pow_limit: Target::MAX_ATTAINABLE_TESTNET,
@@ -208,11 +248,12 @@ impl Params {
         no_pow_retargeting: true,
     };
 
-    /// Creates parameters set for the given network.    /// Creates parameters set for the given network.
+    /// Creates parameters set for the given network.
     pub const fn new(network: Network) -> Self {
         match network {
             Network::Bitcoin => Params::MAINNET,
-            Network::Testnet(TestnetVersion::V3) => Params::TESTNET,
+            Network::Testnet(TestnetVersion::V3) => Params::TESTNET3,
+            Network::Testnet(TestnetVersion::V4) => Params::TESTNET4,
             Network::Signet => Params::SIGNET,
             Network::Regtest => Params::REGTEST,
         }
@@ -245,12 +286,5 @@ impl AsRef<Params> for Params {
 }
 
 impl AsRef<Params> for Network {
-    fn as_ref(&self) -> &Params {
-        match *self {
-            Network::Bitcoin => &MAINNET,
-            Network::Testnet(TestnetVersion::V3) => &TESTNET,
-            Network::Signet => &SIGNET,
-            Network::Regtest => &REGTEST,
-        }
-    }
+    fn as_ref(&self) -> &Params { Self::params(*self) }
 }

--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -73,6 +73,7 @@ use crate::network::Network;
 #[cfg(doc)]
 use crate::pow::CompactTarget;
 use crate::pow::Target;
+use crate::TestnetVersion;
 
 /// Parameters that influence chain consensus.
 #[non_exhaustive]
@@ -158,7 +159,7 @@ impl Params {
 
     /// The testnet parameters.
     pub const TESTNET: Params = Params {
-        network: Network::Testnet,
+        network: Network::Testnet(TestnetVersion::V3),
         bip16_time: 1333238400,                      // Apr 1 2012
         bip34_height: BlockHeight::from_u32(21111), // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
         bip65_height: BlockHeight::from_u32(581885), // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
@@ -211,7 +212,7 @@ impl Params {
     pub const fn new(network: Network) -> Self {
         match network {
             Network::Bitcoin => Params::MAINNET,
-            Network::Testnet => Params::TESTNET,
+            Network::Testnet(TestnetVersion::V3) => Params::TESTNET,
             Network::Signet => Params::SIGNET,
             Network::Regtest => Params::REGTEST,
         }
@@ -247,7 +248,7 @@ impl AsRef<Params> for Network {
     fn as_ref(&self) -> &Params {
         match *self {
             Network::Bitcoin => &MAINNET,
-            Network::Testnet => &TESTNET,
+            Network::Testnet(TestnetVersion::V3) => &TESTNET,
             Network::Signet => &SIGNET,
             Network::Regtest => &REGTEST,
         }

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -217,7 +217,12 @@ impl Magic {
     /// Bitcoin mainnet network magic bytes.
     pub const BITCOIN: Self = Self([0xF9, 0xBE, 0xB4, 0xD9]);
     /// Bitcoin testnet3 network magic bytes.
+    #[deprecated(since = "0.33.0", note = "Use TESTNET3 instead")]
     pub const TESTNET: Self = Self([0x0B, 0x11, 0x09, 0x07]);
+    /// Bitcoin testnet3 network magic bytes.
+    pub const TESTNET3: Self = Self([0x0B, 0x11, 0x09, 0x07]);
+    /// Bitcoin testnet4 network magic bytes.
+    pub const TESTNET4: Self = Self([0x1c, 0x16, 0x3f, 0x28]);
     /// Bitcoin signet network magic bytes.
     pub const SIGNET: Self = Self([0x0A, 0x03, 0xCF, 0x40]);
     /// Bitcoin regtest network magic bytes.
@@ -274,7 +279,8 @@ macro_rules! generate_network_magic_conversion {
 // `Network -> Magic` and `Magic -> Network`
 generate_network_magic_conversion! {
     Network::Bitcoin => Magic::BITCOIN,
-    Network::Testnet(TestnetVersion::V3) => Magic::TESTNET,
+    Network::Testnet(TestnetVersion::V3) => Magic::TESTNET3,
+    Network::Testnet(TestnetVersion::V4) => Magic::TESTNET4,
     Network::Signet => Magic::SIGNET,
     Network::Regtest => Magic::REGTEST,
 }
@@ -432,6 +438,7 @@ mod tests {
         let known_network_magic_strs = [
             ("f9beb4d9", Network::Bitcoin),
             ("0b110907", Network::Testnet(TestnetVersion::V3)),
+            ("1c163f28", Network::Testnet(TestnetVersion::V4)),
             ("fabfb5da", Network::Regtest),
             ("0a03cf40", Network::Signet),
         ];

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -94,7 +94,7 @@ fn psbt_sign_taproot() {
         //
         let keystore = Keystore {
             mfp: mfp.parse::<Fingerprint>().unwrap(),
-            sk: PrivateKey::new(kp.secret_key(), Network::Testnet),
+            sk: PrivateKey::new(kp.secret_key(), Network::Testnet(bitcoin::TestnetVersion::V3)),
         };
         let _ = psbt_key_path_spend.sign(&keystore, secp);
 
@@ -124,7 +124,7 @@ fn psbt_sign_taproot() {
 
         let keystore = Keystore {
             mfp: mfp.parse::<Fingerprint>().unwrap(),
-            sk: PrivateKey::new(kp.secret_key(), Network::Testnet),
+            sk: PrivateKey::new(kp.secret_key(), Network::Testnet(bitcoin::TestnetVersion::V3)),
         };
 
         //
@@ -195,7 +195,7 @@ fn create_taproot_tree(
 
 fn create_p2tr_address(tree: TaprootSpendInfo) -> Address {
     let output_key = tree.output_key();
-    Address::p2tr_tweaked(output_key, Network::Testnet)
+    Address::p2tr_tweaked(output_key, Network::Testnet(bitcoin::TestnetVersion::V3))
 }
 
 fn create_psbt_for_taproot_key_path_spend(


### PR DESCRIPTION
Fixed: https://github.com/rust-bitcoin/rust-bitcoin/issues/2749

1. Adjust `Network` to support `Testnet4`. (Based on https://github.com/rust-bitcoin/rust-bitcoin/issues/2749#issuecomment-2152366608 as an implementation idea.)

2. Handle conflicting procedure macros and declaration macros, since the original macros can't handle the new `Network::Testnet(TestnetVersion)` structure properly, and make internal implementations compatible with previous versions (e.g., `testnet` for `Testnet3`, `testnet4` for `Testnet4`, to minimize user-side effects). 

3. add `Testnet4` related Params, Block. 

4. optimize compatibility test cases.

5. Regarding `fn: genesis_block`, calling `bitcoin_genesis_tx` with any Network type internally gets a reasonable `merkle_root`, but not `Testnet4`. (By comparison, I confirmed that the built-in transaction data provided is correct, and combined with the fixed `merkle_root` of `Testnet4` the correct block hash can be computed, which is not possible if the transaction data is incorrect.) **I'd appreciate it if some developer could guide me on what the problem is, and I'll work on it.**

Of course, all these changes are based on https://github.com/rust-bitcoin/rust-bitcoin/issues/2749 , and the consensus of the discussion, if you have any comments, please leave a message, I will actively improve, and promote the support of `Testnet4`.
