### PR TITLE
Introduce helper function name policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,7 @@ in Bitcoin Core, with the following exceptions:
 - the case should follow Rust standards (i.e. PascalCase for types and
   snake_case for fields and variants);
 - omit `C`-prefixes.
+- if function `foo` needs a private helper function, use `foo_internal`.
 
 ### Upgrading dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,10 +172,9 @@ Library reflects Bitcoin Core approach whenever possible.
 
 Naming of data structures/enums and their fields/variants must follow names used
 in Bitcoin Core, with the following exceptions:
-- the case should follow Rust standards (i.e. PascalCase for types and
-  snake_case for fields and variants);
-- omit `C`-prefixes.
-- if function `foo` needs a private helper function, use `foo_internal`.
+- The case should follow Rust standards (i.e. PascalCase for types and snake_case for fields and variants).
+- Omit `C`-prefixes.
+- If function `foo` needs a private helper function, use `foo_internal`.
 
 ### Upgrading dependencies
 

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -372,7 +372,7 @@ impl Script {
     ///
     /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
     pub fn minimal_non_dust(&self) -> crate::Amount {
-        self.minimal_non_dust_inner(DUST_RELAY_TX_FEE.into())
+        self.minimal_non_dust_internal(DUST_RELAY_TX_FEE.into())
     }
 
     /// Returns the minimum value an output with this script should have in order to be
@@ -387,10 +387,10 @@ impl Script {
     ///
     /// [`minimal_non_dust`]: Script::minimal_non_dust
     pub fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
-        self.minimal_non_dust_inner(dust_relay_fee.to_sat_per_kwu() * 4)
+        self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu() * 4)
     }
 
-    fn minimal_non_dust_inner(&self, dust_relay_fee: u64) -> crate::Amount {
+    fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> crate::Amount {
         // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
         // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
         let sats = dust_relay_fee


### PR DESCRIPTION
As much as it hurts the C hacker inside me we have settled on using `_internal` to mark private function names that clash with a public function of the same name.

Introduce a policy section and rename one instance, I did not grep the codebase looking for other violations.

This came up because I had to look at what `_inner` implied when reading the function name somewhere else.