### PR TITLE
hashes: Use `$crate` in macro

### DIFF
--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -10,7 +10,7 @@
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::{ripemd160, sha256, FromSliceError};
+use crate::{ripemd160, sha256};
 
 crate::internal_macros::hash_type! {
     160,

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -113,7 +113,7 @@ macro_rules! hash_trait_impls {
             const LEN: usize = $bits / 8;
             const DISPLAY_BACKWARD: bool = $reverse;
 
-            fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<Hash<$($gen),*>, FromSliceError> {
+            fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<Hash<$($gen),*>, $crate::FromSliceError> {
                 Self::from_slice(sl)
             }
 
@@ -174,9 +174,9 @@ macro_rules! hash_type {
             /// Copies a byte slice into a hash object.
             pub fn from_slice(
                 sl: &[u8],
-            ) -> $crate::_export::_core::result::Result<Hash, FromSliceError> {
+            ) -> $crate::_export::_core::result::Result<Hash, $crate::FromSliceError> {
                 if sl.len() != $bits / 8 {
-                    Err(FromSliceError { expected: $bits / 8, got: sl.len() })
+                    Err($crate::FromSliceError { expected: $bits / 8, got: sl.len() })
                 } else {
                     let mut ret = [0; $bits / 8];
                     ret.copy_from_slice(sl);

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -6,7 +6,7 @@ use core::cmp;
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::{FromSliceError, HashEngine as _};
+use crate::HashEngine as _;
 
 crate::internal_macros::hash_type! {
     160,

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -6,7 +6,7 @@ use core::cmp;
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::{FromSliceError, HashEngine as _};
+use crate::HashEngine as _;
 
 crate::internal_macros::hash_type! {
     160,

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -5,7 +5,7 @@
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::{sha256, FromSliceError};
+use crate::sha256;
 
 crate::internal_macros::hash_type! {
     256,

--- a/hashes/src/sha384.rs
+++ b/hashes/src/sha384.rs
@@ -5,7 +5,7 @@
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::{sha512, FromSliceError};
+use crate::sha512;
 
 crate::internal_macros::hash_type! {
     384,

--- a/hashes/src/sha512.rs
+++ b/hashes/src/sha512.rs
@@ -6,7 +6,7 @@ use core::cmp;
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::{FromSliceError, HashEngine as _};
+use crate::HashEngine as _;
 
 crate::internal_macros::hash_type! {
     512,

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -10,7 +10,7 @@
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::{sha512, FromSliceError};
+use crate::sha512;
 
 crate::internal_macros::hash_type! {
     256,

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -6,7 +6,7 @@ use core::ops::Index;
 use core::slice::SliceIndex;
 use core::{cmp, mem, ptr};
 
-use crate::{FromSliceError, HashEngine as _};
+use crate::HashEngine as _;
 
 crate::internal_macros::hash_type! {
     64,


### PR DESCRIPTION
Depending on types being in scope when calling macros is bad practice but we have mistakenly done so in `internal_macros` when using the `FromSliceError`.

Use `$crate::FromSliceError` in the macro and remove import statements.