### PR TITLE
ci: fix semver-checks in `master`

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -22,15 +22,24 @@ jobs:
         run: cargo binstall cargo-semver-checks --no-confirm
       - name: "Run semver checker script"
         run: ./contrib/check-semver.sh
-      - name: "Add PR label to breaking changes"
-        uses: actions-ecosystem/action-add-labels@v1
+      - name: "Add PR label/comment announcing breaking changes"
+        uses: actions/github-script@v7
         if: ${{ hashFiles('semver-break') != '' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
-          labels: "API break"
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v2
-        if: ${{ hashFiles('semver-break') != '' }}
-        with:
-          message: |
-            :rotating_light: API BREAKING CHANGE DETECTED
+          github-token: ${{ secrets.APOELSTRA_CREATE_PR_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ env.PR_NUMBER }},
+              body: ':rotating_light: API BREAKING CHANGE DETECTED'
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ env.PR_NUMBER }},
+              labels: ['API break']
+            });
 


### PR DESCRIPTION
Closes #3018.

This is a simplified version that uses `actions/github-script` (officially maintained by GitHub) with VERY MINIMAL JS to add a comment and a label to API semver breaking changes.

The comment will be done by @apoelstra since we are using his `APOELSTRA_CREATE_PR_TOKEN`.

So we don't need the whole CI dance between `pull_request` and `pull_request_target` in #3003 / #3020.
And also fixes `master` right now.

## How I tested this?

> [!CAUTION]
> This might still not work if I have not recreated everything in my tests.

1. I merged this PR to my `master` branch in my `storopoli/rust-bitcoin` repo.
2. I've set the following settings in the repo settings to mimic what we have for `rust-bitcoin`:

   ![image](https://github.com/user-attachments/assets/7bea176f-c67c-4c0c-94ba-d7775af9fdb5)

3. I've created a token with the `admin:org` scope (same as the `APOELSTRA_CREATE_PR_TOKEN`) and added it as a repository secret with the same name `APOELSTRA_CREATE_PR_TOKEN` as what we use here in `rust-bitcoin`
   
   ![image](https://github.com/user-attachments/assets/127e42ca-41f7-4fd4-a08c-814a7f2b0b5a)

4. I've made a PR (cherry-picked from Toby) that breaks semver, see https://github.com/storopoli/rust-bitcoin/pull/10. It correctly labelled as `API break` and added a comment to the PR under my name (since it uses my token)

  ![image](https://github.com/user-attachments/assets/1c4d111f-29bd-4cb6-b672-355fa3ed432e)

