### PR TITLE
Remove build cfg for versions less than MSRV

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -89,4 +89,4 @@ required-features = ["rand-std"]
 name = "sighash"
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(mutate)', 'cfg(rust_v_1_60)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(mutate)'] }

--- a/bitcoin/build.rs
+++ b/bitcoin/build.rs
@@ -1,4 +1,4 @@
-const MSRV_MINOR: u64 = 56;
+const MSRV_MINOR: u64 = 63;
 
 fn main() {
     let rustc = std::env::var_os("RUSTC");

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -58,7 +58,7 @@ pub mod witness_program;
 pub mod witness_version;
 
 use alloc::rc::Rc;
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
 use core::cmp::Ordering;
 use core::fmt;
@@ -366,7 +366,7 @@ impl<'a> From<&'a Script> for Cow<'a, Script> {
 }
 
 /// Note: This will fail to compile on old Rust for targets that don't support atomics
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 impl<'a> From<&'a Script> for Arc<Script> {
     fn from(value: &'a Script) -> Self {
         let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -820,7 +820,7 @@ impl<T: Encodable> Encodable for rc::Rc<T> {
 }
 
 /// Note: This will fail to compile on old Rust for targets that don't support atomics
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 impl<T: Encodable> Encodable for sync::Arc<T> {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         (**self).consensus_encode(w)

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -143,7 +143,7 @@ mod prelude {
     #[cfg(all(not(feature = "std"), not(test)))]
     pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, slice, rc};
 
-    #[cfg(all(not(feature = "std"), not(test), any(not(rust_v_1_60), target_has_atomic = "ptr")))]
+    #[cfg(all(not(feature = "std"), not(test), target_has_atomic = "ptr"))]
     pub use alloc::sync;
 
     #[cfg(any(feature = "std", test))]

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -34,4 +34,4 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(rust_v_1_64)', 'cfg(rust_v_1_61)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(rust_v_1_64)'] }

--- a/internals/build.rs
+++ b/internals/build.rs
@@ -1,4 +1,4 @@
-const MSRV_MINOR: u64 = 56;
+const MSRV_MINOR: u64 = 63;
 
 fn main() {
     let rustc = std::env::var_os("RUSTC");

--- a/internals/src/array_vec.rs
+++ b/internals/src/array_vec.rs
@@ -22,36 +22,25 @@ mod safety_boundary {
     }
 
     impl<T: Copy, const CAP: usize> ArrayVec<T, CAP> {
-        // The bounds are const-unstable until 1.61
-        cond_const! {
-            /// Creates an empty `ArrayVec`.
-            pub const(in rust_v_1_61 = "1.61") fn new() -> Self {
-                Self {
-                    len: 0,
-                    data: [MaybeUninit::uninit(); CAP],
-                }
+        /// Creates an empty `ArrayVec`.
+        pub const fn new() -> Self { Self { len: 0, data: [MaybeUninit::uninit(); CAP] } }
+
+        /// Creates an `ArrayVec` initialized with the contets of `slice`.
+        ///
+        /// # Panics
+        ///
+        /// If the slice is longer than `CAP`.
+        pub const fn from_slice(slice: &[T]) -> Self {
+            assert!(slice.len() <= CAP);
+            let mut data = [MaybeUninit::uninit(); CAP];
+            let mut i = 0;
+            // can't use mutable references and operators in const
+            while i < slice.len() {
+                data[i] = MaybeUninit::new(slice[i]);
+                i += 1;
             }
 
-            /// Creates an `ArrayVec` initialized with the contets of `slice`.
-            ///
-            /// # Panics
-            ///
-            /// If the slice is longer than `CAP`.
-            pub const(in rust_v_1_61 = "1.61") fn from_slice(slice: &[T]) -> Self {
-                assert!(slice.len() <= CAP);
-                let mut data = [MaybeUninit::uninit(); CAP];
-                let mut i = 0;
-                // can't use mutable references and operators in const
-                while i < slice.len() {
-                    data[i] = MaybeUninit::new(slice[i]);
-                    i += 1;
-                }
-
-                Self {
-                    len: slice.len(),
-                    data,
-                }
-            }
+            Self { len: slice.len(), data }
         }
 
         // from_raw_parts is const-unstable until 1.64


### PR DESCRIPTION
Recently we upgraded the MSRV but forgot to remove the Rust version specific `cfg`s.