### PR TITLE
hashes: Call through to trait methods

### DIFF
--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -186,13 +186,7 @@ macro_rules! hash_type {
 
             /// Hashes some bytes.
             #[allow(clippy::self_named_constructors)] // Hash is a noun and a verb.
-            pub fn hash(data: &[u8]) -> Self {
-                use $crate::HashEngine;
-
-                let mut engine = Self::engine();
-                engine.input(data);
-                Self::from_engine(engine)
-            }
+            pub fn hash(data: &[u8]) -> Self { <Self as crate::GeneralHash>::hash(data) }
 
             /// Hashes all the byte slices retrieved from the iterator together.
             pub fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
@@ -200,13 +194,7 @@ macro_rules! hash_type {
                 B: AsRef<[u8]>,
                 I: IntoIterator<Item = B>,
             {
-                use $crate::HashEngine;
-
-                let mut engine = Self::engine();
-                for slice in byte_slices {
-                    engine.input(slice.as_ref());
-                }
-                Self::from_engine(engine)
+                <Self as crate::GeneralHash>::hash_byte_chunks(byte_slices)
             }
 
             /// Returns the underlying byte array.

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -209,11 +209,7 @@ macro_rules! sha256t_hash_newtype {
             /// Hashes some bytes.
             #[allow(unused)] // the user of macro may not need this
             pub fn hash(data: &[u8]) -> Self {
-                use $crate::HashEngine;
-
-                let mut engine = Self::engine();
-                engine.input(data);
-                Self::from_engine(engine)
+                <$hash_name as $crate::GeneralHash>::hash(data)
             }
 
             /// Hashes all the byte slices retrieved from the iterator together.
@@ -223,13 +219,7 @@ macro_rules! sha256t_hash_newtype {
                 B: AsRef<[u8]>,
                 I: IntoIterator<Item = B>,
             {
-                use $crate::HashEngine;
-
-                let mut engine = Self::engine();
-                for slice in byte_slices {
-                    engine.input(slice.as_ref());
-                }
-                Self::from_engine(engine)
+                <$hash_name as $crate::GeneralHash>::hash_byte_chunks(byte_slices)
             }
         }
 


### PR DESCRIPTION
Currently we have duplicate code in inherent functions that also occurs in the default implementation of the `GeneralHash` trait methods, this is unnecessary because we can call through to the trait methods.