### PR TITLE
Rename variable assignment

### DIFF
--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -158,11 +158,11 @@ mod tests {
 
     #[test]
     fn from_vb() {
-        let vb = Weight::from_vb(1).expect("expected weight unit");
-        assert_eq!(Weight(4), vb);
+        let w = Weight::from_vb(1).expect("expected weight unit");
+        assert_eq!(Weight(4), w);
 
-        let vb = Weight::from_vb(u64::MAX);
-        assert_eq!(None, vb);
+        let w = Weight::from_vb(u64::MAX);
+        assert_eq!(None, w);
     }
 
     #[test]
@@ -173,8 +173,8 @@ mod tests {
 
     #[test]
     fn from_vb_unchecked() {
-        let vb = Weight::from_vb_unchecked(1);
-        assert_eq!(Weight(4), vb);
+        let w = Weight::from_vb_unchecked(1);
+        assert_eq!(Weight(4), w);
     }
 
     #[test]


### PR DESCRIPTION
The type created after assignment is a Weight type.  Using a var name vb which is short for virtual byte is incorrect.

Pulled this out of stale PR 2215