### PR TITLE
internals: Remove derive from test-serde

### DIFF
--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 std = ["alloc"]
 alloc = []
 
-test-serde = ["serde/derive", "serde_json", "bincode"]
+test-serde = ["serde", "serde_json", "bincode"]
 
 [dependencies]
 serde = { version = "1.0.103", default-features = false, optional = true }


### PR DESCRIPTION
During review of #2889 it was noted that we don't need to enable the `derive` feature of `serde` in the `test-serde` feature.

Do not enable `derive` in the `test-serde` feature.