### PR TITLE
Use super for imports in script module

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -7,24 +7,23 @@ use core::ops::{
 
 use secp256k1::{Secp256k1, Verification};
 
-use super::PushBytes;
+use super::witness_version::WitnessVersion;
+use super::{
+    bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions, PushBytes,
+    RedeemScriptSizeError, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
+};
 use crate::consensus::Encodable;
 use crate::key::{PublicKey, UntweakedPublicKey, WPubkeyHash};
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::policy::DUST_RELAY_TX_FEE;
 use crate::prelude::{sink, Box, DisplayHex, String, ToOwned, Vec};
-use crate::script::witness_version::WitnessVersion;
-use crate::script::{
-    bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions,
-    RedeemScriptSizeError, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
-};
 use crate::taproot::{LeafVersion, TapLeafHash, TapNodeHash};
 use crate::FeeRate;
 
 /// Bitcoin script slice.
 ///
-/// *[See also the `bitcoin::script` module](crate::script).*
+/// *[See also the `bitcoin::script` module](super).*
 ///
 /// `Script` is a script slice, the most primitive script type. It's usually seen in its borrowed
 /// form `&Script`. It is always encoded as a series of bytes representing the opcodes and data

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -4,12 +4,12 @@ use core::fmt;
 
 use secp256k1::XOnlyPublicKey;
 
+use super::{opcode_to_verify, write_scriptint, PushBytes, Script, ScriptBuf};
 use crate::key::PublicKey;
 use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::script::{opcode_to_verify, write_scriptint, PushBytes, Script, ScriptBuf};
 use crate::transaction::Sequence;
 
 /// An Object which can be used to construct a script piece by piece.

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
+use super::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
 use crate::opcodes::{self, Opcode};
-use crate::script::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
 
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -6,17 +6,15 @@ use core::ops::Deref;
 use hex::FromHex;
 use secp256k1::{Secp256k1, Verification};
 
+use super::witness_program::WitnessProgram;
+use super::witness_version::WitnessVersion;
+use super::{opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash};
 use crate::key::{
     PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
 };
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
-use crate::script::witness_program::WitnessProgram;
-use crate::script::witness_version::WitnessVersion;
-use crate::script::{
-    opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash,
-};
 use crate::taproot::TapNodeHash;
 
 /// An owned, growable script.

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -12,9 +12,9 @@ use core::fmt;
 use internals::array_vec::ArrayVec;
 use secp256k1::{Secp256k1, Verification};
 
+use super::witness_version::WitnessVersion;
+use super::{PushBytes, Script, WScriptHash, WitnessScriptSizeError};
 use crate::crypto::key::{CompressedPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
-use crate::script::witness_version::WitnessVersion;
-use crate::script::{PushBytes, Script, WScriptHash, WitnessScriptSizeError};
 use crate::taproot::TapNodeHash;
 
 /// The minimum byte size of a segregated witness program.


### PR DESCRIPTION
In the `script` module we currently import `script` types using the fully qualified path, as recently discussed code is easier to maintain if we use `super` when `super != crate`.

Internal change only, no external changes.