### PR TITLE
WIP: IC: Put fuzz at the end of crates list

### DIFF
--- a/contrib/crates.sh
+++ b/contrib/crates.sh
@@ -5,4 +5,4 @@
 # shellcheck disable=SC2034
 
 # Crates in this workspace to test (note "fuzz" is only built not tested).
-CRATES=("addresses" "base58" "bitcoin" "fuzz" "hashes" "internals" "io" "units")
+CRATES=("addresses" "base58" "bitcoin" "hashes" "internals" "io" "units" "fuzz")

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -324,7 +324,7 @@ impl std::error::Error for FromSliceError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{sha256, sha256d};
+    use crate::sha256d;
 
     hash_newtype! {
         /// A test newtype
@@ -351,7 +351,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "bitcoin-io")]
     fn hash_reader() {
+        use crate::sha256;
+
         let mut reader: &[u8] = b"hello";
         assert_eq!(sha256::Hash::hash_reader(&mut reader).unwrap(), sha256::Hash::hash(b"hello"),)
     }

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -81,7 +81,7 @@ extern crate alloc;
 extern crate core;
 
 #[cfg(feature = "bitcoin-io")]
-extern crate bitcoin_io as io;
+pub extern crate bitcoin_io as io;
 
 #[cfg(feature = "serde")]
 /// A generic serialization/deserialization framework.

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -244,7 +244,7 @@ macro_rules! sha256t_hash_newtype {
             /// Hashes the entire contents of the `reader`.
             #[cfg(feature = "bitcoin-io")]
             #[allow(unused)] // the user of macro may not need this
-            fn hash_reader<R: io::BufRead>(reader: &mut R) -> Result<Self, io::Error> {
+            fn hash_reader<R: $crate::io::BufRead>(reader: &mut R) -> Result<Self, $crate::io::Error> {
                 <$hash_name as $crate::GeneralHash>::hash_reader(reader)
             }
         }


### PR DESCRIPTION
WIP: While I use CI to check this over (also patch 1 is #3147)

There are a couple of problems with the current `run_task` ci script.

We attempted to treat `fuzz` as a special case and only build not test it. In doing so we (I) wrote `break` instead of `continue` causing the loop to terminate early and no crates listed after `fuzz` to be tested.

We can ameliorate the problem here by just putting `fuzz` at the end of the list.

ref: https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/issues/10