### PR TITLE
ci: add `all-features` semver-checks and run on rust `stable`

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -5,7 +5,7 @@ name: Check semver breaks
 
 jobs:
   API:
-    name: API - nightly toolchain
+    name: API - stable toolchain
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -15,10 +15,7 @@ jobs:
         with:
           fetch-depth: 0 # we need full history for cargo semver-checks
       - name: "Install Rustup"
-        uses: dtolnay/rust-toolchain@nightly
-      - name: "Select nightly-version"
-        run: |
-          rustup default $(cat nightly-version)
+        uses: dtolnay/rust-toolchain@stable
       - name: "Install cargo-binstall"
         uses: cargo-bins/cargo-binstall@main
       - name: "Binstall cargo-semver-checks"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ requirement to test unsafe code with sanitizers including Miri.
 All PRs that change the public API of `rust-bitcoin` will be checked on CI for
 semversioning compliance. This means that if the PR changes the public API in a
 way that is not backwards compatible, the PR will be flagged as a breaking change.
-Please check the [Rust workflow](.github/workflows/rust.yml).
+Please check the [`semver-checks` workflow](.github/workflows/semver-checks.yml).
 Under the hood we use [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks).
 
 

--- a/contrib/check-semver.sh
+++ b/contrib/check-semver.sh
@@ -41,15 +41,18 @@ main() {
     generate_json_files_all_features "base58ck" "current"
     generate_json_files_no_default_features "base58ck" "current"
 
-    # 3. bitcoin_hashes: no-default-features and alloc feature.
+    # 3. bitcoin_hashes: all-features, no-default-features and alloc feature.
+    generate_json_files_all_features "bitcoin_hashes" "current"
     generate_json_files_no_default_features "bitcoin_hashes" "current"
     generate_json_files_features_alloc "bitcoin_hashes" "current"
 
-    # 4. bitcoin-units: no-default-features and alloc feature.
+    # 4. bitcoin-units: all-features, no-default-features and alloc feature.
+    generate_json_files_all_features "bitcoin-units" "current"
     generate_json_files_no_default_features "bitcoin-units" "current"
     generate_json_files_features_alloc "bitcoin-units" "current"
 
-    # 5. bitcoin-io: no-default-features and alloc feature.
+    # 5. bitcoin-io: all-features, no-default-features and alloc feature.
+    generate_json_files_all_features "bitcoin-io" "current"
     generate_json_files_no_default_features "bitcoin-io" "current"
     generate_json_files_features_alloc "bitcoin-io" "current"
 
@@ -67,15 +70,18 @@ main() {
     generate_json_files_all_features "base58ck" "master"
     generate_json_files_no_default_features "base58ck" "master"
 
-    # 3. bitcoin_hashes: no-default-features and alloc feature.
+    # 3. bitcoin_hashes: all-features, no-default-features and alloc feature.
+    generate_json_files_all_features "bitcoin_hashes" "master"
     generate_json_files_no_default_features "bitcoin_hashes" "master"
     generate_json_files_features_alloc "bitcoin_hashes" "master"
 
-    # 4. bitcoin-units: no-default-features and alloc feature.
+    # 4. bitcoin-units: all-features, no-default-features and alloc feature.
+    generate_json_files_all_features "bitcoin-units" "master"
     generate_json_files_no_default_features "bitcoin-units" "master"
     generate_json_files_features_alloc "bitcoin-units" "master"
 
-    # 5. bitcoin-io: no-default-features and alloc feature.
+    # 5. bitcoin-io: all-features, no-default-features and alloc feature.
+    generate_json_files_all_features "bitcoin-io" "master"
     generate_json_files_no_default_features "bitcoin-io" "master"
     generate_json_files_features_alloc "bitcoin-io" "master"
 
@@ -84,10 +90,13 @@ main() {
     run_cargo_semver_check "bitcoin" "no-default-features"
     run_cargo_semver_check "base58ck" "all-features"
     run_cargo_semver_check "base58ck" "no-default-features"
+    run_cargo_semver_check "bitcoin_hashes" "all-features"
     run_cargo_semver_check "bitcoin_hashes" "no-default-features"
     run_cargo_semver_check "bitcoin_hashes" "alloc"
+    run_cargo_semver_check "bitcoin-units" "all-features"
     run_cargo_semver_check "bitcoin-units" "no-default-features"
     run_cargo_semver_check "bitcoin-units" "alloc"
+    run_cargo_semver_check "bitcoin-io" "all-features"
     run_cargo_semver_check "bitcoin-io" "no-default-features"
     run_cargo_semver_check "bitcoin-io" "alloc"
 


### PR DESCRIPTION
Crates missing:
- `bitcoin_hashes`
- `bitcoin-units`
- `bitcoin-io`

Also adds:

1. corrects a small error in the CONTRIBUTING.md; and
2. runs on `stable` since `cargo-semver-checks` do not support `nightly` (rustdocs JSON format breaks almost daily)

Closes #2999.