### PR TITLE
Rename Siphash::as_u64 to Siphash::to_u64

### DIFF
--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -206,7 +206,7 @@ impl Hash {
     }
 
     /// Returns the (little endian) 64-bit integer representation of the hash value.
-    pub fn as_u64(&self) -> u64 { u64::from_le_bytes(self.0) }
+    pub fn to_u64(&self) -> u64 { u64::from_le_bytes(self.0) }
 
     /// Creates a hash from its (little endian) 64-bit integer representation.
     pub fn from_u64(hash: u64) -> Hash { Hash(hash.to_le_bytes()) }


### PR DESCRIPTION
Resolves #3114