### PR TITLE
Use index size rather than pointer size to enforce convertibility of `u32` to `usize`

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -37,12 +37,19 @@
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
-// Disable 16-bit support at least for now as we can't guarantee it yet.
-#[cfg(target_pointer_width = "16")]
-compile_error!(
-    "rust-bitcoin currently only supports architectures with pointers wider than 16 bits, let us
-    know if you want 16-bit support. Note that we do NOT guarantee that we will implement it!"
-);
+use core::mem;
+
+// We only support machines with index size of 4 bytes or more.
+//
+// Bitcoin consensus code relies on being able to have containers with more than 65536 (2^16)
+// entries in them so we cannot support consensus logic on machines that only have 16-bit memory
+// addresses.
+//
+// We specifically do not use `target_pointer_width` because of the possibility that pointer width
+// does not equal index size.
+//
+// ref: https://github.com/rust-bitcoin/rust-bitcoin/pull/2929#discussion_r1661848565
+internals::const_assert!(mem::size_of::<usize>() >= 4);
 
 #[cfg(bench)]
 extern crate test;

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -139,9 +139,9 @@ macro_rules! debug_from_display {
 /// Asserts a boolean expression at compile time.
 #[macro_export]
 macro_rules! const_assert {
-    ($x:expr) => {{
+    ($x:expr) => {
         const _: [(); 0 - !$x as usize] = [];
-    }};
+    };
 }
 
 /// Derives `From<core::convert::Infallible>` for the given type.

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -14,13 +14,6 @@
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 #![no_std]
 
-// Disable 16-bit support at least for now as we can't guarantee it yet.
-#[cfg(target_pointer_width = "16")]
-compile_error!(
-    "rust-bitcoin currently only supports architectures with pointers wider than 16 bits, let us
-    know if you want 16-bit support. Note that we do NOT guarantee that we will implement it!"
-);
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 


### PR DESCRIPTION
3 patches in preparation for other size related work, this PR does not touch the `ToU64` issue which will be handled separately.

- Patch 1: Don't check pointer width in `units` because its not consensus code
- Patch 2: Modify internal macro `const_assert`
- Patch 3: Use index size to enforce not building on a 16 bit machine