### PR TITLE
Add validation extension to script

### DIFF
--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -682,6 +682,8 @@ fn script_ord() {
 #[test]
 #[cfg(feature = "bitcoinconsensus")]
 fn test_bitcoinconsensus() {
+    use crate::consensus_validation::ScriptExt as _;
+
     // a random segwit transaction from the blockchain using native segwit
     let spent_bytes = hex!("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d");
     let spent = Script::from_bytes(&spent_bytes);

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -12,6 +12,7 @@ use crate::amount::Amount;
 use crate::consensus::encode;
 #[cfg(doc)]
 use crate::consensus_validation;
+use crate::internal_macros::define_extension_trait;
 use crate::script::Script;
 use crate::transaction::{OutPoint, Transaction, TxOut};
 
@@ -115,45 +116,48 @@ where
     Ok(())
 }
 
-impl Script {
-    /// Verifies spend of an input script.
-    ///
-    /// Shorthand for [`Self::verify_with_flags`] with flag [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`].
-    ///
-    /// # Parameters
-    ///
-    ///  * `index` - The input index in spending which is spending this transaction.
-    ///  * `amount` - The amount this script guards.
-    ///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
-    ///
-    /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`]: https://docs.rs/bitcoinconsensus/0.106.0+26.0/bitcoinconsensus/constant.VERIFY_ALL_PRE_TAPROOT.html
-    pub fn verify(
-        &self,
-        index: usize,
-        amount: crate::Amount,
-        spending_tx: &[u8],
-    ) -> Result<(), BitcoinconsensusError> {
-        verify_script(self, index, amount, spending_tx)
-    }
+define_extension_trait! {
+    /// Extension functionality to add validation support to the [`Script`] type.
+    pub trait ScriptExt impl for Script {
+        /// Verifies spend of an input script.
+        ///
+        /// Shorthand for [`Self::verify_with_flags`] with flag [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`].
+        ///
+        /// # Parameters
+        ///
+        ///  * `index` - The input index in spending which is spending this transaction.
+        ///  * `amount` - The amount this script guards.
+        ///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
+        ///
+        /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`]: https://docs.rs/bitcoinconsensus/0.106.0+26.0/bitcoinconsensus/constant.VERIFY_ALL_PRE_TAPROOT.html
+        fn verify(
+            &self,
+            index: usize,
+            amount: crate::Amount,
+            spending_tx: &[u8],
+        ) -> Result<(), BitcoinconsensusError> {
+            verify_script(self, index, amount, spending_tx)
+        }
 
-    /// Verifies spend of an input script.
-    ///
-    /// # Parameters
-    ///
-    ///  * `index` - The input index in spending which is spending this transaction.
-    ///  * `amount` - The amount this script guards.
-    ///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
-    ///  * `flags` - Verification flags, see [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`] and similar.
-    ///
-    /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`]: https://docs.rs/bitcoinconsensus/0.106.0+26.0/bitcoinconsensus/constant.VERIFY_ALL_PRE_TAPROOT.html
-    pub fn verify_with_flags(
-        &self,
-        index: usize,
-        amount: crate::Amount,
-        spending_tx: &[u8],
-        flags: impl Into<u32>,
-    ) -> Result<(), BitcoinconsensusError> {
-        verify_script_with_flags(self, index, amount, spending_tx, flags)
+        /// Verifies spend of an input script.
+        ///
+        /// # Parameters
+        ///
+        ///  * `index` - The input index in spending which is spending this transaction.
+        ///  * `amount` - The amount this script guards.
+        ///  * `spending_tx` - The transaction that attempts to spend the output holding this script.
+        ///  * `flags` - Verification flags, see [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`] and similar.
+        ///
+        /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`]: https://docs.rs/bitcoinconsensus/0.106.0+26.0/bitcoinconsensus/constant.VERIFY_ALL_PRE_TAPROOT.html
+        fn verify_with_flags(
+            &self,
+            index: usize,
+            amount: crate::Amount,
+            spending_tx: &[u8],
+            flags: impl Into<u32>,
+        ) -> Result<(), BitcoinconsensusError> {
+            verify_script_with_flags(self, index, amount, spending_tx, flags)
+        }
     }
 }
 

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -146,12 +146,12 @@ impl Script {
     ///  * `flags` - Verification flags, see [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`] and similar.
     ///
     /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`]: https://docs.rs/bitcoinconsensus/0.106.0+26.0/bitcoinconsensus/constant.VERIFY_ALL_PRE_TAPROOT.html
-    pub fn verify_with_flags<F: Into<u32>>(
+    pub fn verify_with_flags(
         &self,
         index: usize,
         amount: crate::Amount,
         spending_tx: &[u8],
-        flags: F,
+        flags: impl Into<u32>,
     ) -> Result<(), BitcoinconsensusError> {
         verify_script_with_flags(self, index, amount, spending_tx, flags)
     }


### PR DESCRIPTION
Add an extension trait for the validation logic in preparation for moving the `Script` type to `primitives`.
