### PR TITLE
Add blanket impl of io traits for `&mut T`

### DIFF
--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -153,6 +153,30 @@ impl<'a, R: BufRead + ?Sized> BufRead for Take<'a, R> {
     }
 }
 
+impl<T: Read> Read for &'_ mut T {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        (**self).read(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        (**self).read_exact(buf)
+    }
+}
+
+impl<T: BufRead> BufRead for &'_ mut T {
+    #[inline]
+    fn fill_buf(&mut self) -> Result<&[u8]> {
+        (**self).fill_buf()
+    }
+
+    #[inline]
+    fn consume(&mut self, amount: usize) {
+        (**self).consume(amount)
+    }
+}
+
 impl Read for &[u8] {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -258,6 +282,23 @@ pub trait Write {
             }
         }
         Ok(())
+    }
+}
+
+impl<T: Write> Write for &'_ mut T {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        (**self).write(buf)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        (**self).write_all(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<()> {
+        (**self).flush()
     }
 }
 


### PR DESCRIPTION
The impl wasn't previously available because we thought we can do a blanket impl for `std` traits. We've removed the `std` blanket impl when we realized it's broken but forgot to add the `&mut T` impls. This adds them.

Note: this is in part an experiment to see if this is API breaking. I suspect it might be.