### PR TITLE
Make last_pushdata a standalone function

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -7,7 +7,7 @@ use core::ops::{
 
 use super::witness_version::WitnessVersion;
 use super::{
-    bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions, PushBytes,
+    bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions,
     RedeemScriptSizeError, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
 };
 use crate::consensus::Encodable;
@@ -555,19 +555,6 @@ impl Script {
     pub(in crate::blockdata::script) fn last_opcode(&self) -> Option<Opcode> {
         match self.instructions().last() {
             Some(Ok(Instruction::Op(op))) => Some(op),
-            _ => None,
-        }
-    }
-
-    /// Iterates the script to find the last pushdata.
-    ///
-    /// Returns `None` if the instruction is an opcode or if the script is empty.
-    pub(crate) fn last_pushdata(&self) -> Option<&PushBytes> {
-        match self.instructions().last() {
-            // Handles op codes up to (but excluding) OP_PUSHNUM_NEG.
-            Some(Ok(Instruction::PushBytes(bytes))) => Some(bytes),
-            // OP_16 (0x60) and lower are considered "pushes" by Bitcoin Core (excl. OP_RESERVED).
-            // However we are only interested in the pushdata so we can ignore them.
             _ => None,
         }
     }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -825,3 +825,16 @@ impl fmt::Display for WitnessScriptSizeError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for WitnessScriptSizeError {}
+
+/// Iterates the script to find the last pushdata.
+///
+/// Returns `None` if the instruction is an opcode or if the script is empty.
+pub(crate) fn last_pushdata(script: &Script) -> Option<&PushBytes> {
+    match script.instructions().last() {
+        // Handles op codes up to (but excluding) OP_PUSHNUM_NEG.
+        Some(Ok(Instruction::PushBytes(bytes))) => Some(bytes),
+        // OP_16 (0x60) and lower are considered "pushes" by Bitcoin Core (excl. OP_RESERVED).
+        // However we are only interested in the pushdata so we can ignore them.
+        _ => None,
+    }
+}

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -23,7 +23,7 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::locktime::absolute::{self, Height, Time};
 use crate::prelude::{Borrow, Vec};
-use crate::script::{Script, ScriptBuf};
+use crate::script::{self, Script, ScriptBuf};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
@@ -759,7 +759,7 @@ impl Transaction {
         fn count_sigops(prevout: &TxOut, input: &TxIn) -> usize {
             let mut count: usize = 0;
             if prevout.script_pubkey.is_p2sh() {
-                if let Some(redeem) = input.script_sig.last_pushdata() {
+                if let Some(redeem) = script::last_pushdata(&input.script_sig) {
                     count =
                         count.saturating_add(Script::from_bytes(redeem.as_bytes()).count_sigops());
                 }
@@ -805,7 +805,7 @@ impl Transaction {
             } else if prevout.script_pubkey.is_p2sh() && script_sig.is_push_only() {
                 // If prevout is P2SH and scriptSig is push only
                 // then we wrap the last push (redeemScript) in a Script
-                if let Some(push_bytes) = script_sig.last_pushdata() {
+                if let Some(push_bytes) = script::last_pushdata(script_sig) {
                     Script::from_bytes(push_bytes.as_bytes())
                 } else {
                     return 0;


### PR DESCRIPTION
We are attempting to move the `Script` type to `primitives`, doing so requires usage of the extension trait mechanism recently introduced. Private methods cannot be created using traits only private traits. An alternative to creating a private trait is to make a method into a function and use the concrete type as a parameter instead of taking `self`.

Make `Script::last_pushdata` a standalone function, this is only an internal change.