### PR TITLE
Introduce `ScriptExt`

### DIFF
--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -1,4 +1,5 @@
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
+use bitcoin::script::ScriptExt as _;
 use bitcoin::{
     consensus, ecdsa, sighash, Amount, CompressedPublicKey, Script, ScriptBuf, Transaction,
 };

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -84,6 +84,7 @@ use bitcoin::consensus::encode;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
 use bitcoin::psbt::{self, Input, Output, Psbt, PsbtSighashType};
+use bitcoin::script::ScriptExt as _;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::{self, SighashCache, TapSighash, TapSighashType};
 use bitcoin::taproot::{self, LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo};

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -51,7 +51,8 @@ use crate::prelude::{String, ToOwned};
 use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{
-    self, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
+    self, RedeemScriptSizeError, Script, ScriptBuf, ScriptExt as _, ScriptHash, WScriptHash,
+    WitnessScriptSizeError,
 };
 use crate::taproot::TapNodeHash;
 

--- a/bitcoin/src/address/script_pubkey.rs
+++ b/bitcoin/src/address/script_pubkey.rs
@@ -13,8 +13,8 @@ use crate::opcodes::all::*;
 use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{
-    self, Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash,
-    WitnessScriptSizeError,
+    self, Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptExt as _, ScriptHash,
+    WScriptHash, WitnessScriptSizeError,
 };
 use crate::taproot::TapNodeHash;
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -49,7 +49,7 @@ use crate::consensus::encode::VarInt;
 use crate::consensus::{Decodable, Encodable};
 use crate::internal_macros::impl_hashencode;
 use crate::prelude::{BTreeSet, Borrow, Vec};
-use crate::script::Script;
+use crate::script::{Script, ScriptExt as _};
 use crate::transaction::OutPoint;
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -19,8 +19,9 @@ use crate::merkle_tree::{MerkleNode as _, TxMerkleNode, WitnessMerkleNode};
 use crate::network::Params;
 use crate::pow::{CompactTarget, Target, Work};
 use crate::prelude::Vec;
+use crate::script::{self, ScriptExt as _};
 use crate::transaction::{Transaction, Wtxid};
-use crate::{script, VarInt};
+use crate::VarInt;
 
 hashes::hash_newtype! {
     /// A bitcoin block hash.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -133,12 +133,12 @@ impl Script {
     }
 }
 
