### PR TITLE
Remove to/from/as_raw_hash functions

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -312,17 +312,6 @@ mod tests {
     ]);
 
     #[test]
-    fn convert_newtypes() {
-        let h1 = DUMMY;
-        let h2: TestNewtype2 = h1.to_raw_hash().into();
-        assert_eq!(&h1[..], &h2[..]);
-
-        let h = sha256d::Hash::hash(&[]);
-        let h2: TestNewtype = h.to_string().parse().unwrap();
-        assert_eq!(h2.to_raw_hash(), h);
-    }
-
-    #[test]
     fn newtype_fmt_roundtrip() {
         let orig = DUMMY;
         let hex = format!("{}", orig);

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -194,21 +194,6 @@ macro_rules! hash_newtype {
 
         #[allow(unused)] // Private wrapper types may not need all functions.
         impl $newtype {
-            /// Creates this wrapper type from the inner hash type.
-            pub const fn from_raw_hash(inner: $hash) -> $newtype {
-                $newtype(inner)
-            }
-
-            /// Returns the inner hash (sha256, sh256d etc.).
-            pub const fn to_raw_hash(self) -> $hash {
-                self.0
-            }
-
-            /// Returns a reference to the inner hash (sha256, sh256d etc.).
-            pub const fn as_raw_hash(&self) -> &$hash {
-                &self.0
-            }
-
             /// Copies a byte slice into a hash object.
             pub fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<$newtype, $crate::FromSliceError> {
                 Ok($newtype(<$hash as $crate::Hash>::from_slice(sl)?))


### PR DESCRIPTION
In an effort to shrink the API of `hashes` remove the `from_raw_hash`, `to_raw_hash`, and `as_raw_hash` inherent functions from types created with the `hash_newtype` macro.

There are a few reasons why this is favourable:

- It allows stable crates to use the macro and not expose unstable `hashes` types in their API.
- It makes types created with the macro less "general" in the sense that its more obscure to just hash any data into them. This allows us to write cleaner APIs in `rust-bitcoin`.


