### PR TITLE
CI: Generate `CRATES` using shell

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: b2ac11556708cd0fb82c8139ff38b1be8d4a62e1
+          ref: 534e4977007760fafe5154bc31acae08cb535fbb
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: b2ac11556708cd0fb82c8139ff38b1be8d4a62e1
+          ref: 534e4977007760fafe5154bc31acae08cb535fbb
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: b2ac11556708cd0fb82c8139ff38b1be8d4a62e1
+          ref: 534e4977007760fafe5154bc31acae08cb535fbb
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: b2ac11556708cd0fb82c8139ff38b1be8d4a62e1
+          ref: 534e4977007760fafe5154bc31acae08cb535fbb
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: b2ac11556708cd0fb82c8139ff38b1be8d4a62e1
+          ref: 534e4977007760fafe5154bc31acae08cb535fbb
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: b2ac11556708cd0fb82c8139ff38b1be8d4a62e1
+          ref: 534e4977007760fafe5154bc31acae08cb535fbb
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -186,7 +186,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: b2ac11556708cd0fb82c8139ff38b1be8d4a62e1
+          ref: 534e4977007760fafe5154bc31acae08cb535fbb
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1

--- a/contrib/crates.sh
+++ b/contrib/crates.sh
@@ -1,8 +1,16 @@
+# Sourced by `rust-bitcoin-maintainer-tools/ci/run_task.sh`.
+#
 # No shebang, this file should not be executed.
 # shellcheck disable=SC2148
 #
 # disable verify unused vars, despite the fact that they are used when sourced
 # shellcheck disable=SC2034
 
-# Crates in this workspace to test (note "fuzz" is only built not tested).
-CRATES=("addresses" "base58" "bitcoin" "primitives" "hashes" "internals" "io" "units" "fuzz")
+REPO_DIR=$(git rev-parse --show-toplevel)
+
+# Generates the crates list based on cargo workspace metadata.
+function generate_crates_list() {
+    cargo metadata --no-deps --format-version 1 | jq -j -r '.packages | map(.manifest_path | rtrimstr("/Cargo.toml") | ltrimstr("'"$REPO_DIR"'/")) | join(" ")'
+}
+
+CRATES=$(generate_crates_list)


### PR DESCRIPTION
Instead of manually setting the crates list it is less error prone to do so mechanically. This required some changes to the `run_task` script which have now merged, so we update to use the new commit hash at the same time.
    
- Use shell to set the `CRATES` env var used by `run_task.sh`.
- Use latest revision of  rust-bitcoin-maintainer-tools
