### PR TITLE
Release tracking PR: `bitcoin-units 0.2.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "bitcoin-internals",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "bitcoin-internals",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -33,7 +33,7 @@ internals = { package = "bitcoin-internals", version = "0.4.0", features = ["all
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
 primitives = { package = "bitcoin-primitives", version = "0.100.0", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
-units = { package = "bitcoin-units", version = "0.1.0", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", version = "0.2.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1", optional = true }
 base64 = { version = "0.22.0", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["bitcoin-io"] }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false }
-units = { package = "bitcoin-units", version = "0.1.0", default-features = false }
+units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1", optional = true }
 ordered = { version = "0.2.0", optional = true }

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 0.2.0 - 2024-09-18
+
+* Bump MSRV to 1.63.0 [#3100](https://github.com/rust-bitcoin/rust-bitcoin/pull/3100)
+* Remove re-export of `ParseIntError` [#3069](https://github.com/rust-bitcoin/rust-bitcoin/pull/3069)
+* Improve docs [#2957](https://github.com/rust-bitcoin/rust-bitcoin/pull/2957)
+* Fix `Amount` decimals handling [#2951](https://github.com/rust-bitcoin/rust-bitcoin/pull/2951)
+* Remove `Denomination::MilliSatoshi` [#2870](https://github.com/rust-bitcoin/rust-bitcoin/pull/2870)
+* Document that the implementation of `Display` for `Amount` is unstable [#3323](https://github.com/rust-bitcoin/rust-bitcoin/pull/3323)
+* Add a condition for parsing zero from string when not denominated [#3346](https://github.com/rust-bitcoin/rust-bitcoin/pull/3346)
+* Enforce displaying `Amount` with trailing zeros [#2604](https://github.com/rust-bitcoin/rust-bitcoin/pull/2604)
+* Fix `Amount` decimals handling [#2951](https://github.com/rust-bitcoin/rust-bitcoin/pull/2951)
+* Error instead of panic when `Time::from_second_ceil` input is too large [#3052](https://github.com/rust-bitcoin/rust-bitcoin/pull/3052)
+* Remove re-export of `ParseIntError` [#3069](https://github.com/rust-bitcoin/rust-bitcoin/pull/3069)
+* Add `FeeRate` addition and subtraction traits [#3381](https://github.com/rust-bitcoin/rust-bitcoin/pull/3381)
+
+## Additional test infrastructure:`Arbitrary`
+
+This release we started adding implementations of
+[`arbitrary::Arbitrary`](https://docs.rs/arbitrary/latest/arbitrary/trait.Arbitrary.html).
+
+Types implemented: `Amount`, `SignedAmount`, `FeeRate`, and `Weight`.
+
+In the following PRs:
+
+* [#3305](https://github.com/rust-bitcoin/rust-bitcoin/pull/3015)
+* [#3257](https://github.com/rust-bitcoin/rust-bitcoin/pull/3257)
+* [#3247](https://github.com/rust-bitcoin/rust-bitcoin/pull/3274)
+
 ## 0.1.2 - 2024-07-01
 
 * Remove enable of `alloc` feature in the `internals` dependency.

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.2 - 2024-07-01
+
+* Remove enable of `alloc` feature in the `internals` dependency.
+
+Note, the bug fixed by this release was introduced in
+[#2655](https://github.com/rust-bitcoin/rust-bitcoin/pull/2655) and
+was incorrect because we have an `alloc` feature that enables
+`internals/alloc`.
+
+`v0.1.1` will be yanked for this reason.
+
 # 0.1.1 - 2024-04-04
 
 * Enable "alloc" feature for `internals` dependency - enables caching

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.2 - 2024-07-01
+## 0.1.2 - 2024-07-01
 
 * Remove enable of `alloc` feature in the `internals` dependency.
 
@@ -9,12 +9,12 @@ was incorrect because we have an `alloc` feature that enables
 
 `v0.1.1` will be yanked for this reason.
 
-# 0.1.1 - 2024-04-04
+## 0.1.1 - 2024-04-04
 
 * Enable "alloc" feature for `internals` dependency - enables caching
   of parsed input strings in a couple of `amount` error types.
 
-# 0.1.0 - Initial Release - 2024-04-03
+## 0.1.0 - Initial Release - 2024-04-03
 
 Initial release of the `bitcoin-units` crate. These unit types are
 integer wrapper types used by the `rust-bitcoin` ecosystem. Note
@@ -28,6 +28,6 @@ The main types are:
 - `FeeRate`
 - `Weight`
 
-# 0.0.0 - Placeholder release
+## 0.0.0 - Placeholder release
 
 Empty crate to reserve the name on crates.io

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
In preparation for releasing `units v0.2.0` bump the version number, add a changelog entry, update the lock files, and depend on the new version in all crates that depend on `units`.

Close: #3095