### PR TITLE
`primitives`: Re-export `units` types

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -32,12 +32,9 @@ pub mod locktime;
 pub mod opcodes;
 pub mod sequence;
 
-#[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 #[cfg(feature = "alloc")]
-pub use self::{
-    locktime::{absolute, relative},
-};
+pub use self::locktime::{absolute, relative};
 #[doc(inline)]
 pub use self::sequence::Sequence;
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -33,6 +33,9 @@ pub mod opcodes;
 pub mod sequence;
 
 #[doc(inline)]
+pub use units::*;
+
+#[doc(inline)]
 #[cfg(feature = "alloc")]
 pub use self::locktime::{absolute, relative};
 #[doc(inline)]

--- a/primitives/src/locktime/absolute.rs
+++ b/primitives/src/locktime/absolute.rs
@@ -17,9 +17,7 @@ use crate::absolute;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use units::locktime::absolute::{
-    Height, Time, LOCK_TIME_THRESHOLD, ConversionError, ParseHeightError, ParseTimeError,
-};
+pub use units::locktime::absolute::*;
 
 /// An absolute lock time value, representing either a block height or a UNIX timestamp (seconds
 /// since epoch).

--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -18,7 +18,7 @@ use crate::Sequence;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use units::locktime::relative::{Height, Time, TimeOverflowError};
+pub use units::locktime::relative::*;
 
 /// A relative lock time value, representing either a block height or time (512 second intervals).
 ///

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -27,10 +27,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-/// A generic serialization/deserialization framework.
-#[cfg(feature = "serde")]
-pub extern crate serde;
-
 pub mod amount;
 #[cfg(feature = "alloc")]
 pub mod block;


### PR DESCRIPTION
Re-export `units` types by doing:

- Patch 1: Remove the public re-export of `serde` so that it does not shadow the private one in `primitives`
- Patch2: Fix formatting (remove attribute and format)
- Patch 3 and 4: Use wildcard re-exports