### PR TITLE
just: add just docsrs

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,6 +21,10 @@ fmt:
 format:
   cargo +$(cat ./nightly-version) fmt --all --check
 
+# Generate documentation.
+docsrs *flags:
+  RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +$(cat ./nightly-version) doc --all-features {{flags}}
+
 # Quick and dirty CI useful for pre-push checks.
 sane: lint
   cargo test --quiet --workspace --all-targets --no-default-features > /dev/null || exit 1


### PR DESCRIPTION
Adds `just docsrs` which takes [variadic arguments](https://just.systems/man/en/chapter_41.html?highlight=zero%20or#recipe-parameters) (zero or more after the command).

Kixunil this allows for `just docsrs` and `just docsrs --open`.

Closes #2965.

Using the command from `rust-bitcoin-maintainer-tools`: https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/blob/3494ceec521cbc2cbe7e4b0d3fb9219a2164f57d/ci/run_task.sh#L277