### PR TITLE
Fix: derive_pub() is now infalible

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -3,12 +3,11 @@ extern crate bitcoin;
 use std::str::FromStr;
 use std::{env, process};
 
-use bitcoin::address::{Address, KnownHrp};
-use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{DerivationPath, NormalDerivationPath, Xpriv, Xpub};
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::{CompressedPublicKey, NetworkKind};
+use bitcoin::{Address, CompressedPublicKey, KnownHrp, NetworkKind};
 
 fn main() {
     // This example derives root xprv from a 32-byte seed,
@@ -47,9 +46,9 @@ fn main() {
     println!("Public key at {}: {}", path, xpub);
 
     // generate first receiving address at m/0/0
-    // manually creating indexes this time
-    let zero = ChildNumber::ZERO_NORMAL;
-    let public_key = xpub.derive_pub(&secp, &[zero, zero]).unwrap().public_key;
+    let zero_path = "0/0".parse::<NormalDerivationPath>().unwrap();
+    // While using only Normal Child Numbers, you can use NormalDerivationPath instead of DerivationPath
+    let public_key = xpub.derive_pub(&secp, &zero_path).public_key;
     let address = Address::p2wpkh(CompressedPublicKey(public_key), KnownHrp::Mainnet);
     println!("First receiving address: {}", address);
 }

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -26,7 +26,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
 use bitcoin::secp256k1::{Secp256k1, Signing};
@@ -59,13 +59,12 @@ fn get_external_address_xpriv<C: Signing>(
     master_xpriv: Xpriv,
     index: u32,
 ) -> Xpriv {
-    let derivation_path =
-        BIP84_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+    let derivation_path = BIP84_DERIVATION_PATH.parse::<DerivationPath>().expect("valid path");
     let child_xpriv = master_xpriv.derive_priv(secp, &derivation_path);
     let external_index = ChildNumber::ZERO_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let idx = ChildNumber::from_normal_index(index).expect("valid index number");
 
-    child_xpriv.derive_priv(secp, &[external_index, idx])
+    child_xpriv.derive_priv(secp, [external_index, idx])
 }
 
 // Derive the internal address xpriv.
@@ -74,13 +73,12 @@ fn get_internal_address_xpriv<C: Signing>(
     master_xpriv: Xpriv,
     index: u32,
 ) -> Xpriv {
-    let derivation_path =
-        BIP84_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+    let derivation_path = BIP84_DERIVATION_PATH.parse::<DerivationPath>().expect("valid path");
     let child_xpriv = master_xpriv.derive_priv(secp, &derivation_path);
     let internal_index = ChildNumber::ONE_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let idx = ChildNumber::from_normal_index(index).expect("valid index number");
 
-    child_xpriv.derive_priv(secp, &[internal_index, idx])
+    child_xpriv.derive_priv(secp, [internal_index, idx])
 }
 
 // The address to send to.

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -33,7 +33,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::consensus::encode;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::{self, Input, Psbt, PsbtSighashType};
@@ -116,11 +116,11 @@ impl ColdStorage {
 
         // Hardened children require secret data to derive.
 
-        let path = "84h/0h/0h".into_derivation_path()?;
+        let path = "84h/0h/0h".parse::<DerivationPath>()?;
         let account_0_xpriv = master_xpriv.derive_priv(secp, &path);
         let account_0_xpub = Xpub::from_priv(secp, &account_0_xpriv);
 
-        let path = INPUT_UTXO_DERIVATION_PATH.into_derivation_path()?;
+        let path = INPUT_UTXO_DERIVATION_PATH.parse::<DerivationPath>()?;
         let input_xpriv = master_xpriv.derive_priv(secp, &path);
         let input_xpub = Xpub::from_priv(secp, &input_xpriv);
 
@@ -256,19 +256,18 @@ impl WatchOnly {
         &self,
         secp: &Secp256k1<C>,
     ) -> Result<(CompressedPublicKey, Address, DerivationPath)> {
-        let path = [ChildNumber::ONE_NORMAL, ChildNumber::ZERO_NORMAL];
-        let derived = self.account_0_xpub.derive_pub(secp, &path)?;
+        let path = "m/0/1".parse::<DerivationPath>().expect("valid &str path");
+        let derived = self.account_0_xpub.try_derive_pub(secp, &path)?;
 
         let pk = derived.to_pub();
         let addr = Address::p2wpkh(pk, NETWORK);
-        let path = path.into_derivation_path()?;
 
         Ok((pk, addr, path))
     }
 }
 
 fn input_derivation_path() -> Result<DerivationPath> {
-    let path = INPUT_UTXO_DERIVATION_PATH.into_derivation_path()?;
+    let path = INPUT_UTXO_DERIVATION_PATH.parse::<DerivationPath>()?;
     Ok(path)
 }
 

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -24,7 +24,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::key::UntweakedPublicKey;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
@@ -58,13 +58,12 @@ fn get_external_address_xpriv<C: Signing>(
     master_xpriv: Xpriv,
     index: u32,
 ) -> Xpriv {
-    let derivation_path =
-        BIP86_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+    let derivation_path = BIP86_DERIVATION_PATH.parse::<DerivationPath>().expect("valid path");
     let child_xpriv = master_xpriv.derive_priv(secp, &derivation_path);
     let external_index = ChildNumber::ZERO_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let idx = ChildNumber::from_normal_index(index).expect("valid index number");
 
-    child_xpriv.derive_priv(secp, &[external_index, idx])
+    child_xpriv.derive_priv(secp, [external_index, idx])
 }
 
 // Derive the internal address xpriv.
@@ -73,13 +72,12 @@ fn get_internal_address_xpriv<C: Signing>(
     master_xpriv: Xpriv,
     index: u32,
 ) -> Xpriv {
-    let derivation_path =
-        BIP86_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+    let derivation_path = BIP86_DERIVATION_PATH.parse::<DerivationPath>().expect("valid path");
     let child_xpriv = master_xpriv.derive_priv(secp, &derivation_path);
     let internal_index = ChildNumber::ONE_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let idx = ChildNumber::from_normal_index(index).expect("valid index number");
 
-    child_xpriv.derive_priv(secp, &[internal_index, idx])
+    child_xpriv.derive_priv(secp, [internal_index, idx])
 }
 
 // Get the Taproot Key Origin.

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -79,7 +79,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::address::script_pubkey::{BuilderExt as _, ScriptBufExt as _};
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
+use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, NormalDerivationPath, Xpriv, Xpub};
 use bitcoin::consensus::encode;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
