### PR TITLE
Update fmt function for Key

### DIFF
--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -16,15 +16,14 @@ use crate::consensus::encode::{
 use crate::prelude::{DisplayHex, Vec};
 use crate::psbt::Error;
 
-/// A PSBT key in its raw byte form.
+/// A PSBT key in its raw byte form, where `<key> := <keylen> <keytype> <keydata>`
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct Key {
     /// The type of this PSBT key.
     pub type_value: u8,
-    /// The key itself in raw byte form.
-    /// `<key> := <keylen> <keytype> <keydata>`
+    /// The key data in raw byte form.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
     pub key: Vec<u8>,
 }
@@ -68,7 +67,7 @@ where
 
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "type: {:#x}, key: {:x}", self.type_value, self.key.as_hex())
+        write!(f, "{:02x}{}", self.type_value, self.key.as_hex())
     }
 }
 


### PR DESCRIPTION
Currently, the `Display` function for `Key` is implemented to display it in the following format: 
```rust
"type: {:#x}, key: {:x}"
```

From #2869 discussions, the plan in the future is to call through to `to_string` from the `to_hex` function, so `to_string` should return a pure-hex representation of the type. For `Key`, this would mean removing the `type: ` and `key: ` labels in the string being returned in `Display`

