### PR TITLE
hashes: Add public `hash_str` function

### DIFF
--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -194,6 +194,11 @@ macro_rules! hash_type {
                 Self::from_engine(engine)
             }
 
+            /// Hashes a string after converting it to bytes using [`str::as_bytes`].
+            ///
+            /// [`str::as_bytes`]: <https://doc.rust-lang.org/std/primitive.str.html#method.as_bytes>
+            pub fn hash_str(s: &str) -> Self { Self::hash(s.as_bytes()) }
+
             /// Hashes all the byte slices retrieved from the iterator together.
             pub fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
             where

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -208,6 +208,11 @@ pub trait GeneralHash: Hash {
         Self::from_engine(engine)
     }
 
+    /// Hashes a string after converting it to bytes using [`str::as_bytes`].
+    ///
+    /// [`str::as_bytes`]: <https://doc.rust-lang.org/std/primitive.str.html#method.as_bytes>
+    fn hash_str(s: &str) -> Self { GeneralHash::hash(s.as_bytes()) }
+
     /// Hashes all the byte slices retrieved from the iterator together.
     fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
     where
@@ -286,7 +291,8 @@ impl std::error::Error for FromSliceError {}
 
 #[cfg(test)]
 mod tests {
-    use crate::sha256d;
+    use super::*;
+    use crate::{sha256, sha256d};
 
     hash_newtype! {
         /// A test newtype
@@ -310,5 +316,13 @@ mod tests {
         let hex = format!("{}", orig);
         let rinsed = hex.parse::<TestNewtype>().expect("failed to parse hex");
         assert_eq!(rinsed, orig)
+    }
+
+    #[test]
+    fn hash_str() {
+        assert_eq!(
+            sha256::Hash::hash(b"boom"),
+            sha256::Hash::hash_str("boom"),
+        )
     }
 }

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -96,6 +96,11 @@ where
         Self::from_engine(engine)
     }
 
+    /// Hashes a string after converting it to bytes using [`str::as_bytes`].
+    ///
+    /// [`str::as_bytes`]: <https://doc.rust-lang.org/std/primitive.str.html#method.as_bytes>
+    pub fn hash_str(s: &str) -> Self { Self::hash(s.as_bytes()) }
+
     /// Hashes all the byte slices retrieved from the iterator together.
     pub fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
     where
@@ -230,6 +235,12 @@ macro_rules! sha256t_hash_newtype {
                 engine.input(data);
                 Self::from_engine(engine)
             }
+
+            /// Hashes a string after converting it to bytes using [`str::as_bytes`].
+            ///
+            /// [`str::as_bytes`]: <https://doc.rust-lang.org/std/primitive.str.html#method.as_bytes>
+            #[allow(unused)] // the user of macro may not need this
+            pub fn hash_str(s: &str) -> Self { Self::hash(s.as_bytes()) }
 
             /// Hashes all the byte slices retrieved from the iterator together.
             #[allow(unused)] // the user of macro may not need this


### PR DESCRIPTION
Add an new `hash_str` function to complement the `hash` function.

Add it to:

- the `GeneralHash` trait
- as an inherent function on all the hash types

Done as part of the work to overhaul the `hashes` API.