### PR TITLE
Rename the `hash_byte_chunks` function

### DIFF
--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -195,7 +195,7 @@ macro_rules! hash_type {
             }
 
             /// Hashes all the byte slices retrieved from the iterator together.
-            pub fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
+            pub fn hash_chunks<B, I>(byte_slices: I) -> Self
             where
                 B: AsRef<[u8]>,
                 I: IntoIterator<Item = B>,

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -209,7 +209,7 @@ pub trait GeneralHash: Hash {
     }
 
     /// Hashes all the byte slices retrieved from the iterator together.
-    fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
+    fn hash_chunks<B, I>(byte_slices: I) -> Self
     where
         B: AsRef<[u8]>,
         I: IntoIterator<Item = B>,

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -97,7 +97,7 @@ where
     }
 
     /// Hashes all the byte slices retrieved from the iterator together.
-    pub fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
+    pub fn hash_chunks<B, I>(byte_slices: I) -> Self
     where
         B: AsRef<[u8]>,
         I: IntoIterator<Item = B>,
@@ -233,7 +233,7 @@ macro_rules! sha256t_hash_newtype {
 
             /// Hashes all the byte slices retrieved from the iterator together.
             #[allow(unused)] // the user of macro may not need this
-            pub fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
+            pub fn hash_chunks<B, I>(byte_slices: I) -> Self
             where
                 B: AsRef<[u8]>,
                 I: IntoIterator<Item = B>,


### PR DESCRIPTION
We are in the process or overhauling the `hashes` API, as part of this make the `hash_byte_chunks` function name more terse with no loss of clarity.
    
This will hopefully be inline with the other functions in the crate once we are done.