@@ -297,7 +297,7 @@ fn generate_bip86_key_spend_tx(
                 .get(&input.tap_internal_key.ok_or("internal key missing in PSBT")?)
                 .ok_or("missing Taproot key origin")?;
 
-            let secret_key = master_xpriv.derive_priv(secp, &derivation_path).to_priv().inner;
+            let secret_key = master_xpriv.derive_priv(secp, derivation_path).to_priv().inner;
             sign_psbt_taproot(
                 secret_key,
                 input.tap_internal_key.unwrap(),
@@ -383,18 +383,19 @@ impl BenefactorWallet {
         lock_time: absolute::LockTime,
         input_utxo: P2trUtxo,
     ) -> Result<(Transaction, Psbt), Box<dyn std::error::Error>> {
-        if let ChildNumber::Normal { index } = self.next {
-            if index > 0 && self.current_spend_info.is_some() {
+        if let ChildNumber::Normal(index) = self.next {
+            if index.to_raw_number() > 0 && self.current_spend_info.is_some() {
                 return Err("transaction already exists, use refresh_inheritance_timelock to refresh the timelock".into());
             }
         }
         // We use some other derivation path in this example for our inheritance protocol. The important thing is to ensure
         // that we use an unhardened path so we can make use of xpubs.
         let derivation_path = DerivationPath::from_str(&format!("101/1/0/0/{}", self.next))?;
+
         let internal_keypair =
             self.master_xpriv.derive_priv(&self.secp, &derivation_path).to_keypair(&self.secp);
         let beneficiary_key =
-            self.beneficiary_xpub.derive_pub(&self.secp, &derivation_path)?.to_x_only_pub();
+            self.beneficiary_xpub.try_derive_pub(&self.secp, &derivation_path)?.to_x_only_pub();
 
         // Build up the leaf script and combine with internal key into a Taproot commitment
         let script = Self::time_lock_script(lock_time, beneficiary_key);
@@ -479,13 +480,13 @@ impl BenefactorWallet {
             // We use some other derivation path in this example for our inheritance protocol. The important thing is to ensure
             // that we use an unhardened path so we can make use of xpubs.
             let new_derivation_path =
-                DerivationPath::from_str(&format!("101/1/0/0/{}", self.next))?;
+                format!("101/1/0/0/{}", self.next).parse::<NormalDerivationPath>()?;
             let new_internal_keypair = self
                 .master_xpriv
-                .derive_priv(&self.secp, &new_derivation_path)
+                .derive_priv(&self.secp, new_derivation_path.clone())
                 .to_keypair(&self.secp);
             let beneficiary_key =
-                self.beneficiary_xpub.derive_pub(&self.secp, &new_derivation_path)?.to_x_only_pub();
+                self.beneficiary_xpub.derive_pub(&self.secp, &new_derivation_path).to_x_only_pub();
 
             // Build up the leaf script and combine with internal key into a Taproot commitment
             let lock_time = absolute::LockTime::from_height(
@@ -531,7 +532,7 @@ impl BenefactorWallet {
                     .get(&input.tap_internal_key.ok_or("internal key missing in PSBT")?)
                     .ok_or("missing Taproot key origin")?;
                 let secret_key =
-                    self.master_xpriv.derive_priv(&self.secp, &derivation_path).to_priv().inner;
+                    self.master_xpriv.derive_priv(&self.secp, derivation_path).to_priv().inner;
                 sign_psbt_taproot(
                     secret_key,
                     spend_info.internal_key(),
@@ -579,7 +580,10 @@ impl BenefactorWallet {
             let mut origins = BTreeMap::new();
             origins.insert(
                 beneficiary_key,
-                (vec![leaf_hash], (self.beneficiary_xpub.fingerprint(), new_derivation_path)),
+                (
+                    vec![leaf_hash],
+                    (self.beneficiary_xpub.fingerprint(), new_derivation_path.to_derivation_path()),
+                ),
             );
             let ty = PsbtSighashType::from_str("SIGHASH_ALL")?;
             let mut tap_scripts = BTreeMap::new();
@@ -652,7 +656,7 @@ impl BeneficiaryWallet {
             &psbt.inputs[0].tap_key_origins.clone()
         {
             let secret_key =
-                self.master_xpriv.derive_priv(&self.secp, &derivation_path).to_priv().inner;
+                self.master_xpriv.derive_priv(&self.secp, derivation_path).to_priv().inner;
             for lh in leaf_hashes {
                 let sighash_type = TapSighashType::All;
                 let hash = SighashCache::new(&unsigned_tx).taproot_script_spend_signature_hash(

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -44,7 +44,7 @@ impl Map for Psbt {
                 value: {
                     let mut ret = Vec::with_capacity(4 + derivation.len() * 4);
                     ret.extend(fingerprint.as_bytes());
-                    derivation.into_iter().for_each(|n| ret.extend(&u32::from(*n).to_le_bytes()));
+                    derivation.into_iter().for_each(|n| ret.extend(&u32::from(n).to_le_bytes()));
                     ret
                 },
             });

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -986,8 +986,9 @@ impl fmt::Display for SignError {
             TaprootError(ref e) => write_err!(f, "Taproot sighash"; e),
             UnknownOutputType => write!(f, "unable to determine the output type"),
             KeyNotFound => write!(f, "unable to find key"),
-            WrongSigningAlgorithm =>
-                write!(f, "attempt to sign an input with the wrong signing algorithm"),
+            WrongSigningAlgorithm => {
+                write!(f, "attempt to sign an input with the wrong signing algorithm")
+            }
             Unsupported => write!(f, "signing request currently unsupported"),
         }
     }
@@ -1061,8 +1062,9 @@ impl fmt::Display for ExtractTxError {
         use ExtractTxError::*;
 
         match *self {
-            AbsurdFeeRate { fee_rate, .. } =>
-                write!(f, "an absurdly high fee rate of {}", fee_rate),
+            AbsurdFeeRate { fee_rate, .. } => {
+                write!(f, "an absurdly high fee rate of {}", fee_rate)
+            }
             MissingInputValue { .. } => write!(
                 f,
                 "one of the inputs lacked value information (witness_utxo or non_witness_utxo)"
@@ -1359,15 +1361,15 @@ mod tests {
         let dpath: Vec<ChildNumber> = vec![
             ChildNumber::ZERO_NORMAL,
             ChildNumber::ONE_NORMAL,
-            ChildNumber::from_normal_idx(2).unwrap(),
-            ChildNumber::from_normal_idx(4).unwrap(),
-            ChildNumber::from_normal_idx(42).unwrap(),
-            ChildNumber::from_hardened_idx(69).unwrap(),
-            ChildNumber::from_normal_idx(420).unwrap(),
-            ChildNumber::from_normal_idx(31337).unwrap(),
+            ChildNumber::from_normal_index(2).unwrap(),
+            ChildNumber::from_normal_index(4).unwrap(),
+            ChildNumber::from_normal_index(42).unwrap(),
+            ChildNumber::from_hardened_index(69).unwrap(),
+            ChildNumber::from_normal_index(420).unwrap(),
+            ChildNumber::from_normal_index(31337).unwrap(),
         ];
 
-        sk = sk.derive_priv(secp, &dpath);
+        sk = sk.derive_priv(secp, dpath.clone());
 
         let pk = Xpub::from_priv(secp, &sk);
 
@@ -2279,7 +2281,7 @@ mod tests {
         psbt.inputs[0].witness_utxo = Some(txout_wpkh);
 
         let mut map = BTreeMap::new();
-        map.insert(pk.inner, (Fingerprint::default(), DerivationPath::default()));
+        map.insert(pk.inner, (Fingerprint::default(), DerivationPath::MASTER));
         psbt.inputs[0].bip32_derivation = map;
 
         // Second input is unspendable by us e.g., from another wallet that supports future upgrades.

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -186,8 +186,8 @@ impl Serialize for KeySource {
 
         rv.append(&mut self.0.to_byte_array().to_vec());
 
-        for cnum in self.1.into_iter() {
-            rv.append(&mut serialize(&u32::from(*cnum)))
+        for cnum in (&self.1).into_iter() {
+            rv.append(&mut serialize(&u32::from(cnum)))
         }
 
         rv
@@ -378,7 +378,7 @@ impl Deserialize for TapTree {
 }
 
 // Helper function to compute key source len
-fn key_source_len(key_source: &KeySource) -> usize { 4 + 4 * (key_source.1).as_ref().len() }
+fn key_source_len(key_source: &KeySource) -> usize { 4 + 4 * (key_source.1).len() }
 
 #[cfg(test)]
 mod tests {

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
-use bitcoin::bip32::{Fingerprint, IntoDerivationPath, KeySource, Xpriv, Xpub};
+use bitcoin::bip32::{DerivationPath, Fingerprint, KeySource, Xpriv, Xpub};
 use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
 use bitcoin::opcodes::OP_0;
@@ -277,7 +277,7 @@ fn bip32_derivation(
         let path = pk_path[i].1;
 
         let pk = PublicKey::from_str(pk).unwrap();
-        let path = path.into_derivation_path().unwrap();
+        let path = DerivationPath::from_str(path).expect("valid path as &str");
 
         tree.insert(pk.inner, (fingerprint, path));
     }
@@ -314,8 +314,8 @@ fn parse_and_verify_keys(
     for (secret_key, derivation_path) in sk_path.iter() {
         let wif_priv = PrivateKey::from_wif(secret_key).expect("failed to parse key");
 
-        let path =
-            derivation_path.into_derivation_path().expect("failed to convert derivation path");
+        let path = DerivationPath::from_str(derivation_path).expect("valid path as &str");
+
         let derived_priv = ext_priv.derive_priv(secp, &path).to_priv();
         assert_eq!(wif_priv, derived_priv);
         let derived_pub = derived_priv.public_key(secp);

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -194,7 +194,7 @@ fn serde_regression_control_block() {
 
 #[test]
 fn serde_regression_child_number() {
-    let num = ChildNumber::Normal { index: 0xDEADBEEF };
+    let num = ChildNumber::from(0xDEADBEEF);
     let got = serialize(&num).unwrap();
     let want = include_bytes!("data/serde/child_number_bincode") as &[_];
     assert_eq!(got, want)


### PR DESCRIPTION
Rest of #2911.

Agreeing with storopoli 's [comment](https://github.com/rust-bitcoin/rust-bitcoin/pull/2911#issuecomment-2196666905) and tried to follow Kixunil [advice](https://github.com/rust-bitcoin/rust-bitcoin/pull/2911#issuecomment-2191552932).

The changes hopefully will confirm that `derive_pub()` never fails.
The `NormalChildIterator` ensures that every `ChildNumber` passed to `internal_derive_pub()` is a `ChildNumber::Normal`, in other case the iterator will end when find a `ChildNumber::Hardened`. This can introduce to a new behavior where we try to insert a `DerivationPath` that contain a `ChildNumber::Hardened` and `derive_pub()` will not fail but instead, yielding a different public key.

The focus was not changing too much the code and make something that serves as a safe filter for `derive_pub()`, because of this, `NormalChildIterator` is meant to only be used inside `derive_pub()` 

Sorry for taking so long to become with a solution.