### PR TITLE
Remove `bech32` from `address::ParseError`

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -61,7 +61,7 @@ use crate::taproot::TapNodeHash;
 pub use self::error::{
         Base58Error, Bech32Error, FromScriptError, InvalidBase58PayloadLengthError,
         InvalidLegacyPrefixError, LegacyAddressTooLongError, NetworkValidationError,
-        ParseError, UnknownAddressTypeError, UnknownHrpError
+        ParseError, UnknownAddressTypeError, UnknownHrpError, ParseBech32Error,
 };
 
 /// The different types of addresses.
@@ -803,7 +803,8 @@ impl Address<NetworkUnchecked> {
 
     /// Parse a bech32 Address string
     pub fn from_bech32_str(s: &str) -> Result<Address<NetworkUnchecked>, Bech32Error> {
-        let (hrp, witness_version, data) = bech32::segwit::decode(s)?;
+        let (hrp, witness_version, data) = bech32::segwit::decode(s)
+            .map_err(|e| Bech32Error::ParseBech32(ParseBech32Error(e)))?;
         let version = WitnessVersion::try_from(witness_version.to_u8())?;
         let program = WitnessProgram::new(version, &data)
             .expect("bech32 guarantees valid program length for witness");


### PR DESCRIPTION
In #2381 we attempted to fully encapsulate the `bech32` crate to help with stabalizing `rust-bitcoin` however we failed to notice the `address:ParseError` has a variant that includes `bech32`. Public enums have public variant internals in Rust. Also the `From<bech32::segtiw::DecodeError` makes `bech32` public.

Closes: #3043