### PR TITLE
Fix error messages

### DIFF
--- a/bitcoin/build.rs
+++ b/bitcoin/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let output = std::process::Command::new(rustc)
         .arg("--version")
         .output()
-        .unwrap_or_else(|error| panic!("Failed to run `{:?} --version`: {:?}", rustc, error));
+        .unwrap_or_else(|error| panic!("failed to run `{:?} --version`: {:?}", rustc, error));
     assert!(output.status.success(), "{:?} -- version returned non-zero exit code", rustc);
     let stdout = String::from_utf8(output.stdout).expect("rustc produced non-UTF-8 output");
     let version_prefix = "rustc ";
@@ -19,7 +19,7 @@ fn main() {
     let version = &version[..end];
     let mut version_components = version.split('.');
     let major = version_components.next().unwrap();
-    assert_eq!(major, "1", "Unexpected Rust major version");
+    assert_eq!(major, "1", "unexpected Rust major version");
     let minor = version_components
         .next()
         .unwrap_or("0")

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -178,7 +178,7 @@ fn main() {
     // Now we'll start the PSBT workflow.
     // Step 1: Creator role; that creates,
     // and add inputs and outputs to the PSBT.
-    let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("Could not create PSBT");
+    let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("could not create PSBT");
 
     // Step 2:Updater role; that adds additional
     // information to the PSBT.

--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -21,7 +21,7 @@ fn main() {
     let str_address = &args[1];
 
     let address: SocketAddr = str_address.parse().unwrap_or_else(|error| {
-        eprintln!("Error parsing address: {:?}", error);
+        eprintln!("error parsing address: {:?}", error);
         process::exit(1);
     });
 
@@ -65,7 +65,7 @@ fn main() {
         }
         let _ = stream.shutdown(Shutdown::Both);
     } else {
-        eprintln!("Failed to open connection");
+        eprintln!("failed to open connection");
     }
 }
 

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -111,13 +111,13 @@ fn compute_sighash_p2wsh(raw_tx: &[u8], inp_idx: usize, value: u64) {
     println!("witness {:?}", witness);
 
     //last element is called witnessScript according to BIP141. It supersedes scriptPubKey.
-    let witness_script_bytes: &[u8] = witness.last().expect("Out of Bounds");
+    let witness_script_bytes: &[u8] = witness.last().expect("out of bounds");
     let witness_script = Script::from_bytes(witness_script_bytes);
     let mut cache = sighash::SighashCache::new(&tx);
 
     //in an M of N multisig, the witness elements from 1 (0-based) to M-2 are signatures (with sighash flags as the last byte)
     for n in 1..=witness.len() - 2 {
-        let sig_bytes = witness.nth(n).expect("Out of Bounds");
+        let sig_bytes = witness.nth(n).expect("out of bounds");
         let sig = ecdsa::Signature::from_slice(sig_bytes).expect("failed to parse sig");
         let sig_len = sig_bytes.len() - 1; //last byte is EcdsaSighashType sighash flag
                                            //ECDSA signature in DER format lengths are between 70 and 72 bytes

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -200,7 +200,7 @@ fn main() {
     // Now we'll start the PSBT workflow.
     // Step 1: Creator role; that creates,
     // and add inputs and outputs to the PSBT.
-    let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("Could not create PSBT");
+    let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("could not create PSBT");
 
     // Step 2:Updater role; that adds additional
     // information to the PSBT.

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -110,7 +110,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .amount_in_sats
         .checked_sub(amount_to_send_in_sats)
         .and_then(|x| x.checked_sub(ABSOLUTE_FEES_IN_SATS))
-        .ok_or("Fees more than input amount!")?;
+        .ok_or("fees more than input amount!")?;
 
     let tx_hex_string = encode::serialize_hex(&generate_bip86_key_spend_tx(
         &secp,
@@ -294,8 +294,8 @@ fn generate_bip86_key_spend_tx(
 
             let (_, (_, derivation_path)) = input
                 .tap_key_origins
-                .get(&input.tap_internal_key.ok_or("Internal key missing in PSBT")?)
-                .ok_or("Missing Taproot key origin")?;
+                .get(&input.tap_internal_key.ok_or("internal key missing in PSBT")?)
+                .ok_or("missing Taproot key origin")?;
 
             let secret_key = master_xpriv.derive_priv(secp, &derivation_path).to_priv().inner;
             sign_psbt_taproot(
@@ -385,7 +385,7 @@ impl BenefactorWallet {
     ) -> Result<(Transaction, Psbt), Box<dyn std::error::Error>> {
         if let ChildNumber::Normal { index } = self.next {
             if index > 0 && self.current_spend_info.is_some() {
-                return Err("Transaction already exists, use refresh_inheritance_timelock to refresh the timelock".into());
+                return Err("transaction already exists, use refresh_inheritance_timelock to refresh the timelock".into());
             }
         }
         // We use some other derivation path in this example for our inheritance protocol. The important thing is to ensure
@@ -403,7 +403,7 @@ impl BenefactorWallet {
         let taproot_spend_info = TaprootBuilder::new()
             .add_leaf(0, script.clone())?
             .finalize(&self.secp, internal_keypair.x_only_public_key().0)
-            .expect("Should be finalizable");
+            .expect("should be finalizable");
         self.current_spend_info = Some(taproot_spend_info.clone());
         let script_pubkey = ScriptBuf::new_p2tr(
             &self.secp,
@@ -471,7 +471,7 @@ impl BenefactorWallet {
         lock_time_delta: u32,
     ) -> Result<(Transaction, Psbt), Box<dyn std::error::Error>> {
         if let Some(ref spend_info) = self.current_spend_info.clone() {
-            let mut psbt = self.next_psbt.clone().expect("Should have next_psbt");
+            let mut psbt = self.next_psbt.clone().expect("should have next_psbt");
             let input = &mut psbt.inputs[0];
             let input_value = input.witness_utxo.as_ref().unwrap().value;
             let output_value = input_value - ABSOLUTE_FEES_IN_SATS;
@@ -498,7 +498,7 @@ impl BenefactorWallet {
             let taproot_spend_info = TaprootBuilder::new()
                 .add_leaf(0, script.clone())?
                 .finalize(&self.secp, new_internal_keypair.x_only_public_key().0)
-                .expect("Should be finalizable");
+                .expect("should be finalizable");
             self.current_spend_info = Some(taproot_spend_info.clone());
             let prevout_script_pubkey = input.witness_utxo.as_ref().unwrap().script_pubkey.clone();
             let output_script_pubkey = ScriptBuf::new_p2tr(
@@ -528,8 +528,8 @@ impl BenefactorWallet {
             {
                 let (_, (_, derivation_path)) = input
                     .tap_key_origins
-                    .get(&input.tap_internal_key.ok_or("Internal key missing in PSBT")?)
-                    .ok_or("Missing Taproot key origin")?;
+                    .get(&input.tap_internal_key.ok_or("internal key missing in PSBT")?)
+                    .ok_or("missing Taproot key origin")?;
                 let secret_key =
                     self.master_xpriv.derive_priv(&self.secp, &derivation_path).to_priv().inner;
                 sign_psbt_taproot(
@@ -611,7 +611,7 @@ impl BenefactorWallet {
             self.next.increment()?;
             Ok((tx, next_psbt))
         } else {
-            Err("No current_spend_info available. Create an inheritance tx first.".into())
+            Err("no current_spend_info available. Create an inheritance tx first.".into())
         }
     }
 }

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -310,7 +310,7 @@ impl Decodable for BlockTransactionsRequest {
                 // transactions that would be allowed in a vector.
                 let byte_size = (nb_indexes)
                     .checked_mul(mem::size_of::<Transaction>())
-                    .ok_or(encode::Error::ParseFailed("Invalid length"))?;
+                    .ok_or(encode::Error::ParseFailed("invalid length"))?;
                 if byte_size > encode::MAX_VEC_SIZE {
                     return Err(encode::Error::OversizedVectorAllocation {
                         requested: byte_size,

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -608,7 +608,7 @@ mod tests {
     fn validate_pow_test() {
         let some_header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
         let some_header: Header =
-            deserialize(&some_header).expect("Can't deserialize correct block header");
+            deserialize(&some_header).expect("can't deserialize correct block header");
         assert_eq!(
             some_header.validate_pow(some_header.target()).unwrap(),
             some_header.block_hash()
@@ -634,7 +634,7 @@ mod tests {
         let some_header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
 
         let header: Header =
-            deserialize(&some_header).expect("Can't deserialize correct block header");
+            deserialize(&some_header).expect("can't deserialize correct block header");
 
         assert_eq!(header.bits, header.target().to_compact_lossy());
     }

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -334,7 +334,7 @@ mod test {
             Network::Testnet => {},
             Network::Signet => {},
             Network::Regtest => {},
-            _ => panic!("Update ChainHash::using_genesis_block and chain_hash_genesis_block with new variants"),
+            _ => panic!("update ChainHash::using_genesis_block and chain_hash_genesis_block with new variants"),
         }
     }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -2120,7 +2120,7 @@ mod tests {
 
         match error {
             TxVerifyError::ScriptVerification(_) => {}
-            _ => panic!("Wrong error type"),
+            _ => panic!("wrong error type"),
         }
     }
 

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -200,7 +200,7 @@ fn encode_cursor(bytes: &mut [u8], start_of_indices: usize, index: usize, value:
     let start = start_of_indices + index * 4;
     let end = start + 4;
     bytes[start..end]
-        .copy_from_slice(&u32::to_ne_bytes(value.try_into().expect("Larger than u32")));
+        .copy_from_slice(&u32::to_ne_bytes(value.try_into().expect("larger than u32")));
 }
 
 #[inline]
@@ -471,7 +471,7 @@ impl Witness {
 impl Index<usize> for Witness {
     type Output = [u8];
 
-    fn index(&self, index: usize) -> &Self::Output { self.nth(index).expect("Out of Bounds") }
+    fn index(&self, index: usize) -> &Self::Output { self.nth(index).expect("out of bounds") }
 }
 
 impl<'a> Iterator for Iter<'a> {

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -52,7 +52,7 @@ impl<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> IterReader<E, I> {
 
             (Err(consensus::encode::Error::Io(io_error)), Some(de_error)) if io_error.kind() == io::ErrorKind::Other && io_error.get_ref().is_none() => Err(DecodeError::Other(de_error)),
             (Err(consensus_error), None) => Err(DecodeError::Consensus(consensus_error)),
-            (Err(consensus::encode::Error::Io(io_error)), de_error) => panic!("Unexpected IO error {:?} returned from {}::consensus_decode(), deserialization error: {:?}", io_error, core::any::type_name::<T>(), de_error),
+            (Err(consensus::encode::Error::Io(io_error)), de_error) => panic!("unexpected IO error {:?} returned from {}::consensus_decode(), deserialization error: {:?}", io_error, core::any::type_name::<T>(), de_error),
             (Err(consensus_error), Some(de_error)) => panic!("{} should've returned `Other` IO error because of deserialization error {:?} but it returned consensus error {:?} instead", core::any::type_name::<T>(), de_error, consensus_error),
         }
     }

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -34,7 +34,7 @@ impl Signature {
                 Ok(Signature { signature, sighash_type: TapSighashType::Default })
             }
             65 => {
-                let (sighash_type, signature) = sl.split_last().expect("Slice len checked == 65");
+                let (sighash_type, signature) = sl.split_last().expect("slice len checked == 65");
                 let sighash_type = TapSighashType::from_consensus_u8(*sighash_type)?;
                 let signature = secp256k1::schnorr::Signature::from_slice(signature)?;
                 Ok(Signature { signature, sighash_type })

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -592,14 +592,14 @@ mod tests {
 
             // Deserialize into a tester copy
             let pmt2: PartialMerkleTree =
-                encode::deserialize(&serialized).expect("Could not deserialize own data");
+                encode::deserialize(&serialized).expect("could not deserialize own data");
 
             // Extract Merkle root and matched txids from copy
             let mut match_txid2: Vec<Txid> = vec![];
             let mut indexes = vec![];
             let merkle_root_2 = pmt2
                 .extract_matches(&mut match_txid2, &mut indexes)
-                .expect("Could not extract matches");
+                .expect("could not extract matches");
 
             // Check that it has the same Merkle root as the original, and a valid one
             assert_eq!(merkle_root_1, merkle_root_2);

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -129,7 +129,7 @@ mod tests {
     fn static_vector() {
         // testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
         let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw");
-        let block: Block = deserialize(&segwit_block[..]).expect("Failed to deserialize block");
+        let block: Block = deserialize(&segwit_block[..]).expect("failed to deserialize block");
 
         assert!(block.check_merkle_root());
 

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -174,14 +174,14 @@ impl Decodable for AddrV2 {
         Ok(match network_id {
             1 => {
                 if len != 4 {
-                    return Err(encode::Error::ParseFailed("Invalid IPv4 address"));
+                    return Err(encode::Error::ParseFailed("invalid IPv4 address"));
                 }
                 let addr: [u8; 4] = Decodable::consensus_decode(r)?;
                 AddrV2::Ipv4(Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]))
             }
             2 => {
                 if len != 16 {
-                    return Err(encode::Error::ParseFailed("Invalid IPv6 address"));
+                    return Err(encode::Error::ParseFailed("invalid IPv6 address"));
                 }
                 let addr: [u16; 8] = read_be_address(r)?;
                 if addr[0..3] == ONION {
@@ -200,33 +200,33 @@ impl Decodable for AddrV2 {
             }
             3 => {
                 if len != 10 {
-                    return Err(encode::Error::ParseFailed("Invalid TorV2 address"));
+                    return Err(encode::Error::ParseFailed("invalid TorV2 address"));
                 }
                 let id = Decodable::consensus_decode(r)?;
                 AddrV2::TorV2(id)
             }
             4 => {
                 if len != 32 {
-                    return Err(encode::Error::ParseFailed("Invalid TorV3 address"));
+                    return Err(encode::Error::ParseFailed("invalid TorV3 address"));
                 }
                 let pubkey = Decodable::consensus_decode(r)?;
                 AddrV2::TorV3(pubkey)
             }
             5 => {
                 if len != 32 {
-                    return Err(encode::Error::ParseFailed("Invalid I2P address"));
+                    return Err(encode::Error::ParseFailed("invalid I2P address"));
                 }
                 let hash = Decodable::consensus_decode(r)?;
                 AddrV2::I2p(hash)
             }
             6 => {
                 if len != 16 {
-                    return Err(encode::Error::ParseFailed("Invalid CJDNS address"));
+                    return Err(encode::Error::ParseFailed("invalid CJDNS address"));
                 }
                 let addr: [u16; 8] = read_be_address(r)?;
                 // check the first byte for the CJDNS marker
                 if addr[0] >> 8 != 0xFC {
-                    return Err(encode::Error::ParseFailed("Invalid CJDNS address"));
+                    return Err(encode::Error::ParseFailed("invalid CJDNS address"));
                 }
                 AddrV2::Cjdns(Ipv6Addr::new(
                     addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7],

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -790,7 +790,7 @@ mod test {
             assert_eq!(version_msg.start_height, 560275);
             assert!(version_msg.relay);
         } else {
-            panic!("Wrong message type");
+            panic!("wrong message type");
         }
     }
 
@@ -836,7 +836,7 @@ mod test {
             assert_eq!(version_msg.start_height, 560275);
             assert!(version_msg.relay);
         } else {
-            panic!("Wrong message type");
+            panic!("wrong message type");
         }
     }
 }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -911,7 +911,7 @@ impl Add for U256 {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
         let (res, overflow) = self.overflowing_add(rhs);
-        debug_assert!(!overflow, "Addition of U256 values overflowed");
+        debug_assert!(!overflow, "addition of U256 values overflowed");
         res
     }
 }
@@ -920,7 +920,7 @@ impl Sub for U256 {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
         let (res, overflow) = self.overflowing_sub(rhs);
-        debug_assert!(!overflow, "Subtraction of U256 values overflowed");
+        debug_assert!(!overflow, "subtraction of U256 values overflowed");
         res
     }
 }
@@ -929,7 +929,7 @@ impl Mul for U256 {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
         let (res, overflow) = self.overflowing_mul(rhs);
-        debug_assert!(!overflow, "Multiplication of U256 values overflowed");
+        debug_assert!(!overflow, "multiplication of U256 values overflowed");
         res
     }
 }

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -114,12 +114,12 @@ impl Psbt {
                             if !pair.key.key.is_empty() {
                                 let xpub = Xpub::decode(&pair.key.key)
                                     .map_err(|_| Error::XPubKey(
-                                        "Can't deserialize ExtendedPublicKey from global XPUB key data"
+                                        "can't deserialize ExtendedPublicKey from global XPUB key data"
                                     ))?;
 
                                 if pair.value.is_empty() || pair.value.len() % 4 != 0 {
                                     return Err(Error::XPubKey(
-                                        "Incorrect length of global xpub derivation data",
+                                        "incorrect length of global xpub derivation data",
                                     ));
                                 }
 
@@ -127,7 +127,7 @@ impl Psbt {
                                 let mut decoder = Cursor::new(pair.value);
                                 let mut fingerprint = [0u8; 4];
                                 decoder.read_exact(&mut fingerprint[..]).map_err(|_| {
-                                    Error::XPubKey("Can't read global xpub fingerprint")
+                                    Error::XPubKey("can't read global xpub fingerprint")
                                 })?;
                                 let mut path = Vec::<ChildNumber>::with_capacity(child_count);
                                 while let Ok(index) = u32::consensus_decode(&mut decoder) {
@@ -139,7 +139,7 @@ impl Psbt {
                                     .insert(xpub, (Fingerprint::from(fingerprint), derivation))
                                     .is_some()
                                 {
-                                    return Err(Error::XPubKey("Repeated global xpub key"));
+                                    return Err(Error::XPubKey("repeated global xpub key"));
                                 }
                             } else {
                                 return Err(Error::XPubKey(

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1063,14 +1063,14 @@ impl fmt::Display for ExtractTxError {
 
         match *self {
             AbsurdFeeRate { fee_rate, .. } =>
-                write!(f, "An absurdly high fee rate of {}", fee_rate),
+                write!(f, "an absurdly high fee rate of {}", fee_rate),
             MissingInputValue { .. } => write!(
                 f,
-                "One of the inputs lacked value information (witness_utxo or non_witness_utxo)"
+                "one of the inputs lacked value information (witness_utxo or non_witness_utxo)"
             ),
             SendingTooMuch { .. } => write!(
                 f,
-                "Transaction would be invalid due to output value being greater than input value."
+                "transaction would be invalid due to output value being greater than input value."
             ),
         }
     }

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -175,7 +175,7 @@ impl Deserialize for ecdsa::Signature {
             ecdsa::Error::EmptySignature => Error::InvalidEcdsaSignature(e),
             ecdsa::Error::SighashType(err) => Error::NonStandardSighashType(err.0),
             ecdsa::Error::Secp256k1(..) => Error::InvalidEcdsaSignature(e),
-            ecdsa::Error::Hex(..) => unreachable!("Decoding from slice, not hex"),
+            ecdsa::Error::Hex(..) => unreachable!("decoding from slice, not hex"),
         })
     }
 }
@@ -362,7 +362,7 @@ impl Deserialize for TapTree {
         let mut builder = TaprootBuilder::new();
         let mut bytes_iter = bytes.iter();
         while let Some(depth) = bytes_iter.next() {
-            let version = bytes_iter.next().ok_or(Error::Taproot("Invalid Taproot Builder"))?;
+            let version = bytes_iter.next().ok_or(Error::Taproot("invalid Taproot Builder"))?;
             let (script, consumed) = deserialize_partial::<ScriptBuf>(bytes_iter.as_slice())?;
             if consumed > 0 {
                 bytes_iter.nth(consumed - 1);

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -354,10 +354,10 @@ macro_rules! hash_newtype_get_direction {
 macro_rules! hash_newtype_forbid_direction {
     ($direction:ident, ) => {};
     ($direction:ident, #[hash_newtype(forward)] $(others:tt)*) => {
-        compile_error!(concat!("Cannot set display direction to forward: ", stringify!($direction), " was already specified"));
+        compile_error!(concat!("cannot set display direction to forward: ", stringify!($direction), " was already specified"));
     };
     ($direction:ident, #[hash_newtype(backward)] $(others:tt)*) => {
-        compile_error!(concat!("Cannot set display direction to backward: ", stringify!($direction), " was already specified"));
+        compile_error!(concat!("cannot set display direction to backward: ", stringify!($direction), " was already specified"));
     };
     ($direction:ident, #[$($ignore:tt)*] $(#[$others:tt])*) => {
         $crate::hash_newtype_forbid_direction!($direction, $(#[$others])*)
@@ -374,7 +374,7 @@ macro_rules! hash_newtype_forbid_direction {
 macro_rules! hash_newtype_known_attrs {
     (#[hash_newtype(forward)]) => {};
     (#[hash_newtype(backward)]) => {};
-    (#[hash_newtype($($unknown:tt)*)]) => { compile_error!(concat!("Unrecognized attribute ", stringify!($($unknown)*))); };
+    (#[hash_newtype($($unknown:tt)*)]) => { compile_error!(concat!("unrecognized attribute ", stringify!($($unknown)*))); };
     ($($ignore:tt)*) => {};
 }
 

--- a/internals/build.rs
+++ b/internals/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let output = std::process::Command::new(rustc)
         .arg("--version")
         .output()
-        .unwrap_or_else(|error| panic!("Failed to run `{:?} --version`: {:?}", rustc, error));
+        .unwrap_or_else(|error| panic!("failed to run `{:?} --version`: {:?}", rustc, error));
     assert!(output.status.success(), "{:?} -- version returned non-zero exit code", rustc);
     let stdout = String::from_utf8(output.stdout).expect("rustc produced non-UTF-8 output");
     let version_prefix = "rustc ";
@@ -19,7 +19,7 @@ fn main() {
     let version = &version[..end];
     let mut version_components = version.split('.');
     let major = version_components.next().unwrap();
-    assert_eq!(major, "1", "Unexpected Rust major version");
+    assert_eq!(major, "1", "unexpected Rust major version");
     let minor = version_components
         .next()
         .unwrap_or("0")

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -2044,7 +2044,7 @@ mod tests {
             for v in &["0", "000"] {
                 let s = format!("{} {}", v, denom);
                 match Amount::from_str(&s) {
-                    Err(e) => panic!("Failed to crate amount from {}: {:?}", s, e),
+                    Err(e) => panic!("failed to crate amount from {}: {:?}", s, e),
                     Ok(amount) => assert_eq!(amount, Amount::from_sat(0)),
                 }
             }
@@ -2055,10 +2055,10 @@ mod tests {
                     e,
                     ParseError::Amount(ParseAmountError::OutOfRange(OutOfRangeError::negative()))
                 ),
-                Ok(_) => panic!("Unsigned amount from {}", s),
+                Ok(_) => panic!("unsigned amount from {}", s),
             }
             match SignedAmount::from_str(&s) {
-                Err(e) => panic!("Failed to crate amount from {}: {:?}", s, e),
+                Err(e) => panic!("failed to crate amount from {}: {:?}", s, e),
                 Ok(amount) => assert_eq!(amount, SignedAmount::from_sat(0)),
             }
         }


### PR DESCRIPTION
Error messages should be lower case, except for proper nouns and variable names.  These have all been changed.

~~They should also state what went wrong.  Some expect error messages were positive, giving the correct behaviour or correct input.  These have been changed so that they are now negative, i.e. saying what went wrong.~~

EDIT: After further discussion it was decided not to change the expect messages.