### PR TITLE
Manually format

### DIFF
--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -113,7 +113,8 @@ impl ScriptBuf {
                 self.0.push((n % 0x100) as u8);
                 self.0.push((n / 0x100) as u8);
             }
-            n => {              // `PushBytes` enforces len < 0x100000000
+            // `PushBytes` enforces len < 0x100000000
+            n => {
                 self.0.push(opcodes::Ordinary::OP_PUSHDATA4.to_u8());
                 self.0.push((n % 0x100) as u8);
                 self.0.push(((n / 0x100) % 0x100) as u8);

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -197,7 +197,6 @@ macro_rules! hash_type {
                 <Self as crate::GeneralHash>::hash_byte_chunks(byte_slices)
             }
 
-
             /// Hashes the entire contents of the `reader`.
             #[cfg(feature = "bitcoin-io")]
             pub fn hash_reader<R: io::BufRead>(reader: &mut R) -> Result<Self, io::Error> {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -247,8 +247,9 @@ pub trait GeneralHash: Hash {
             let bytes = reader.fill_buf()?;
 
             let read = bytes.len();
-            if read == 0 {      // Empty slice means EOF.
-                break
+            // Empty slice means EOF.
+            if read == 0 {
+                break;
             }
 
             engine.input(bytes);
@@ -352,9 +353,6 @@ mod tests {
     #[test]
     fn hash_reader() {
         let mut reader: &[u8] = b"hello";
-        assert_eq!(
-            sha256::Hash::hash_reader(&mut reader).unwrap(),
-            sha256::Hash::hash(b"hello"),
-        )
+        assert_eq!(sha256::Hash::hash_reader(&mut reader).unwrap(), sha256::Hash::hash(b"hello"),)
     }
 }

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -104,8 +104,9 @@ where
             let bytes = reader.fill_buf()?;
 
             let read = bytes.len();
-            if read == 0 {      // Empty slice means EOF.
-                break
+            // Empty slice means EOF.
+            if read == 0 {
+                break;
             }
 
             engine.input(bytes);


### PR DESCRIPTION
Run `rustfmt` and manually fix the places where comments are moved to the wrong place.