### PR TITLE
Remove public error re-export

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -29,11 +29,6 @@ use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
 use crate::{Amount, FeeRate, SignedAmount, VarInt};
 
-#[rustfmt::skip]                // Keep public re-exports separate.
-#[cfg(feature = "bitcoinconsensus")]
-#[doc(inline)]
-pub use crate::consensus::validation::TxVerifyError;
-
 hashes::hash_newtype! {
     /// A bitcoin transaction hash/transaction ID.
     ///
@@ -1846,6 +1841,7 @@ mod tests {
     fn transaction_verify() {
         use std::collections::HashMap;
 
+        use crate::consensus::validation::TxVerifyError;
         use crate::witness::Witness;
 
         // a random recent segwit transaction from blockchain using both old and segwit inputs


### PR DESCRIPTION
We do not have a policy to re-export things from other modules just because they are in the public API - I don't see any other reason to re-export this error, users should go to the `validation` module directly to get the error type.

Raising this trivial change as a separate PR so that we can really pin down our re-export policy. Please review the policy implications as well as the code change.

Note please that this change was introduced in 7d695f6b4 by me, and buried in a PR that did not mention the change. This was wrong, as in the code change was wrong and also the patching method was wrong.