### PR TITLE
Run CI for `primitives`

### DIFF
--- a/contrib/crates.sh
+++ b/contrib/crates.sh
@@ -5,4 +5,4 @@
 # shellcheck disable=SC2034
 
 # Crates in this workspace to test (note "fuzz" is only built not tested).
-CRATES=("addresses" "base58" "bitcoin" "fuzz" "hashes" "internals" "io" "units")
+CRATES=("addresses" "base58" "bitcoin" "primitives" "fuzz" "hashes" "internals" "io" "units")

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["tests", "contrib"]
 default = ["std"]
 std = ["alloc", "internals/std", "io/std", "units/std"]
 alloc = ["internals/alloc", "io/alloc", "units/alloc"]
-serde = ["dep:serde", "internals/serde", "units/serde"]
+serde = ["dep:serde", "internals/serde", "units/serde", "alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", version = "0.3.0" }

--- a/primitives/contrib/test_vars.sh
+++ b/primitives/contrib/test_vars.sh
@@ -5,10 +5,10 @@
 # shellcheck disable=SC2034
 
 # Test these features with "std" enabled.
-FEATURES_WITH_STD="serde"
+FEATURES_WITH_STD="ordered serde"
 
 # Test these features without "std" enabled.
-FEATURES_WITHOUT_STD="alloc serde"
+FEATURES_WITHOUT_STD="alloc ordered serde"
 
 # Run these examples.
 EXAMPLES=""


### PR DESCRIPTION
Epic fail here, `primitives` is not being checked in CI. This is the second big CI bug we have had in as many weeks.

Turns out we have a bunch `serde` code that assumes there is an allocator. Patch 2 enables `alloc` from `serde` - this is in line with feature gating wildly on `alloc` when moving code from `bitcoin` during crates smashing. 

This PR does not claim to be the best solution but is a small step forward.