### PR TITLE
Remove unused test module

### DIFF
--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -52,8 +52,6 @@ mod builder;
 mod instruction;
 mod owned;
 mod push_bytes;
-#[cfg(test)]
-mod tests;
 pub mod witness_program;
 pub mod witness_version;
 


### PR DESCRIPTION
I was searching the code for some tests and found an import of a `tests` module in the blockdata module. Doesn't seem like we should need to import a test module here, so removing it