### PR TITLE
hashes: Re-name `const_hash` to `hash_unoptimized`

### DIFF
--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -114,7 +114,7 @@ impl Hash {
     /// Computes hash from `bytes` in `const` context.
     ///
     /// Warning: this function is inefficient. It should be only used in `const` context.
-    pub const fn const_hash(bytes: &[u8]) -> Self { Hash(Midstate::const_hash(bytes, true).0) }
+    pub const fn hash_unoptimized(bytes: &[u8]) -> Self { Hash(Midstate::hash_unoptimized(bytes, true).0) }
 }
 
 /// Output of the SHA256 hash function.
@@ -170,14 +170,14 @@ impl Midstate {
     /// Computes non-finalized hash of `sha256(tag) || sha256(tag)` for use in
     /// [`sha256t`](super::sha256t). It's provided for use with [`sha256t`](crate::sha256t).
     pub const fn hash_tag(tag: &[u8]) -> Self {
-        let hash = Hash::const_hash(tag);
+        let hash = Hash::hash_unoptimized(tag);
         let mut buf = [0u8; 64];
         let mut i = 0usize;
         while i < buf.len() {
             buf[i] = hash.0[i % hash.0.len()];
             i += 1;
         }
-        Self::const_hash(&buf, false)
+        Self::hash_unoptimized(&buf, false)
     }
 }
 
@@ -281,7 +281,7 @@ impl Midstate {
         w
     }
 
-    const fn const_hash(bytes: &[u8], finalize: bool) -> Self {
+    const fn hash_unoptimized(bytes: &[u8], finalize: bool) -> Self {
         let mut state = [
             0x6a09e667u32,
             0xbb67ae85,
@@ -976,15 +976,15 @@ mod tests {
     }
 
     #[test]
-    fn const_hash() {
-        assert_eq!(Hash::hash(&[]), Hash::const_hash(&[]));
+    fn hash_unoptimized() {
+        assert_eq!(Hash::hash(&[]), Hash::hash_unoptimized(&[]));
 
         let mut bytes = Vec::new();
         for i in 0..256 {
             bytes.push(i as u8);
             assert_eq!(
                 Hash::hash(&bytes),
-                Hash::const_hash(&bytes),
+                Hash::hash_unoptimized(&bytes),
                 "hashes don't match for length {}",
                 i + 1
             );


### PR DESCRIPTION
In `sha256` the `const_hash` functions are not as efficient as the `hash` function because they don't have access to the SIMD optimizations.

We decided in #3049 to rename the functions to `hash_unoptimized`.