### PR TITLE
base58: Remove or document casts

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -73,11 +73,11 @@ pub fn decode(data: &str) -> Result<Vec<u8>, InvalidCharacterError> {
     // Build in base 256
     for d58 in data.bytes() {
         // Compute "X = X * 58 + next_digit" in base 256
-        if d58 as usize >= BASE58_DIGITS.len() {
+        if usize::from(d58) >= BASE58_DIGITS.len() {
             return Err(InvalidCharacterError { invalid: d58 });
         }
-        let mut carry = match BASE58_DIGITS[d58 as usize] {
-            Some(d58) => d58 as u32,
+        let mut carry = match BASE58_DIGITS[usize::from(d58)] {
+            Some(d58) => u32::from(d58),
             None => {
                 return Err(InvalidCharacterError { invalid: d58 });
             }

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -208,7 +208,7 @@ where
     let mut leading_zeroes = true;
     // Build string in little endian with 0-58 in place of characters...
     for d256 in data {
-        let mut carry = usize::from(d256);
+        let mut carry = u32::from(d256);
         if leading_zeroes && carry == 0 {
             leading_zero_count += 1;
         } else {
@@ -216,7 +216,7 @@ where
         }
 
         for ch in buf.slice_mut() {
-            let new_ch = usize::from(*ch) * 256 + carry;
+            let new_ch = u32::from(*ch) * 256 + carry;
             *ch = (new_ch % 58) as u8; // cast loses data intentionally
             carry = new_ch / 58;
         }

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -83,8 +83,8 @@ pub fn decode(data: &str) -> Result<Vec<u8>, InvalidCharacterError> {
             }
         };
         for d256 in scratch.iter_mut().rev() {
-            carry += *d256 as u32 * 58;
-            *d256 = carry as u8;
+            carry += u32::from(*d256) * 58;
+            *d256 = carry as u8; // cast loses data intentionally
             carry /= 256;
         }
         assert_eq!(carry, 0);
@@ -208,7 +208,7 @@ where
     let mut leading_zeroes = true;
     // Build string in little endian with 0-58 in place of characters...
     for d256 in data {
-        let mut carry = d256 as usize;
+        let mut carry = usize::from(d256);
         if leading_zeroes && carry == 0 {
             leading_zero_count += 1;
         } else {
@@ -216,13 +216,13 @@ where
         }
 
         for ch in buf.slice_mut() {
-            let new_ch = *ch as usize * 256 + carry;
-            *ch = (new_ch % 58) as u8;
+            let new_ch = usize::from(*ch) * 256 + carry;
+            *ch = (new_ch % 58) as u8; // cast loses data intentionally
             carry = new_ch / 58;
         }
 
         while carry > 0 {
-            buf.push((carry % 58) as u8);
+            buf.push((carry % 58) as u8); // cast loses data intentionally
             carry /= 58;
         }
     }
@@ -233,7 +233,7 @@ where
     }
 
     for ch in buf.slice().iter().rev() {
-        writer.write_char(BASE58_CHARS[*ch as usize] as char)?;
+        writer.write_char(char::from(BASE58_CHARS[usize::from(*ch)]))?;
     }
 
     Ok(())


### PR DESCRIPTION
Done as part of #2941.

Remove or document casts in the `base58` crate. Two separate patches because to assist review, with the hope that reviewers are able to just read the diff without going to the crate's code.