### PR TITLE
Rename key field in Key to key_data

### DIFF
--- a/bitcoin/src/psbt/macros.rs
+++ b/bitcoin/src/psbt/macros.rs
@@ -84,7 +84,7 @@ macro_rules! impl_psbtmap_ser_de_serialize {
 #[rustfmt::skip]
 macro_rules! impl_psbt_insert_pair {
     ($slf:ident.$unkeyed_name:ident <= <$raw_key:ident: _>|<$raw_value:ident: $unkeyed_value_type:ty>) => {
-        if $raw_key.key.is_empty() {
+        if $raw_key.key_data.is_empty() {
             if $slf.$unkeyed_name.is_none() {
                 let val: $unkeyed_value_type = $crate::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
                 $slf.$unkeyed_name = Some(val)
@@ -96,8 +96,8 @@ macro_rules! impl_psbt_insert_pair {
         }
     };
     ($slf:ident.$keyed_name:ident <= <$raw_key:ident: $keyed_key_type:ty>|<$raw_value:ident: $keyed_value_type:ty>) => {
-        if !$raw_key.key.is_empty() {
-            let key_val: $keyed_key_type = $crate::psbt::serialize::Deserialize::deserialize(&$raw_key.key)?;
+        if !$raw_key.key_data.is_empty() {
+            let key_val: $keyed_key_type = $crate::psbt::serialize::Deserialize::deserialize(&$raw_key.key_data)?;
             match $slf.$keyed_name.entry(key_val) {
                 $crate::prelude::btree_map::Entry::Vacant(empty_key) => {
                     let val: $keyed_value_type = $crate::psbt::serialize::Deserialize::deserialize(&$raw_value)?;
@@ -114,10 +114,10 @@ macro_rules! impl_psbt_insert_pair {
 #[rustfmt::skip]
 macro_rules! psbt_insert_hash_pair {
     (&mut $slf:ident.$map:ident <= $raw_key:ident|$raw_value:ident|$hash:path|$hash_type_error:path) => {
-        if $raw_key.key.is_empty() {
+        if $raw_key.key_data.is_empty() {
             return Err(psbt::Error::InvalidKey($raw_key));
         }
-        let key_val: $hash = Deserialize::deserialize(&$raw_key.key)?;
+        let key_val: $hash = Deserialize::deserialize(&$raw_key.key_data)?;
         match $slf.$map.entry(key_val) {
             btree_map::Entry::Vacant(empty_key) => {
                 let val: Vec<u8> = Deserialize::deserialize(&$raw_value)?;
@@ -142,7 +142,7 @@ macro_rules! impl_psbt_get_pair {
             $rv.push($crate::psbt::raw::Pair {
                 key: $crate::psbt::raw::Key {
                     type_value: $unkeyed_typeval,
-                    key: vec![],
+                    key_data: vec![],
                 },
                 value: $crate::psbt::serialize::Serialize::serialize($unkeyed_name),
             });
@@ -153,7 +153,7 @@ macro_rules! impl_psbt_get_pair {
             $rv.push($crate::psbt::raw::Pair {
                 key: $crate::psbt::raw::Key {
                     type_value: $keyed_typeval,
-                    key: $crate::psbt::serialize::Serialize::serialize(key),
+                    key_data: $crate::psbt::serialize::Serialize::serialize(key),
                 },
                 value: $crate::psbt::serialize::Serialize::serialize(val),
             });

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -24,7 +24,7 @@ impl Map for Psbt {
         let mut rv: Vec<raw::Pair> = Default::default();
 
         rv.push(raw::Pair {
-            key: raw::Key { type_value: PSBT_GLOBAL_UNSIGNED_TX, key: vec![] },
+            key: raw::Key { type_value: PSBT_GLOBAL_UNSIGNED_TX, key_data: vec![] },
             value: {
                 // Manually serialized to ensure 0-input txs are serialized
                 // without witnesses.
@@ -39,7 +39,7 @@ impl Map for Psbt {
 
         for (xpub, (fingerprint, derivation)) in &self.xpub {
             rv.push(raw::Pair {
-                key: raw::Key { type_value: PSBT_GLOBAL_XPUB, key: xpub.encode().to_vec() },
+                key: raw::Key { type_value: PSBT_GLOBAL_XPUB, key_data: xpub.encode().to_vec() },
                 value: {
                     let mut ret = Vec::with_capacity(4 + derivation.len() * 4);
                     ret.extend(fingerprint.as_bytes());
@@ -52,7 +52,7 @@ impl Map for Psbt {
         // Serializing version only for non-default value; otherwise test vectors fail
         if self.version > 0 {
             rv.push(raw::Pair {
-                key: raw::Key { type_value: PSBT_GLOBAL_VERSION, key: vec![] },
+                key: raw::Key { type_value: PSBT_GLOBAL_VERSION, key_data: vec![] },
                 value: self.version.to_le_bytes().to_vec(),
             });
         }
@@ -84,7 +84,7 @@ impl Psbt {
                     match pair.key.type_value {
                         PSBT_GLOBAL_UNSIGNED_TX => {
                             // key has to be empty
-                            if pair.key.key.is_empty() {
+                            if pair.key.key_data.is_empty() {
                                 // there can only be one unsigned transaction
                                 if tx.is_none() {
                                     let vlen: usize = pair.value.len();
@@ -111,8 +111,8 @@ impl Psbt {
                             }
                         }
                         PSBT_GLOBAL_XPUB => {
-                            if !pair.key.key.is_empty() {
-                                let xpub = Xpub::decode(&pair.key.key)
+                            if !pair.key.key_data.is_empty() {
+                                let xpub = Xpub::decode(&pair.key.key_data)
                                     .map_err(|_| Error::XPubKey(
                                         "Can't deserialize ExtendedPublicKey from global XPUB key data"
                                     ))?;
@@ -149,7 +149,7 @@ impl Psbt {
                         }
                         PSBT_GLOBAL_VERSION => {
                             // key has to be empty
-                            if pair.key.key.is_empty() {
+                            if pair.key.key_data.is_empty() {
                                 // there can only be one version
                                 if version.is_none() {
                                     let vlen: usize = pair.value.len();

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1438,7 +1438,7 @@ mod tests {
     #[test]
     fn serialize_then_deserialize_psbtkvpair() {
         let expected = raw::Pair {
-            key: raw::Key { type_value: 0u8, key: vec![42u8, 69u8] },
+            key: raw::Key { type_value: 0u8, key_data: vec![42u8, 69u8] },
             value: vec![69u8, 42u8, 4u8],
         };
 
@@ -1489,7 +1489,7 @@ mod tests {
             }],
         };
         let unknown: BTreeMap<raw::Key, Vec<u8>> =
-            vec![(raw::Key { type_value: 1, key: vec![0, 1] }, vec![3, 4, 5])]
+            vec![(raw::Key { type_value: 1, key_data: vec![0, 1] }, vec![3, 4, 5])]
                 .into_iter()
                 .collect();
         let key_source = ("deadbeef".parse().unwrap(), "0'/1".parse().unwrap());
@@ -1629,14 +1629,14 @@ mod tests {
         }
 
         #[test]
-        #[should_panic(expected = "DuplicateKey(Key { type_value: 0, key: [] })")]
+        #[should_panic(expected = "DuplicateKey(Key { type_value: 0, key_data: [] })")]
         fn invalid_vector_5() {
             hex_psbt("70736274ff0100750200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf60000000000feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300000100fda5010100000000010289a3c71eab4d20e0371bbba4cc698fa295c9463afa2e397f8533ccb62f9567e50100000017160014be18d152a9b012039daf3da7de4f53349eecb985ffffffff86f8aa43a71dff1448893a530a7237ef6b4608bbb2dd2d0171e63aec6a4890b40100000017160014fe3e9ef1a745e974d902c4355943abcb34bd5353ffffffff0200c2eb0b000000001976a91485cff1097fd9e008bb34af709c62197b38978a4888ac72fef84e2c00000017a914339725ba21efd62ac753a9bcd067d6c7a6a39d05870247304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c012103d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f210502483045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01210223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab30000000001003f0200000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000ffffffff010000000000000000036a010000000000000000").unwrap();
         }
 
         #[cfg(feature = "base64")]
         #[test]
-        #[should_panic(expected = "DuplicateKey(Key { type_value: 0, key: [] })")]
+        #[should_panic(expected = "DuplicateKey(Key { type_value: 0, key_data: [] })")]
         fn invalid_vector_5_base64() {
             Psbt::from_str("cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAQA/AgAAAAH//////////////////////////////////////////wAAAAAA/////wEAAAAAAAAAAANqAQAAAAAAAAAA").unwrap();
         }
@@ -1850,7 +1850,7 @@ mod tests {
             );
 
             let mut unknown: BTreeMap<raw::Key, Vec<u8>> = BTreeMap::new();
-            let key: raw::Key = raw::Key { type_value: 0x0fu8, key: hex!("010203040506070809") };
+            let key: raw::Key = raw::Key { type_value: 0x0fu8, key_data: hex!("010203040506070809") };
             let value: Vec<u8> = hex!("0102030405060708090a0b0c0d0e0f");
 
             unknown.insert(key, value);

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -27,7 +27,7 @@ pub struct Key {
     pub type_value: u8,
     /// The key data itself in raw byte form.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::hex_bytes"))]
-    pub key: Vec<u8>,
+    pub key_data: Vec<u8>,
 }
 
 /// A PSBT key-value pair in its raw byte form.
@@ -69,7 +69,7 @@ where
 
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "type: {:#x}, key: {:x}", self.type_value, self.key.as_hex())
+        write!(f, "type: {:#x}, key: {:x}", self.type_value, self.key_data.as_hex())
     }
 }
 
@@ -93,25 +93,25 @@ impl Key {
 
         let type_value: u8 = Decodable::consensus_decode(r)?;
 
-        let mut key = Vec::with_capacity(key_byte_size as usize);
+        let mut key_data = Vec::with_capacity(key_byte_size as usize);
         for _ in 0..key_byte_size {
-            key.push(Decodable::consensus_decode(r)?);
+            key_data.push(Decodable::consensus_decode(r)?);
         }
 
-        Ok(Key { type_value, key })
+        Ok(Key { type_value, key_data })
     }
 }
 
 impl Serialize for Key {
     fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        VarInt::from(self.key.len() + 1)
+        VarInt::from(self.key_data.len() + 1)
             .consensus_encode(&mut buf)
             .expect("in-memory writers don't error");
 
         self.type_value.consensus_encode(&mut buf).expect("in-memory writers don't error");
 
-        for key in &self.key {
+        for key in &self.key_data {
             key.consensus_encode(&mut buf).expect("in-memory writers don't error");
         }
 
@@ -177,7 +177,7 @@ where
     Subtype: Copy + From<u8> + Into<u8>,
 {
     /// Constructs full [Key] corresponding to this proprietary key type
-    pub fn to_key(&self) -> Key { Key { type_value: 0xFC, key: serialize(self) } }
+    pub fn to_key(&self) -> Key { Key { type_value: 0xFC, key_data: serialize(self) } }
 }
 
 impl<Subtype> TryFrom<Key> for ProprietaryKey<Subtype>
@@ -196,6 +196,6 @@ where
             return Err(Error::InvalidProprietaryKey);
         }
 
-        Ok(deserialize(&key.key)?)
+        Ok(deserialize(&key.key_data)?)
     }
 }

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -244,7 +244,7 @@ fn serde_regression_psbt() {
         }],
     };
     let unknown: BTreeMap<raw::Key, Vec<u8>> =
-        vec![(raw::Key { type_value: 9, key: vec![0, 1] }, vec![3, 4, 5])].into_iter().collect();
+        vec![(raw::Key { type_value: 9, key_data: vec![0, 1] }, vec![3, 4, 5])].into_iter().collect();
     let key_source = ("deadbeef".parse().unwrap(), "0'/1".parse().unwrap());
     let keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = vec![(
         "0339880dc92394b7355e3d0439fa283c31de7590812ea011c4245c0674a685e883".parse().unwrap(),
@@ -323,7 +323,7 @@ fn serde_regression_psbt() {
 #[test]
 fn serde_regression_raw_pair() {
     let pair = Pair {
-        key: Key { type_value: 1u8, key: vec![0u8, 1u8, 2u8, 3u8] },
+        key: Key { type_value: 1u8, key_data: vec![0u8, 1u8, 2u8, 3u8] },
         value: vec![0u8, 1u8, 2u8, 3u8],
     };
     let got = serialize(&pair).unwrap();


### PR DESCRIPTION
Follow-up change from [a comment](https://github.com/rust-bitcoin/rust-bitcoin/pull/3022#issuecomment-2226166039) in #3022 that updates the `key` field in the PSBT `Key` to `key_data`, which more closely follows the doc