### PR TITLE
Extension traits for `ScriptBuf`

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -37,6 +37,7 @@ use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPat
 use bitcoin::consensus::encode;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::{self, Input, Psbt, PsbtSighashType};
+use bitcoin::script::ScriptBufExt as _;
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};
 use bitcoin::{
     transaction, Address, Amount, CompressedPublicKey, Network, OutPoint, ScriptBuf, Sequence,

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -84,7 +84,7 @@ use bitcoin::consensus::encode;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
 use bitcoin::psbt::{self, Input, Output, Psbt, PsbtSighashType};
-use bitcoin::script::ScriptExt as _;
+use bitcoin::script::{ScriptBufExt as _, ScriptExt as _};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::{self, SighashCache, TapSighash, TapSighashType};
 use bitcoin::taproot::{self, LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo};

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -894,6 +894,7 @@ mod tests {
     use super::*;
     use crate::network::params;
     use crate::network::Network::{Bitcoin, Testnet};
+    use crate::script::ScriptBufExt as _;
 
     fn roundtrips(addr: &Address, network: Network) {
         assert_eq!(

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -7,7 +7,7 @@ use crate::locktime::absolute;
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::script::{ScriptExt as _, ScriptExtPriv as _};
+use crate::script::{ScriptBufExt as _, ScriptExt as _, ScriptExtPriv as _};
 use crate::Sequence;
 
 /// An Object which can be used to construct a script piece by piece.

--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use super::{read_uint_iter, Error, PushBytes, Script, ScriptBuf, UintError};
+use super::{
+    read_uint_iter, Error, PushBytes, Script, ScriptBuf, ScriptBufExtPriv as _, UintError,
+};
 use crate::opcodes::{self, Opcode};
 
 /// A "parsed opcode" which allows iterating over a [`Script`] in a more sensible way.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -144,7 +144,7 @@ impl ScriptBuf {
     }
 
     /// Computes the sum of `len` and the length of an appropriate push opcode.
-    pub(in crate::blockdata::script) fn reserved_len_for_slice(len: usize) -> usize {
+    pub(crate) fn reserved_len_for_slice(len: usize) -> usize {
         len + match len {
             0..=0x4b => 1,
             0x4c..=0xff => 2,
@@ -195,7 +195,7 @@ impl ScriptBuf {
     /// alternative.
     ///
     /// See the public fn [`Self::scan_and_push_verify`] to learn more.
-    pub(in crate::blockdata::script) fn push_verify(&mut self, last_opcode: Option<Opcode>) {
+    pub(crate) fn push_verify(&mut self, last_opcode: Option<Opcode>) {
         match opcode_to_verify(last_opcode) {
             Some(opcode) => {
                 self.0.pop();

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -154,7 +154,7 @@ impl ScriptBuf {
 
 impl ScriptBuf {
     /// Pushes the slice without reserving
-    fn push_slice_no_opt(&mut self, data: &PushBytes) {
+    pub(crate) fn push_slice_no_opt(&mut self, data: &PushBytes) {
         // Start with a PUSH opcode
         match data.len().to_u64() {
             n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -89,6 +89,8 @@ impl ScriptBuf {
     }
 }
 
+mod tmp_pub {
+    use super::*;
 impl ScriptBuf {
     /// Creates a new script builder
     pub fn builder() -> Builder { Builder::new() }
@@ -151,7 +153,10 @@ impl ScriptBuf {
     /// multiple times.
     pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
 }
+}
 
+mod tmp_priv {
+    use super::*;
 impl ScriptBuf {
     /// Pretends to convert `&mut ScriptBuf` to `&mut Vec<u8>` so that it can be modified.
     ///
@@ -215,6 +220,7 @@ impl ScriptBuf {
             None => self.push_opcode(OP_VERIFY),
         }
     }
+}
 }
 
 impl<'a> core::iter::FromIterator<Instruction<'a>> for ScriptBuf {

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -89,30 +89,30 @@ impl ScriptBuf {
     }
 }
 
-mod tmp_pub {
-    use super::*;
-    impl ScriptBuf {
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`ScriptBuf`] type.
+    pub trait ScriptBufExt impl for ScriptBuf {
         /// Creates a new script builder
-        pub fn builder() -> Builder { Builder::new() }
+        fn builder() -> Builder { Builder::new() }
 
         /// Generates OP_RETURN-type of scriptPubkey for the given data.
-        pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
+        fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
             Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
         }
 
         /// Creates a [`ScriptBuf`] from a hex string.
-        pub fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError> {
+        fn from_hex(s: &str) -> Result<ScriptBuf, hex::HexToBytesError> {
             let v = Vec::from_hex(s)?;
             Ok(ScriptBuf::from_bytes(v))
         }
 
         /// Adds a single opcode to the script.
-        pub fn push_opcode(&mut self, data: Opcode) { self.as_byte_vec().push(data.to_u8()); }
+        fn push_opcode(&mut self, data: Opcode) { self.as_byte_vec().push(data.to_u8()); }
 
         /// Adds instructions to push some arbitrary data onto the stack.
-        pub fn push_slice<T: AsRef<PushBytes>>(&mut self, data: T) {
+        fn push_slice<T: AsRef<PushBytes>>(&mut self, data: T) {
             let data = data.as_ref();
-            self.reserve(Self::reserved_len_for_slice(data.len()));
+            self.reserve(ScriptBuf::reserved_len_for_slice(data.len()));
             self.push_slice_no_opt(data);
         }
 
@@ -122,7 +122,7 @@ mod tmp_pub {
         ///
         /// The method panics if the instruction is a data push with length greater or equal to
         /// 0x100000000.
-        pub fn push_instruction(&mut self, instruction: Instruction<'_>) {
+        fn push_instruction(&mut self, instruction: Instruction<'_>) {
             match instruction {
                 Instruction::Op(opcode) => self.push_opcode(opcode),
                 Instruction::PushBytes(bytes) => self.push_slice(bytes),
@@ -130,7 +130,7 @@ mod tmp_pub {
         }
 
         /// Like push_instruction, but avoids calling `reserve` to not re-check the length.
-        pub fn push_instruction_no_opt(&mut self, instruction: Instruction<'_>) {
+        fn push_instruction_no_opt(&mut self, instruction: Instruction<'_>) {
             match instruction {
                 Instruction::Op(opcode) => self.push_opcode(opcode),
                 Instruction::PushBytes(bytes) => self.push_slice_no_opt(bytes),
@@ -151,23 +151,22 @@ mod tmp_pub {
         /// This function needs to iterate over the script to find the last instruction. Prefer
         /// `Builder` if you're creating the script from scratch or if you want to push `OP_VERIFY`
         /// multiple times.
-        pub fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
+        fn scan_and_push_verify(&mut self) { self.push_verify(self.last_opcode()); }
     }
 }
 
-mod tmp_priv {
-    use super::*;
-    impl ScriptBuf {
+crate::internal_macros::define_extension_trait! {
+    pub(crate) trait ScriptBufExtPriv impl for ScriptBuf {
         /// Pretends to convert `&mut ScriptBuf` to `&mut Vec<u8>` so that it can be modified.
         ///
         /// Note: if the returned value leaks the original `ScriptBuf` will become empty.
-        pub(crate) fn as_byte_vec(&mut self) -> ScriptBufAsVec<'_> {
+        fn as_byte_vec(&mut self) -> ScriptBufAsVec<'_> {
             let vec = core::mem::take(self).into_bytes();
             ScriptBufAsVec(self, vec)
         }
 
         /// Pushes the slice without reserving
-        pub(crate) fn push_slice_no_opt(&mut self, data: &PushBytes) {
+        fn push_slice_no_opt(&mut self, data: &PushBytes) {
             let mut this = self.as_byte_vec();
             // Start with a PUSH opcode
             match data.len().to_u64() {
@@ -197,7 +196,7 @@ mod tmp_priv {
         }
 
         /// Computes the sum of `len` and the length of an appropriate push opcode.
-        pub(crate) fn reserved_len_for_slice(len: usize) -> usize {
+        fn reserved_len_for_slice(len: usize) -> usize {
             len + match len {
                 0..=0x4b => 1,
                 0x4c..=0xff => 2,
@@ -211,7 +210,7 @@ mod tmp_priv {
         /// alternative.
         ///
         /// See the public fn [`Self::scan_and_push_verify`] to learn more.
-        pub(crate) fn push_verify(&mut self, last_opcode: Option<Opcode>) {
+        fn push_verify(&mut self, last_opcode: Option<Opcode>) {
             match opcode_to_verify(last_opcode) {
                 Some(opcode) => {
                     self.as_byte_vec().pop();

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -13,6 +13,8 @@ use io::Write;
 
 use crate::prelude::{DisplayHex, Vec};
 use crate::script::PushBytes;
+#[cfg(doc)]
+use crate::script::ScriptBufExt as _;
 use crate::sighash::{EcdsaSighashType, NonStandardSighashTypeError};
 
 const MAX_SIG_LEN: usize = 73;

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1470,6 +1470,7 @@ mod tests {
     use super::*;
     use crate::consensus::deserialize;
     use crate::locktime::absolute;
+    use crate::script::ScriptBufExt as _;
 
     extern crate serde_json;
 

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -251,7 +251,7 @@ macro_rules! define_extension_trait {
     ($(#[$($trait_attrs:tt)*])* $trait_vis:vis trait $trait_name:ident impl for $ty:ident {
         $(
             $(#[$($fn_attrs:tt)*])*
-            fn $fn:ident$(<$($gen:ident: $gent:ident),*>)?($($params:tt)*) $( -> $ret:ty )? $body:block
+            fn $fn:ident$(<$($gen:ident: $gent:path),*>)?($($params:tt)*) $( -> $ret:ty )? $body:block
         )*
     }) => {
         $(#[$($trait_attrs)*])* $trait_vis trait $trait_name {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1216,7 +1216,7 @@ mod tests {
     use crate::locktime::absolute;
     use crate::network::NetworkKind;
     use crate::psbt::serialize::{Deserialize, Serialize};
-    use crate::script::ScriptBuf;
+    use crate::script::{ScriptBuf, ScriptBufExt as _};
     use crate::transaction::{self, OutPoint, TxIn};
     use crate::witness::Witness;
     use crate::Sequence;

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -383,6 +383,7 @@ fn key_source_len(key_source: &KeySource) -> usize { 4 + 4 * (key_source.1).as_r
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::script::ScriptBufExt as _;
 
     // Composes tree matching a given depth map, filled with dumb script leafs,
     // each of which consists of a single push-int op code, with int value

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1544,6 +1544,7 @@ mod test {
     use secp256k1::VerifyOnly;
 
     use super::*;
+    use crate::script::ScriptBufExt as _;
     use crate::sighash::{TapSighash, TapSighashTag};
     use crate::{Address, KnownHrp};
     extern crate serde_json;

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -9,7 +9,7 @@ use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
 use bitcoin::opcodes::OP_0;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
-use bitcoin::script::PushBytes;
+use bitcoin::script::{PushBytes, ScriptBufExt as _};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{
     absolute, script, transaction, Amount, Denomination, NetworkKind, OutPoint, PrivateKey,

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -33,6 +33,7 @@ use bitcoin::hex::FromHex;
 use bitcoin::locktime::{absolute, relative};
 use bitcoin::psbt::raw::{self, Key, Pair, ProprietaryKey};
 use bitcoin::psbt::{Input, Output, Psbt, PsbtSighashType};
+use bitcoin::script::ScriptBufExt as _;
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapTree, TaprootBuilder};
 use bitcoin::witness::Witness;


### PR DESCRIPTION
Similar to #3155 but for `ScriptBuf`, however it is a little more involved.

Note:
- the change to use `impl` syntax (and addition of #3179)
- mad trickery of `ScriptBufAsVec` (props to Kix)
- widening of scope of private functions

Onward and upward!