### PR TITLE
Move `validation` module to `consensus_validation`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1841,7 +1841,7 @@ mod tests {
     fn transaction_verify() {
         use std::collections::HashMap;
 
-        use crate::consensus::validation::TxVerifyError;
+        use crate::consensus_validation::TxVerifyError;
         use crate::witness::Witness;
 
         // a random recent segwit transaction from blockchain using both old and segwit inputs

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -9,8 +9,6 @@ pub mod encode;
 pub mod params;
 #[cfg(feature = "serde")]
 pub mod serde;
-#[cfg(feature = "bitcoinconsensus")]
-pub mod validation;
 
 use core::fmt;
 
@@ -24,12 +22,6 @@ use crate::consensus;
 pub use self::{
     encode::{deserialize, deserialize_partial, serialize, Decodable, Encodable, ReadExt, WriteExt},
     params::Params,
-};
-
-#[cfg(feature = "bitcoinconsensus")]
-#[doc(inline)]
-pub use self::validation::{
-    verify_script, verify_script_with_flags, verify_transaction, verify_transaction_with_flags,
 };
 
 struct IterReader<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> {

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -10,14 +10,14 @@ use internals::write_err;
 
 use crate::amount::Amount;
 #[cfg(doc)]
-use crate::consensus;
+use crate::consensus_validation;
 use crate::consensus::encode;
 use crate::script::Script;
 use crate::transaction::{OutPoint, Transaction, TxOut};
 
 /// Verifies spend of an input script.
 ///
-/// Shorthand for [`consensus::verify_script_with_flags`] with flag
+/// Shorthand for [`consensus_validation::verify_script_with_flags`] with flag
 /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`].
 ///
 /// # Parameters
@@ -72,7 +72,7 @@ pub fn verify_script_with_flags<F: Into<u32>>(
 
 /// Verifies that this transaction is able to spend its inputs.
 ///
-/// Shorthand for [`consensus::verify_transaction_with_flags`] with flag
+/// Shorthand for [`consensus_validation::verify_transaction_with_flags`] with flag
 /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`].
 ///
 /// The `spent` closure should not return the same [`TxOut`] twice!

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -93,6 +93,8 @@ pub mod bip158;
 pub mod bip32;
 pub mod blockdata;
 pub mod consensus;
+#[cfg(feature = "bitcoinconsensus")]
+pub mod consensus_validation;
 // Private until we either make this a crate or flatten it - still to be decided.
 pub(crate) mod crypto;
 pub mod hash_types;


### PR DESCRIPTION
The `consensus` module is currently doing two things, validation and encoding. These two things are orthogonal.
    
Move the `consensus::validation` module to `consensus_validation`. Remove the function re-exports from `consensus`.

This was originally discussed here: https://github.com/rust-bitcoin/rust-bitcoin/issues/2779