+/// Creates a new script builder
+pub fn builder() -> Builder { Builder::new() }
+
 impl Script {
     /// Returns an iterator over script bytes.
     pub fn bytes(&self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
-
-    /// Creates a new script builder
-    pub fn builder() -> Builder { Builder::new() }
 
     /// Returns 160-bit hash of the script for P2SH outputs.
     pub fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError> {

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -370,7 +370,7 @@ impl Script {
     ///
     /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
     pub fn minimal_non_dust(&self) -> crate::Amount {
-        self.minimal_non_dust_internal(DUST_RELAY_TX_FEE.into())
+        minimal_non_dust_internal(self, DUST_RELAY_TX_FEE.into())
     }
 
     /// Returns the minimum value an output with this script should have in order to be
@@ -385,30 +385,7 @@ impl Script {
     ///
     /// [`minimal_non_dust`]: Script::minimal_non_dust
     pub fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
-        self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu() * 4)
-    }
-
-    fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> crate::Amount {
-        // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
-        // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
-        let sats = dust_relay_fee
-            .checked_mul(if self.is_op_return() {
-                0
-            } else if self.is_witness_program() {
-                32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
-                    8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
-            } else {
-                32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
-                    8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
-            })
-            .expect("dust_relay_fee or script length should not be absurdly large")
-            / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE
-                    // Note: We ensure the division happens at the end, since Core performs the division at the end.
-                    //       This will make sure none of the implicit floor operations mess with the value.
-
-        crate::Amount::from_sat(sats)
+        minimal_non_dust_internal(self, dust_relay_fee.to_sat_per_kwu() * 4)
     }
 
     /// Counts the sigops for this Script using accurate counting.
@@ -565,6 +542,29 @@ impl Script {
             _ => None,
         }
     }
+}
+
+fn minimal_non_dust_internal(script: &Script, dust_relay_fee: u64) -> crate::Amount {
+    // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
+    // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
+    let sats = dust_relay_fee
+        .checked_mul(if script.is_op_return() {
+            0
+        } else if script.is_witness_program() {
+            32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
+                8 + // The serialized size of the TxOut's amount field
+                script.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+        } else {
+            32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
+                8 + // The serialized size of the TxOut's amount field
+                script.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+        })
+        .expect("dust_relay_fee or script length should not be absurdly large")
+        / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE
+                // Note: We ensure the division happens at the end, since Core performs the division at the end.
+                //       This will make sure none of the implicit floor operations mess with the value.
+
+    crate::Amount::from_sat(sats)
 }
 
 /// Iterator over bytes of a script

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -152,15 +152,15 @@ define_extension_trait! {
         fn wscript_hash(&self) -> Result<WScriptHash, WitnessScriptSizeError> {
             WScriptHash::from_script(self)
         }
+
+        /// Computes leaf hash of tapscript.
+        fn tapscript_leaf_hash(&self) -> TapLeafHash {
+            TapLeafHash::from_script(self, LeafVersion::TapScript)
+        }
     }
 }
 
 impl Script {
-    /// Computes leaf hash of tapscript.
-    pub fn tapscript_leaf_hash(&self) -> TapLeafHash {
-        TapLeafHash::from_script(self, LeafVersion::TapScript)
-    }
-
     /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
     ///
     /// # Returns

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -135,26 +135,22 @@ impl Script {
 
 impl Script {
     /// Returns an iterator over script bytes.
-    #[inline]
     pub fn bytes(&self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
 
     /// Creates a new script builder
     pub fn builder() -> Builder { Builder::new() }
 
     /// Returns 160-bit hash of the script for P2SH outputs.
-    #[inline]
     pub fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError> {
         ScriptHash::from_script(self)
     }
 
     /// Returns 256-bit hash of the script for P2WSH outputs.
-    #[inline]
     pub fn wscript_hash(&self) -> Result<WScriptHash, WitnessScriptSizeError> {
         WScriptHash::from_script(self)
     }
 
     /// Computes leaf hash of tapscript.
-    #[inline]
     pub fn tapscript_leaf_hash(&self) -> TapLeafHash {
         TapLeafHash::from_script(self, LeafVersion::TapScript)
     }
@@ -169,7 +165,6 @@ impl Script {
     /// > push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
     /// > special meaning. The value of the first push is called the "version byte". The following
     /// > byte vector pushed is called the "witness program".
-    #[inline]
     pub fn witness_version(&self) -> Option<WitnessVersion> {
         let script_len = self.0.len();
         if !(4..=42).contains(&script_len) {
@@ -191,7 +186,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2SH output.
-    #[inline]
     pub fn is_p2sh(&self) -> bool {
         self.0.len() == 23
             && self.0[0] == OP_HASH160.to_u8()
@@ -200,7 +194,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2PKH output.
-    #[inline]
     pub fn is_p2pkh(&self) -> bool {
         self.0.len() == 25
             && self.0[0] == OP_DUP.to_u8()
@@ -214,7 +207,6 @@ impl Script {
     ///
     /// Note: `OP_RESERVED` (`0x50`) and all the OP_PUSHNUM operations
     /// are considered push operations.
-    #[inline]
     pub fn is_push_only(&self) -> bool {
         for inst in self.instructions() {
             match inst {
@@ -235,7 +227,6 @@ impl Script {
     /// is of the form:
     ///
     ///    `2 <pubkey1> <pubkey2> <pubkey3> 3 OP_CHECKMULTISIG`
-    #[inline]
     pub fn is_multisig(&self) -> bool {
         let required_sigs;
 
@@ -283,11 +274,9 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
-    #[inline]
     pub fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
 
     /// Checks whether a script pubkey is a P2WSH output.
-    #[inline]
     pub fn is_p2wsh(&self) -> bool {
         self.0.len() == 34
             && self.witness_version() == Some(WitnessVersion::V0)
@@ -295,7 +284,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2WPKH output.
-    #[inline]
     pub fn is_p2wpkh(&self) -> bool {
         self.0.len() == 22
             && self.witness_version() == Some(WitnessVersion::V0)
@@ -303,7 +291,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2TR output.
-    #[inline]
     pub fn is_p2tr(&self) -> bool {
         self.0.len() == 34
             && self.witness_version() == Some(WitnessVersion::V1)
@@ -314,7 +301,6 @@ impl Script {
     ///
     /// To validate if the OP_RETURN obeys Bitcoin Core's current standardness policy, use
     /// [`is_standard_op_return()`](Self::is_standard_op_return) instead.
-    #[inline]
     pub fn is_op_return(&self) -> bool {
         match self.0.first() {
             Some(b) => *b == OP_RETURN.to_u8(),
@@ -326,7 +312,6 @@ impl Script {
     ///
     /// What this function considers to be standard may change without warning pending Bitcoin Core
     /// changes.
-    #[inline]
     pub fn is_standard_op_return(&self) -> bool { self.is_op_return() && self.0.len() <= 80 }
 
     /// Checks whether a script is trivially known to have no satisfying input.
@@ -337,7 +322,6 @@ impl Script {
         since = "0.32.0",
         note = "The method has potentially confusing semantics and is going to be removed, you might want `is_op_return`"
     )]
-    #[inline]
     pub fn is_provably_unspendable(&self) -> bool {
         use crate::opcodes::Class::{IllegalOp, ReturnOp};
 
@@ -504,7 +488,6 @@ impl Script {
     /// the script as sequence of bytes call the [`bytes`](Self::bytes) method.
     ///
     /// To force minimal pushes, use [`instructions_minimal`](Self::instructions_minimal).
-    #[inline]
     pub fn instructions(&self) -> Instructions {
         Instructions { data: self.0.iter(), enforce_minimal: false }
     }
@@ -513,7 +496,6 @@ impl Script {
     ///
     /// This is similar to [`instructions`](Self::instructions) but an error is returned if a push
     /// is not minimal.
-    #[inline]
     pub fn instructions_minimal(&self) -> Instructions {
         Instructions { data: self.0.iter(), enforce_minimal: true }
     }
@@ -525,7 +507,6 @@ impl Script {
     /// opcode or data push.
     ///
     /// To force minimal pushes, use [`Self::instruction_indices_minimal`].
-    #[inline]
     pub fn instruction_indices(&self) -> InstructionIndices {
         InstructionIndices::from_instructions(self.instructions())
     }
@@ -534,7 +515,6 @@ impl Script {
     ///
     /// This is similar to [`instruction_indices`](Self::instruction_indices) but an error is
     /// returned if a push is not minimal.
-    #[inline]
     pub fn instruction_indices_minimal(&self) -> InstructionIndices {
         InstructionIndices::from_instructions(self.instructions_minimal())
     }

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -223,62 +223,62 @@ define_extension_trait! {
             }
             true
         }
+
+        /// Checks whether a script pubkey is a bare multisig output.
+        ///
+        /// In a bare multisig pubkey script the keys are not hashed, the script
+        /// is of the form:
+        ///
+        ///    `2 <pubkey1> <pubkey2> <pubkey3> 3 OP_CHECKMULTISIG`
+        fn is_multisig(&self) -> bool {
+            let required_sigs;
+
+            let mut instructions = self.instructions();
+            if let Some(Ok(Instruction::Op(op))) = instructions.next() {
+                if let Some(pushnum) = op.decode_pushnum() {
+                    required_sigs = pushnum;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+
+            let mut num_pubkeys: u8 = 0;
+            while let Some(Ok(instruction)) = instructions.next() {
+                match instruction {
+                    Instruction::PushBytes(_) => {
+                        num_pubkeys += 1;
+                    }
+                    Instruction::Op(op) => {
+                        if let Some(pushnum) = op.decode_pushnum() {
+                            if pushnum != num_pubkeys {
+                                return false;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+
+            if required_sigs > num_pubkeys {
+                return false;
+            }
+
+            if let Some(Ok(Instruction::Op(op))) = instructions.next() {
+                if op != OP_CHECKMULTISIG {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+
+            instructions.next().is_none()
+        }
     }
 }
 
 impl Script {
-    /// Checks whether a script pubkey is a bare multisig output.
-    ///
-    /// In a bare multisig pubkey script the keys are not hashed, the script
-    /// is of the form:
-    ///
-    ///    `2 <pubkey1> <pubkey2> <pubkey3> 3 OP_CHECKMULTISIG`
-    pub fn is_multisig(&self) -> bool {
-        let required_sigs;
-
-        let mut instructions = self.instructions();
-        if let Some(Ok(Instruction::Op(op))) = instructions.next() {
-            if let Some(pushnum) = op.decode_pushnum() {
-                required_sigs = pushnum;
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
-
-        let mut num_pubkeys: u8 = 0;
-        while let Some(Ok(instruction)) = instructions.next() {
-            match instruction {
-                Instruction::PushBytes(_) => {
-                    num_pubkeys += 1;
-                }
-                Instruction::Op(op) => {
-                    if let Some(pushnum) = op.decode_pushnum() {
-                        if pushnum != num_pubkeys {
-                            return false;
-                        }
-                    }
-                    break;
-                }
-            }
-        }
-
-        if required_sigs > num_pubkeys {
-            return false;
-        }
-
-        if let Some(Ok(Instruction::Op(op))) = instructions.next() {
-            if op != OP_CHECKMULTISIG {
-                return false;
-            }
-        } else {
-            return false;
-        }
-
-        instructions.next().is_none()
-    }
-
     /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
     pub fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
 

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -187,28 +187,28 @@ define_extension_trait! {
 
             WitnessVersion::try_from(ver_opcode).ok()
         }
+
+        /// Checks whether a script pubkey is a P2SH output.
+        fn is_p2sh(&self) -> bool {
+            self.0.len() == 23
+                && self.0[0] == OP_HASH160.to_u8()
+                && self.0[1] == OP_PUSHBYTES_20.to_u8()
+                && self.0[22] == OP_EQUAL.to_u8()
+        }
+
+        /// Checks whether a script pubkey is a P2PKH output.
+        fn is_p2pkh(&self) -> bool {
+            self.0.len() == 25
+                && self.0[0] == OP_DUP.to_u8()
+                && self.0[1] == OP_HASH160.to_u8()
+                && self.0[2] == OP_PUSHBYTES_20.to_u8()
+                && self.0[23] == OP_EQUALVERIFY.to_u8()
+                && self.0[24] == OP_CHECKSIG.to_u8()
+        }
     }
 }
 
 impl Script {
-    /// Checks whether a script pubkey is a P2SH output.
-    pub fn is_p2sh(&self) -> bool {
-        self.0.len() == 23
-            && self.0[0] == OP_HASH160.to_u8()
-            && self.0[1] == OP_PUSHBYTES_20.to_u8()
-            && self.0[22] == OP_EQUAL.to_u8()
-    }
-
-    /// Checks whether a script pubkey is a P2PKH output.
-    pub fn is_p2pkh(&self) -> bool {
-        self.0.len() == 25
-            && self.0[0] == OP_DUP.to_u8()
-            && self.0[1] == OP_HASH160.to_u8()
-            && self.0[2] == OP_PUSHBYTES_20.to_u8()
-            && self.0[23] == OP_EQUALVERIFY.to_u8()
-            && self.0[24] == OP_CHECKSIG.to_u8()
-    }
-
     /// Checks whether a script is push only.
     ///
     /// Note: `OP_RESERVED` (`0x50`) and all the OP_PUSHNUM operations

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -338,29 +338,29 @@ define_extension_trait! {
                 None => false,
             }
         }
+
+        /// Get redeemScript following BIP16 rules regarding P2SH spending.
+        ///
+        /// This does not guarantee that this represents a P2SH input [`Script`].
+        /// It merely gets the last push of the script.
+        ///
+        /// Use [`Script::is_p2sh`] on the scriptPubKey to check whether it is actually a P2SH script.
+        fn redeem_script(&self) -> Option<&Script> {
+            // Script must consist entirely of pushes.
+            if self.instructions().any(|i| i.is_err() || i.unwrap().push_bytes().is_none()) {
+                return None;
+            }
+
+            if let Some(Ok(Instruction::PushBytes(b))) = self.instructions().last() {
+                Some(Script::from_bytes(b.as_bytes()))
+            } else {
+                None
+            }
+        }
     }
 }
 
 impl Script {
-    /// Get redeemScript following BIP16 rules regarding P2SH spending.
-    ///
-    /// This does not guarantee that this represents a P2SH input [`Script`].
-    /// It merely gets the last push of the script.
-    ///
-    /// Use [`Script::is_p2sh`] on the scriptPubKey to check whether it is actually a P2SH script.
-    pub fn redeem_script(&self) -> Option<&Script> {
-        // Script must consist entirely of pushes.
-        if self.instructions().any(|i| i.is_err() || i.unwrap().push_bytes().is_none()) {
-            return None;
-        }
-
-        if let Some(Ok(Instruction::PushBytes(b))) = self.instructions().last() {
-            Some(Script::from_bytes(b.as_bytes()))
-        } else {
-            None
-        }
-    }
-
     /// Returns the minimum value an output with this script should have in order to be
     /// broadcastable on today’s Bitcoin network.
     #[deprecated(since = "0.32.0", note = "use minimal_non_dust and friends")]

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -277,31 +277,31 @@ define_extension_trait! {
         }
         /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
         fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
+
+        /// Checks whether a script pubkey is a P2WSH output.
+        fn is_p2wsh(&self) -> bool {
+            self.0.len() == 34
+                && self.witness_version() == Some(WitnessVersion::V0)
+                && self.0[1] == OP_PUSHBYTES_32.to_u8()
+        }
+
+        /// Checks whether a script pubkey is a P2WPKH output.
+        fn is_p2wpkh(&self) -> bool {
+            self.0.len() == 22
+                && self.witness_version() == Some(WitnessVersion::V0)
+                && self.0[1] == OP_PUSHBYTES_20.to_u8()
+        }
+
+        /// Checks whether a script pubkey is a P2TR output.
+        fn is_p2tr(&self) -> bool {
+            self.0.len() == 34
+                && self.witness_version() == Some(WitnessVersion::V1)
+                && self.0[1] == OP_PUSHBYTES_32.to_u8()
+        }
     }
 }
 
 impl Script {
-    /// Checks whether a script pubkey is a P2WSH output.
-    pub fn is_p2wsh(&self) -> bool {
-        self.0.len() == 34
-            && self.witness_version() == Some(WitnessVersion::V0)
-            && self.0[1] == OP_PUSHBYTES_32.to_u8()
-    }
-
-    /// Checks whether a script pubkey is a P2WPKH output.
-    pub fn is_p2wpkh(&self) -> bool {
-        self.0.len() == 22
-            && self.witness_version() == Some(WitnessVersion::V0)
-            && self.0[1] == OP_PUSHBYTES_20.to_u8()
-    }
-
-    /// Checks whether a script pubkey is a P2TR output.
-    pub fn is_p2tr(&self) -> bool {
-        self.0.len() == 34
-            && self.witness_version() == Some(WitnessVersion::V1)
-            && self.0[1] == OP_PUSHBYTES_32.to_u8()
-    }
-
     /// Check if this is a consensus-valid OP_RETURN output.
     ///
     /// To validate if the OP_RETURN obeys Bitcoin Core's current standardness policy, use

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -11,6 +11,7 @@ use super::{
     RedeemScriptSizeError, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
 };
 use crate::consensus::Encodable;
+use crate::internal_macros::define_extension_trait;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::policy::DUST_RELAY_TX_FEE;
@@ -136,10 +137,15 @@ impl Script {
 /// Creates a new script builder
 pub fn builder() -> Builder { Builder::new() }
 
-impl Script {
-    /// Returns an iterator over script bytes.
-    pub fn bytes(&self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
+define_extension_trait! {
+    /// Extension functionality for the [`Script`] type.
+    pub trait ScriptExt impl for Script {
+        /// Returns an iterator over script bytes.
+        fn bytes(&self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
+    }
+}
 
+impl Script {
     /// Returns 160-bit hash of the script for P2SH outputs.
     pub fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError> {
         ScriptHash::from_script(self)

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -205,28 +205,28 @@ define_extension_trait! {
                 && self.0[23] == OP_EQUALVERIFY.to_u8()
                 && self.0[24] == OP_CHECKSIG.to_u8()
         }
+
+        /// Checks whether a script is push only.
+        ///
+        /// Note: `OP_RESERVED` (`0x50`) and all the OP_PUSHNUM operations
+        /// are considered push operations.
+        fn is_push_only(&self) -> bool {
+            for inst in self.instructions() {
+                match inst {
+                    Err(_) => return false,
+                    Ok(Instruction::PushBytes(_)) => {}
+                    Ok(Instruction::Op(op)) if op.to_u8() <= 0x60 => {}
+                    // From Bitcoin Core
+                    // if (opcode > OP_PUSHNUM_16 (0x60)) return false
+                    Ok(Instruction::Op(_)) => return false,
+                }
+            }
+            true
+        }
     }
 }
 
 impl Script {
-    /// Checks whether a script is push only.
-    ///
-    /// Note: `OP_RESERVED` (`0x50`) and all the OP_PUSHNUM operations
-    /// are considered push operations.
-    pub fn is_push_only(&self) -> bool {
-        for inst in self.instructions() {
-            match inst {
-                Err(_) => return false,
-                Ok(Instruction::PushBytes(_)) => {}
-                Ok(Instruction::Op(op)) if op.to_u8() <= 0x60 => {}
-                // From Bitcoin Core
-                // if (opcode > OP_PUSHNUM_16 (0x60)) return false
-                Ok(Instruction::Op(_)) => return false,
-            }
-        }
-        true
-    }
-
     /// Checks whether a script pubkey is a bare multisig output.
     ///
     /// In a bare multisig pubkey script the keys are not hashed, the script

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -357,43 +357,43 @@ define_extension_trait! {
                 None
             }
         }
+
+        /// Returns the minimum value an output with this script should have in order to be
+        /// broadcastable on today’s Bitcoin network.
+        #[deprecated(since = "0.32.0", note = "use minimal_non_dust and friends")]
+        fn dust_value(&self) -> crate::Amount { self.minimal_non_dust() }
+
+        /// Returns the minimum value an output with this script should have in order to be
+        /// broadcastable on today's Bitcoin network.
+        ///
+        /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
+        /// This function uses the default value of 0.00003 BTC/kB (3 sat/vByte).
+        ///
+        /// To use a custom value, use [`minimal_non_dust_custom`].
+        ///
+        /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
+        fn minimal_non_dust(&self) -> crate::Amount {
+            minimal_non_dust_internal(self, DUST_RELAY_TX_FEE.into())
+        }
+
+        /// Returns the minimum value an output with this script should have in order to be
+        /// broadcastable on today's Bitcoin network.
+        ///
+        /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
+        /// This function lets you set the fee rate used in dust calculation.
+        ///
+        /// The current default value in Bitcoin Core (as of v26) is 3 sat/vByte.
+        ///
+        /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
+        ///
+        /// [`minimal_non_dust`]: Script::minimal_non_dust
+        fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
+            minimal_non_dust_internal(self, dust_relay_fee.to_sat_per_kwu() * 4)
+        }
     }
 }
 
 impl Script {
-    /// Returns the minimum value an output with this script should have in order to be
-    /// broadcastable on today’s Bitcoin network.
-    #[deprecated(since = "0.32.0", note = "use minimal_non_dust and friends")]
-    pub fn dust_value(&self) -> crate::Amount { self.minimal_non_dust() }
-
-    /// Returns the minimum value an output with this script should have in order to be
-    /// broadcastable on today's Bitcoin network.
-    ///
-    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
-    /// This function uses the default value of 0.00003 BTC/kB (3 sat/vByte).
-    ///
-    /// To use a custom value, use [`minimal_non_dust_custom`].
-    ///
-    /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
-    pub fn minimal_non_dust(&self) -> crate::Amount {
-        minimal_non_dust_internal(self, DUST_RELAY_TX_FEE.into())
-    }
-
-    /// Returns the minimum value an output with this script should have in order to be
-    /// broadcastable on today's Bitcoin network.
-    ///
-    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
-    /// This function lets you set the fee rate used in dust calculation.
-    ///
-    /// The current default value in Bitcoin Core (as of v26) is 3 sat/vByte.
-    ///
-    /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
-    ///
-    /// [`minimal_non_dust`]: Script::minimal_non_dust
-    pub fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
-        minimal_non_dust_internal(self, dust_relay_fee.to_sat_per_kwu() * 4)
-    }
-
     /// Counts the sigops for this Script using accurate counting.
     ///
     /// In Bitcoin Core, there are two ways to count sigops, "accurate" and "legacy".

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -142,20 +142,20 @@ define_extension_trait! {
     pub trait ScriptExt impl for Script {
         /// Returns an iterator over script bytes.
         fn bytes(&self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
+
+        /// Returns 160-bit hash of the script for P2SH outputs.
+        fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError> {
+            ScriptHash::from_script(self)
+        }
+
+        /// Returns 256-bit hash of the script for P2WSH outputs.
+        fn wscript_hash(&self) -> Result<WScriptHash, WitnessScriptSizeError> {
+            WScriptHash::from_script(self)
+        }
     }
 }
 
 impl Script {
-    /// Returns 160-bit hash of the script for P2SH outputs.
-    pub fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError> {
-        ScriptHash::from_script(self)
-    }
-
-    /// Returns 256-bit hash of the script for P2WSH outputs.
-    pub fn wscript_hash(&self) -> Result<WScriptHash, WitnessScriptSizeError> {
-        WScriptHash::from_script(self)
-    }
-
     /// Computes leaf hash of tapscript.
     pub fn tapscript_leaf_hash(&self) -> TapLeafHash {
         TapLeafHash::from_script(self, LeafVersion::TapScript)

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -420,48 +420,48 @@ define_extension_trait! {
         /// nor do they have CHECKMULTISIG operations. This function does not count OP_CHECKSIGADD,
         /// so do not use this to try and estimate if a Taproot script goes over the sigop budget.)
         fn count_sigops_legacy(&self) -> usize { count_sigops_internal(self, false) }
+
+        /// Iterates over the script instructions.
+        ///
+        /// Each returned item is a nested enum covering opcodes, datapushes and errors.
+        /// At most one error will be returned and then the iterator will end. To instead iterate over
+        /// the script as sequence of bytes call the [`bytes`](Self::bytes) method.
+        ///
+        /// To force minimal pushes, use [`instructions_minimal`](Self::instructions_minimal).
+        fn instructions(&self) -> Instructions {
+            Instructions { data: self.0.iter(), enforce_minimal: false }
+        }
+
+        /// Iterates over the script instructions while enforcing minimal pushes.
+        ///
+        /// This is similar to [`instructions`](Self::instructions) but an error is returned if a push
+        /// is not minimal.
+        fn instructions_minimal(&self) -> Instructions {
+            Instructions { data: self.0.iter(), enforce_minimal: true }
+        }
+
+        /// Iterates over the script instructions and their indices.
+        ///
+        /// Unless the script contains an error, the returned item consists of an index pointing to the
+        /// position in the script where the instruction begins and the decoded instruction - either an
+        /// opcode or data push.
+        ///
+        /// To force minimal pushes, use [`Self::instruction_indices_minimal`].
+        fn instruction_indices(&self) -> InstructionIndices {
+            InstructionIndices::from_instructions(self.instructions())
+        }
+
+        /// Iterates over the script instructions and their indices while enforcing minimal pushes.
+        ///
+        /// This is similar to [`instruction_indices`](Self::instruction_indices) but an error is
+        /// returned if a push is not minimal.
+        fn instruction_indices_minimal(&self) -> InstructionIndices {
+            InstructionIndices::from_instructions(self.instructions_minimal())
+        }
     }
 }
 
 impl Script {
-    /// Iterates over the script instructions.
-    ///
-    /// Each returned item is a nested enum covering opcodes, datapushes and errors.
-    /// At most one error will be returned and then the iterator will end. To instead iterate over
-    /// the script as sequence of bytes call the [`bytes`](Self::bytes) method.
-    ///
-    /// To force minimal pushes, use [`instructions_minimal`](Self::instructions_minimal).
-    pub fn instructions(&self) -> Instructions {
-        Instructions { data: self.0.iter(), enforce_minimal: false }
-    }
-
-    /// Iterates over the script instructions while enforcing minimal pushes.
-    ///
-    /// This is similar to [`instructions`](Self::instructions) but an error is returned if a push
-    /// is not minimal.
-    pub fn instructions_minimal(&self) -> Instructions {
-        Instructions { data: self.0.iter(), enforce_minimal: true }
-    }
-
-    /// Iterates over the script instructions and their indices.
-    ///
-    /// Unless the script contains an error, the returned item consists of an index pointing to the
-    /// position in the script where the instruction begins and the decoded instruction - either an
-    /// opcode or data push.
-    ///
-    /// To force minimal pushes, use [`Self::instruction_indices_minimal`].
-    pub fn instruction_indices(&self) -> InstructionIndices {
-        InstructionIndices::from_instructions(self.instructions())
-    }
-
-    /// Iterates over the script instructions and their indices while enforcing minimal pushes.
-    ///
-    /// This is similar to [`instruction_indices`](Self::instruction_indices) but an error is
-    /// returned if a push is not minimal.
-    pub fn instruction_indices_minimal(&self) -> InstructionIndices {
-        InstructionIndices::from_instructions(self.instructions_minimal())
-    }
-
     /// Writes the human-readable assembly representation of the script to the formatter.
     pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
         bytes_to_asm_fmt(self.as_ref(), f)

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -479,29 +479,6 @@ impl Script {
     pub fn first_opcode(&self) -> Option<Opcode> {
         self.as_bytes().first().copied().map(From::from)
     }
-
-    /// Iterates the script to find the last opcode.
-    ///
-    /// Returns `None` is the instruction is data push or if the script is empty.
-    pub(in crate::blockdata::script) fn last_opcode(&self) -> Option<Opcode> {
-        match self.instructions().last() {
-            Some(Ok(Instruction::Op(op))) => Some(op),
-            _ => None,
-        }
-    }
-
-    /// Iterates the script to find the last pushdata.
-    ///
-    /// Returns `None` if the instruction is an opcode or if the script is empty.
-    pub(crate) fn last_pushdata(&self) -> Option<&PushBytes> {
-        match self.instructions().last() {
-            // Handles op codes up to (but excluding) OP_PUSHNUM_NEG.
-            Some(Ok(Instruction::PushBytes(bytes))) => Some(bytes),
-            // OP_16 (0x60) and lower are considered "pushes" by Bitcoin Core (excl. OP_RESERVED).
-            // However we are only interested in the pushdata so we can ignore them.
-            _ => None,
-        }
-    }
 }
 
 fn minimal_non_dust_internal(script: &Script, dust_relay_fee: u64) -> crate::Amount {
@@ -565,6 +542,29 @@ fn count_sigops_internal(script: &Script, accurate: bool) -> usize {
     }
 
     n
+}
+
+/// Iterates the script to find the last opcode.
+///
+/// Returns `None` is the instruction is data push or if the script is empty.
+pub(in crate::blockdata::script) fn last_opcode(script: &Script) -> Option<Opcode> {
+    match script.instructions().last() {
+        Some(Ok(Instruction::Op(op))) => Some(op),
+        _ => None,
+    }
+}
+
+/// Iterates the script to find the last pushdata.
+///
+/// Returns `None` if the instruction is an opcode or if the script is empty.
+pub(crate) fn last_pushdata(script: &Script) -> Option<&PushBytes> {
+    match script.instructions().last() {
+        // Handles op codes up to (but excluding) OP_PUSHNUM_NEG.
+        Some(Ok(Instruction::PushBytes(bytes))) => Some(bytes),
+        // OP_16 (0x60) and lower are considered "pushes" by Bitcoin Core (excl. OP_RESERVED).
+        // However we are only interested in the pushdata so we can ignore them.
+        _ => None,
+    }
 }
 
 /// Iterator over bytes of a script

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -470,20 +470,18 @@ define_extension_trait! {
             self.fmt_asm(&mut buf).unwrap();
             buf
         }
-    }
-}
 
-impl Script {
-    /// Formats the script as lower-case hex.
-    ///
-    /// This is a more convenient and performant way to write `format!("{:x}", script)`.
-    /// For better performance you should generally prefer displaying the script but if `String` is
-    /// required (this is common in tests) this method can be used.
-    pub fn to_hex_string(&self) -> String { self.as_bytes().to_lower_hex_string() }
+        /// Formats the script as lower-case hex.
+        ///
+        /// This is a more convenient and performant way to write `format!("{:x}", script)`.
+        /// For better performance you should generally prefer displaying the script but if `String` is
+        /// required (this is common in tests) this method can be used.
+        fn to_hex_string(&self) -> String { self.as_bytes().to_lower_hex_string() }
 
-    /// Returns the first opcode of the script (if there is any).
-    pub fn first_opcode(&self) -> Option<Opcode> {
-        self.as_bytes().first().copied().map(From::from)
+        /// Returns the first opcode of the script (if there is any).
+        fn first_opcode(&self) -> Option<Opcode> {
+            self.as_bytes().first().copied().map(From::from)
+        }
     }
 }
 

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -458,22 +458,22 @@ define_extension_trait! {
         fn instruction_indices_minimal(&self) -> InstructionIndices {
             InstructionIndices::from_instructions(self.instructions_minimal())
         }
+
+        /// Writes the human-readable assembly representation of the script to the formatter.
+        fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
+            bytes_to_asm_fmt(self.as_ref(), f)
+        }
+
+        /// Returns the human-readable assembly representation of the script.
+        fn to_asm_string(&self) -> String {
+            let mut buf = String::new();
+            self.fmt_asm(&mut buf).unwrap();
+            buf
+        }
     }
 }
 
 impl Script {
-    /// Writes the human-readable assembly representation of the script to the formatter.
-    pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
-        bytes_to_asm_fmt(self.as_ref(), f)
-    }
-
-    /// Returns the human-readable assembly representation of the script.
-    pub fn to_asm_string(&self) -> String {
-        let mut buf = String::new();
-        self.fmt_asm(&mut buf).unwrap();
-        buf
-    }
-
     /// Formats the script as lower-case hex.
     ///
     /// This is a more convenient and performant way to write `format!("{:x}", script)`.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -275,13 +275,12 @@ define_extension_trait! {
 
             instructions.next().is_none()
         }
+        /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
+        fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
     }
 }
 
 impl Script {
-    /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
-    pub fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
-
     /// Checks whether a script pubkey is a P2WSH output.
     pub fn is_p2wsh(&self) -> bool {
         self.0.len() == 34

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,7 @@ use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::Sequence;
+use crate::{script, Sequence};
 
 /// An Object which can be used to construct a script piece by piece.
 #[derive(PartialEq, Eq, Clone)]
@@ -119,7 +119,7 @@ impl Default for Builder {
 impl From<Vec<u8>> for Builder {
     fn from(v: Vec<u8>) -> Builder {
         let script = ScriptBuf::from(v);
-        let last_op = script.last_opcode();
+        let last_op = script::last_opcode(&script);
         Builder(script, last_op)
     }
 }

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,8 @@ use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::{script, Sequence};
+use crate::script::{self, ScriptExt as _};
+use crate::Sequence;
 
 /// An Object which can be used to construct a script piece by piece.
 #[derive(PartialEq, Eq, Clone)]

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -9,6 +9,7 @@ use super::{opcode_to_verify, Builder, Instruction, PushBytes, Script};
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
+use crate::script;
 
 /// An owned, growable script.
 ///
@@ -172,7 +173,7 @@ impl ScriptBuf {
     /// This function needs to iterate over the script to find the last instruction. Prefer
     /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
     /// multiple times.
-    pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
+    pub fn scan_and_push_verify(&mut self) { self.push_verify(script::last_opcode(self)); }
 
     /// Adds an `OP_VERIFY` to the script or changes the most-recently-added opcode to `VERIFY`
     /// alternative.

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -10,7 +10,7 @@ use crate::address::script_pubkey::{
 };
 use crate::consensus::encode::{deserialize, serialize};
 use crate::crypto::key::{PublicKey, XOnlyPublicKey};
-use crate::FeeRate;
+use crate::{script, FeeRate};
 
 #[test]
 #[rustfmt::skip]
@@ -53,7 +53,7 @@ fn script() {
 fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
+    let p2pk = script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
     assert_eq!(actual.to_vec(), key.to_bytes());
 }
@@ -62,20 +62,20 @@ fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
 fn p2pk_pubkey_bytes_no_checksig_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let no_checksig = Script::builder().push_key(key).into_script();
+    let no_checksig = script::builder().push_key(key).into_script();
     assert_eq!(no_checksig.p2pk_pubkey_bytes(), None);
 }
 
 #[test]
 fn p2pk_pubkey_bytes_emptry_script_returns_none() {
-    let empty_script = Script::builder().into_script();
+    let empty_script = script::builder().into_script();
     assert!(empty_script.p2pk_pubkey_bytes().is_none());
 }
 
 #[test]
 fn p2pk_pubkey_bytes_no_key_returns_none() {
     // scripts with no key should return None
-    let no_push_bytes = Script::builder().push_opcode(OP_CHECKSIG).into_script();
+    let no_push_bytes = script::builder().push_opcode(OP_CHECKSIG).into_script();
     assert!(no_push_bytes.p2pk_pubkey_bytes().is_none());
 }
 
@@ -83,7 +83,7 @@ fn p2pk_pubkey_bytes_no_key_returns_none() {
 fn p2pk_pubkey_bytes_different_op_code_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let different_op_code = Script::builder().push_key(key).push_opcode(OP_NOP).into_script();
+    let different_op_code = script::builder().push_key(key).push_opcode(OP_NOP).into_script();
     assert!(different_op_code.p2pk_pubkey_bytes().is_none());
 }
 
@@ -92,7 +92,7 @@ fn p2pk_pubkey_bytes_incorrect_key_size_returns_none() {
     // 63 byte key
     let malformed_key = b"21032e58afe51f9ed8ad3cc7897f634d881fdbe49816429ded8156bebd2ffd1";
     let invalid_p2pk_script =
-        Script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
+        script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
     assert!(invalid_p2pk_script.p2pk_pubkey_bytes().is_none());
 }
 
@@ -100,7 +100,7 @@ fn p2pk_pubkey_bytes_incorrect_key_size_returns_none() {
 fn p2pk_pubkey_bytes_invalid_key_returns_some() {
     let malformed_key = b"21032e58afe51f9ed8ad3cc7897f634d881fdbe49816429ded8156bebd2ffd1ux";
     let invalid_key_script =
-        Script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
+        script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
     assert!(invalid_key_script.p2pk_pubkey_bytes().is_some());
 }
 
@@ -108,7 +108,7 @@ fn p2pk_pubkey_bytes_invalid_key_returns_some() {
 fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
     let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
     let key = PublicKey::from_str(compressed_key_str).unwrap();
-    let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
+    let p2pk = script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
     assert_eq!(actual.to_vec(), key.to_bytes());
 }
@@ -117,7 +117,7 @@ fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
 fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
+    let p2pk = script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_public_key().unwrap();
     assert_eq!(actual, key);
 }
@@ -126,19 +126,19 @@ fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
 fn p2pk_public_key_no_checksig_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let no_checksig = Script::builder().push_key(key).into_script();
+    let no_checksig = script::builder().push_key(key).into_script();
     assert_eq!(no_checksig.p2pk_public_key(), None);
 }
 
 #[test]
 fn p2pk_public_key_empty_script_returns_none() {
-    let empty_script = Script::builder().into_script();
+    let empty_script = script::builder().into_script();
     assert!(empty_script.p2pk_public_key().is_none());
 }
 
 #[test]
 fn p2pk_public_key_no_key_returns_none() {
-    let no_push_bytes = Script::builder().push_opcode(OP_CHECKSIG).into_script();
+    let no_push_bytes = script::builder().push_opcode(OP_CHECKSIG).into_script();
     assert!(no_push_bytes.p2pk_public_key().is_none());
 }
 
@@ -146,7 +146,7 @@ fn p2pk_public_key_no_key_returns_none() {
 fn p2pk_public_key_different_op_code_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
     let key = PublicKey::from_str(key_str).unwrap();
-    let different_op_code = Script::builder().push_key(key).push_opcode(OP_NOP).into_script();
+    let different_op_code = script::builder().push_key(key).push_opcode(OP_NOP).into_script();
     assert!(different_op_code.p2pk_public_key().is_none());
 }
 
@@ -154,7 +154,7 @@ fn p2pk_public_key_different_op_code_returns_none() {
 fn p2pk_public_key_incorrect_size_returns_none() {
     let malformed_key = b"21032e58afe51f9ed8ad3cc7897f634d881fdbe49816429ded8156bebd2ffd1";
     let malformed_key_script =
-        Script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
+        script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
     assert!(malformed_key_script.p2pk_public_key().is_none());
 }
 
@@ -162,7 +162,7 @@ fn p2pk_public_key_incorrect_size_returns_none() {
 fn p2pk_public_key_invalid_key_returns_none() {
     let malformed_key = b"21032e58afe51f9ed8ad3cc7897f634d881fdbe49816429ded8156bebd2ffd1ux";
     let invalid_key_script =
-        Script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
+        script::builder().push_slice(malformed_key).push_opcode(OP_CHECKSIG).into_script();
     assert!(invalid_key_script.p2pk_public_key().is_none());
 }
 
@@ -170,7 +170,7 @@ fn p2pk_public_key_invalid_key_returns_none() {
 fn p2pk_public_key_compressed_key_returns_some() {
     let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
     let key = PublicKey::from_str(compressed_key_str).unwrap();
-    let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
+    let p2pk = script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_public_key().unwrap();
     assert_eq!(actual, key);
 }

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -15,6 +15,7 @@ use secp256k1::{Secp256k1, Verification};
 use super::witness_version::WitnessVersion;
 use super::{PushBytes, Script, WScriptHash, WitnessScriptSizeError};
 use crate::crypto::key::{CompressedPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
+use crate::script::ScriptExt as _;
 use crate::taproot::TapNodeHash;
 
 /// The minimum byte size of a segregated witness program.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -23,7 +23,7 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::locktime::absolute::{self, Height, Time};
 use crate::prelude::{Borrow, Vec};
-use crate::script::{Script, ScriptBuf};
+use crate::script::{Script, ScriptBuf, ScriptExt as _};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -27,7 +27,7 @@ use crate::script::{Script, ScriptBuf};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
-use crate::{Amount, FeeRate, SignedAmount, VarInt};
+use crate::{script, Amount, FeeRate, SignedAmount, VarInt};
 
 hashes::hash_newtype! {
     /// A bitcoin transaction hash/transaction ID.
@@ -756,7 +756,7 @@ impl Transaction {
         fn count_sigops(prevout: &TxOut, input: &TxIn) -> usize {
             let mut count: usize = 0;
             if prevout.script_pubkey.is_p2sh() {
-                if let Some(redeem) = input.script_sig.last_pushdata() {
+                if let Some(redeem) = script::last_pushdata(&input.script_sig) {
                     count =
                         count.saturating_add(Script::from_bytes(redeem.as_bytes()).count_sigops());
                 }
@@ -802,7 +802,7 @@ impl Transaction {
             } else if prevout.script_pubkey.is_p2sh() && script_sig.is_push_only() {
                 // If prevout is P2SH and scriptSig is push only
                 // then we wrap the last push (redeemScript) in a Script
-                if let Some(push_bytes) = script_sig.last_pushdata() {
+                if let Some(push_bytes) = script::last_pushdata(script_sig) {
                     Script::from_bytes(push_bytes.as_bytes())
                 } else {
                     return 0;

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -13,6 +13,8 @@ use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::crypto::ecdsa;
 use crate::prelude::Vec;
+#[cfg(doc)]
+use crate::script::ScriptExt as _;
 use crate::taproot::{self, TAPROOT_ANNEX_PREFIX};
 use crate::{Script, VarInt};
 

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -25,6 +25,7 @@ use crate::crypto::key::{PrivateKey, PublicKey};
 use crate::crypto::{ecdsa, taproot};
 use crate::key::{TapTweak, XOnlyPublicKey};
 use crate::prelude::{btree_map, BTreeMap, BTreeSet, Borrow, Box, Vec};
+use crate::script::ScriptExt as _;
 use crate::sighash::{self, EcdsaSighashType, Prevouts, SighashCache};
 use crate::transaction::{self, Transaction, TxOut};
 use crate::{Amount, FeeRate, TapLeafHash, TapSighashType};

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -7,6 +7,7 @@ use bitcoin::bip32::{DerivationPath, Fingerprint};
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::opcodes::all::OP_CHECKSIG;
 use bitcoin::psbt::{GetKey, Input, KeyRequest, PsbtSighashType, SignError};
+use bitcoin::script::ScriptExt as _;
 use bitcoin::taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::transaction::Version;
 use bitcoin::{

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -1,6 +1,7 @@
 use bitcoin::address::Address;
 use bitcoin::consensus::encode;
-use bitcoin::{script, Network};
+use bitcoin::script::{self, ScriptExt as _};
+use bitcoin::Network;
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
+++ b/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use bitcoin::script::ScriptExt as _;
 use honggfuzz::fuzz;
 
 // faster than String, we don't need to actually produce the value, just check absence of panics


### PR DESCRIPTION
Consider reading #3143 before looking at this.

Turns out `rustfmt` will not re-indent stuff in a macro. So this is the `ScriptExt` stuff from #3099 broken up into painfully small pieces.

This is a test run for the dev methodology, so far I'm not happy because:

- Its a punish to rebase and work out which patch broke to get past CI.
- Its going to choke your CI machine Andrew.
- I'm sure I'll miss something and then we will have to repeat.