### PR TITLE
Push up the Default bound on HashEngine in order to better support keyed hash functions

### DIFF
--- a/hashes/src/hkdf.rs
+++ b/hashes/src/hkdf.rs
@@ -37,7 +37,10 @@ pub struct Hkdf<T: GeneralHash> {
     prk: Hmac<T>,
 }
 
-impl<T: GeneralHash> Hkdf<T> {
+impl<T: GeneralHash> Hkdf<T>
+where
+    <T as GeneralHash>::Engine: Default,
+{
     /// Initialize a HKDF by performing the extract step.
     pub fn new(salt: &[u8], ikm: &[u8]) -> Self {
         let mut hmac_engine: HmacEngine<T> = HmacEngine::new(salt);

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -42,7 +42,10 @@ pub struct HmacEngine<T: GeneralHash> {
     oengine: T::Engine,
 }
 
-impl<T: GeneralHash> Default for HmacEngine<T> {
+impl<T: GeneralHash> Default for HmacEngine<T>
+where
+    <T as GeneralHash>::Engine: Default,
+{
     fn default() -> Self { HmacEngine::new(&[]) }
 }
 
@@ -54,7 +57,10 @@ impl<T: GeneralHash> HmacEngine<T> {
     /// # Panics
     ///
     /// Larger hashes will result in a panic.
-    pub fn new(key: &[u8]) -> HmacEngine<T> {
+    pub fn new(key: &[u8]) -> HmacEngine<T>
+    where
+        <T as GeneralHash>::Engine: Default,
+    {
         debug_assert!(T::Engine::BLOCK_SIZE <= 128);
 
         let mut ipad = [0x36u8; 128];

--- a/hashes/src/impls.rs
+++ b/hashes/src/impls.rs
@@ -153,8 +153,6 @@ mod tests {
         "a9608c952c8dbcc20c53803d2ca5ad31d64d9313",
     );
 
-    write_test!(siphash24, "d70077739d4b921e", "3a3ccefde9b5b1e3", "ce456e4e4ecbc5bf",);
-
     #[test]
     fn hmac() {
         let mut engine = hmac::HmacEngine::<sha256::Hash>::new(&[0xde, 0xad, 0xbe, 0xef]);
@@ -177,5 +175,20 @@ mod tests {
             format!("{}", hmac::Hmac::from_engine(engine)),
             "30df499717415a395379a1eaabe50038036e4abb5afc94aa55c952f4aa57be08"
         );
+    }
+
+    #[test]
+    fn siphash24() {
+        let mut engine = siphash24::HashEngine::with_keys(0, 0);
+        engine.write_all(&[]).unwrap();
+        assert_eq!(format!("{}", siphash24::Hash::from_engine(engine)), "d70077739d4b921e");
+
+        let mut engine = siphash24::HashEngine::with_keys(0, 0);
+        engine.write_all(&[1; 256]).unwrap();
+        assert_eq!(format!("{}", siphash24::Hash::from_engine(engine)), "3a3ccefde9b5b1e3");
+
+        let mut engine = siphash24::HashEngine::with_keys(0, 0);
+        engine.write_all(&[99; 64000]).unwrap();
+        assert_eq!(format!("{}", siphash24::Hash::from_engine(engine)), "ce456e4e4ecbc5bf");
     }
 }

--- a/hashes/tests/regression.rs
+++ b/hashes/tests/regression.rs
@@ -30,7 +30,6 @@ impl_regression_test! {
     regression_sha384, sha384, "f545bd83d297978d47a7f26b858a54188499dfb4d7d570a6a2362c765031d57a29d7e002df5e34d184e70b65a4f47153";
     regression_sha512, sha512, "057d0a37e9e0ac9a93acde0752748da059a27bcf946c7af00692ac1a95db8d21f965f40af22efc4710f100f8d3e43f79f77b1f48e1e400a95b7344b7bc0dfd10";
     regression_sha512_256, sha512_256, "e204244c429b5bca037a2a8a6e7ed8a42b808ceaff182560840bb8c5c8e9a2ec";
-    regression_siphash24, siphash24, "e823ed82311d601a";
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
@@ -88,5 +87,16 @@ fn regression_hmac_sha512_with_key() {
 
     let got = format!("{}", hash);
     let want = "8511773748f89ba22c07fb3a2981a12c1823695119de41f4a62aead6b848bd34939acf16475c35ed7956114fead3e794cc162ecd35e447a4dabc3227d55f757b";
+    assert_eq!(got, want);
+}
+
+#[test]
+fn regression_siphash24_with_key() {
+    let mut engine = siphash24::HashEngine::with_keys(0, 0);
+    engine.input(DATA.as_bytes());
+    let hash = siphash24::Hash::from_engine(engine);
+
+    let got = format!("{}", hash);
+    let want = "e823ed82311d601a";
     assert_eq!(got, want);
 }


### PR DESCRIPTION
Backstory for this patch is in #3084, and this might be enough to close that issue, but I think some follow up work might be required.

I took Kixunil's advice and pushed up the `Default` bound on `HashEngine` all the way to the default methods themselves on the `GeneralHash` trait. I initially placed the bound just on the assocated type `Engine` of `GeneralHash`, which is a tad cleaner and keeps the bound from "leaking" downstream into things like `Hmac` and `Hkdf` implementations. However, that restricts `GeneralHash` implementations to just unkeyed hash functions and I believe there will be value in having `Poly1305` and `SipHash24` still leverage the interface. I struggled a bit on the best spots to put these bounds (even found the syntax a little jarring at times, I found [RFC2289](https://rust-lang.github.io/rfcs/2289-associated-type-bounds.html) helpful if others do too).

Refactored the existing keyed hash function, `SipHash24`, to no longer have `Default` functions with zero-value keys. I kept the test coverage though by just hardcoding the zero-value keys over in the tests.

Refactoring the `hash_type` macro for keyed hashes was getting a little hairy, so backed off and just wrote the bare minimum for `SipHash24` inline. Once `Poly1305` lands there will be two keyed hash functions and I think it will make more sense to then generalize over them.