### PR TITLE
Panic in const context

### DIFF
--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -188,11 +188,7 @@ impl Midstate {
     /// Panics if `bytes_hashed` is not a multiple of 64.
     pub const fn new(state: [u8; 32], bytes_hashed: usize) -> Self {
         if bytes_hashed % 64 != 0 {
-            // When MSRV is 1.57+ we can use `panic!()`.
-            #[allow(unconditional_panic)]
-            #[allow(clippy::let_unit_value)]
-            #[allow(clippy::out_of_bounds_indexing)]
-            let _panic = [(); 0][1];
+            panic!("bytes hashed is not a multiple of 64");
         }
 
         Midstate { bytes: state, length: bytes_hashed }

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -901,14 +901,7 @@ impl Amount {
     pub const fn from_int_btc(btc: u64) -> Amount {
         match btc.checked_mul(100_000_000) {
             Some(amount) => Amount::from_sat(amount),
-            None => {
-                // When MSRV is 1.57+ we can use `panic!()`.
-                #[allow(unconditional_panic)]
-                #[allow(clippy::let_unit_value)]
-                #[allow(clippy::out_of_bounds_indexing)]
-                let _int_overflow_converting_btc_to_sats = [(); 0][1];
-                Amount(0)
-            }
+            None => panic!("checked_mul overflowed"),
         }
     }
 

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -65,14 +65,7 @@ impl Weight {
     pub const fn from_vb_unwrap(vb: u64) -> Weight {
         match vb.checked_mul(Self::WITNESS_SCALE_FACTOR) {
             Some(weight) => Weight(weight),
-            None => {
-                // When MSRV is 1.57+ we can use `panic!()`.
-                #[allow(unconditional_panic)]
-                #[allow(clippy::let_unit_value)]
-                #[allow(clippy::out_of_bounds_indexing)]
-                let _int_overflow_scaling_weight = [(); 0][1];
-                Weight(0)
-            }
+            None => panic!("checked_mul overflowed"),
         }
     }
 


### PR DESCRIPTION
Now that our MSRV is past 1.57 we can panic in const contexts.

Fix: #2427