### PR TITLE
feat(p2p): implement conversion of RawNetworkMessage to NetworkMessage

### DIFF
--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -536,6 +536,12 @@ impl Decodable for RawNetworkMessage {
     }
 }
 
+impl From<RawNetworkMessage> for NetworkMessage {
+    fn from(value: RawNetworkMessage) -> Self {
+        value.payload
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::net::Ipv4Addr;


### PR DESCRIPTION
In some cases borrowing the payload from a `RawNetworkMessage` may not be enough, like returning a `NetworkMessage` from a function. Here is a simple conversion for users. 