### PR TITLE
Remove private prelude module from `units` crate

### DIFF
--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -59,13 +59,3 @@ pub use self::{
     parse::ParseIntError,
     weight::Weight
 };
-
-#[rustfmt::skip]
-#[allow(unused_imports)]
-mod prelude {
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, slice, rc};
-
-    #[cfg(feature = "std")]
-    pub use std::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, rc};
-}

--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -2,6 +2,8 @@
 
 //! Provides type `Height` and `Time` types used by the `rust-bitcoin` `absolute::LockTime` type.
 
+#[cfg(feature = "alloc")]
+use alloc::{string::String, boxed::Box};
 use core::fmt;
 
 use internals::write_err;
@@ -9,8 +11,6 @@ use internals::write_err;
 #[cfg(feature = "alloc")]
 use crate::parse;
 use crate::parse::ParseIntError;
-#[cfg(feature = "alloc")]
-use crate::prelude::{Box, String};
 
 /// The Threshold for deciding whether a lock time value is a height or a time (see [Bitcoin Core]).
 ///


### PR DESCRIPTION
The private prelude module has been removed from the units crate and instead imports are stated in full when needed.  As discussed in #2926.