### PR TITLE
hashes: Add docs to manifest bitcoin-io feature

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -25,9 +25,11 @@ small-hash = []
 [dependencies]
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
 
-bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
 schemars = { version = "0.8.3", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
+
+# This is not indtended to be used directly, it is expected that users will enable `std` or `io`.
+bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"


### PR DESCRIPTION
The optional `bitcoin-io` feature is unusual in that it is enabled from `std`. This confused me, so to save the next guy add a comment to the dependency and move it down below the other optional dependencies.

(It has previously been discussed that we should document features in the `lib.rs` file not in the manifest, this is currently not done in any of our crates except `bitcoin` and the whole idea is a bit broken in the rust eccosystem - acknowledging but leaving as is for now.)