### PR TITLE
Move `Script` and `ScriptBuf` to `primitives`

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -89,4 +89,4 @@ required-features = ["rand-std"]
 name = "sighash"
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(mutate)', 'cfg(rust_v_1_60)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(mutate)'] }

--- a/bitcoin/build.rs
+++ b/bitcoin/build.rs
@@ -1,4 +1,4 @@
-const MSRV_MINOR: u64 = 56;
+const MSRV_MINOR: u64 = 63;
 
 fn main() {
     let rustc = std::env::var_os("RUSTC");

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -1,4 +1,5 @@
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
+use bitcoin::script::ScriptExt as _;
 use bitcoin::{
     consensus, ecdsa, sighash, Amount, CompressedPublicKey, Script, ScriptBuf, Transaction,
 };

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -84,6 +84,7 @@ use bitcoin::consensus::encode;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
 use bitcoin::psbt::{self, Input, Output, Psbt, PsbtSighashType};
+use bitcoin::script::ScriptExt as _;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::{self, SighashCache, TapSighash, TapSighashType};
 use bitcoin::taproot::{self, LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo};

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -51,7 +51,8 @@ use crate::prelude::{String, ToOwned};
 use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{
-    self, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
+    self, RedeemScriptSizeError, Script, ScriptBuf, ScriptExt as _, ScriptHash, WScriptHash,
+    WitnessScriptSizeError,
 };
 use crate::taproot::TapNodeHash;
 

--- a/bitcoin/src/address/script_pubkey.rs
+++ b/bitcoin/src/address/script_pubkey.rs
@@ -22,7 +22,7 @@ define_extension_trait! {
     /// Extension functionality to add scriptPubkey support to the [`Builder`] type.
     pub trait BuilderExt impl for Builder {
         /// Adds instructions to push a public key onto the stack.
-        fn push_key(self, key: PublicKey) -> Builder {
+        fn push_key(self: Self, key: PublicKey) -> Builder {
             if key.compressed {
                 self.push_slice(key.inner.serialize())
             } else {
@@ -31,7 +31,7 @@ define_extension_trait! {
         }
 
         /// Adds instructions to push an XOnly public key onto the stack.
-        fn push_x_only_key(self, x_only_key: XOnlyPublicKey) -> Builder {
+        fn push_x_only_key(self: Self, x_only_key: XOnlyPublicKey) -> Builder {
             self.push_slice(x_only_key.serialize())
         }
     }
@@ -42,14 +42,14 @@ define_extension_trait! {
     pub trait ScriptExt impl for Script {
         /// Computes the P2WSH output corresponding to this witnessScript (aka the "witness redeem
         /// script").
-        fn to_p2wsh(&self) -> Result<ScriptBuf, WitnessScriptSizeError> {
+        fn to_p2wsh(self: &Self) -> Result<ScriptBuf, WitnessScriptSizeError> {
             self.wscript_hash().map(ScriptBuf::new_p2wsh)
         }
 
         /// Computes P2TR output with a given internal key and a single script spending path equal to
         /// the current script, assuming that the script is a Tapscript.
         fn to_p2tr<C: Verification>(
-            &self,
+            self: &Self,
             secp: &Secp256k1<C>,
             internal_key: UntweakedPublicKey,
         ) -> ScriptBuf {
@@ -59,7 +59,7 @@ define_extension_trait! {
         }
 
         /// Computes the P2SH output corresponding to this redeem script.
-        fn to_p2sh(&self) -> Result<ScriptBuf, RedeemScriptSizeError> {
+        fn to_p2sh(self: &Self) -> Result<ScriptBuf, RedeemScriptSizeError> {
             self.script_hash().map(ScriptBuf::new_p2sh)
         }
 
@@ -67,7 +67,7 @@ define_extension_trait! {
         /// for a P2WPKH output. The `scriptCode` is described in [BIP143].
         ///
         /// [BIP143]: <https://github.com/bitcoin/bips/blob/99701f68a88ce33b2d0838eb84e115cef505b4c2/bip-0143.mediawiki>
-        fn p2wpkh_script_code(&self) -> Option<ScriptBuf> {
+        fn p2wpkh_script_code(self: &Self) -> Option<ScriptBuf> {
             if self.is_p2wpkh() {
                 // The `self` script is 0x00, 0x14, <pubkey_hash>
                 let bytes = &self.as_bytes()[2..];
@@ -82,14 +82,14 @@ define_extension_trait! {
         ///
         /// You can obtain the public key, if its valid,
         /// by calling [`p2pk_public_key()`](Self::p2pk_public_key)
-        fn is_p2pk(&self) -> bool { self.p2pk_pubkey_bytes().is_some() }
+        fn is_p2pk(self: &Self) -> bool { self.p2pk_pubkey_bytes().is_some() }
 
         /// Returns the public key if this script is P2PK with a **valid** public key.
         ///
         /// This may return `None` even when [`is_p2pk()`](Self::is_p2pk) returns true.
         /// This happens when the public key is invalid (e.g. the point not being on the curve).
         /// In this situation the script is unspendable.
-        fn p2pk_public_key(&self) -> Option<PublicKey> {
+        fn p2pk_public_key(self: &Self) -> Option<PublicKey> {
             PublicKey::from_slice(self.p2pk_pubkey_bytes()?).ok()
         }
     }
@@ -98,7 +98,7 @@ define_extension_trait! {
 define_extension_trait! {
     pub(crate) trait ScriptExtPrivate impl for Script {
         /// Returns the bytes of the (possibly invalid) public key if this script is P2PK.
-        fn p2pk_pubkey_bytes(&self) -> Option<&[u8]> {
+        fn p2pk_pubkey_bytes(self: &Self) -> Option<&[u8]> {
             match self.len() {
                 67 if self.as_bytes()[0] == OP_PUSHBYTES_65.to_u8()
                     && self.as_bytes()[66] == OP_CHECKSIG.to_u8() =>

--- a/bitcoin/src/address/script_pubkey.rs
+++ b/bitcoin/src/address/script_pubkey.rs
@@ -13,8 +13,8 @@ use crate::opcodes::all::*;
 use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{
-    self, Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash,
-    WitnessScriptSizeError,
+    self, Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptExt as _, ScriptHash,
+    WScriptHash, WitnessScriptSizeError,
 };
 use crate::taproot::TapNodeHash;
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -49,7 +49,7 @@ use crate::consensus::encode::VarInt;
 use crate::consensus::{Decodable, Encodable};
 use crate::internal_macros::impl_hashencode;
 use crate::prelude::{BTreeSet, Borrow, Vec};
-use crate::script::Script;
+use crate::script::{Script, ScriptExt as _};
 use crate::transaction::OutPoint;
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -19,8 +19,9 @@ use crate::merkle_tree::{MerkleNode as _, TxMerkleNode, WitnessMerkleNode};
 use crate::network::Params;
 use crate::pow::{CompactTarget, Target, Work};
 use crate::prelude::Vec;
+use crate::script::{self, ScriptExt as _};
 use crate::transaction::{Transaction, Wtxid};
-use crate::{script, VarInt};
+use crate::VarInt;
 
 hashes::hash_newtype! {
     /// A bitcoin block hash.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -66,7 +66,7 @@ use crate::FeeRate;
 ///
 #[derive(PartialOrd, Ord, PartialEq, Eq, Hash)]
 #[repr(transparent)]
-pub struct Script(pub(in crate::blockdata::script) [u8]);
+pub struct Script(pub(in super) [u8]);
 
 impl ToOwned for Script {
     type Owned = ScriptBuf;
@@ -551,7 +551,7 @@ fn count_sigops_internal(script: &Script, accurate: bool) -> usize {
 /// Iterates the script to find the last opcode.
 ///
 /// Returns `None` is the instruction is data push or if the script is empty.
-pub(in crate::blockdata::script) fn last_opcode(script: &Script) -> Option<Opcode> {
+pub(in super) fn last_opcode(script: &Script) -> Option<Opcode> {
     match script.instructions().last() {
         Some(Ok(Instruction::Op(op))) => Some(op),
         _ => None,

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -370,7 +370,7 @@ impl Script {
     ///
     /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
     pub fn minimal_non_dust(&self) -> crate::Amount {
-        self.minimal_non_dust_internal(DUST_RELAY_TX_FEE.into())
+        minimal_non_dust_internal(self, DUST_RELAY_TX_FEE.into())
     }
 
     /// Returns the minimum value an output with this script should have in order to be
@@ -385,30 +385,7 @@ impl Script {
     ///
     /// [`minimal_non_dust`]: Script::minimal_non_dust
     pub fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
-        self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu() * 4)
-    }
-
-    fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> crate::Amount {
-        // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
-        // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
-        let sats = dust_relay_fee
-            .checked_mul(if self.is_op_return() {
-                0
-            } else if self.is_witness_program() {
-                32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
-                    8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
-            } else {
-                32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
-                    8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
-            })
-            .expect("dust_relay_fee or script length should not be absurdly large")
-            / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE
-                    // Note: We ensure the division happens at the end, since Core performs the division at the end.
-                    //       This will make sure none of the implicit floor operations mess with the value.
-
-        crate::Amount::from_sat(sats)
+        minimal_non_dust_internal(self, dust_relay_fee.to_sat_per_kwu() * 4)
     }
 
     /// Counts the sigops for this Script using accurate counting.
@@ -565,6 +542,29 @@ impl Script {
             _ => None,
         }
     }
+}
+
+fn minimal_non_dust_internal(script: &Script, dust_relay_fee: u64) -> crate::Amount {
+    // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
+    // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
+    let sats = dust_relay_fee
+        .checked_mul(if script.is_op_return() {
+            0
+        } else if script.is_witness_program() {
+            32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
+                8 + // The serialized size of the TxOut's amount field
+                script.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+        } else {
+            32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
+                8 + // The serialized size of the TxOut's amount field
+                script.consensus_encode(&mut sink()).expect("sinks don't error") as u64 // The serialized size of this script_pubkey
+        })
+        .expect("dust_relay_fee or script length should not be absurdly large")
+        / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE
+                // Note: We ensure the division happens at the end, since Core performs the division at the end.
+                //       This will make sure none of the implicit floor operations mess with the value.
+
+    crate::Amount::from_sat(sats)
 }
 
 /// Iterator over bytes of a script

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -169,13 +169,13 @@ define_extension_trait! {
         /// > special meaning. The value of the first push is called the "version byte". The following
         /// > byte vector pushed is called the "witness program".
         fn witness_version(self: &Self) -> Option<WitnessVersion> {
-            let script_len = self.0.len();
+            let script_len = self.len();
             if !(4..=42).contains(&script_len) {
                 return None;
             }
 
-            let ver_opcode = Opcode::from(self.0[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
-            let push_opbyte = self.0[1]; // Second byte push opcode 2-40 bytes
+            let ver_opcode = Opcode::from(self.as_bytes()[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
+            let push_opbyte = self.as_bytes()[1]; // Second byte push opcode 2-40 bytes
 
             if push_opbyte < OP_PUSHBYTES_2.to_u8() || push_opbyte > OP_PUSHBYTES_40.to_u8() {
                 return None;
@@ -190,20 +190,20 @@ define_extension_trait! {
 
         /// Checks whether a script pubkey is a P2SH output.
         fn is_p2sh(self: &Self) -> bool {
-            self.0.len() == 23
-                && self.0[0] == OP_HASH160.to_u8()
-                && self.0[1] == OP_PUSHBYTES_20.to_u8()
-                && self.0[22] == OP_EQUAL.to_u8()
+            self.len() == 23
+                && self.as_bytes()[0] == OP_HASH160.to_u8()
+                && self.as_bytes()[1] == OP_PUSHBYTES_20.to_u8()
+                && self.as_bytes()[22] == OP_EQUAL.to_u8()
         }
 
         /// Checks whether a script pubkey is a P2PKH output.
         fn is_p2pkh(self: &Self) -> bool {
-            self.0.len() == 25
-                && self.0[0] == OP_DUP.to_u8()
-                && self.0[1] == OP_HASH160.to_u8()
-                && self.0[2] == OP_PUSHBYTES_20.to_u8()
-                && self.0[23] == OP_EQUALVERIFY.to_u8()
-                && self.0[24] == OP_CHECKSIG.to_u8()
+            self.len() == 25
+                && self.as_bytes()[0] == OP_DUP.to_u8()
+                && self.as_bytes()[1] == OP_HASH160.to_u8()
+                && self.as_bytes()[2] == OP_PUSHBYTES_20.to_u8()
+                && self.as_bytes()[23] == OP_EQUALVERIFY.to_u8()
+                && self.as_bytes()[24] == OP_CHECKSIG.to_u8()
         }
 
         /// Checks whether a script is push only.
@@ -280,23 +280,23 @@ define_extension_trait! {
 
         /// Checks whether a script pubkey is a P2WSH output.
         fn is_p2wsh(self: &Self) -> bool {
-            self.0.len() == 34
+            self.len() == 34
                 && self.witness_version() == Some(WitnessVersion::V0)
-                && self.0[1] == OP_PUSHBYTES_32.to_u8()
+                && self.as_bytes()[1] == OP_PUSHBYTES_32.to_u8()
         }
 
         /// Checks whether a script pubkey is a P2WPKH output.
         fn is_p2wpkh(self: &Self) -> bool {
-            self.0.len() == 22
+            self.len() == 22
                 && self.witness_version() == Some(WitnessVersion::V0)
-                && self.0[1] == OP_PUSHBYTES_20.to_u8()
+                && self.as_bytes()[1] == OP_PUSHBYTES_20.to_u8()
         }
 
         /// Checks whether a script pubkey is a P2TR output.
         fn is_p2tr(self: &Self) -> bool {
-            self.0.len() == 34
+            self.len() == 34
                 && self.witness_version() == Some(WitnessVersion::V1)
-                && self.0[1] == OP_PUSHBYTES_32.to_u8()
+                && self.as_bytes()[1] == OP_PUSHBYTES_32.to_u8()
         }
 
         /// Check if this is a consensus-valid OP_RETURN output.
@@ -304,7 +304,7 @@ define_extension_trait! {
         /// To validate if the OP_RETURN obeys Bitcoin Core's current standardness policy, use
         /// [`is_standard_op_return()`](Self::is_standard_op_return) instead.
         fn is_op_return(self: &Self) -> bool {
-            match self.0.first() {
+            match self.as_bytes().first() {
                 Some(b) => *b == OP_RETURN.to_u8(),
                 None => false,
             }
@@ -314,7 +314,7 @@ define_extension_trait! {
         ///
         /// What this function considers to be standard may change without warning pending Bitcoin Core
         /// changes.
-        fn is_standard_op_return(self: &Self) -> bool { self.is_op_return() && self.0.len() <= 80 }
+        fn is_standard_op_return(self: &Self) -> bool { self.is_op_return() && self.len() <= 80 }
 
 
         /// Checks whether a script is trivially known to have no satisfying input.
@@ -328,7 +328,7 @@ define_extension_trait! {
         fn is_provably_unspendable(self: &Self) -> bool {
             use crate::opcodes::Class::{IllegalOp, ReturnOp};
 
-            match self.0.first() {
+            match self.as_bytes().first() {
                 Some(b) => {
                     let first = Opcode::from(*b);
                     let class = first.classify(opcodes::ClassifyContext::Legacy);
@@ -429,7 +429,7 @@ define_extension_trait! {
         ///
         /// To force minimal pushes, use [`instructions_minimal`](Self::instructions_minimal).
         fn instructions(self: &Self) -> Instructions {
-            Instructions { data: self.0.iter(), enforce_minimal: false }
+            Instructions { data: self.as_bytes().iter(), enforce_minimal: false }
         }
 
         /// Iterates over the script instructions while enforcing minimal pushes.
@@ -437,7 +437,7 @@ define_extension_trait! {
         /// This is similar to [`instructions`](Self::instructions) but an error is returned if a push
         /// is not minimal.
         fn instructions_minimal(self: &Self) -> Instructions {
-            Instructions { data: self.0.iter(), enforce_minimal: true }
+            Instructions { data: self.as_bytes().iter(), enforce_minimal: true }
         }
 
         /// Iterates over the script instructions and their indices.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -135,26 +135,22 @@ impl Script {
 
 impl Script {
     /// Returns an iterator over script bytes.
-    #[inline]
     pub fn bytes(&self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
 
     /// Creates a new script builder
     pub fn builder() -> Builder { Builder::new() }
 
     /// Returns 160-bit hash of the script for P2SH outputs.
-    #[inline]
     pub fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError> {
         ScriptHash::from_script(self)
     }
 
     /// Returns 256-bit hash of the script for P2WSH outputs.
-    #[inline]
     pub fn wscript_hash(&self) -> Result<WScriptHash, WitnessScriptSizeError> {
         WScriptHash::from_script(self)
     }
 
     /// Computes leaf hash of tapscript.
-    #[inline]
     pub fn tapscript_leaf_hash(&self) -> TapLeafHash {
         TapLeafHash::from_script(self, LeafVersion::TapScript)
     }
@@ -169,7 +165,6 @@ impl Script {
     /// > push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
     /// > special meaning. The value of the first push is called the "version byte". The following
     /// > byte vector pushed is called the "witness program".
-    #[inline]
     pub fn witness_version(&self) -> Option<WitnessVersion> {
         let script_len = self.0.len();
         if !(4..=42).contains(&script_len) {
@@ -191,7 +186,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2SH output.
-    #[inline]
     pub fn is_p2sh(&self) -> bool {
         self.0.len() == 23
             && self.0[0] == OP_HASH160.to_u8()
@@ -200,7 +194,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2PKH output.
-    #[inline]
     pub fn is_p2pkh(&self) -> bool {
         self.0.len() == 25
             && self.0[0] == OP_DUP.to_u8()
@@ -214,7 +207,6 @@ impl Script {
     ///
     /// Note: `OP_RESERVED` (`0x50`) and all the OP_PUSHNUM operations
     /// are considered push operations.
-    #[inline]
     pub fn is_push_only(&self) -> bool {
         for inst in self.instructions() {
             match inst {
@@ -235,7 +227,6 @@ impl Script {
     /// is of the form:
     ///
     ///    `2 <pubkey1> <pubkey2> <pubkey3> 3 OP_CHECKMULTISIG`
-    #[inline]
     pub fn is_multisig(&self) -> bool {
         let required_sigs;
 
@@ -283,11 +274,9 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
-    #[inline]
     pub fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
 
     /// Checks whether a script pubkey is a P2WSH output.
-    #[inline]
     pub fn is_p2wsh(&self) -> bool {
         self.0.len() == 34
             && self.witness_version() == Some(WitnessVersion::V0)
@@ -295,7 +284,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2WPKH output.
-    #[inline]
     pub fn is_p2wpkh(&self) -> bool {
         self.0.len() == 22
             && self.witness_version() == Some(WitnessVersion::V0)
@@ -303,7 +291,6 @@ impl Script {
     }
 
     /// Checks whether a script pubkey is a P2TR output.
-    #[inline]
     pub fn is_p2tr(&self) -> bool {
         self.0.len() == 34
             && self.witness_version() == Some(WitnessVersion::V1)
@@ -314,7 +301,6 @@ impl Script {
     ///
     /// To validate if the OP_RETURN obeys Bitcoin Core's current standardness policy, use
     /// [`is_standard_op_return()`](Self::is_standard_op_return) instead.
-    #[inline]
     pub fn is_op_return(&self) -> bool {
         match self.0.first() {
             Some(b) => *b == OP_RETURN.to_u8(),
@@ -326,7 +312,6 @@ impl Script {
     ///
     /// What this function considers to be standard may change without warning pending Bitcoin Core
     /// changes.
-    #[inline]
     pub fn is_standard_op_return(&self) -> bool { self.is_op_return() && self.0.len() <= 80 }
 
     /// Checks whether a script is trivially known to have no satisfying input.
@@ -337,7 +322,6 @@ impl Script {
         since = "0.32.0",
         note = "The method has potentially confusing semantics and is going to be removed, you might want `is_op_return`"
     )]
-    #[inline]
     pub fn is_provably_unspendable(&self) -> bool {
         use crate::opcodes::Class::{IllegalOp, ReturnOp};
 
@@ -504,7 +488,6 @@ impl Script {
     /// the script as sequence of bytes call the [`bytes`](Self::bytes) method.
     ///
     /// To force minimal pushes, use [`instructions_minimal`](Self::instructions_minimal).
-    #[inline]
     pub fn instructions(&self) -> Instructions {
         Instructions { data: self.0.iter(), enforce_minimal: false }
     }
@@ -513,7 +496,6 @@ impl Script {
     ///
     /// This is similar to [`instructions`](Self::instructions) but an error is returned if a push
     /// is not minimal.
-    #[inline]
     pub fn instructions_minimal(&self) -> Instructions {
         Instructions { data: self.0.iter(), enforce_minimal: true }
     }
@@ -525,7 +507,6 @@ impl Script {
     /// opcode or data push.
     ///
     /// To force minimal pushes, use [`Self::instruction_indices_minimal`].
-    #[inline]
     pub fn instruction_indices(&self) -> InstructionIndices {
         InstructionIndices::from_instructions(self.instructions())
     }
@@ -534,7 +515,6 @@ impl Script {
     ///
     /// This is similar to [`instruction_indices`](Self::instruction_indices) but an error is
     /// returned if a push is not minimal.
-    #[inline]
     pub fn instruction_indices_minimal(&self) -> InstructionIndices {
         InstructionIndices::from_instructions(self.instructions_minimal())
     }

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -1,138 +1,20 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use core::fmt;
-use core::ops::{
-    Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
-};
+use primitives::script::Script;
 
 use super::witness_version::WitnessVersion;
 use super::{
-    bytes_to_asm_fmt, Builder, Instruction, InstructionIndices, Instructions, PushBytes,
-    RedeemScriptSizeError, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
+    Builder, Instruction, InstructionIndices, Instructions, PushBytes, RedeemScriptSizeError,
+    ScriptHash, WScriptHash, WitnessScriptSizeError,
 };
 use crate::consensus::Encodable;
 use crate::internal_macros::define_extension_trait;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::policy::DUST_RELAY_TX_FEE;
-use crate::prelude::{sink, Box, DisplayHex, String, ToOwned, Vec};
+use crate::prelude::{sink, DisplayHex, String};
 use crate::taproot::{LeafVersion, TapLeafHash};
 use crate::FeeRate;
-
-/// Bitcoin script slice.
-///
-/// *[See also the `bitcoin::script` module](super).*
-///
-/// `Script` is a script slice, the most primitive script type. It's usually seen in its borrowed
-/// form `&Script`. It is always encoded as a series of bytes representing the opcodes and data
-/// pushes.
-///
-/// ## Validity
-///
-/// `Script` does not have any validity invariants - it's essentially just a marked slice of
-/// bytes. This is similar to [`Path`](std::path::Path) vs [`OsStr`](std::ffi::OsStr) where they
-/// are trivially cast-able to each-other and `Path` doesn't guarantee being a usable FS path but
-/// having a newtype still has value because of added methods, readability and basic type checking.
-///
-/// Although at least data pushes could be checked not to overflow the script, bad scripts are
-/// allowed to be in a transaction (outputs just become unspendable) and there even are such
-/// transactions in the chain. Thus we must allow such scripts to be placed in the transaction.
-///
-/// ## Slicing safety
-///
-/// Slicing is similar to how `str` works: some ranges may be incorrect and indexing by
-/// `usize` is not supported. However, as opposed to `std`, we have no way of checking
-/// correctness without causing linear complexity so there are **no panics on invalid
-/// ranges!** If you supply an invalid range, you'll get a garbled script.
-///
-/// The range is considered valid if it's at a boundary of instruction. Care must be taken
-/// especially with push operations because you could get a reference to arbitrary
-/// attacker-supplied bytes that look like a valid script.
-///
-/// It is recommended to use `.instructions()` method to get an iterator over script
-/// instructions and work with that instead.
-///
-/// ## Memory safety
-///
-/// The type is `#[repr(transparent)]` for internal purposes only!
-/// No consumer crate may rely on the representation of the struct!
-///
-/// ## References
-///
-///
-/// ### Bitcoin Core References
-///
-/// * [CScript definition](https://github.com/bitcoin/bitcoin/blob/d492dc1cdaabdc52b0766bf4cba4bd73178325d0/src/script/script.h#L410)
-///
-#[derive(PartialOrd, Ord, PartialEq, Eq, Hash)]
-#[repr(transparent)]
-pub struct Script(pub(in super) [u8]);
-
-impl ToOwned for Script {
-    type Owned = ScriptBuf;
-
-    fn to_owned(&self) -> Self::Owned { ScriptBuf(self.0.to_owned()) }
-}
-
-impl Script {
-    /// Creates a new empty script.
-    #[inline]
-    pub fn new() -> &'static Script { Script::from_bytes(&[]) }
-
-    /// Treat byte slice as `Script`
-    #[inline]
-    pub fn from_bytes(bytes: &[u8]) -> &Script {
-        // SAFETY: copied from `std`
-        // The pointer was just created from a reference which is still alive.
-        // Casting slice pointer to a transparent struct wrapping that slice is sound (same
-        // layout).
-        unsafe { &*(bytes as *const [u8] as *const Script) }
-    }
-
-    /// Treat mutable byte slice as `Script`
-    #[inline]
-    pub fn from_bytes_mut(bytes: &mut [u8]) -> &mut Script {
-        // SAFETY: copied from `std`
-        // The pointer was just created from a reference which is still alive.
-        // Casting slice pointer to a transparent struct wrapping that slice is sound (same
-        // layout).
-        // Function signature prevents callers from accessing `bytes` while the returned reference
-        // is alive.
-        unsafe { &mut *(bytes as *mut [u8] as *mut Script) }
-    }
-
-    /// Returns the script data as a byte slice.
-    #[inline]
-    pub fn as_bytes(&self) -> &[u8] { &self.0 }
-
-    /// Returns the script data as a mutable byte slice.
-    #[inline]
-    pub fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self.0 }
-
-    /// Returns the length in bytes of the script.
-    #[inline]
-    pub fn len(&self) -> usize { self.0.len() }
-
-    /// Returns whether the script is the empty script.
-    #[inline]
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
-
-    /// Returns a copy of the script data.
-    #[inline]
-    pub fn to_bytes(&self) -> Vec<u8> { self.0.to_owned() }
-
-    /// Converts a [`Box<Script>`](Box) into a [`ScriptBuf`] without copying or allocating.
-    #[must_use = "`self` will be dropped if the result is not used"]
-    pub fn into_script_buf(self: Box<Self>) -> ScriptBuf {
-        let rw = Box::into_raw(self) as *mut [u8];
-        // SAFETY: copied from `std`
-        // The pointer was just created from a box without deallocating
-        // Casting a transparent struct wrapping a slice to the slice pointer is sound (same
-        // layout).
-        let inner = unsafe { Box::from_raw(rw) };
-        ScriptBuf(Vec::from(inner))
-    }
-}
 
 define_extension_trait! {
     /// Extension functionality for the [`Script`] type.
@@ -459,18 +341,6 @@ define_extension_trait! {
             InstructionIndices::from_instructions(self.instructions_minimal())
         }
 
-        /// Writes the human-readable assembly representation of the script to the formatter.
-        fn fmt_asm(self: &Self, f: &mut dyn fmt::Write) -> fmt::Result {
-            bytes_to_asm_fmt(self.as_ref(), f)
-        }
-
-        /// Returns the human-readable assembly representation of the script.
-        fn to_asm_string(self: &Self) -> String {
-            let mut buf = String::new();
-            self.fmt_asm(&mut buf).unwrap();
-            buf
-        }
-
         /// Formats the script as lower-case hex.
         ///
         /// This is a more convenient and performant way to write `format!("{:x}", script)`.
@@ -551,7 +421,7 @@ fn count_sigops_internal(script: &Script, accurate: bool) -> usize {
 /// Iterates the script to find the last opcode.
 ///
 /// Returns `None` is the instruction is data push or if the script is empty.
-pub(in super) fn last_opcode(script: &Script) -> Option<Opcode> {
+pub(super) fn last_opcode(script: &Script) -> Option<Opcode> {
     match script.instructions().last() {
         Some(Ok(Instruction::Op(op))) => Some(op),
         _ => None,
@@ -597,29 +467,3 @@ impl DoubleEndedIterator for Bytes<'_> {
 
 impl ExactSizeIterator for Bytes<'_> {}
 impl core::iter::FusedIterator for Bytes<'_> {}
-
-macro_rules! delegate_index {
-    ($($type:ty),* $(,)?) => {
-        $(
-            /// Script subslicing operation - read [slicing safety](#slicing-safety)!
-            impl Index<$type> for Script {
-                type Output = Self;
-
-                #[inline]
-                fn index(&self, index: $type) -> &Self::Output {
-                    Self::from_bytes(&self.0[index])
-                }
-            }
-        )*
-    }
-}
-
-delegate_index!(
-    Range<usize>,
-    RangeFrom<usize>,
-    RangeTo<usize>,
-    RangeFull,
-    RangeInclusive<usize>,
-    RangeToInclusive<usize>,
-    (Bound<usize>, Bound<usize>)
-);

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -479,29 +479,6 @@ impl Script {
     pub fn first_opcode(&self) -> Option<Opcode> {
         self.as_bytes().first().copied().map(From::from)
     }
-
-    /// Iterates the script to find the last opcode.
-    ///
-    /// Returns `None` is the instruction is data push or if the script is empty.
-    pub(in crate::blockdata::script) fn last_opcode(&self) -> Option<Opcode> {
-        match self.instructions().last() {
-            Some(Ok(Instruction::Op(op))) => Some(op),
-            _ => None,
-        }
-    }
-
-    /// Iterates the script to find the last pushdata.
-    ///
-    /// Returns `None` if the instruction is an opcode or if the script is empty.
-    pub(crate) fn last_pushdata(&self) -> Option<&PushBytes> {
-        match self.instructions().last() {
-            // Handles op codes up to (but excluding) OP_PUSHNUM_NEG.
-            Some(Ok(Instruction::PushBytes(bytes))) => Some(bytes),
-            // OP_16 (0x60) and lower are considered "pushes" by Bitcoin Core (excl. OP_RESERVED).
-            // However we are only interested in the pushdata so we can ignore them.
-            _ => None,
-        }
-    }
 }
 
 fn minimal_non_dust_internal(script: &Script, dust_relay_fee: u64) -> crate::Amount {
@@ -565,6 +542,29 @@ fn count_sigops_internal(script: &Script, accurate: bool) -> usize {
     }
 
     n
+}
+
+/// Iterates the script to find the last opcode.
+///
+/// Returns `None` is the instruction is data push or if the script is empty.
+pub(in crate::blockdata::script) fn last_opcode(script: &Script) -> Option<Opcode> {
+    match script.instructions().last() {
+        Some(Ok(Instruction::Op(op))) => Some(op),
+        _ => None,
+    }
+}
+
+/// Iterates the script to find the last pushdata.
+///
+/// Returns `None` if the instruction is an opcode or if the script is empty.
+pub(crate) fn last_pushdata(script: &Script) -> Option<&PushBytes> {
+    match script.instructions().last() {
+        // Handles op codes up to (but excluding) OP_PUSHNUM_NEG.
+        Some(Ok(Instruction::PushBytes(bytes))) => Some(bytes),
+        // OP_16 (0x60) and lower are considered "pushes" by Bitcoin Core (excl. OP_RESERVED).
+        // However we are only interested in the pushdata so we can ignore them.
+        _ => None,
+    }
 }
 
 /// Iterator over bytes of a script

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -11,6 +11,7 @@ use super::{
     RedeemScriptSizeError, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
 };
 use crate::consensus::Encodable;
+use crate::internal_macros::define_extension_trait;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::policy::DUST_RELAY_TX_FEE;
@@ -133,351 +134,354 @@ impl Script {
     }
 }
 
-impl Script {
-    /// Returns an iterator over script bytes.
-    pub fn bytes(&self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
+define_extension_trait! {
+    /// Extension functionality for the [`Script`] type.
+    pub trait ScriptExt impl for Script {
+        /// Returns an iterator over script bytes.
+        fn bytes(self: &Self) -> Bytes<'_> { Bytes(self.as_bytes().iter().copied()) }
 
-    /// Creates a new script builder
-    pub fn builder() -> Builder { Builder::new() }
+        /// Creates a new script builder
+        fn builder() -> Builder { Builder::new() }
 
-    /// Returns 160-bit hash of the script for P2SH outputs.
-    pub fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError> {
-        ScriptHash::from_script(self)
-    }
-
-    /// Returns 256-bit hash of the script for P2WSH outputs.
-    pub fn wscript_hash(&self) -> Result<WScriptHash, WitnessScriptSizeError> {
-        WScriptHash::from_script(self)
-    }
-
-    /// Computes leaf hash of tapscript.
-    pub fn tapscript_leaf_hash(&self) -> TapLeafHash {
-        TapLeafHash::from_script(self, LeafVersion::TapScript)
-    }
-
-    /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
-    ///
-    /// # Returns
-    ///
-    /// The witness version if this script is found to conform to the SegWit rules:
-    ///
-    /// > A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
-    /// > push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
-    /// > special meaning. The value of the first push is called the "version byte". The following
-    /// > byte vector pushed is called the "witness program".
-    pub fn witness_version(&self) -> Option<WitnessVersion> {
-        let script_len = self.0.len();
-        if !(4..=42).contains(&script_len) {
-            return None;
+        /// Returns 160-bit hash of the script for P2SH outputs.
+        fn script_hash(self: &Self) -> Result<ScriptHash, RedeemScriptSizeError> {
+            ScriptHash::from_script(self)
         }
 
-        let ver_opcode = Opcode::from(self.0[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
-        let push_opbyte = self.0[1]; // Second byte push opcode 2-40 bytes
-
-        if push_opbyte < OP_PUSHBYTES_2.to_u8() || push_opbyte > OP_PUSHBYTES_40.to_u8() {
-            return None;
-        }
-        // Check that the rest of the script has the correct size
-        if script_len - 2 != push_opbyte as usize {
-            return None;
+        /// Returns 256-bit hash of the script for P2WSH outputs.
+        fn wscript_hash(self: &Self) -> Result<WScriptHash, WitnessScriptSizeError> {
+            WScriptHash::from_script(self)
         }
 
-        WitnessVersion::try_from(ver_opcode).ok()
-    }
+        /// Computes leaf hash of tapscript.
+        fn tapscript_leaf_hash(self: &Self) -> TapLeafHash {
+            TapLeafHash::from_script(self, LeafVersion::TapScript)
+        }
 
-    /// Checks whether a script pubkey is a P2SH output.
-    pub fn is_p2sh(&self) -> bool {
-        self.0.len() == 23
-            && self.0[0] == OP_HASH160.to_u8()
-            && self.0[1] == OP_PUSHBYTES_20.to_u8()
-            && self.0[22] == OP_EQUAL.to_u8()
-    }
-
-    /// Checks whether a script pubkey is a P2PKH output.
-    pub fn is_p2pkh(&self) -> bool {
-        self.0.len() == 25
-            && self.0[0] == OP_DUP.to_u8()
-            && self.0[1] == OP_HASH160.to_u8()
-            && self.0[2] == OP_PUSHBYTES_20.to_u8()
-            && self.0[23] == OP_EQUALVERIFY.to_u8()
-            && self.0[24] == OP_CHECKSIG.to_u8()
-    }
-
-    /// Checks whether a script is push only.
-    ///
-    /// Note: `OP_RESERVED` (`0x50`) and all the OP_PUSHNUM operations
-    /// are considered push operations.
-    pub fn is_push_only(&self) -> bool {
-        for inst in self.instructions() {
-            match inst {
-                Err(_) => return false,
-                Ok(Instruction::PushBytes(_)) => {}
-                Ok(Instruction::Op(op)) if op.to_u8() <= 0x60 => {}
-                // From Bitcoin Core
-                // if (opcode > OP_PUSHNUM_16 (0x60)) return false
-                Ok(Instruction::Op(_)) => return false,
+        /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
+        ///
+        /// # Returns
+        ///
+        /// The witness version if this script is found to conform to the SegWit rules:
+        ///
+        /// > A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
+        /// > push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
+        /// > special meaning. The value of the first push is called the "version byte". The following
+        /// > byte vector pushed is called the "witness program".
+        fn witness_version(self: &Self) -> Option<WitnessVersion> {
+            let script_len = self.0.len();
+            if !(4..=42).contains(&script_len) {
+                return None;
             }
+
+            let ver_opcode = Opcode::from(self.0[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
+            let push_opbyte = self.0[1]; // Second byte push opcode 2-40 bytes
+
+            if push_opbyte < OP_PUSHBYTES_2.to_u8() || push_opbyte > OP_PUSHBYTES_40.to_u8() {
+                return None;
+            }
+            // Check that the rest of the script has the correct size
+            if script_len - 2 != push_opbyte as usize {
+                return None;
+            }
+
+            WitnessVersion::try_from(ver_opcode).ok()
         }
-        true
-    }
 
-    /// Checks whether a script pubkey is a bare multisig output.
-    ///
-    /// In a bare multisig pubkey script the keys are not hashed, the script
-    /// is of the form:
-    ///
-    ///    `2 <pubkey1> <pubkey2> <pubkey3> 3 OP_CHECKMULTISIG`
-    pub fn is_multisig(&self) -> bool {
-        let required_sigs;
+        /// Checks whether a script pubkey is a P2SH output.
+        fn is_p2sh(self: &Self) -> bool {
+            self.0.len() == 23
+                && self.0[0] == OP_HASH160.to_u8()
+                && self.0[1] == OP_PUSHBYTES_20.to_u8()
+                && self.0[22] == OP_EQUAL.to_u8()
+        }
 
-        let mut instructions = self.instructions();
-        if let Some(Ok(Instruction::Op(op))) = instructions.next() {
-            if let Some(pushnum) = op.decode_pushnum() {
-                required_sigs = pushnum;
+        /// Checks whether a script pubkey is a P2PKH output.
+        fn is_p2pkh(self: &Self) -> bool {
+            self.0.len() == 25
+                && self.0[0] == OP_DUP.to_u8()
+                && self.0[1] == OP_HASH160.to_u8()
+                && self.0[2] == OP_PUSHBYTES_20.to_u8()
+                && self.0[23] == OP_EQUALVERIFY.to_u8()
+                && self.0[24] == OP_CHECKSIG.to_u8()
+        }
+
+        /// Checks whether a script is push only.
+        ///
+        /// Note: `OP_RESERVED` (`0x50`) and all the OP_PUSHNUM operations
+        /// are considered push operations.
+        fn is_push_only(self: &Self) -> bool {
+            for inst in self.instructions() {
+                match inst {
+                    Err(_) => return false,
+                    Ok(Instruction::PushBytes(_)) => {}
+                    Ok(Instruction::Op(op)) if op.to_u8() <= 0x60 => {}
+                    // From Bitcoin Core
+                    // if (opcode > OP_PUSHNUM_16 (0x60)) return false
+                    Ok(Instruction::Op(_)) => return false,
+                }
+            }
+            true
+        }
+
+        /// Checks whether a script pubkey is a bare multisig output.
+        ///
+        /// In a bare multisig pubkey script the keys are not hashed, the script
+        /// is of the form:
+        ///
+        ///    `2 <pubkey1> <pubkey2> <pubkey3> 3 OP_CHECKMULTISIG`
+        fn is_multisig(self: &Self) -> bool {
+            let required_sigs;
+
+            let mut instructions = self.instructions();
+            if let Some(Ok(Instruction::Op(op))) = instructions.next() {
+                if let Some(pushnum) = op.decode_pushnum() {
+                    required_sigs = pushnum;
+                } else {
+                    return false;
+                }
             } else {
                 return false;
             }
-        } else {
-            return false;
-        }
 
-        let mut num_pubkeys: u8 = 0;
-        while let Some(Ok(instruction)) = instructions.next() {
-            match instruction {
-                Instruction::PushBytes(_) => {
-                    num_pubkeys += 1;
-                }
-                Instruction::Op(op) => {
-                    if let Some(pushnum) = op.decode_pushnum() {
-                        if pushnum != num_pubkeys {
-                            return false;
-                        }
+            let mut num_pubkeys: u8 = 0;
+            while let Some(Ok(instruction)) = instructions.next() {
+                match instruction {
+                    Instruction::PushBytes(_) => {
+                        num_pubkeys += 1;
                     }
-                    break;
+                    Instruction::Op(op) => {
+                        if let Some(pushnum) = op.decode_pushnum() {
+                            if pushnum != num_pubkeys {
+                                return false;
+                            }
+                        }
+                        break;
+                    }
                 }
             }
-        }
 
-        if required_sigs > num_pubkeys {
-            return false;
-        }
-
-        if let Some(Ok(Instruction::Op(op))) = instructions.next() {
-            if op != OP_CHECKMULTISIG {
+            if required_sigs > num_pubkeys {
                 return false;
             }
-        } else {
-            return false;
-        }
 
-        instructions.next().is_none()
-    }
-
-    /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
-    pub fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
-
-    /// Checks whether a script pubkey is a P2WSH output.
-    pub fn is_p2wsh(&self) -> bool {
-        self.0.len() == 34
-            && self.witness_version() == Some(WitnessVersion::V0)
-            && self.0[1] == OP_PUSHBYTES_32.to_u8()
-    }
-
-    /// Checks whether a script pubkey is a P2WPKH output.
-    pub fn is_p2wpkh(&self) -> bool {
-        self.0.len() == 22
-            && self.witness_version() == Some(WitnessVersion::V0)
-            && self.0[1] == OP_PUSHBYTES_20.to_u8()
-    }
-
-    /// Checks whether a script pubkey is a P2TR output.
-    pub fn is_p2tr(&self) -> bool {
-        self.0.len() == 34
-            && self.witness_version() == Some(WitnessVersion::V1)
-            && self.0[1] == OP_PUSHBYTES_32.to_u8()
-    }
-
-    /// Check if this is a consensus-valid OP_RETURN output.
-    ///
-    /// To validate if the OP_RETURN obeys Bitcoin Core's current standardness policy, use
-    /// [`is_standard_op_return()`](Self::is_standard_op_return) instead.
-    pub fn is_op_return(&self) -> bool {
-        match self.0.first() {
-            Some(b) => *b == OP_RETURN.to_u8(),
-            None => false,
-        }
-    }
-
-    /// Check if this is an OP_RETURN that obeys Bitcoin Core standardness policy.
-    ///
-    /// What this function considers to be standard may change without warning pending Bitcoin Core
-    /// changes.
-    pub fn is_standard_op_return(&self) -> bool { self.is_op_return() && self.0.len() <= 80 }
-
-    /// Checks whether a script is trivially known to have no satisfying input.
-    ///
-    /// This method has potentially confusing semantics and an unclear purpose, so it's going to be
-    /// removed. Use `is_op_return` if you want `OP_RETURN` semantics.
-    #[deprecated(
-        since = "0.32.0",
-        note = "The method has potentially confusing semantics and is going to be removed, you might want `is_op_return`"
-    )]
-    pub fn is_provably_unspendable(&self) -> bool {
-        use crate::opcodes::Class::{IllegalOp, ReturnOp};
-
-        match self.0.first() {
-            Some(b) => {
-                let first = Opcode::from(*b);
-                let class = first.classify(opcodes::ClassifyContext::Legacy);
-
-                class == ReturnOp || class == IllegalOp
+            if let Some(Ok(Instruction::Op(op))) = instructions.next() {
+                if op != OP_CHECKMULTISIG {
+                    return false;
+                }
+            } else {
+                return false;
             }
-            None => false,
-        }
-    }
 
-    /// Get redeemScript following BIP16 rules regarding P2SH spending.
-    ///
-    /// This does not guarantee that this represents a P2SH input [`Script`].
-    /// It merely gets the last push of the script.
-    ///
-    /// Use [`Script::is_p2sh`] on the scriptPubKey to check whether it is actually a P2SH script.
-    pub fn redeem_script(&self) -> Option<&Script> {
-        // Script must consist entirely of pushes.
-        if self.instructions().any(|i| i.is_err() || i.unwrap().push_bytes().is_none()) {
-            return None;
+            instructions.next().is_none()
+        }
+        /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
+        fn is_witness_program(self: &Self) -> bool { self.witness_version().is_some() }
+
+        /// Checks whether a script pubkey is a P2WSH output.
+        fn is_p2wsh(self: &Self) -> bool {
+            self.0.len() == 34
+                && self.witness_version() == Some(WitnessVersion::V0)
+                && self.0[1] == OP_PUSHBYTES_32.to_u8()
         }
 
-        if let Some(Ok(Instruction::PushBytes(b))) = self.instructions().last() {
-            Some(Script::from_bytes(b.as_bytes()))
-        } else {
-            None
+        /// Checks whether a script pubkey is a P2WPKH output.
+        fn is_p2wpkh(self: &Self) -> bool {
+            self.0.len() == 22
+                && self.witness_version() == Some(WitnessVersion::V0)
+                && self.0[1] == OP_PUSHBYTES_20.to_u8()
         }
-    }
 
-    /// Returns the minimum value an output with this script should have in order to be
-    /// broadcastable on today’s Bitcoin network.
-    #[deprecated(since = "0.32.0", note = "use minimal_non_dust and friends")]
-    pub fn dust_value(&self) -> crate::Amount { self.minimal_non_dust() }
+        /// Checks whether a script pubkey is a P2TR output.
+        fn is_p2tr(self: &Self) -> bool {
+            self.0.len() == 34
+                && self.witness_version() == Some(WitnessVersion::V1)
+                && self.0[1] == OP_PUSHBYTES_32.to_u8()
+        }
 
-    /// Returns the minimum value an output with this script should have in order to be
-    /// broadcastable on today's Bitcoin network.
-    ///
-    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
-    /// This function uses the default value of 0.00003 BTC/kB (3 sat/vByte).
-    ///
-    /// To use a custom value, use [`minimal_non_dust_custom`].
-    ///
-    /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
-    pub fn minimal_non_dust(&self) -> crate::Amount {
-        minimal_non_dust_internal(self, DUST_RELAY_TX_FEE.into())
-    }
+        /// Check if this is a consensus-valid OP_RETURN output.
+        ///
+        /// To validate if the OP_RETURN obeys Bitcoin Core's current standardness policy, use
+        /// [`is_standard_op_return()`](Self::is_standard_op_return) instead.
+        fn is_op_return(self: &Self) -> bool {
+            match self.0.first() {
+                Some(b) => *b == OP_RETURN.to_u8(),
+                None => false,
+            }
+        }
 
-    /// Returns the minimum value an output with this script should have in order to be
-    /// broadcastable on today's Bitcoin network.
-    ///
-    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
-    /// This function lets you set the fee rate used in dust calculation.
-    ///
-    /// The current default value in Bitcoin Core (as of v26) is 3 sat/vByte.
-    ///
-    /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
-    ///
-    /// [`minimal_non_dust`]: Script::minimal_non_dust
-    pub fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
-        minimal_non_dust_internal(self, dust_relay_fee.to_sat_per_kwu() * 4)
-    }
+        /// Check if this is an OP_RETURN that obeys Bitcoin Core standardness policy.
+        ///
+        /// What this function considers to be standard may change without warning pending Bitcoin Core
+        /// changes.
+        fn is_standard_op_return(self: &Self) -> bool { self.is_op_return() && self.0.len() <= 80 }
 
-    /// Counts the sigops for this Script using accurate counting.
-    ///
-    /// In Bitcoin Core, there are two ways to count sigops, "accurate" and "legacy".
-    /// This method uses "accurate" counting. This means that OP_CHECKMULTISIG and its
-    /// verify variant count for N sigops where N is the number of pubkeys used in the
-    /// multisig. However, it will count for 20 sigops if CHECKMULTISIG is not preceded by an
-    /// OP_PUSHNUM from 1 - 16 (this would be an invalid script)
-    ///
-    /// Bitcoin Core uses accurate counting for sigops contained within redeemScripts (P2SH)
-    /// and witnessScripts (P2WSH) only. It uses legacy for sigops in scriptSigs and scriptPubkeys.
-    ///
-    /// (Note: Taproot scripts don't count toward the sigop count of the block,
-    /// nor do they have CHECKMULTISIG operations. This function does not count OP_CHECKSIGADD,
-    /// so do not use this to try and estimate if a Taproot script goes over the sigop budget.)
-    pub fn count_sigops(&self) -> usize { count_sigops_internal(self, true) }
 
-    /// Counts the sigops for this Script using legacy counting.
-    ///
-    /// In Bitcoin Core, there are two ways to count sigops, "accurate" and "legacy".
-    /// This method uses "legacy" counting. This means that OP_CHECKMULTISIG and its
-    /// verify variant count for 20 sigops.
-    ///
-    /// Bitcoin Core uses legacy counting for sigops contained within scriptSigs and
-    /// scriptPubkeys. It uses accurate for redeemScripts (P2SH) and witnessScripts (P2WSH).
-    ///
-    /// (Note: Taproot scripts don't count toward the sigop count of the block,
-    /// nor do they have CHECKMULTISIG operations. This function does not count OP_CHECKSIGADD,
-    /// so do not use this to try and estimate if a Taproot script goes over the sigop budget.)
-    pub fn count_sigops_legacy(&self) -> usize { count_sigops_internal(self, false) }
+        /// Checks whether a script is trivially known to have no satisfying input.
+        ///
+        /// This method has potentially confusing semantics and an unclear purpose, so it's going to be
+        /// removed. Use `is_op_return` if you want `OP_RETURN` semantics.
+        #[deprecated(
+            since = "0.32.0",
+            note = "The method has potentially confusing semantics and is going to be removed, you might want `is_op_return`"
+        )]
+        fn is_provably_unspendable(self: &Self) -> bool {
+            use crate::opcodes::Class::{IllegalOp, ReturnOp};
 
-    /// Iterates over the script instructions.
-    ///
-    /// Each returned item is a nested enum covering opcodes, datapushes and errors.
-    /// At most one error will be returned and then the iterator will end. To instead iterate over
-    /// the script as sequence of bytes call the [`bytes`](Self::bytes) method.
-    ///
-    /// To force minimal pushes, use [`instructions_minimal`](Self::instructions_minimal).
-    pub fn instructions(&self) -> Instructions {
-        Instructions { data: self.0.iter(), enforce_minimal: false }
-    }
+            match self.0.first() {
+                Some(b) => {
+                    let first = Opcode::from(*b);
+                    let class = first.classify(opcodes::ClassifyContext::Legacy);
 
-    /// Iterates over the script instructions while enforcing minimal pushes.
-    ///
-    /// This is similar to [`instructions`](Self::instructions) but an error is returned if a push
-    /// is not minimal.
-    pub fn instructions_minimal(&self) -> Instructions {
-        Instructions { data: self.0.iter(), enforce_minimal: true }
-    }
+                    class == ReturnOp || class == IllegalOp
+                }
+                None => false,
+            }
+        }
 
-    /// Iterates over the script instructions and their indices.
-    ///
-    /// Unless the script contains an error, the returned item consists of an index pointing to the
-    /// position in the script where the instruction begins and the decoded instruction - either an
-    /// opcode or data push.
-    ///
-    /// To force minimal pushes, use [`Self::instruction_indices_minimal`].
-    pub fn instruction_indices(&self) -> InstructionIndices {
-        InstructionIndices::from_instructions(self.instructions())
-    }
+        /// Get redeemScript following BIP16 rules regarding P2SH spending.
+        ///
+        /// This does not guarantee that this represents a P2SH input [`Script`].
+        /// It merely gets the last push of the script.
+        ///
+        /// Use [`Script::is_p2sh`] on the scriptPubKey to check whether it is actually a P2SH script.
+        fn redeem_script(self: &Self) -> Option<&Script> {
+            // Script must consist entirely of pushes.
+            if self.instructions().any(|i| i.is_err() || i.unwrap().push_bytes().is_none()) {
+                return None;
+            }
 
-    /// Iterates over the script instructions and their indices while enforcing minimal pushes.
-    ///
-    /// This is similar to [`instruction_indices`](Self::instruction_indices) but an error is
-    /// returned if a push is not minimal.
-    pub fn instruction_indices_minimal(&self) -> InstructionIndices {
-        InstructionIndices::from_instructions(self.instructions_minimal())
-    }
+            if let Some(Ok(Instruction::PushBytes(b))) = self.instructions().last() {
+                Some(Script::from_bytes(b.as_bytes()))
+            } else {
+                None
+            }
+        }
 
-    /// Writes the human-readable assembly representation of the script to the formatter.
-    pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
-        bytes_to_asm_fmt(self.as_ref(), f)
-    }
+        /// Returns the minimum value an output with this script should have in order to be
+        /// broadcastable on today’s Bitcoin network.
+        #[deprecated(since = "0.32.0", note = "use minimal_non_dust and friends")]
+        fn dust_value(self: &Self) -> crate::Amount { self.minimal_non_dust() }
 
-    /// Returns the human-readable assembly representation of the script.
-    pub fn to_asm_string(&self) -> String {
-        let mut buf = String::new();
-        self.fmt_asm(&mut buf).unwrap();
-        buf
-    }
+        /// Returns the minimum value an output with this script should have in order to be
+        /// broadcastable on today's Bitcoin network.
+        ///
+        /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
+        /// This function uses the default value of 0.00003 BTC/kB (3 sat/vByte).
+        ///
+        /// To use a custom value, use [`minimal_non_dust_custom`].
+        ///
+        /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
+        fn minimal_non_dust(self: &Self) -> crate::Amount {
+            minimal_non_dust_internal(self, DUST_RELAY_TX_FEE.into())
+        }
 
-    /// Formats the script as lower-case hex.
-    ///
-    /// This is a more convenient and performant way to write `format!("{:x}", script)`.
-    /// For better performance you should generally prefer displaying the script but if `String` is
-    /// required (this is common in tests) this method can be used.
-    pub fn to_hex_string(&self) -> String { self.as_bytes().to_lower_hex_string() }
+        /// Returns the minimum value an output with this script should have in order to be
+        /// broadcastable on today's Bitcoin network.
+        ///
+        /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
+        /// This function lets you set the fee rate used in dust calculation.
+        ///
+        /// The current default value in Bitcoin Core (as of v26) is 3 sat/vByte.
+        ///
+        /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
+        ///
+        /// [`minimal_non_dust`]: Script::minimal_non_dust
+        fn minimal_non_dust_custom(self: &Self, dust_relay_fee: FeeRate) -> crate::Amount {
+            minimal_non_dust_internal(self, dust_relay_fee.to_sat_per_kwu() * 4)
+        }
 
-    /// Returns the first opcode of the script (if there is any).
-    pub fn first_opcode(&self) -> Option<Opcode> {
-        self.as_bytes().first().copied().map(From::from)
+        /// Counts the sigops for this Script using accurate counting.
+        ///
+        /// In Bitcoin Core, there are two ways to count sigops, "accurate" and "legacy".
+        /// This method uses "accurate" counting. This means that OP_CHECKMULTISIG and its
+        /// verify variant count for N sigops where N is the number of pubkeys used in the
+        /// multisig. However, it will count for 20 sigops if CHECKMULTISIG is not preceded by an
+        /// OP_PUSHNUM from 1 - 16 (this would be an invalid script)
+        ///
+        /// Bitcoin Core uses accurate counting for sigops contained within redeemScripts (P2SH)
+        /// and witnessScripts (P2WSH) only. It uses legacy for sigops in scriptSigs and scriptPubkeys.
+        ///
+        /// (Note: Taproot scripts don't count toward the sigop count of the block,
+        /// nor do they have CHECKMULTISIG operations. This function does not count OP_CHECKSIGADD,
+        /// so do not use this to try and estimate if a Taproot script goes over the sigop budget.)
+        fn count_sigops(self: &Self) -> usize { count_sigops_internal(self, true) }
+
+        /// Counts the sigops for this Script using legacy counting.
+        ///
+        /// In Bitcoin Core, there are two ways to count sigops, "accurate" and "legacy".
+        /// This method uses "legacy" counting. This means that OP_CHECKMULTISIG and its
+        /// verify variant count for 20 sigops.
+        ///
+        /// Bitcoin Core uses legacy counting for sigops contained within scriptSigs and
+        /// scriptPubkeys. It uses accurate for redeemScripts (P2SH) and witnessScripts (P2WSH).
+        ///
+        /// (Note: Taproot scripts don't count toward the sigop count of the block,
+        /// nor do they have CHECKMULTISIG operations. This function does not count OP_CHECKSIGADD,
+        /// so do not use this to try and estimate if a Taproot script goes over the sigop budget.)
+        fn count_sigops_legacy(self: &Self) -> usize { count_sigops_internal(self, false) }
+
+        /// Iterates over the script instructions.
+        ///
+        /// Each returned item is a nested enum covering opcodes, datapushes and errors.
+        /// At most one error will be returned and then the iterator will end. To instead iterate over
+        /// the script as sequence of bytes call the [`bytes`](Self::bytes) method.
+        ///
+        /// To force minimal pushes, use [`instructions_minimal`](Self::instructions_minimal).
+        fn instructions(self: &Self) -> Instructions {
+            Instructions { data: self.0.iter(), enforce_minimal: false }
+        }
+
+        /// Iterates over the script instructions while enforcing minimal pushes.
+        ///
+        /// This is similar to [`instructions`](Self::instructions) but an error is returned if a push
+        /// is not minimal.
+        fn instructions_minimal(self: &Self) -> Instructions {
+            Instructions { data: self.0.iter(), enforce_minimal: true }
+        }
+
+        /// Iterates over the script instructions and their indices.
+        ///
+        /// Unless the script contains an error, the returned item consists of an index pointing to the
+        /// position in the script where the instruction begins and the decoded instruction - either an
+        /// opcode or data push.
+        ///
+        /// To force minimal pushes, use [`Self::instruction_indices_minimal`].
+        fn instruction_indices(self: &Self) -> InstructionIndices {
+            InstructionIndices::from_instructions(self.instructions())
+        }
+
+        /// Iterates over the script instructions and their indices while enforcing minimal pushes.
+        ///
+        /// This is similar to [`instruction_indices`](Self::instruction_indices) but an error is
+        /// returned if a push is not minimal.
+        fn instruction_indices_minimal(self: &Self) -> InstructionIndices {
+            InstructionIndices::from_instructions(self.instructions_minimal())
+        }
+
+        /// Writes the human-readable assembly representation of the script to the formatter.
+        fn fmt_asm(self: &Self, f: &mut dyn fmt::Write) -> fmt::Result {
+            bytes_to_asm_fmt(self.as_ref(), f)
+        }
+
+        /// Returns the human-readable assembly representation of the script.
+        fn to_asm_string(self: &Self) -> String {
+            let mut buf = String::new();
+            self.fmt_asm(&mut buf).unwrap();
+            buf
+        }
+
+        /// Formats the script as lower-case hex.
+        ///
+        /// This is a more convenient and performant way to write `format!("{:x}", script)`.
+        /// For better performance you should generally prefer displaying the script but if `String` is
+        /// required (this is common in tests) this method can be used.
+        fn to_hex_string(self: &Self) -> String { self.as_bytes().to_lower_hex_string() }
+
+        /// Returns the first opcode of the script (if there is any).
+        fn first_opcode(self: &Self) -> Option<Opcode> {
+            self.as_bytes().first().copied().map(From::from)
+        }
     }
 }
 

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,7 @@ use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::script::{self, ScriptBufExt as _, ScriptExt as _};
+use crate::script::{self, ScriptBufExt as _};
 use crate::Sequence;
 
 /// An Object which can be used to construct a script piece by piece.
@@ -82,7 +82,7 @@ impl Builder {
         // "duplicated code" because we need to update `1` field
         match opcode_to_verify(self.1) {
             Some(opcode) => {
-                (self.0).0.pop();
+                (self.0).pop();
                 self.push_opcode(opcode)
             }
             None => self.push_opcode(OP_VERIFY),

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,7 @@ use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::Sequence;
+use crate::{script, Sequence};
 
 /// An Object which can be used to construct a script piece by piece.
 #[derive(PartialEq, Eq, Clone)]
@@ -119,7 +119,7 @@ impl Default for Builder {
 impl From<Vec<u8>> for Builder {
     fn from(v: Vec<u8>) -> Builder {
         let script = ScriptBuf::from(v);
-        let last_op = script.last_opcode();
+        let last_op = script::last_opcode(&script);
         Builder(script, last_op)
     }
 }

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,8 @@ use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::{script, Sequence};
+use crate::script::{self, ScriptExt as _};
+use crate::Sequence;
 
 /// An Object which can be used to construct a script piece by piece.
 #[derive(PartialEq, Eq, Clone)]

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,7 @@ use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::script::{self, ScriptExt as _};
+use crate::script::{self, ScriptBufExt as _, ScriptExt as _};
 use crate::Sequence;
 
 /// An Object which can be used to construct a script piece by piece.

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use super::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
+use super::{read_uint_iter, Error, PushBytes, Script, UintError};
 use crate::opcodes::{self, Opcode};
 
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
@@ -58,7 +58,7 @@ impl<'a> Instruction<'a> {
     pub(super) fn script_serialized_len(&self) -> usize {
         match self {
             Instruction::Op(_) => 1,
-            Instruction::PushBytes(bytes) => ScriptBuf::reserved_len_for_slice(bytes.len()),
+            Instruction::PushBytes(bytes) => super::reserved_script_buf_len_for_slice(bytes.len()),
         }
     }
 

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use super::{read_uint_iter, Error, PushBytes, Script, UintError};
+use internals::UintError;
+
+use super::{Error, PushBytes, Script};
 use crate::opcodes::{self, Opcode};
 
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.
@@ -127,7 +129,7 @@ impl<'a> Instructions<'a> {
         len: PushDataLenLen,
         min_push_len: usize,
     ) -> Option<Result<Instruction<'a>, Error>> {
-        let n = match read_uint_iter(&mut self.data, len as usize) {
+        let n = match internals::read_uint_iter(&mut self.data, len as usize) {
             Ok(n) => n,
             // We do exhaustive matching to not forget to handle new variants if we extend
             // `UintError` type.

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -58,7 +58,7 @@ pub mod witness_program;
 pub mod witness_version;
 
 use alloc::rc::Rc;
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
 use core::cmp::Ordering;
 use core::fmt;
@@ -366,7 +366,7 @@ impl<'a> From<&'a Script> for Cow<'a, Script> {
 }
 
 /// Note: This will fail to compile on old Rust for targets that don't support atomics
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 impl<'a> From<&'a Script> for Arc<Script> {
     fn from(value: &'a Script) -> Self {
         let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -57,14 +57,10 @@ mod tests;
 pub mod witness_program;
 pub mod witness_version;
 
-use alloc::rc::Rc;
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
-use core::cmp::Ordering;
 use core::fmt;
-use core::ops::{Deref, DerefMut};
 
 use hashes::{hash160, sha256};
+use internals::UintError;
 use io::{BufRead, Write};
 
 use crate::consensus::{encode, Decodable, Encodable};
@@ -72,8 +68,7 @@ use crate::constants::{MAX_REDEEM_SCRIPT_SIZE, MAX_WITNESS_SCRIPT_SIZE};
 use crate::internal_macros::impl_asref_push_bytes;
 use crate::key::WPubkeyHash;
 use crate::opcodes::all::*;
-use crate::opcodes::{self, Opcode};
-use crate::prelude::{Borrow, BorrowMut, Box, Cow, DisplayHex, ToOwned, Vec};
+use crate::opcodes::Opcode;
 use crate::OutPoint;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -85,6 +80,8 @@ pub use self::{
     owned::*,
     push_bytes::*,
 };
+#[doc(inline)]
+pub use primitives::script::*;
 
 hashes::hash_newtype! {
     /// A hash of Bitcoin Script bytecode.
@@ -293,28 +290,6 @@ pub fn read_scriptbool(v: &[u8]) -> bool {
     }
 }
 
-// We internally use implementation based on iterator so that it automatically advances as needed
-// Errors are same as above, just different type.
-fn read_uint_iter(data: &mut core::slice::Iter<'_, u8>, size: usize) -> Result<usize, UintError> {
-    if data.len() < size {
-        Err(UintError::EarlyEndOfScript)
-    } else if size > usize::from(u16::MAX / 8) {
-        // Casting to u32 would overflow
-        Err(UintError::NumericOverflow)
-    } else {
-        let mut ret = 0;
-        for (i, item) in data.take(size).enumerate() {
-            ret = usize::from(*item)
-                // Casting is safe because we checked above to not repeat the same check in a loop
-                .checked_shl((i * 8) as u32)
-                .ok_or(UintError::NumericOverflow)?
-                .checked_add(ret)
-                .ok_or(UintError::NumericOverflow)?;
-        }
-        Ok(ret)
-    }
-}
-
 fn opcode_to_verify(opcode: Option<Opcode>) -> Option<Opcode> {
     opcode.and_then(|opcode| match opcode {
         OP_EQUAL => Some(OP_EQUALVERIFY),
@@ -325,323 +300,20 @@ fn opcode_to_verify(opcode: Option<Opcode>) -> Option<Opcode> {
     })
 }
 
-// We keep all the `Script` and `ScriptBuf` impls together since its easier to see side-by-side.
-
-impl From<ScriptBuf> for Box<Script> {
-    fn from(v: ScriptBuf) -> Self { v.into_boxed_script() }
-}
-
-impl From<ScriptBuf> for Cow<'_, Script> {
-    fn from(value: ScriptBuf) -> Self { Cow::Owned(value) }
-}
-
-impl<'a> From<Cow<'a, Script>> for ScriptBuf {
-    fn from(value: Cow<'a, Script>) -> Self {
-        match value {
-            Cow::Owned(owned) => owned,
-            Cow::Borrowed(borrwed) => borrwed.into(),
-        }
-    }
-}
-
-impl<'a> From<Cow<'a, Script>> for Box<Script> {
-    fn from(value: Cow<'a, Script>) -> Self {
-        match value {
-            Cow::Owned(owned) => owned.into(),
-            Cow::Borrowed(borrwed) => borrwed.into(),
-        }
-    }
-}
-
-impl<'a> From<&'a Script> for Box<Script> {
-    fn from(value: &'a Script) -> Self { value.to_owned().into() }
-}
-
-impl<'a> From<&'a Script> for ScriptBuf {
-    fn from(value: &'a Script) -> Self { value.to_owned() }
-}
-
-impl<'a> From<&'a Script> for Cow<'a, Script> {
-    fn from(value: &'a Script) -> Self { Cow::Borrowed(value) }
-}
-
-/// Note: This will fail to compile on old Rust for targets that don't support atomics
-#[cfg(target_has_atomic = "ptr")]
-impl<'a> From<&'a Script> for Arc<Script> {
-    fn from(value: &'a Script) -> Self {
-        let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));
-        // SAFETY: copied from `std`
-        // The pointer was just created from an Arc without deallocating
-        // Casting a slice to a transparent struct wrapping that slice is sound (same
-        // layout).
-        unsafe { Arc::from_raw(rw as *const Script) }
-    }
-}
-
-impl<'a> From<&'a Script> for Rc<Script> {
-    fn from(value: &'a Script) -> Self {
-        let rw: *const [u8] = Rc::into_raw(Rc::from(&value.0));
-        // SAFETY: copied from `std`
-        // The pointer was just created from an Rc without deallocating
-        // Casting a slice to a transparent struct wrapping that slice is sound (same
-        // layout).
-        unsafe { Rc::from_raw(rw as *const Script) }
-    }
-}
-
-impl From<Vec<u8>> for ScriptBuf {
-    fn from(v: Vec<u8>) -> Self { ScriptBuf(v) }
-}
-
-impl From<ScriptBuf> for Vec<u8> {
-    fn from(v: ScriptBuf) -> Self { v.0 }
-}
-
-impl AsRef<Script> for Script {
-    #[inline]
-    fn as_ref(&self) -> &Script { self }
-}
-
-impl AsRef<Script> for ScriptBuf {
-    fn as_ref(&self) -> &Script { self }
-}
-
-impl AsRef<[u8]> for Script {
-    #[inline]
-    fn as_ref(&self) -> &[u8] { self.as_bytes() }
-}
-
-impl AsRef<[u8]> for ScriptBuf {
-    fn as_ref(&self) -> &[u8] { self.as_bytes() }
-}
-
-impl AsMut<Script> for Script {
-    fn as_mut(&mut self) -> &mut Script { self }
-}
-
-impl AsMut<Script> for ScriptBuf {
-    fn as_mut(&mut self) -> &mut Script { self }
-}
-
-impl AsMut<[u8]> for Script {
-    #[inline]
-    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
-}
-
-impl AsMut<[u8]> for ScriptBuf {
-    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
-}
-
-impl fmt::Debug for Script {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("Script(")?;
-        self.fmt_asm(f)?;
-        f.write_str(")")
-    }
-}
-
-impl fmt::Debug for ScriptBuf {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Debug::fmt(self.as_script(), f) }
-}
-
-impl fmt::Display for Script {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.fmt_asm(f) }
-}
-
-impl fmt::Display for ScriptBuf {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self.as_script(), f) }
-}
-
-impl fmt::LowerHex for Script {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.as_bytes().as_hex(), f)
-    }
-}
-
-impl fmt::LowerHex for ScriptBuf {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self.as_script(), f) }
-}
-
-impl fmt::UpperHex for Script {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::UpperHex::fmt(&self.as_bytes().as_hex(), f)
-    }
-}
-
-impl fmt::UpperHex for ScriptBuf {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(self.as_script(), f) }
-}
-
-impl Deref for ScriptBuf {
-    type Target = Script;
-
-    fn deref(&self) -> &Self::Target { Script::from_bytes(&self.0) }
-}
-
-impl DerefMut for ScriptBuf {
-    fn deref_mut(&mut self) -> &mut Self::Target { Script::from_bytes_mut(&mut self.0) }
-}
-
-impl Borrow<Script> for ScriptBuf {
-    fn borrow(&self) -> &Script { self }
-}
-
-impl BorrowMut<Script> for ScriptBuf {
-    fn borrow_mut(&mut self) -> &mut Script { self }
-}
-
-impl PartialEq<ScriptBuf> for Script {
-    fn eq(&self, other: &ScriptBuf) -> bool { self.eq(other.as_script()) }
-}
-
-impl PartialEq<Script> for ScriptBuf {
-    fn eq(&self, other: &Script) -> bool { self.as_script().eq(other) }
-}
-
-impl PartialOrd<Script> for ScriptBuf {
-    fn partial_cmp(&self, other: &Script) -> Option<Ordering> {
-        self.as_script().partial_cmp(other)
-    }
-}
-
-impl PartialOrd<ScriptBuf> for Script {
-    fn partial_cmp(&self, other: &ScriptBuf) -> Option<Ordering> {
-        self.partial_cmp(other.as_script())
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for Script {
-    /// User-facing serialization for `Script`.
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        if serializer.is_human_readable() {
-            serializer.collect_str(&format_args!("{:x}", self))
-        } else {
-            serializer.serialize_bytes(self.as_bytes())
-        }
-    }
-}
-
-/// Can only deserialize borrowed bytes.
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for &'de Script {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            use crate::serde::de::Error;
-
-            return Err(D::Error::custom(
-                "deserialization of `&Script` from human-readable formats is not possible",
-            ));
-        }
-
-        struct Visitor;
-        impl<'de> serde::de::Visitor<'de> for Visitor {
-            type Value = &'de Script;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("borrowed bytes")
-            }
-
-            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Script::from_bytes(v))
-            }
-        }
-        deserializer.deserialize_bytes(Visitor)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for ScriptBuf {
-    /// User-facing serialization for `Script`.
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        (**self).serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for ScriptBuf {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use core::fmt::Formatter;
-
-        use hex::FromHex;
-
-        if deserializer.is_human_readable() {
-            struct Visitor;
-            impl<'de> serde::de::Visitor<'de> for Visitor {
-                type Value = ScriptBuf;
-
-                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                    formatter.write_str("a script hex")
-                }
-
-                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                where
-                    E: serde::de::Error,
-                {
-                    let v = Vec::from_hex(v).map_err(E::custom)?;
-                    Ok(ScriptBuf::from(v))
-                }
-            }
-            deserializer.deserialize_str(Visitor)
-        } else {
-            struct BytesVisitor;
-
-            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
-                type Value = ScriptBuf;
-
-                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                    formatter.write_str("a script Vec<u8>")
-                }
-
-                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-                where
-                    E: serde::de::Error,
-                {
-                    Ok(ScriptBuf::from(v.to_vec()))
-                }
-
-                fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
-                where
-                    E: serde::de::Error,
-                {
-                    Ok(ScriptBuf::from(v))
-                }
-            }
-            deserializer.deserialize_byte_buf(BytesVisitor)
-        }
-    }
-}
-
 impl Encodable for Script {
     #[inline]
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        crate::consensus::encode::consensus_encode_with_size(&self.0, w)
+        crate::consensus::encode::consensus_encode_with_size(&self.as_bytes(), w)
     }
 }
 
 impl Encodable for ScriptBuf {
     #[inline]
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        self.0.consensus_encode(w)
+        // FIXME: This introduces an additional allocation.
+        // ScriptBuf deref to Script and call `Script::to_bytes` which allocates.
+        // We cannot get at the inner ScriptBuf vector anymore because doing so consumes self.
+        self.to_bytes().consensus_encode(w)
     }
 }
 
@@ -650,90 +322,8 @@ impl Decodable for ScriptBuf {
     fn consensus_decode_from_finite_reader<R: BufRead + ?Sized>(
         r: &mut R,
     ) -> Result<Self, encode::Error> {
-        Ok(ScriptBuf(Decodable::consensus_decode_from_finite_reader(r)?))
+        Ok(ScriptBuf::from_bytes(Decodable::consensus_decode_from_finite_reader(r)?))
     }
-}
-
-/// Writes the assembly decoding of the script bytes to the formatter.
-pub(super) fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
-    // This has to be a macro because it needs to break the loop
-    macro_rules! read_push_data_len {
-        ($iter:expr, $len:literal, $formatter:expr) => {
-            match read_uint_iter($iter, $len) {
-                Ok(n) => {
-                    n
-                },
-                Err(UintError::EarlyEndOfScript) => {
-                    $formatter.write_str("<unexpected end>")?;
-                    break;
-                }
-                // We got the data in a slice which implies it being shorter than `usize::MAX`
-                // So if we got overflow, we can confidently say the number is higher than length of
-                // the slice even though we don't know the exact number. This implies attempt to push
-                // past end.
-                Err(UintError::NumericOverflow) => {
-                    $formatter.write_str("<push past end>")?;
-                    break;
-                }
-            }
-        }
-    }
-
-    let mut iter = script.iter();
-    // Was at least one opcode emitted?
-    let mut at_least_one = false;
-    // `iter` needs to be borrowed in `read_push_data_len`, so we have to use `while let` instead
-    // of `for`.
-    while let Some(byte) = iter.next() {
-        let opcode = Opcode::from(*byte);
-
-        let data_len = if let opcodes::Class::PushBytes(n) =
-            opcode.classify(opcodes::ClassifyContext::Legacy)
-        {
-            n as usize
-        } else {
-            match opcode {
-                OP_PUSHDATA1 => {
-                    // side effects: may write and break from the loop
-                    read_push_data_len!(&mut iter, 1, f)
-                }
-                OP_PUSHDATA2 => {
-                    // side effects: may write and break from the loop
-                    read_push_data_len!(&mut iter, 2, f)
-                }
-                OP_PUSHDATA4 => {
-                    // side effects: may write and break from the loop
-                    read_push_data_len!(&mut iter, 4, f)
-                }
-                _ => 0,
-            }
-        };
-
-        if at_least_one {
-            f.write_str(" ")?;
-        } else {
-            at_least_one = true;
-        }
-        // Write the opcode
-        if opcode == OP_PUSHBYTES_0 {
-            f.write_str("OP_0")?;
-        } else {
-            write!(f, "{:?}", opcode)?;
-        }
-        // Write any pushdata
-        if data_len > 0 {
-            f.write_str(" ")?;
-            if data_len <= iter.len() {
-                for ch in iter.by_ref().take(data_len) {
-                    write!(f, "{:02x}", ch)?;
-                }
-            } else {
-                f.write_str("<push past end>")?;
-                break;
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Ways that a script might fail. Not everything is split up as
@@ -787,15 +377,6 @@ impl std::error::Error for Error {
         }
     }
 }
-
-// Our internal error proves that we only return these two cases from `read_uint_iter`.
-// Since it's private we don't bother with trait impls besides From.
-enum UintError {
-    EarlyEndOfScript,
-    NumericOverflow,
-}
-
-internals::impl_from_infallible!(UintError);
 
 impl From<UintError> for Error {
     fn from(error: UintError) -> Self {

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -3,119 +3,13 @@
 #[cfg(doc)]
 use core::ops::Deref;
 
-use hex::FromHex;
+use primitives::script::ScriptBuf;
 
-use super::{opcode_to_verify, Builder, Instruction, PushBytes, Script};
+use super::{opcode_to_verify, Builder, Instruction, PushBytes};
 use crate::internal_macros::define_extension_trait;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
-use crate::prelude::{Box, Vec};
 use crate::script;
-
-/// An owned, growable script.
-///
-/// `ScriptBuf` is the most common script type that has the ownership over the contents of the
-/// script. It has a close relationship with its borrowed counterpart, [`Script`].
-///
-/// Just as other similar types, this implements [`Deref`], so [deref coercions] apply. Also note
-/// that all the safety/validity restrictions that apply to [`Script`] apply to `ScriptBuf` as well.
-///
-/// [deref coercions]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion
-#[derive(Default, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct ScriptBuf(pub(in crate::blockdata::script) Vec<u8>);
-
-impl ScriptBuf {
-    /// Creates a new empty script.
-    #[inline]
-    pub const fn new() -> Self { ScriptBuf(Vec::new()) }
-
-    /// Creates a new empty script with pre-allocated capacity.
-    pub fn with_capacity(capacity: usize) -> Self { ScriptBuf(Vec::with_capacity(capacity)) }
-
-    /// Pre-allocates at least `additional_len` bytes if needed.
-    ///
-    /// Reserves capacity for at least `additional_len` more bytes to be inserted in the given
-    /// script. The script may reserve more space to speculatively avoid frequent reallocations.
-    /// After calling `reserve`, capacity will be greater than or equal to
-    /// `self.len() + additional_len`. Does nothing if capacity is already sufficient.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the new capacity exceeds `isize::MAX bytes`.
-    pub fn reserve(&mut self, additional_len: usize) { self.0.reserve(additional_len); }
-
-    /// Pre-allocates exactly `additional_len` bytes if needed.
-    ///
-    /// Unlike `reserve`, this will not deliberately over-allocate to speculatively avoid frequent
-    /// allocations. After calling `reserve_exact`, capacity will be greater than or equal to
-    /// `self.len() + additional`. Does nothing if the capacity is already sufficient.
-    ///
-    /// Note that the allocator may give the collection more space than it requests. Therefore,
-    /// capacity can not be relied upon to be precisely minimal. Prefer [`reserve`](Self::reserve)
-    /// if future insertions are expected.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the new capacity exceeds `isize::MAX bytes`.
-    pub fn reserve_exact(&mut self, additional_len: usize) { self.0.reserve_exact(additional_len); }
-
-    /// Returns a reference to unsized script.
-    pub fn as_script(&self) -> &Script { Script::from_bytes(&self.0) }
-
-    /// Returns a mutable reference to unsized script.
-    pub fn as_mut_script(&mut self) -> &mut Script { Script::from_bytes_mut(&mut self.0) }
-
-    /// Creates a [`ScriptBuf`] from a hex string.
-    pub fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError> {
-        let v = Vec::from_hex(s)?;
-        Ok(ScriptBuf::from_bytes(v))
-    }
-
-    /// Converts byte vector into script.
-    ///
-    /// This method doesn't (re)allocate.
-    pub fn from_bytes(bytes: Vec<u8>) -> Self { ScriptBuf(bytes) }
-
-    /// Converts the script into a byte vector.
-    ///
-    /// This method doesn't (re)allocate.
-    pub fn into_bytes(self) -> Vec<u8> { self.0 }
-
-    /// Converts this `ScriptBuf` into a [boxed](Box) [`Script`].
-    ///
-    /// This method reallocates if the capacity is greater than length of the script but should not
-    /// when they are equal. If you know beforehand that you need to create a script of exact size
-    /// use [`reserve_exact`](Self::reserve_exact) before adding data to the script so that the
-    /// reallocation can be avoided.
-    #[must_use = "`self` will be dropped if the result is not used"]
-    #[inline]
-    pub fn into_boxed_script(self) -> Box<Script> {
-        // Copied from PathBuf::into_boxed_path
-        let rw = Box::into_raw(self.0.into_boxed_slice()) as *mut Script;
-        unsafe { Box::from_raw(rw) }
-    }
-
-    /// Pushes `n` onto the script.
-    ///
-    /// Only meant for usage by the `bitcoin::script::ScriptBufExt` trait, consider using the API
-    /// provided by that trait.
-    #[doc(hidden)]
-    pub fn push(&mut self, n: u8) { self.0.push(n) }
-
-    /// Pops the last byte from the script if there is one.
-    ///
-    /// Only meant for usage by the `bitcoin::script::ScriptBufExt` trait, consider using the API
-    /// provided by that trait.
-    #[doc(hidden)]
-    pub fn pop(&mut self) -> Option<u8> { self.0.pop() }
-
-    /// Extends the script with bytes from `other`.
-    ///
-    /// Only meant for usage by the `bitcoin::script::ScriptBufExt` trait, consider using the API
-    /// provided by that trait.
-    #[doc(hidden)]
-    pub fn extend_from_slice(&mut self, other: &[u8]) { self.0.extend_from_slice(other) }
-}
 
 define_extension_trait! {
     /// Extension functionality for the [`ScriptBuf`] type.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -149,21 +149,7 @@ impl ScriptBuf {
     /// This function needs to iterate over the script to find the last instruction. Prefer
     /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
     /// multiple times.
-    pub fn scan_and_push_verify(&mut self) { self.push_verify(script::last_opcode(self)); }
-
-    /// Adds an `OP_VERIFY` to the script or changes the most-recently-added opcode to `VERIFY`
-    /// alternative.
-    ///
-    /// See the public fn [`Self::scan_and_push_verify`] to learn more.
-    pub(in crate::blockdata::script) fn push_verify(&mut self, last_opcode: Option<Opcode>) {
-        match opcode_to_verify(last_opcode) {
-            Some(opcode) => {
-                self.0.pop();
-                self.push_opcode(opcode);
-            }
-            None => self.push_opcode(OP_VERIFY),
-        }
-    }
+    pub fn scan_and_push_verify(&mut self) { push_verify(self, script::last_opcode(self)); }
 }
 
 /// Pushes the slice without reserving
@@ -203,6 +189,20 @@ pub(in crate::blockdata::script) fn reserved_script_buf_len_for_slice(len: usize
         0x100..=0xffff => 3,
         // we don't care about oversized, the other fn will panic anyway
         _ => 5,
+    }
+}
+
+/// Adds an `OP_VERIFY` to the script or changes the most-recently-added opcode to `VERIFY`
+/// alternative.
+///
+/// See the public fn [`Self::scan_and_push_verify`] to learn more.
+fn push_verify(script: &mut ScriptBuf, last_opcode: Option<Opcode>) {
+    match opcode_to_verify(last_opcode) {
+        Some(opcode) => {
+            script.0.pop();
+            script.push_opcode(opcode);
+        }
+        None => script.push_opcode(OP_VERIFY),
     }
 }
 

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -9,6 +9,7 @@ use super::{opcode_to_verify, Builder, Instruction, PushBytes, Script};
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
+use crate::script;
 
 /// An owned, growable script.
 ///
@@ -172,7 +173,7 @@ impl ScriptBuf {
     /// This function needs to iterate over the script to find the last instruction. Prefer
     /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
     /// multiple times.
-    pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
+    pub fn scan_and_push_verify(&mut self) { self.push_verify(script::last_opcode(self)); }
 
     /// Adds an `OP_VERIFY` to the script or changes the most-recently-added opcode to `VERIFY`
     /// alternative.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -64,14 +64,6 @@ impl ScriptBuf {
     /// Returns a mutable reference to unsized script.
     pub fn as_mut_script(&mut self) -> &mut Script { Script::from_bytes_mut(&mut self.0) }
 
-    /// Creates a new script builder
-    pub fn builder() -> Builder { Builder::new() }
-
-    /// Generates OP_RETURN-type of scriptPubkey for the given data.
-    pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
-        Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
-    }
-
     /// Creates a [`ScriptBuf`] from a hex string.
     pub fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError> {
         let v = Vec::from_hex(s)?;
@@ -87,6 +79,30 @@ impl ScriptBuf {
     ///
     /// This method doesn't (re)allocate.
     pub fn into_bytes(self) -> Vec<u8> { self.0 }
+
+    /// Converts this `ScriptBuf` into a [boxed](Box) [`Script`].
+    ///
+    /// This method reallocates if the capacity is greater than length of the script but should not
+    /// when they are equal. If you know beforehand that you need to create a script of exact size
+    /// use [`reserve_exact`](Self::reserve_exact) before adding data to the script so that the
+    /// reallocation can be avoided.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    #[inline]
+    pub fn into_boxed_script(self) -> Box<Script> {
+        // Copied from PathBuf::into_boxed_path
+        let rw = Box::into_raw(self.0.into_boxed_slice()) as *mut Script;
+        unsafe { Box::from_raw(rw) }
+    }
+}
+
+impl ScriptBuf {
+    /// Creates a new script builder
+    pub fn builder() -> Builder { Builder::new() }
+
+    /// Generates OP_RETURN-type of scriptPubkey for the given data.
+    pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
+        Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
+    }
 
     /// Adds a single opcode to the script.
     pub fn push_opcode(&mut self, data: Opcode) { self.0.push(data.to_u8()); }
@@ -187,20 +203,6 @@ impl ScriptBuf {
             }
             None => self.push_opcode(OP_VERIFY),
         }
-    }
-
-    /// Converts this `ScriptBuf` into a [boxed](Box) [`Script`].
-    ///
-    /// This method reallocates if the capacity is greater than length of the script but should not
-    /// when they are equal. If you know beforehand that you need to create a script of exact size
-    /// use [`reserve_exact`](Self::reserve_exact) before adding data to the script so that the
-    /// reallocation can be avoided.
-    #[must_use = "`self` will be dropped if the result is not used"]
-    #[inline]
-    pub fn into_boxed_script(self) -> Box<Script> {
-        // Copied from PathBuf::into_boxed_path
-        let rw = Box::into_raw(self.0.into_boxed_slice()) as *mut Script;
-        unsafe { Box::from_raw(rw) }
     }
 }
 

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -113,7 +113,8 @@ impl ScriptBuf {
                 self.0.push((n % 0x100) as u8);
                 self.0.push((n / 0x100) as u8);
             }
-            n => {              // `PushBytes` enforces len < 0x100000000
+            // `PushBytes` enforces len < 0x100000000
+            n => {
                 self.0.push(opcodes::Ordinary::OP_PUSHDATA4.to_u8());
                 self.0.push((n % 0x100) as u8);
                 self.0.push(((n / 0x100) % 0x100) as u8);

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -100,7 +100,7 @@ impl ScriptBuf {
     pub fn builder() -> Builder { Builder::new() }
 
     /// Generates OP_RETURN-type of scriptPubkey for the given data.
-    pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
+    pub fn new_op_return(data: impl AsRef<PushBytes>) -> Self {
         Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
     }
 
@@ -108,7 +108,7 @@ impl ScriptBuf {
     pub fn push_opcode(&mut self, data: Opcode) { self.0.push(data.to_u8()); }
 
     /// Adds instructions to push some arbitrary data onto the stack.
-    pub fn push_slice<T: AsRef<PushBytes>>(&mut self, data: T) {
+    pub fn push_slice(&mut self, data: impl AsRef<PushBytes>) {
         let data = data.as_ref();
         self.reserve(reserved_script_buf_len_for_slice(data.len()));
         push_slice_no_opt(self, data);

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -10,7 +10,7 @@ use crate::address::script_pubkey::{
 };
 use crate::consensus::encode::{deserialize, serialize};
 use crate::crypto::key::{PublicKey, XOnlyPublicKey};
-use crate::FeeRate;
+use crate::{FeeRate, Script};
 
 #[test]
 #[rustfmt::skip]

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -3,6 +3,7 @@
 use core::str::FromStr;
 
 use hex_lit::hex;
+use primitives::opcodes;
 
 use super::*;
 use crate::address::script_pubkey::{

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -15,6 +15,7 @@ use secp256k1::{Secp256k1, Verification};
 use super::witness_version::WitnessVersion;
 use super::{PushBytes, Script, WScriptHash, WitnessScriptSizeError};
 use crate::crypto::key::{CompressedPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
+use crate::script::ScriptExt as _;
 use crate::taproot::TapNodeHash;
 
 /// The minimum byte size of a segregated witness program.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -23,7 +23,7 @@ use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::locktime::absolute::{self, Height, Time};
 use crate::prelude::{Borrow, Vec};
-use crate::script::{Script, ScriptBuf};
+use crate::script::{Script, ScriptBuf, ScriptExt as _};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -27,7 +27,7 @@ use crate::script::{Script, ScriptBuf};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
-use crate::{Amount, FeeRate, SignedAmount, VarInt};
+use crate::{script, Amount, FeeRate, SignedAmount, VarInt};
 
 hashes::hash_newtype! {
     /// A bitcoin transaction hash/transaction ID.
@@ -756,7 +756,7 @@ impl Transaction {
         fn count_sigops(prevout: &TxOut, input: &TxIn) -> usize {
             let mut count: usize = 0;
             if prevout.script_pubkey.is_p2sh() {
-                if let Some(redeem) = input.script_sig.last_pushdata() {
+                if let Some(redeem) = script::last_pushdata(&input.script_sig) {
                     count =
                         count.saturating_add(Script::from_bytes(redeem.as_bytes()).count_sigops());
                 }
@@ -802,7 +802,7 @@ impl Transaction {
             } else if prevout.script_pubkey.is_p2sh() && script_sig.is_push_only() {
                 // If prevout is P2SH and scriptSig is push only
                 // then we wrap the last push (redeemScript) in a Script
-                if let Some(push_bytes) = script_sig.last_pushdata() {
+                if let Some(push_bytes) = script::last_pushdata(script_sig) {
                     Script::from_bytes(push_bytes.as_bytes())
                 } else {
                     return 0;

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -13,6 +13,8 @@ use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::crypto::ecdsa;
 use crate::prelude::Vec;
+#[cfg(doc)]
+use crate::script::ScriptExt as _;
 use crate::taproot::{self, TAPROOT_ANNEX_PREFIX};
 use crate::{Script, VarInt};
 

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -820,7 +820,7 @@ impl<T: Encodable> Encodable for rc::Rc<T> {
 }
 
 /// Note: This will fail to compile on old Rust for targets that don't support atomics
-#[cfg(any(not(rust_v_1_60), target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 impl<T: Encodable> Encodable for sync::Arc<T> {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         (**self).consensus_encode(w)

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -131,7 +131,7 @@ define_extension_trait! {
         ///
         /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`]: https://docs.rs/bitcoinconsensus/0.106.0+26.0/bitcoinconsensus/constant.VERIFY_ALL_PRE_TAPROOT.html
         fn verify(
-            &self,
+            self: &Self,
             index: usize,
             amount: crate::Amount,
             spending_tx: &[u8],
@@ -150,7 +150,7 @@ define_extension_trait! {
         ///
         /// [`bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT`]: https://docs.rs/bitcoinconsensus/0.106.0+26.0/bitcoinconsensus/constant.VERIFY_ALL_PRE_TAPROOT.html
         fn verify_with_flags(
-            &self,
+            self: &Self,
             index: usize,
             amount: crate::Amount,
             spending_tx: &[u8],

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -214,67 +214,6 @@ pub(crate) use impl_asref_push_bytes;
 
 /// Defines an trait `$trait_name` and implements it for `ty`, used to define extension traits.
 macro_rules! define_extension_trait {
-    // With self, no generics.
-    ($(#[$($trait_attrs:tt)*])* $trait_vis:vis trait $trait_name:ident impl for $ty:ident {
-        $(
-            $(#[$($fn_attrs:tt)*])*
-            fn $fn:ident($slf:ident $(, $param_name:ident: $param_type:ty)* $(,)?) $( -> $ret:ty )? $body:block
-        )*
-    }) => {
-        $(#[$($trait_attrs)*])* $trait_vis trait $trait_name {
-            $(
-                $(#[$($fn_attrs)*])*
-                fn $fn($slf $(, $param_name: $param_type)*) $( -> $ret )?;
-            )*
-        }
-
-        impl $trait_name for $ty {
-            $(
-                fn $fn($slf $(, $param_name: $param_type)*) $( -> $ret )? $body
-            )*
-        }
-    };
-    // With &self, no generics.
-    ($(#[$($trait_attrs:tt)*])* $trait_vis:vis trait $trait_name:ident impl for $ty:ident {
-        $(
-            $(#[$($fn_attrs:tt)*])*
-            fn $fn:ident(&$slf:ident $(, $param_name:ident: $param_type:ty)* $(,)?) $( -> $ret:ty )? $body:block
-        )*
-    }) => {
-        $(#[$($trait_attrs)*])* $trait_vis trait $trait_name {
-            $(
-                $(#[$($fn_attrs)*])*
-                fn $fn(&$slf $(, $param_name: $param_type)*) $( -> $ret )?;
-            )*
-        }
-
-        impl $trait_name for $ty {
-            $(
-                fn $fn(&$slf $(, $param_name: $param_type)*) $( -> $ret )? $body
-            )*
-        }
-    };
-    // With &self, with generics.
-    ($(#[$($trait_attrs:tt)*])* $trait_vis:vis trait $trait_name:ident impl for $ty:ident {
-        $(
-            $(#[$($fn_attrs:tt)*])*
-            fn $fn:ident$(<$($gen:ident: $gent:ident),*>)?(&$slf:ident $(, $param_name:ident: $param_type:ty)* $(,)?) $( -> $ret:ty )? $body:block
-        )*
-    }) => {
-        $(#[$($trait_attrs)*])* $trait_vis trait $trait_name {
-            $(
-                $(#[$($fn_attrs)*])*
-                fn $fn$(<$($gen: $gent),*>)?(&$slf $(, $param_name: $param_type)*) $( -> $ret )?;
-            )*
-        }
-
-        impl $trait_name for $ty {
-            $(
-                fn $fn$(<$($gen: $gent),*>)?(&$slf $(, $param_name: $param_type)*) $( -> $ret )? $body
-            )*
-        }
-    };
-    // No self, with generics.
     ($(#[$($trait_attrs:tt)*])* $trait_vis:vis trait $trait_name:ident impl for $ty:ident {
         $(
             $(#[$($fn_attrs:tt)*])*
@@ -291,26 +230,6 @@ macro_rules! define_extension_trait {
         impl $trait_name for $ty {
             $(
                 fn $fn$(<$($gen: $gent),*>)?($($param_name: $param_type),*) $( -> $ret )? $body
-            )*
-        }
-    };
-    // No self, with generic `<T: AsRef<PushBytes>>`
-    ($(#[$($trait_attrs:tt)*])* $trait_vis:vis trait $trait_name:ident impl for $ty:ident {
-        $(
-            $(#[$($fn_attrs:tt)*])*
-            fn $fn:ident<T: AsRef<PushBytes>>($($param_name:ident: $param_type:ty),* $(,)?) $( -> $ret:ty )? $body:block
-        )*
-    }) => {
-        $(#[$($trait_attrs)*])* $trait_vis trait $trait_name {
-            $(
-                $(#[$($fn_attrs)*])*
-                fn $fn<T: AsRef<PushBytes>>($($param_name: $param_type),*) $( -> $ret )?;
-            )*
-        }
-
-        impl $trait_name for $ty {
-            $(
-                fn $fn<T: AsRef<PushBytes>>($($param_name: $param_type),*) $( -> $ret )? $body
             )*
         }
     };

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -143,7 +143,7 @@ mod prelude {
     #[cfg(all(not(feature = "std"), not(test)))]
     pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, slice, rc};
 
-    #[cfg(all(not(feature = "std"), not(test), any(not(rust_v_1_60), target_has_atomic = "ptr")))]
+    #[cfg(all(not(feature = "std"), not(test), target_has_atomic = "ptr"))]
     pub use alloc::sync;
 
     #[cfg(any(feature = "std", test))]

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -25,6 +25,7 @@ use crate::crypto::key::{PrivateKey, PublicKey};
 use crate::crypto::{ecdsa, taproot};
 use crate::key::{TapTweak, XOnlyPublicKey};
 use crate::prelude::{btree_map, BTreeMap, BTreeSet, Borrow, Box, Vec};
+use crate::script::ScriptExt as _;
 use crate::sighash::{self, EcdsaSighashType, Prevouts, SighashCache};
 use crate::transaction::{self, Transaction, TxOut};
 use crate::{Amount, FeeRate, TapLeafHash, TapSighashType};

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -7,6 +7,7 @@ use bitcoin::bip32::{DerivationPath, Fingerprint};
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::opcodes::all::OP_CHECKSIG;
 use bitcoin::psbt::{GetKey, Input, KeyRequest, PsbtSighashType, SignError};
+use bitcoin::script::ScriptExt as _;
 use bitcoin::taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::transaction::Version;
 use bitcoin::{

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -1,6 +1,7 @@
 use bitcoin::address::Address;
 use bitcoin::consensus::encode;
-use bitcoin::{script, Network};
+use bitcoin::script::{self, ScriptExt as _};
+use bitcoin::Network;
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
+++ b/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use bitcoin::script::ScriptExt as _;
 use honggfuzz::fuzz;
 
 // faster than String, we don't need to actually produce the value, just check absence of panics

--- a/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
+++ b/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use bitcoin::script::ScriptExt as _;
 use honggfuzz::fuzz;
 
 // faster than String, we don't need to actually produce the value, just check absence of panics

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -197,7 +197,6 @@ macro_rules! hash_type {
                 <Self as crate::GeneralHash>::hash_byte_chunks(byte_slices)
             }
 
-
             /// Hashes the entire contents of the `reader`.
             #[cfg(feature = "bitcoin-io")]
             pub fn hash_reader<R: io::BufRead>(reader: &mut R) -> Result<Self, io::Error> {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -247,8 +247,9 @@ pub trait GeneralHash: Hash {
             let bytes = reader.fill_buf()?;
 
             let read = bytes.len();
-            if read == 0 {      // Empty slice means EOF.
-                break
+            // Empty slice means EOF.
+            if read == 0 {
+                break;
             }
 
             engine.input(bytes);
@@ -352,9 +353,6 @@ mod tests {
     #[test]
     fn hash_reader() {
         let mut reader: &[u8] = b"hello";
-        assert_eq!(
-            sha256::Hash::hash_reader(&mut reader).unwrap(),
-            sha256::Hash::hash(b"hello"),
-        )
+        assert_eq!(sha256::Hash::hash_reader(&mut reader).unwrap(), sha256::Hash::hash(b"hello"),)
     }
 }

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -104,8 +104,9 @@ where
             let bytes = reader.fill_buf()?;
 
             let read = bytes.len();
-            if read == 0 {      // Empty slice means EOF.
-                break
+            // Empty slice means EOF.
+            if read == 0 {
+                break;
             }
 
             engine.input(bytes);

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -34,4 +34,4 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(rust_v_1_64)', 'cfg(rust_v_1_61)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(rust_v_1_64)'] }

--- a/internals/build.rs
+++ b/internals/build.rs
@@ -1,4 +1,4 @@
-const MSRV_MINOR: u64 = 56;
+const MSRV_MINOR: u64 = 63;
 
 fn main() {
     let rustc = std::env::var_os("RUSTC");

--- a/internals/src/array_vec.rs
+++ b/internals/src/array_vec.rs
@@ -22,36 +22,25 @@ mod safety_boundary {
     }
 
     impl<T: Copy, const CAP: usize> ArrayVec<T, CAP> {
-        // The bounds are const-unstable until 1.61
-        cond_const! {
-            /// Creates an empty `ArrayVec`.
-            pub const(in rust_v_1_61 = "1.61") fn new() -> Self {
-                Self {
-                    len: 0,
-                    data: [MaybeUninit::uninit(); CAP],
-                }
+        /// Creates an empty `ArrayVec`.
+        pub const fn new() -> Self { Self { len: 0, data: [MaybeUninit::uninit(); CAP] } }
+
+        /// Creates an `ArrayVec` initialized with the contets of `slice`.
+        ///
+        /// # Panics
+        ///
+        /// If the slice is longer than `CAP`.
+        pub const fn from_slice(slice: &[T]) -> Self {
+            assert!(slice.len() <= CAP);
+            let mut data = [MaybeUninit::uninit(); CAP];
+            let mut i = 0;
+            // can't use mutable references and operators in const
+            while i < slice.len() {
+                data[i] = MaybeUninit::new(slice[i]);
+                i += 1;
             }
 
-            /// Creates an `ArrayVec` initialized with the contets of `slice`.
-            ///
-            /// # Panics
-            ///
-            /// If the slice is longer than `CAP`.
-            pub const(in rust_v_1_61 = "1.61") fn from_slice(slice: &[T]) -> Self {
-                assert!(slice.len() <= CAP);
-                let mut data = [MaybeUninit::uninit(); CAP];
-                let mut i = 0;
-                // can't use mutable references and operators in const
-                while i < slice.len() {
-                    data[i] = MaybeUninit::new(slice[i]);
-                    i += 1;
-                }
-
-                Self {
-                    len: slice.len(),
-                    data,
-                }
-            }
+            Self { len: slice.len(), data }
         }
 
         // from_raw_parts is const-unstable until 1.64

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -35,3 +35,39 @@ mod parse;
 #[cfg(feature = "serde")]
 #[macro_use]
 pub mod serde;
+
+/// Reads a `usize` from an iterator of bytes.
+// TODO: Where should this live?
+pub fn read_uint_iter(
+    data: &mut core::slice::Iter<'_, u8>,
+    size: usize,
+) -> Result<usize, UintError> {
+    if data.len() < size {
+        Err(UintError::EarlyEndOfScript)
+    } else if size > usize::from(u16::MAX / 8) {
+        // Casting to u32 would overflow
+        Err(UintError::NumericOverflow) // FIXME: Add another error variant for here?
+    } else {
+        let mut ret = 0;
+        for (i, item) in data.take(size).enumerate() {
+            ret = usize::from(*item)
+                // Casting is safe because we checked above to not repeat the same check in a loop
+                .checked_shl((i * 8) as u32)
+                .ok_or(UintError::NumericOverflow)? // FIXME: This is related to `size` not overflow.
+                .checked_add(ret)
+                // FIXME: Isn't this unreachable because we are adding a byte at a time?
+                .ok_or(UintError::NumericOverflow)?;
+        }
+        Ok(ret)
+    }
+}
+
+/// Error returned by `read_uint_iter`.
+pub enum UintError {
+    /// FIXME: This name does not make sense anymore.
+    EarlyEndOfScript,
+    /// Input data caused `usize` to overflow.
+    NumericOverflow,
+}
+
+crate::impl_from_infallible!(UintError);

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,8 +16,8 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "internals/std", "io/std", "units/std"]
-alloc = ["internals/alloc", "io/alloc", "units/alloc"]
+std = ["alloc", "hex?/std", "internals/std", "io/std", "units/std"]
+alloc = ["hex?/alloc", "internals/alloc", "io/alloc", "units/alloc"]
 serde = ["dep:serde", "internals/serde", "units/serde"]
 
 [dependencies]
@@ -25,6 +25,7 @@ internals = { package = "bitcoin-internals", version = "0.3.0" }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false }
 
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false, optional = true }
 ordered = { version = "0.2.0", optional = true }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -18,6 +18,7 @@
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -44,9 +45,6 @@ pub use self::sequence::Sequence;
 #[rustfmt::skip]
 #[allow(unused_imports)]
 mod prelude {
-    #[cfg(all(not(feature = "std"), not(test)))]
+    #[cfg(feature = "alloc")]
     pub use alloc::string::ToString;
-
-    #[cfg(any(feature = "std", test))]
-    pub use std::string::ToString;
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -46,5 +46,8 @@ pub use self::sequence::Sequence;
 #[allow(unused_imports)]
 mod prelude {
     #[cfg(feature = "alloc")]
-    pub use alloc::string::ToString;
+    pub use alloc::{borrow::{Borrow, BorrowMut, Cow, ToOwned}, boxed::Box, rc::Rc, string::{String, ToString}, vec::Vec};
+
+    #[cfg(target_has_atomic = "ptr")]
+    pub use alloc::sync::Arc;
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -31,6 +31,7 @@ extern crate serde;
 #[cfg(feature = "alloc")]
 pub mod locktime;
 pub mod opcodes;
+pub mod script;
 pub mod sequence;
 
 #[doc(inline)]

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+use core::ops::{
+    Bound, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
+
+use super::ScriptBuf;
+
+/// Bitcoin script slice.
+///
+/// *[See also the `bitcoin::script` module](super).*
+///
+/// `Script` is a script slice, the most primitive script type. It's usually seen in its borrowed
+/// form `&Script`. It is always encoded as a series of bytes representing the opcodes and data
+/// pushes.
+///
+/// ## Validity
+///
+/// `Script` does not have any validity invariants - it's essentially just a marked slice of
+/// bytes. This is similar to [`Path`](std::path::Path) vs [`OsStr`](std::ffi::OsStr) where they
+/// are trivially cast-able to each-other and `Path` doesn't guarantee being a usable FS path but
+/// having a newtype still has value because of added methods, readability and basic type checking.
+///
+/// Although at least data pushes could be checked not to overflow the script, bad scripts are
+/// allowed to be in a transaction (outputs just become unspendable) and there even are such
+/// transactions in the chain. Thus we must allow such scripts to be placed in the transaction.
+///
+/// ## Slicing safety
+///
+/// Slicing is similar to how `str` works: some ranges may be incorrect and indexing by
+/// `usize` is not supported. However, as opposed to `std`, we have no way of checking
+/// correctness without causing linear complexity so there are **no panics on invalid
+/// ranges!** If you supply an invalid range, you'll get a garbled script.
+///
+/// The range is considered valid if it's at a boundary of instruction. Care must be taken
+/// especially with push operations because you could get a reference to arbitrary
+/// attacker-supplied bytes that look like a valid script.
+///
+/// It is recommended to use `.instructions()` method to get an iterator over script
+/// instructions and work with that instead.
+///
+/// ## Memory safety
+///
+/// The type is `#[repr(transparent)]` for internal purposes only!
+/// No consumer crate may rely on the representation of the struct!
+///
+/// ## References
+///
+///
+/// ### Bitcoin Core References
+///
+/// * [CScript definition](https://github.com/bitcoin/bitcoin/blob/d492dc1cdaabdc52b0766bf4cba4bd73178325d0/src/script/script.h#L410)
+///
+#[derive(PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct Script(pub(in crate::script) [u8]);
+
+impl ToOwned for Script {
+    type Owned = ScriptBuf;
+
+    fn to_owned(&self) -> Self::Owned { ScriptBuf(self.0.to_owned()) }
+}
+
+impl Script {
+    /// Creates a new empty script.
+    #[inline]
+    pub fn new() -> &'static Script { Script::from_bytes(&[]) }
+
+    /// Treat byte slice as `Script`
+    #[inline]
+    pub fn from_bytes(bytes: &[u8]) -> &Script {
+        // SAFETY: copied from `std`
+        // The pointer was just created from a reference which is still alive.
+        // Casting slice pointer to a transparent struct wrapping that slice is sound (same
+        // layout).
+        unsafe { &*(bytes as *const [u8] as *const Script) }
+    }
+
+    /// Treat mutable byte slice as `Script`
+    #[inline]
+    pub fn from_bytes_mut(bytes: &mut [u8]) -> &mut Script {
+        // SAFETY: copied from `std`
+        // The pointer was just created from a reference which is still alive.
+        // Casting slice pointer to a transparent struct wrapping that slice is sound (same
+        // layout).
+        // Function signature prevents callers from accessing `bytes` while the returned reference
+        // is alive.
+        unsafe { &mut *(bytes as *mut [u8] as *mut Script) }
+    }
+
+    /// Returns the script data as a byte slice.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] { &self.0 }
+
+    /// Returns the script data as a mutable byte slice.
+    #[inline]
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self.0 }
+
+    /// Returns the length in bytes of the script.
+    #[inline]
+    pub fn len(&self) -> usize { self.0.len() }
+
+    /// Returns whether the script is the empty script.
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+
+    /// Returns a copy of the script data.
+    #[inline]
+    pub fn to_bytes(&self) -> Vec<u8> { self.0.to_owned() }
+
+    /// Converts a [`Box<Script>`](Box) into a [`ScriptBuf`] without copying or allocating.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn into_script_buf(self: Box<Self>) -> ScriptBuf {
+        let rw = Box::into_raw(self) as *mut [u8];
+        // SAFETY: copied from `std`
+        // The pointer was just created from a box without deallocating
+        // Casting a transparent struct wrapping a slice to the slice pointer is sound (same
+        // layout).
+        let inner = unsafe { Box::from_raw(rw) };
+        ScriptBuf(Vec::from(inner))
+    }
+
+    /// Writes the human-readable assembly representation of the script to the formatter.
+    pub fn fmt_asm(self: &Self, f: &mut dyn fmt::Write) -> fmt::Result {
+        super::bytes_to_asm_fmt(self.as_ref(), f)
+    }
+
+    /// Returns the human-readable assembly representation of the script.
+    pub fn to_asm_string(self: &Self) -> String {
+        let mut buf = String::new();
+        self.fmt_asm(&mut buf).unwrap();
+        buf
+    }
+}
+
+macro_rules! delegate_index {
+    ($($type:ty),* $(,)?) => {
+        $(
+            /// Script subslicing operation - read [slicing safety](#slicing-safety)!
+            impl Index<$type> for Script {
+                type Output = Self;
+
+                #[inline]
+                fn index(&self, index: $type) -> &Self::Output {
+                    Self::from_bytes(&self.0[index])
+                }
+            }
+        )*
+    }
+}
+
+delegate_index!(
+    Range<usize>,
+    RangeFrom<usize>,
+    RangeTo<usize>,
+    RangeFull,
+    RangeInclusive<usize>,
+    RangeToInclusive<usize>,
+    (Bound<usize>, Bound<usize>)
+);

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin scripts.
+//!
+//! *[See also the `Script` type](Script).*
+//!
+//! This module provides the structures needed to support scripts see [`bitcoin::script`] for more info.
+//!
+//! [`bitcoin::script`]: <https://docs.rs/bitcoin/latest/bitcoin/script/index.html>
+
+mod borrowed;
+mod owned;
+
+use core::cmp::Ordering;
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+
+#[cfg(feature = "hex")]
+use hex::DisplayHex;
+
+use crate::opcodes::all::*;
+use crate::opcodes::{self, Opcode};
+use crate::prelude::{Arc, Borrow, BorrowMut, Box, Cow, Rc, ToOwned, Vec};
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    borrowed::*,
+    owned::*,
+};
+
+// We keep all the `Script` and `ScriptBuf` impls together since its easier to see side-by-side.
+
+impl From<ScriptBuf> for Box<Script> {
+    fn from(v: ScriptBuf) -> Self { v.into_boxed_script() }
+}
+
+impl From<ScriptBuf> for Cow<'_, Script> {
+    fn from(value: ScriptBuf) -> Self { Cow::Owned(value) }
+}
+
+impl<'a> From<Cow<'a, Script>> for ScriptBuf {
+    fn from(value: Cow<'a, Script>) -> Self {
+        match value {
+            Cow::Owned(owned) => owned,
+            Cow::Borrowed(borrwed) => borrwed.into(),
+        }
+    }
+}
+
+impl<'a> From<Cow<'a, Script>> for Box<Script> {
+    fn from(value: Cow<'a, Script>) -> Self {
+        match value {
+            Cow::Owned(owned) => owned.into(),
+            Cow::Borrowed(borrwed) => borrwed.into(),
+        }
+    }
+}
+
+impl<'a> From<&'a Script> for Box<Script> {
+    fn from(value: &'a Script) -> Self { value.to_owned().into() }
+}
+
+impl<'a> From<&'a Script> for ScriptBuf {
+    fn from(value: &'a Script) -> Self { value.to_owned() }
+}
+
+impl<'a> From<&'a Script> for Cow<'a, Script> {
+    fn from(value: &'a Script) -> Self { Cow::Borrowed(value) }
+}
+
+/// Note: This will fail to compile on old Rust for targets that don't support atomics
+#[cfg(target_has_atomic = "ptr")]
+impl<'a> From<&'a Script> for Arc<Script> {
+    fn from(value: &'a Script) -> Self {
+        let rw: *const [u8] = Arc::into_raw(Arc::from(&value.0));
+        // SAFETY: copied from `std`
+        // The pointer was just created from an Arc without deallocating
+        // Casting a slice to a transparent struct wrapping that slice is sound (same
+        // layout).
+        unsafe { Arc::from_raw(rw as *const Script) }
+    }
+}
+
+impl<'a> From<&'a Script> for Rc<Script> {
+    fn from(value: &'a Script) -> Self {
+        let rw: *const [u8] = Rc::into_raw(Rc::from(&value.0));
+        // SAFETY: copied from `std`
+        // The pointer was just created from an Rc without deallocating
+        // Casting a slice to a transparent struct wrapping that slice is sound (same
+        // layout).
+        unsafe { Rc::from_raw(rw as *const Script) }
+    }
+}
+
+impl From<Vec<u8>> for ScriptBuf {
+    fn from(v: Vec<u8>) -> Self { ScriptBuf(v) }
+}
+
+impl From<ScriptBuf> for Vec<u8> {
+    fn from(v: ScriptBuf) -> Self { v.0 }
+}
+
+impl AsRef<Script> for Script {
+    #[inline]
+    fn as_ref(&self) -> &Script { self }
+}
+
+impl AsRef<Script> for ScriptBuf {
+    fn as_ref(&self) -> &Script { self }
+}
+
+impl AsRef<[u8]> for Script {
+    #[inline]
+    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+}
+
+impl AsRef<[u8]> for ScriptBuf {
+    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+}
+
+impl AsMut<Script> for Script {
+    fn as_mut(&mut self) -> &mut Script { self }
+}
+
+impl AsMut<Script> for ScriptBuf {
+    fn as_mut(&mut self) -> &mut Script { self }
+}
+
+impl AsMut<[u8]> for Script {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
+}
+
+impl AsMut<[u8]> for ScriptBuf {
+    fn as_mut(&mut self) -> &mut [u8] { self.as_mut_bytes() }
+}
+
+impl Deref for ScriptBuf {
+    type Target = Script;
+
+    fn deref(&self) -> &Self::Target { Script::from_bytes(&self.0) }
+}
+
+impl DerefMut for ScriptBuf {
+    fn deref_mut(&mut self) -> &mut Self::Target { Script::from_bytes_mut(&mut self.0) }
+}
+
+impl Borrow<Script> for ScriptBuf {
+    fn borrow(&self) -> &Script { self }
+}
+
+impl BorrowMut<Script> for ScriptBuf {
+    fn borrow_mut(&mut self) -> &mut Script { self }
+}
+
+impl PartialEq<ScriptBuf> for Script {
+    fn eq(&self, other: &ScriptBuf) -> bool { self.eq(other.as_script()) }
+}
+
+impl PartialEq<Script> for ScriptBuf {
+    fn eq(&self, other: &Script) -> bool { self.as_script().eq(other) }
+}
+
+impl PartialOrd<Script> for ScriptBuf {
+    fn partial_cmp(&self, other: &Script) -> Option<Ordering> {
+        self.as_script().partial_cmp(other)
+    }
+}
+
+impl PartialOrd<ScriptBuf> for Script {
+    fn partial_cmp(&self, other: &ScriptBuf) -> Option<Ordering> {
+        self.partial_cmp(other.as_script())
+    }
+}
+
+impl fmt::Debug for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("Script(")?;
+        self.fmt_asm(f)?;
+        f.write_str(")")
+    }
+}
+
+impl fmt::Debug for ScriptBuf {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Debug::fmt(self.as_script(), f) }
+}
+
+impl fmt::Display for Script {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.fmt_asm(f) }
+}
+
+impl fmt::Display for ScriptBuf {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self.as_script(), f) }
+}
+
+#[cfg(feature = "hex")]
+impl fmt::LowerHex for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.as_bytes().as_hex(), f)
+    }
+}
+
+#[cfg(feature = "hex")]
+impl fmt::LowerHex for ScriptBuf {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self.as_script(), f) }
+}
+
+#[cfg(feature = "hex")]
+impl fmt::UpperHex for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.as_bytes().as_hex(), f)
+    }
+}
+
+#[cfg(feature = "hex")]
+impl fmt::UpperHex for ScriptBuf {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(self.as_script(), f) }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Script {
+    /// User-facing serialization for `Script`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.collect_str(&format_args!("{:x}", self))
+        } else {
+            serializer.serialize_bytes(self.as_bytes())
+        }
+    }
+}
+
+/// Can only deserialize borrowed bytes.
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for &'de Script {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            use crate::serde::de::Error;
+
+            return Err(D::Error::custom(
+                "deserialization of `&Script` from human-readable formats is not possible",
+            ));
+        }
+
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = &'de Script;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("borrowed bytes")
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Script::from_bytes(v))
+            }
+        }
+        deserializer.deserialize_bytes(Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for ScriptBuf {
+    /// User-facing serialization for `Script`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        (**self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ScriptBuf {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt::Formatter;
+
+        use hex::FromHex;
+
+        if deserializer.is_human_readable() {
+            struct Visitor;
+            impl<'de> serde::de::Visitor<'de> for Visitor {
+                type Value = ScriptBuf;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script hex")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    let v = Vec::from_hex(v).map_err(E::custom)?;
+                    Ok(ScriptBuf::from(v))
+                }
+            }
+            deserializer.deserialize_str(Visitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = ScriptBuf;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script Vec<u8>")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(ScriptBuf::from(v.to_vec()))
+                }
+
+                fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(ScriptBuf::from(v))
+                }
+            }
+            deserializer.deserialize_byte_buf(BytesVisitor)
+        }
+    }
+}
+
+/// Writes the assembly decoding of the script bytes to the formatter.
+pub(super) fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
+    // This has to be a macro because it needs to break the loop
+    macro_rules! read_push_data_len {
+        ($iter:expr, $len:literal, $formatter:expr) => {
+            match internals::read_uint_iter($iter, $len) {
+                Ok(n) => {
+                    n
+                },
+                Err(internals::UintError::EarlyEndOfScript) => {
+                    $formatter.write_str("<unexpected end>")?;
+                    break;
+                }
+                // We got the data in a slice which implies it being shorter than `usize::MAX`
+                // So if we got overflow, we can confidently say the number is higher than length of
+                // the slice even though we don't know the exact number. This implies attempt to push
+                // past end.
+                Err(internals::UintError::NumericOverflow) => {
+                    $formatter.write_str("<push past end>")?;
+                    break;
+                }
+            }
+        }
+    }
+
+    let mut iter = script.iter();
+    // Was at least one opcode emitted?
+    let mut at_least_one = false;
+    // `iter` needs to be borrowed in `read_push_data_len`, so we have to use `while let` instead
+    // of `for`.
+    while let Some(byte) = iter.next() {
+        let opcode = Opcode::from(*byte);
+
+        let data_len = if let opcodes::Class::PushBytes(n) =
+            opcode.classify(opcodes::ClassifyContext::Legacy)
+        {
+            n as usize
+        } else {
+            match opcode {
+                OP_PUSHDATA1 => {
+                    // side effects: may write and break from the loop
+                    read_push_data_len!(&mut iter, 1, f)
+                }
+                OP_PUSHDATA2 => {
+                    // side effects: may write and break from the loop
+                    read_push_data_len!(&mut iter, 2, f)
+                }
+                OP_PUSHDATA4 => {
+                    // side effects: may write and break from the loop
+                    read_push_data_len!(&mut iter, 4, f)
+                }
+                _ => 0,
+            }
+        };
+
+        if at_least_one {
+            f.write_str(" ")?;
+        } else {
+            at_least_one = true;
+        }
+        // Write the opcode
+        if opcode == OP_PUSHBYTES_0 {
+            f.write_str("OP_0")?;
+        } else {
+            write!(f, "{:?}", opcode)?;
+        }
+        // Write any pushdata
+        if data_len > 0 {
+            f.write_str(" ")?;
+            if data_len <= iter.len() {
+                for ch in iter.by_ref().take(data_len) {
+                    write!(f, "{:02x}", ch)?;
+                }
+            } else {
+                f.write_str("<push past end>")?;
+                break;
+            }
+        }
+    }
+    Ok(())
+}

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#[cfg(doc)]
+use core::ops::Deref;
+
+#[cfg(feature = "hex")]
+use hex::FromHex;
+
+use super::Script;
+use crate::prelude::{Box, Vec};
+
+/// An owned, growable script.
+///
+/// `ScriptBuf` is the most common script type that has the ownership over the contents of the
+/// script. It has a close relationship with its borrowed counterpart, [`Script`].
+///
+/// Just as other similar types, this implements [`Deref`], so [deref coercions] apply. Also note
+/// that all the safety/validity restrictions that apply to [`Script`] apply to `ScriptBuf` as well.
+///
+/// [deref coercions]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion
+#[derive(Default, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct ScriptBuf(pub(in crate::script) Vec<u8>);
+
+impl ScriptBuf {
+    /// Creates a new empty script.
+    #[inline]
+    pub const fn new() -> Self { ScriptBuf(Vec::new()) }
+
+    /// Creates a new empty script with pre-allocated capacity.
+    pub fn with_capacity(capacity: usize) -> Self { ScriptBuf(Vec::with_capacity(capacity)) }
+
+    /// Pre-allocates at least `additional_len` bytes if needed.
+    ///
+    /// Reserves capacity for at least `additional_len` more bytes to be inserted in the given
+    /// script. The script may reserve more space to speculatively avoid frequent reallocations.
+    /// After calling `reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional_len`. Does nothing if capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX bytes`.
+    pub fn reserve(&mut self, additional_len: usize) { self.0.reserve(additional_len); }
+
+    /// Pre-allocates exactly `additional_len` bytes if needed.
+    ///
+    /// Unlike `reserve`, this will not deliberately over-allocate to speculatively avoid frequent
+    /// allocations. After calling `reserve_exact`, capacity will be greater than or equal to
+    /// `self.len() + additional`. Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore,
+    /// capacity can not be relied upon to be precisely minimal. Prefer [`reserve`](Self::reserve)
+    /// if future insertions are expected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX bytes`.
+    pub fn reserve_exact(&mut self, additional_len: usize) { self.0.reserve_exact(additional_len); }
+
+    /// Returns a reference to unsized script.
+    pub fn as_script(&self) -> &Script { Script::from_bytes(&self.0) }
+
+    /// Returns a mutable reference to unsized script.
+    pub fn as_mut_script(&mut self) -> &mut Script { Script::from_bytes_mut(&mut self.0) }
+
+    /// Creates a [`ScriptBuf`] from a hex string.
+    #[cfg(feature = "hex")]
+    pub fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError> {
+        let v = Vec::from_hex(s)?;
+        Ok(ScriptBuf::from_bytes(v))
+    }
+
+    /// Converts byte vector into script.
+    ///
+    /// This method doesn't (re)allocate.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self { ScriptBuf(bytes) }
+
+    /// Converts the script into a byte vector.
+    ///
+    /// This method doesn't (re)allocate.
+    pub fn into_bytes(self) -> Vec<u8> { self.0 }
+
+    /// Converts this `ScriptBuf` into a [boxed](Box) [`Script`].
+    ///
+    /// This method reallocates if the capacity is greater than length of the script but should not
+    /// when they are equal. If you know beforehand that you need to create a script of exact size
+    /// use [`reserve_exact`](Self::reserve_exact) before adding data to the script so that the
+    /// reallocation can be avoided.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    #[inline]
+    pub fn into_boxed_script(self) -> Box<Script> {
+        // Copied from PathBuf::into_boxed_path
+        let rw = Box::into_raw(self.0.into_boxed_slice()) as *mut Script;
+        unsafe { Box::from_raw(rw) }
+    }
+
+    /// Pushes `n` onto the script.
+    ///
+    /// Only meant for usage by the `bitcoin::script::ScriptBufExt` trait, consider using the API
+    /// provided by that trait.
+    #[doc(hidden)]
+    pub fn push(&mut self, n: u8) { self.0.push(n) }
+
+    /// Pops the last byte from the script if there is one.
+    ///
+    /// Only meant for usage by the `bitcoin::script::ScriptBufExt` trait, consider using the API
+    /// provided by that trait.
+    #[doc(hidden)]
+    pub fn pop(&mut self) -> Option<u8> { self.0.pop() }
+
+    /// Extends the script with bytes from `other`.
+    ///
+    /// Only meant for usage by the `bitcoin::script::ScriptBufExt` trait, consider using the API
+    /// provided by that trait.
+    #[doc(hidden)]
+    pub fn extend_from_slice(&mut self, other: &[u8]) { self.0.extend_from_slice(other) }
+}


### PR DESCRIPTION
EDIT: See #3155 before considering looking at this.

My latest attempt to make progress on `primitives`. Draft because there is no way to merge this.

This all of the following patches on a single branch (in order)
- Patch 1: #3139 
- Patch 2: #3140
- Patch 3: #3138 
- Patch 4: #3137
- Next 6  patches are: #3134 squashed down a bunch
- Next 6 are: Create the `ScriptBufExt`
- Next 4 are: Preparation for moving types to `primitives`
- Last WIP patch is the move

### Open questions:

- Dumps rubbish in `internals/src/lib.rs`
- The additional functions on `ScriptBuf` (`push`, `pop`, `extend_from_slice`)
- How the f*** do we make this reviewable/mergable