### PR TITLE
hashes: Re-export io crate publicly

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -81,7 +81,7 @@ extern crate alloc;
 extern crate core;
 
 #[cfg(feature = "bitcoin-io")]
-extern crate bitcoin_io as io;
+pub extern crate bitcoin_io as io;
 
 #[cfg(feature = "serde")]
 /// A generic serialization/deserialization framework.

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -244,7 +244,7 @@ macro_rules! sha256t_hash_newtype {
             /// Hashes the entire contents of the `reader`.
             #[cfg(feature = "bitcoin-io")]
             #[allow(unused)] // the user of macro may not need this
-            fn hash_reader<R: io::BufRead>(reader: &mut R) -> Result<Self, io::Error> {
+            fn hash_reader<R: $crate::io::BufRead>(reader: &mut R) -> Result<Self, $crate::io::Error> {
                 <$hash_name as $crate::GeneralHash>::hash_reader(reader)
             }
         }


### PR DESCRIPTION
We use the `io` crate in the public `sha256t_hash_newtype` macro so it has to be in scope. Publicly re-export it and use `$crate::io::Foo`.

Also, because of a bug [0] in the `rust-bitcoin-maintainer-tools` `run_task` script this breakage was not noticed when it was introduced in https://github.com/rust-bitcoin/rust-bitcoin/pull/3077

[0] https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/issues/10