### PR TITLE
Fix rustdocs in `blockdata`

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -341,9 +341,9 @@ impl Script {
     /// Get redeemScript following BIP16 rules regarding P2SH spending.
     ///
     /// This does not guarantee that this represents a P2SH input [`Script`].
-    /// It merely gets the last push of the script. Use
-    /// [`Script::is_p2sh`](crate::blockdata::script::Script::is_p2sh) on the
-    /// scriptPubKey to check whether it is actually a P2SH script.
+    /// It merely gets the last push of the script.
+    ///
+    /// Use [`Script::is_p2sh`] on the scriptPubKey to check whether it is actually a P2SH script.
     pub fn redeem_script(&self) -> Option<&Script> {
         // Script must consist entirely of pushes.
         if self.instructions().any(|i| i.is_err() || i.unwrap().push_bytes().is_none()) {

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -241,6 +241,7 @@ pub fn write_scriptint(out: &mut [u8; 8], n: i64) -> usize {
 /// Decodes an integer in script format without non-minimal error.
 ///
 /// The overflow error for slices over 4 bytes long is still there.
+///
 /// See [`push_bytes::PushBytes::read_scriptint`] for a description of some subtleties of
 /// this function.
 pub fn read_scriptint_non_minimal(v: &[u8]) -> Result<i64, Error> {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -40,7 +40,9 @@ hashes::hash_newtype! {
     /// For compatibility with the existing Bitcoin infrastructure and historical and current
     /// versions of the Bitcoin Core software itself, this and other [`sha256d::Hash`] types, are
     /// serialized in reverse byte order when converted to a hex string via [`std::fmt::Display`]
-    /// trait operations. See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
+    /// trait operations.
+    ///
+    /// See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
     pub struct Txid(sha256d::Hash);
 
     /// A bitcoin witness transaction ID.

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -399,9 +399,9 @@ impl Witness {
     ///
     /// This does not guarantee that this represents a P2TR [`Witness`]. It
     /// merely gets the second to last or third to last element depending on
-    /// the first byte of the last element being equal to 0x50. See
-    /// [Script::is_p2tr](crate::script::Script::is_p2tr) to
-    /// check whether this is actually a Taproot witness.
+    /// the first byte of the last element being equal to 0x50.
+    ///
+    /// See [`Script::is_p2tr`] to check whether this is actually a Taproot witness.
     pub fn tapscript(&self) -> Option<&Script> {
         self.last().and_then(|last| {
             // From BIP341:
@@ -422,9 +422,9 @@ impl Witness {
     ///
     /// This does not guarantee that this represents a P2TR [`Witness`]. It
     /// merely gets the last or second to last element depending on the first
-    /// byte of the last element being equal to 0x50. See
-    /// [Script::is_p2tr](crate::blockdata::script::Script::is_p2tr) to
-    /// check whether this is actually a Taproot witness.
+    /// byte of the last element being equal to 0x50.
+    ///
+    /// See [`Script::is_p2tr`] to check whether this is actually a Taproot witness.
     pub fn taproot_control_block(&self) -> Option<&[u8]> {
         self.last().and_then(|last| {
             // From BIP341:
@@ -443,9 +443,9 @@ impl Witness {
 
     /// Get the taproot annex following BIP341 rules.
     ///
-    /// This does not guarantee that this represents a P2TR [`Witness`]. See
-    /// [Script::is_p2tr](crate::blockdata::script::Script::is_p2tr) to
-    /// check whether this is actually a Taproot witness.
+    /// This does not guarantee that this represents a P2TR [`Witness`].
+    ///
+    /// See [`Script::is_p2tr`] to check whether this is actually a Taproot witness.
     pub fn taproot_annex(&self) -> Option<&[u8]> {
         self.last().and_then(|last| {
             // From BIP341:
@@ -462,9 +462,9 @@ impl Witness {
 
     /// Get the p2wsh witness script following BIP141 rules.
     ///
-    /// This does not guarantee that this represents a P2WS [`Witness`]. See
-    /// [Script::is_p2wsh](crate::blockdata::script::Script::is_p2wsh) to
-    /// check whether this is actually a P2WSH witness.
+    /// This does not guarantee that this represents a P2WS [`Witness`].
+    ///
+    /// See [`Script::is_p2wsh`] to check whether this is actually a P2WSH witness.
     pub fn witness_script(&self) -> Option<&Script> { self.last().map(Script::from_bytes) }
 }
 


### PR DESCRIPTION
Following up on the [comment](https://github.com/rust-bitcoin/rust-bitcoin/pull/2646#discussion_r1548848611) in #2646 the rustdocs formatting was fixed in `blockdata`.