### PR TITLE
Fix `Amount` decimals handling

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -8,8 +8,6 @@
 #[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
 use core::cmp::Ordering;
-#[cfg(feature = "alloc")]
-use core::fmt::Write as _;
 use core::str::FromStr;
 use core::{default, fmt, ops};
 
@@ -986,6 +984,7 @@ impl Amount {
     ///
     /// Does not include the denomination.
     #[rustfmt::skip]
+    #[deprecated(since = "TBD", note = "Use `display_in()` instead")]
     pub fn fmt_value_in(self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.to_sat(), false, f, denom, false, FormatOptions::default())
     }
@@ -995,19 +994,14 @@ impl Amount {
     /// Does not include the denomination.
     #[cfg(feature = "alloc")]
     pub fn to_string_in(self, denom: Denomination) -> String {
-        let mut buf = String::new();
-        self.fmt_value_in(&mut buf, denom).unwrap();
-        buf
+        self.display_in(denom).to_string()
     }
 
     /// Get a formatted string of this [Amount] in the given denomination,
     /// suffixed with the abbreviation for the denomination.
     #[cfg(feature = "alloc")]
     pub fn to_string_with_denomination(self, denom: Denomination) -> String {
-        let mut buf = String::new();
-        self.fmt_value_in(&mut buf, denom).unwrap();
-        write!(buf, " {}", denom).unwrap();
-        buf
+        self.display_in(denom).show_denomination().to_string()
     }
 
     // Some arithmetic that doesn't fit in `core::ops` traits.
@@ -1348,6 +1342,7 @@ impl SignedAmount {
     ///
     /// Does not include the denomination.
     #[rustfmt::skip]
+    #[deprecated(since = "TBD", note = "Use `display_in()` instead")]
     pub fn fmt_value_in(self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.unsigned_abs().to_sat(), self.is_negative(), f, denom, false, FormatOptions::default())
     }
@@ -1357,19 +1352,14 @@ impl SignedAmount {
     /// Does not include the denomination.
     #[cfg(feature = "alloc")]
     pub fn to_string_in(self, denom: Denomination) -> String {
-        let mut buf = String::new();
-        self.fmt_value_in(&mut buf, denom).unwrap();
-        buf
+        self.display_in(denom).to_string()
     }
 
     /// Get a formatted string of this [SignedAmount] in the given denomination,
     /// suffixed with the abbreviation for the denomination.
     #[cfg(feature = "alloc")]
     pub fn to_string_with_denomination(self, denom: Denomination) -> String {
-        let mut buf = String::new();
-        self.fmt_value_in(&mut buf, denom).unwrap();
-        write!(buf, " {}", denom).unwrap();
-        buf
+        self.display_in(denom).show_denomination().to_string()
     }
 
     // Some arithmetic that doesn't fit in `core::ops` traits.

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1070,15 +1070,7 @@ impl fmt::Debug for Amount {
 // Just using Bitcoin denominated string.
 impl fmt::Display for Amount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let satoshis = self.to_sat();
-        let denomination = Denomination::Bitcoin;
-        let mut format_options = FormatOptions::from_formatter(f);
-
-        if f.precision().is_none() && satoshis.rem_euclid(Amount::ONE_BTC.to_sat()) != 0 {
-            format_options.precision = Some(8);
-        }
-
-        fmt_satoshi_in(satoshis, false, f, denomination, true, format_options)
+        fmt::Display::fmt(&self.display_in(Denomination::Bitcoin).show_denomination(), f)
     }
 }
 
@@ -1478,8 +1470,7 @@ impl fmt::Debug for SignedAmount {
 // Just using Bitcoin denominated string.
 impl fmt::Display for SignedAmount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.fmt_value_in(f, Denomination::Bitcoin)?;
-        write!(f, " {}", Denomination::Bitcoin)
+        fmt::Display::fmt(&self.display_in(Denomination::Bitcoin).show_denomination(), f)
     }
 }
 
@@ -2876,10 +2867,11 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn trailing_zeros_for_amount() {
+        assert_eq!(format!("{}", Amount::from_sat(1000000)), "0.01 BTC");
         assert_eq!(format!("{}", Amount::ONE_SAT), "0.00000001 BTC");
         assert_eq!(format!("{}", Amount::ONE_BTC), "1 BTC");
         assert_eq!(format!("{}", Amount::from_sat(1)), "0.00000001 BTC");
-        assert_eq!(format!("{}", Amount::from_sat(10)), "0.00000010 BTC");
+        assert_eq!(format!("{}", Amount::from_sat(10)), "0.0000001 BTC");
         assert_eq!(format!("{:.2}", Amount::from_sat(10)), "0.0000001 BTC");
         assert_eq!(format!("{:.2}", Amount::from_sat(100)), "0.000001 BTC");
         assert_eq!(format!("{:.2}", Amount::from_sat(1000)), "0.00001 BTC");
@@ -2891,7 +2883,7 @@ mod tests {
         assert_eq!(format!("{}", Amount::from_sat(100_000_000)), "1 BTC");
         assert_eq!(format!("{}", Amount::from_sat(40_000_000_000)), "400 BTC");
         assert_eq!(format!("{:.10}", Amount::from_sat(100_000_000)), "1.0000000000 BTC");
-        assert_eq!(format!("{}", Amount::from_sat(400_000_000_000_010)), "4000000.00000010 BTC");
+        assert_eq!(format!("{}", Amount::from_sat(400_000_000_000_010)), "4000000.0000001 BTC");
         assert_eq!(format!("{}", Amount::from_sat(400_000_000_000_000)), "4000000 BTC");
     }
 }


### PR DESCRIPTION
Displaying with minimal number of zeros is the default in Rust and we want to follow it. This was originally implemented in #716 but #2604 reversed it claiming this is common, however it broke people who rely on minimal display (e.g. BIP21) without fixing the root cause of #2136.

This reverts commit d887423efcdad8db4c60ffe61f53d2356c82c87c adds a test to prevent this change and also fixes the problem with `{:0.8}` not working.

Closes #2136
Closes #2948

Can we backport this one too?