### PR TITLE
hashes: Add a new `hash_reader` function

### DIFF
--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -209,6 +209,13 @@ macro_rules! hash_type {
                 Self::from_engine(engine)
             }
 
+
+            /// Hashes the entire contents of the `reader`.
+            #[cfg(feature = "bitcoin-io")]
+            pub fn hash_reader<R: io::BufRead>(reader: &mut R) -> Result<Self, io::Error> {
+                <Self as crate::GeneralHash>::hash_reader(reader)
+            }
+
             /// Returns the underlying byte array.
             pub const fn to_byte_array(self) -> [u8; $bits / 8] { self.0 }
 


### PR DESCRIPTION
Add a function `hash_reader` that uses the `BufRead` trait to read bytes directly into the hash engine.

Add the functionality to:

- as a trait method in the `GeneralHash` trait with default implementation
- as inherent functions to all the hash types

Close: #3050
