### PR TITLE
units: Remove serde re-export

### DIFF
--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -27,10 +27,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-/// A generic serialization/deserialization framework.
-#[cfg(feature = "serde")]
-pub extern crate serde;
-
 pub mod amount;
 #[cfg(feature = "alloc")]
 pub mod block;


### PR DESCRIPTION
We re-export to help users keep their dependencies in sync but `serde` is at `v1.0` so this is not really a problem.

Remove the public re-export of `serde`.