### PR TITLE
Move `CompactTarget` to `primitives`

### DIFF
--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -18,6 +18,10 @@ use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::internal_macros::define_extension_trait;
 use crate::network::Params;
 
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use primitives::CompactTarget;
+
 /// Implement traits and methods shared by `Target` and `Work`.
 macro_rules! do_impl {
     ($ty:ident) => {
@@ -330,32 +334,6 @@ impl Target {
 }
 do_impl!(Target);
 
-/// Encoding of 256-bit target as 32-bit float.
-///
-/// This is used to encode a target into the block header. Satoshi made this part of consensus code
-/// in the original version of Bitcoin, likely copying an idea from OpenSSL.
-///
-/// OpenSSL's bignum (BN) type has an encoding, which is even called "compact" as in bitcoin, which
-/// is exactly this format.
-///
-/// # Note on order/equality
-///
-/// Usage of the ordering and equality traits for this type may be surprising. Converting between
-/// `CompactTarget` and `Target` is lossy *in both directions* (there are multiple `CompactTarget`
-/// values that map to the same `Target` value). Ordering and equality for this type are defined in
-/// terms of the underlying `u32`.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct CompactTarget(u32);
-
-impl CompactTarget {
-    /// Creates a [`CompactTarget`] from a consensus encoded `u32`.
-    pub fn from_consensus(bits: u32) -> Self { Self(bits) }
-
-    /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
-    pub fn to_consensus(self) -> u32 { self.0 }
-}
-
 define_extension_trait! {
     /// Extension functionality for the [`CompactTarget`] type.
     pub trait CompactTargetExt impl for CompactTarget {
@@ -465,16 +443,6 @@ impl Decodable for CompactTarget {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         u32::consensus_decode(r).map(CompactTarget::from_consensus)
     }
-}
-
-impl fmt::LowerHex for CompactTarget {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
-}
-
-impl fmt::UpperHex for CompactTarget {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
 }
 
 /// Big-endian 256 bit integer type.

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -164,7 +164,7 @@ impl Target {
     ///
     /// ref: <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
     pub fn from_compact(c: CompactTarget) -> Target {
-        let bits = c.0;
+        let bits = c.to_consensus();
         // This is a floating-point "compact" encoding originally used by
         // OpenSSL, which satoshi put into consensus code, so we're stuck
         // with it. The exponent needs to have 3 subtracted from it, hence
@@ -204,7 +204,7 @@ impl Target {
             size += 1;
         }
 
-        CompactTarget(compact | (size << 24))
+        CompactTarget::from_consensus(compact | (size << 24))
     }
 
     /// Returns true if block hash is less than or equal to this [`Target`].
@@ -450,14 +450,14 @@ impl From<CompactTarget> for Target {
 impl Encodable for CompactTarget {
     #[inline]
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        self.0.consensus_encode(w)
+        self.to_consensus().consensus_encode(w)
     }
 }
 
 impl Decodable for CompactTarget {
     #[inline]
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        u32::consensus_decode(r).map(CompactTarget)
+        u32::consensus_decode(r).map(CompactTarget::from_consensus)
     }
 }
 
@@ -1725,25 +1725,25 @@ mod tests {
     #[test]
     fn compact_target_from_hex_lower() {
         let target = CompactTarget::from_hex("0x010034ab").unwrap();
-        assert_eq!(target, CompactTarget(0x010034ab));
+        assert_eq!(target, CompactTarget::from_consensus(0x010034ab));
     }
 
     #[test]
     fn compact_target_from_hex_upper() {
         let target = CompactTarget::from_hex("0X010034AB").unwrap();
-        assert_eq!(target, CompactTarget(0x010034ab));
+        assert_eq!(target, CompactTarget::from_consensus(0x010034ab));
     }
 
     #[test]
     fn compact_target_from_unprefixed_hex_lower() {
         let target = CompactTarget::from_unprefixed_hex("010034ab").unwrap();
-        assert_eq!(target, CompactTarget(0x010034ab));
+        assert_eq!(target, CompactTarget::from_consensus(0x010034ab));
     }
 
     #[test]
     fn compact_target_from_unprefixed_hex_upper() {
         let target = CompactTarget::from_unprefixed_hex("010034AB").unwrap();
-        assert_eq!(target, CompactTarget(0x010034ab));
+        assert_eq!(target, CompactTarget::from_consensus(0x010034ab));
     }
 
     #[test]
@@ -1755,8 +1755,8 @@ mod tests {
 
     #[test]
     fn compact_target_lower_hex_and_upper_hex() {
-        assert_eq!(format!("{:08x}", CompactTarget(0x01D0F456)), "01d0f456");
-        assert_eq!(format!("{:08X}", CompactTarget(0x01d0f456)), "01D0F456");
+        assert_eq!(format!("{:08x}", CompactTarget::from_consensus(0x01D0F456)), "01d0f456");
+        assert_eq!(format!("{:08X}", CompactTarget::from_consensus(0x01d0f456)), "01D0F456");
     }
 
     #[test]

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -15,6 +15,7 @@ use units::parse::{self, ParseIntError, PrefixedHexError, UnprefixedHexError};
 
 use crate::block::{BlockHash, Header};
 use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::internal_macros::define_extension_trait;
 use crate::network::Params;
 
 /// Implement traits and methods shared by `Target` and `Work`.
@@ -355,18 +356,17 @@ impl CompactTarget {
     pub fn to_consensus(self) -> u32 { self.0 }
 }
 
-mod tmp {
-    use super::*;
-
-    impl CompactTarget {
+define_extension_trait! {
+    /// Extension functionality for the [`CompactTarget`] type.
+    pub trait CompactTargetExt impl for CompactTarget {
         /// Creates a `CompactTarget` from a prefixed hex string.
-        pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
+        fn from_hex(s: &str) -> Result<CompactTarget, PrefixedHexError> {
             let target = parse::hex_u32_prefixed(s)?;
             Ok(Self::from_consensus(target))
         }
 
         /// Creates a `CompactTarget` from an unprefixed hex string.
-        pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
+        fn from_unprefixed_hex(s: &str) -> Result<CompactTarget, UnprefixedHexError> {
             let target = parse::hex_u32_unprefixed(s)?;
             Ok(Self::from_consensus(target))
         }
@@ -393,7 +393,7 @@ mod tmp {
         /// # Returns
         ///
         /// The expected [`CompactTarget`] recalculation.
-        pub fn from_next_work_required(
+        fn from_next_work_required(
             last: CompactTarget,
             timespan: u64,
             params: impl AsRef<Params>,
@@ -437,7 +437,7 @@ mod tmp {
         /// # Returns
         ///
         /// The expected [`CompactTarget`] recalculation.
-        pub fn from_header_difficulty_adjustment(
+        fn from_header_difficulty_adjustment(
             last_epoch_boundary: Header,
             current: Header,
             params: impl AsRef<Params>,

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -348,6 +348,14 @@ do_impl!(Target);
 pub struct CompactTarget(u32);
 
 impl CompactTarget {
+    /// Creates a [`CompactTarget`] from a consensus encoded `u32`.
+    pub fn from_consensus(bits: u32) -> Self { Self(bits) }
+
+    /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
+    pub fn to_consensus(self) -> u32 { self.0 }
+}
+
+impl CompactTarget {
     /// Creates a `CompactTarget` from a prefixed hex string.
     pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
         let target = parse::hex_u32_prefixed(s)?;
@@ -435,12 +443,6 @@ impl CompactTarget {
         let bits = current.bits;
         CompactTarget::from_next_work_required(bits, timespan.into(), params)
     }
-
-    /// Creates a [`CompactTarget`] from a consensus encoded `u32`.
-    pub fn from_consensus(bits: u32) -> Self { Self(bits) }
-
-    /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
-    pub fn to_consensus(self) -> u32 { self.0 }
 }
 
 impl From<CompactTarget> for Target {

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -355,6 +355,9 @@ impl CompactTarget {
     pub fn to_consensus(self) -> u32 { self.0 }
 }
 
+mod tmp {
+    use super::*;
+
 impl CompactTarget {
     /// Creates a `CompactTarget` from a prefixed hex string.
     pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
@@ -443,6 +446,7 @@ impl CompactTarget {
         let bits = current.bits;
         CompactTarget::from_next_work_required(bits, timespan.into(), params)
     }
+}
 }
 
 impl From<CompactTarget> for Target {

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1099,8 +1099,12 @@ impl kani::Arbitrary for U256 {
 mod tests {
     use super::*;
 
-    impl<T: Into<u128>> From<T> for Target {
-        fn from(x: T) -> Self { Self(U256::from(x)) }
+    impl From<u64> for Target {
+        fn from(x: u64) -> Self { Self(U256::from(x)) }
+    }
+
+    impl From<u32> for Target {
+        fn from(x: u32) -> Self { Self(U256::from(x)) }
     }
 
     impl<T: Into<u128>> From<T> for Work {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -31,6 +31,7 @@ extern crate serde;
 #[cfg(feature = "alloc")]
 pub mod locktime;
 pub mod opcodes;
+pub mod pow;
 pub mod sequence;
 
 #[doc(inline)]
@@ -40,7 +41,10 @@ pub use units::*;
 #[cfg(feature = "alloc")]
 pub use self::locktime::{absolute, relative};
 #[doc(inline)]
-pub use self::sequence::Sequence;
+pub use self::{
+    pow::CompactTarget,
+    sequence::Sequence,
+};
 
 #[rustfmt::skip]
 #[allow(unused_imports)]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -18,6 +18,7 @@
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -44,9 +45,6 @@ pub use self::sequence::Sequence;
 #[rustfmt::skip]
 #[allow(unused_imports)]
 mod prelude {
-    #[cfg(all(not(feature = "std"), not(test)))]
+    #[cfg(feature = "alloc")]
     pub use alloc::string::ToString;
-
-    #[cfg(any(feature = "std", test))]
-    pub use std::string::ToString;
 }

--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Proof-of-work related integer types.
+
+use core::fmt;
+
+/// Encoding of 256-bit target as 32-bit float.
+///
+/// This is used to encode a target into the block header. Satoshi made this part of consensus code
+/// in the original version of Bitcoin, likely copying an idea from OpenSSL.
+///
+/// OpenSSL's bignum (BN) type has an encoding, which is even called "compact" as in bitcoin, which
+/// is exactly this format.
+///
+/// # Note on order/equality
+///
+/// Usage of the ordering and equality traits for this type may be surprising. Converting between
+/// `CompactTarget` and `Target` is lossy *in both directions* (there are multiple `CompactTarget`
+/// values that map to the same `Target` value). Ordering and equality for this type are defined in
+/// terms of the underlying `u32`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct CompactTarget(u32);
+
+impl CompactTarget {
+    /// Creates a [`CompactTarget`] from a consensus encoded `u32`.
+    pub fn from_consensus(bits: u32) -> Self { Self(bits) }
+
+    /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
+    pub fn to_consensus(self) -> u32 { self.0 }
+}
+
+impl fmt::LowerHex for CompactTarget {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
+}
+
+impl fmt::UpperHex for CompactTarget {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
+}


### PR DESCRIPTION
Done in preparation for moving `BlockHash` and `block::Header` to `primitives`. 

- Patch 1 introduces an extension trait using `define_extension_trait!`
- Patch 2 is the trivial copy and past to move the type to `primitives`

This one shouldn't be to arduous to review, thanks.