### PR TITLE
Set `diff=rust` for `*.rs` in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rs	diff=rust


### PR DESCRIPTION
This slightly improves the diffs shown by git commands.