### PR TITLE
Make `ScriptBuf::p2wpkh_script_code` stand alone

### DIFF
--- a/bitcoin/src/address/script_pubkey.rs
+++ b/bitcoin/src/address/script_pubkey.rs
@@ -13,7 +13,7 @@ use crate::opcodes::all::*;
 use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{
-    Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash,
+    self, Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash,
     WitnessScriptSizeError,
 };
 use crate::taproot::TapNodeHash;
@@ -72,7 +72,7 @@ define_extension_trait! {
                 // The `self` script is 0x00, 0x14, <pubkey_hash>
                 let bytes = &self.as_bytes()[2..];
                 let wpkh = WPubkeyHash::from_slice(bytes).expect("length checked in is_p2wpkh()");
-                Some(ScriptBuf::p2wpkh_script_code(wpkh))
+                Some(script::p2wpkh_script_code(wpkh))
             } else {
                 None
             }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -70,6 +70,7 @@ use io::{BufRead, Write};
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::constants::{MAX_REDEEM_SCRIPT_SIZE, MAX_WITNESS_SCRIPT_SIZE};
 use crate::internal_macros::impl_asref_push_bytes;
+use crate::key::WPubkeyHash;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Borrow, BorrowMut, Box, Cow, DisplayHex, ToOwned, Vec};
@@ -197,6 +198,21 @@ impl TryFrom<&Script> for WScriptHash {
     fn try_from(witness_script: &Script) -> Result<Self, Self::Error> {
         Self::from_script(witness_script)
     }
+}
+
+/// Creates the script code used for spending a P2WPKH output.
+///
+/// The `scriptCode` is described in [BIP143].
+///
+/// [BIP143]: <https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0143.mediawiki>
+pub fn p2wpkh_script_code(wpkh: WPubkeyHash) -> ScriptBuf {
+    Builder::new()
+        .push_opcode(OP_DUP)
+        .push_opcode(OP_HASH160)
+        .push_slice(wpkh)
+        .push_opcode(OP_EQUALVERIFY)
+        .push_opcode(OP_CHECKSIG)
+        .into_script()
 }
 
 /// Encodes an integer in script(minimal CScriptNum) format.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -6,7 +6,6 @@ use core::ops::Deref;
 use hex::FromHex;
 
 use super::{opcode_to_verify, Builder, Instruction, PushBytes, Script};
-use crate::key::WPubkeyHash;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
@@ -66,21 +65,6 @@ impl ScriptBuf {
 
     /// Creates a new script builder
     pub fn builder() -> Builder { Builder::new() }
-
-    /// Creates the script code used for spending a P2WPKH output.
-    ///
-    /// The `scriptCode` is described in [BIP143].
-    ///
-    /// [BIP143]: <https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0143.mediawiki>
-    pub fn p2wpkh_script_code(wpkh: WPubkeyHash) -> ScriptBuf {
-        Builder::new()
-            .push_opcode(OP_DUP)
-            .push_opcode(OP_HASH160)
-            .push_slice(wpkh)
-            .push_opcode(OP_EQUALVERIFY)
-            .push_opcode(OP_CHECKSIG)
-            .into_script()
-    }
 
     /// Generates OP_RETURN-type of scriptPubkey for the given data.
     pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -19,7 +19,7 @@ use crate::crypto::ecdsa;
 use crate::internal_macros::impl_asref_push_bytes;
 use crate::network::NetworkKind;
 use crate::prelude::{DisplayHex, String, Vec};
-use crate::script::ScriptBuf;
+use crate::script::{self, ScriptBuf};
 use crate::taproot::{TapNodeHash, TapTweakHash};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -286,7 +286,7 @@ impl CompressedPublicKey {
 
     /// Returns the script code used to spend a P2WPKH input.
     pub fn p2wpkh_script_code(&self) -> ScriptBuf {
-        ScriptBuf::p2wpkh_script_code(self.wpubkey_hash())
+        script::p2wpkh_script_code(self.wpubkey_hash())
     }
 
     /// Writes the public key into a writer.


### PR DESCRIPTION
We would like to move the `Script` type to `primitives` without moving any key stuff, including pubkey hashes. We may later, before releasing `primitives`, move the `WPubkeyHash` at which time this patch can be reverted or re-implemented on `ScriptBuf`.

The `ScriptBuf::p2wpkh_script_code` function does not take `self` as a parameter but it does return `Self` - this can trivially be made into a standalone function.

Make `ScriptBuf::p2wpkh_script_code` a standalone function.