### PR TITLE
Remove unused variable from LockTime example

### DIFF
--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -175,7 +175,6 @@ impl LockTime {
     /// # let lock = Sequence::from_height(required_height).to_relative_lock_time().expect("valid height");
     ///
     /// // Users that have chain data can get the current height and time to check against a lock.
-    /// let height_and_time = (current_time(), current_height());  // tuple order does not matter.
     /// assert!(lock.is_satisfied_by(current_height(), current_time()));
     /// ```
     #[inline]


### PR DESCRIPTION
Following up on [a comment](https://github.com/rust-bitcoin/rust-bitcoin/pull/3026#discussion_r1676744486) from #3026 and removing an unused variable from the LockTime example