### PR TITLE
Introduce empty primitives crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -94,6 +94,10 @@ name = "bitcoin-io"
 version = "0.1.2"
 
 [[package]]
+name = "bitcoin-primitives"
+version = "0.100.0"
+
+[[package]]
 name = "bitcoin-units"
 version = "0.1.1"
 dependencies = [

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -93,6 +93,10 @@ name = "bitcoin-io"
 version = "0.1.2"
 
 [[package]]
+name = "bitcoin-primitives"
+version = "0.100.0"
+
+[[package]]
 name = "bitcoin-units"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bitcoin", "fuzz", "hashes", "internals", "io", "units"]
+members = ["addresses", "base58", "bitcoin", "fuzz", "hashes", "internals", "io", "primitives", "units"]
 resolver = "2"
 
 [patch.crates-io.bitcoin-addresses]
@@ -19,6 +19,9 @@ path = "internals"
 
 [patch.crates-io.bitcoin-io]
 path = "io"
+
+[patch.crates-io.bitcoin-primitives]
+path = "primitives"
 
 [patch.crates-io.bitcoin-units]
 path = "units"

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 0.100.0 - 2024-07-01
+
+* Initial release of the `github.com/rust-bitcoin/rust-bitcoin/primitives` crate as
+  `bitcoin-primitives`. The name on crates.io was generously transferred to us.

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bitcoin-primitives"
+# Arbitrary high version number so as to not clash with the original
+# `bitcoin-primitives` crate that we replaced `v0.1.16-alpha`.
+version = "0.100.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+description = "Primitive types used by the rust-bitcoin eccosystem"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "types"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.56.1"
+exclude = ["tests", "contrib"]
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]
+
+[dev-dependencies]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/primitives/README.md
+++ b/primitives/README.md
@@ -1,0 +1,13 @@
+# Rust Bitcoin - primitive types.
+
+This crate provides primitive data types that are used throughout the
+[`rust-bitcoin`](https://github.com/rust-bitcoin) ecosystem.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with any combination of features on **Rust 1.56.1**.
+
+## Licensing
+
+The code in this project is licensed under the [Creative Commons CC0 1.0 Universal license](LICENSE).
+We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX IDs](https://spdx.dev/ids/).

--- a/primitives/contrib/test_vars.sh
+++ b/primitives/contrib/test_vars.sh
@@ -1,0 +1,14 @@
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
+
+# Test these features with "std" enabled.
+FEATURES_WITH_STD=""
+
+# Test these features without "std" enabled.
+FEATURES_WITHOUT_STD=""
+
+# Run these examples.
+EXAMPLES=""

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! # Rust Bitcoin - primitive types.
+//!
+//! Primitive data types that are used throughout the [`rust-bitcoin`] ecosystem.
+//!
+//! [`rust-bitcoin`]: <https://github.com/rust-bitcoin>
+
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// Coding conventions.
+#![warn(missing_docs)]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;


### PR DESCRIPTION
Introduce an empty `bitcoin-primitives` crate.

We were give the name on crates.io and previously a version `v0.1.16-alpha` was released so we use `v0.100.0`.

Does not include adding api files since that whole thing is in flux. This is an even smaller step than #2908 that does not include dependencies.