### PR TITLE
Move opcodes to `primitives`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -55,6 +55,7 @@ dependencies = [
  "bincode",
  "bitcoin-internals",
  "bitcoin-io",
+ "bitcoin-primitives",
  "bitcoin-units",
  "bitcoin_hashes",
  "bitcoinconsensus",
@@ -98,6 +99,10 @@ version = "0.1.2"
 [[package]]
 name = "bitcoin-primitives"
 version = "0.100.0"
+dependencies = [
+ "bitcoin-internals",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-units"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -54,6 +54,7 @@ dependencies = [
  "bincode",
  "bitcoin-internals",
  "bitcoin-io",
+ "bitcoin-primitives",
  "bitcoin-units",
  "bitcoin_hashes",
  "bitcoinconsensus",
@@ -97,6 +98,10 @@ version = "0.1.2"
 [[package]]
 name = "bitcoin-primitives"
 version = "0.100.0"
+dependencies = [
+ "bitcoin-internals",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-units"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -16,10 +16,10 @@ exclude = ["tests", "contrib"]
 # If you change features or optional dependencies in any way please update the "# Cargo features" section in lib.rs as well.
 [features]
 default = [ "std", "secp-recovery" ]
-std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "secp256k1/std", "units/std"]
+std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "primitives/std", "secp256k1/std", "units/std"]
 rand-std = ["secp256k1/rand-std", "std"]
 rand = ["secp256k1/rand"]
-serde = ["actual-serde", "hashes/serde", "internals/serde", "secp256k1/serde", "units/serde"]
+serde = ["actual-serde", "hashes/serde", "internals/serde", "primitives/serde", "secp256k1/serde", "units/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
@@ -31,6 +31,7 @@ hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = fa
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
+primitives = { package = "bitcoin-primitives", version = "0.100.0", default-features = false }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false, features = ["alloc"] }
 

--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -39,5 +39,8 @@ path = "../../internals"
 [patch.crates-io.bitcoin-io]
 path = "../../io"
 
+[patch.crates-io.bitcoin-primitives]
+path = "../../primitives"
+
 [patch.crates-io.bitcoin-units]
 path = "../../units"

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -8,7 +8,6 @@
 pub mod block;
 pub mod constants;
 pub mod locktime;
-pub mod opcodes;
 pub mod script;
 pub mod transaction;
 pub mod witness;
@@ -46,6 +45,12 @@ pub mod fee_rate {
             assert_eq!(rate.fee_vb(tx.vsize() as u64), rate.fee_wu(tx.weight()));
         }
     }
+}
+
+/// Bitcoin script opcodes.
+pub mod opcodes {
+    /// Re-export everything from the [`primitives::opcodes`] module.
+    pub use primitives::opcodes::*;
 }
 
 /// Implements `Weight` and associated features.

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,9 +16,14 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = []
+std = ["internals/std"]
+serde = ["actual-serde", "internals/serde"]
 
 [dependencies]
+internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
+
+# Do NOT use this as a feature! Use the `serde` feature instead.
+actual-serde = { package = "serde", version = "1.0.103", default-features = false, features = [ "alloc" ], optional = true }
 
 [dev-dependencies]
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -20,3 +20,18 @@ extern crate alloc;
 
 #[cfg(feature = "std")]
 extern crate std;
+
+#[cfg(feature = "serde")]
+extern crate actual_serde as serde;
+
+pub mod opcodes;
+
+#[rustfmt::skip]
+#[allow(unused_imports)]
+mod prelude {
+    #[cfg(all(not(feature = "std"), not(test)))]
+    pub use alloc::string::ToString;
+
+    #[cfg(any(feature = "std", test))]
+    pub use std::string::ToString;
+}

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -424,7 +424,7 @@ impl Opcode {
     ///
     /// Returns `None` if `self` is not a PUSHNUM.
     #[inline]
-    pub(crate) const fn decode_pushnum(self) -> Option<u8> {
+    pub const fn decode_pushnum(self) -> Option<u8> {
         const START: u8 = OP_PUSHNUM_1.code;
         const END: u8 = OP_PUSHNUM_16.code;
         match self.code {


### PR DESCRIPTION
Move the `opcodes` module to the new `primitives` crate. This is pretty straight forward, some things to note:

- Are we ok with the public wildcard re-export from `blockdata`? I think so because the whole `blockdata` module should, IMO, be deleted after everything in it is moved to `primitives`.

- `decode_pushnum` becomes public.