### PR TITLE
Remove re-export of `ParseIntError`

### DIFF
--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -11,7 +11,7 @@ use core::fmt;
 use core::str::FromStr;
 
 use internals::write_err;
-use units::{parse, ParseIntError};
+use units::parse::{self, ParseIntError};
 
 use crate::opcodes::all::*;
 use crate::opcodes::Opcode;

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -51,7 +51,5 @@ pub use self::amount::{Amount, SignedAmount};
 pub use self::{
     block::{BlockHeight, BlockInterval},
     fee_rate::FeeRate,
-    // ParseIntError is used by other modules, so we re-export it.
-    parse::ParseIntError,
     weight::Weight
 };


### PR DESCRIPTION
In d242125 I claimed that `ParseIntError` was somehow special, I no longer thing this is the case. As we pin down the re-export policy (for errors and other types) it is hard if we have one non-typical re-export.

We have https://github.com/rust-bitcoin/rust-bitcoin/issues/3068 to discuss the policy, for now just remove the unusual re-export.