### PR TITLE
Improve const_assert

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -37,8 +37,6 @@
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
-use core::mem;
-
 // We only support machines with index size of 4 bytes or more.
 //
 // Bitcoin consensus code relies on being able to have containers with more than 65536 (2^16)
@@ -49,7 +47,10 @@ use core::mem;
 // does not equal index size.
 //
 // ref: https://github.com/rust-bitcoin/rust-bitcoin/pull/2929#discussion_r1661848565
-internals::const_assert!(mem::size_of::<usize>() >= 4);
+internals::const_assert!(
+    core::mem::size_of::<usize>() >= 4;
+    "platforms that have usize less than 32 bits are not supported"
+);
 
 #[cfg(bench)]
 extern crate test;

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -63,7 +63,10 @@ impl_to_u64!(u8, u16, u32, u64);
 
 impl ToU64 for usize {
     fn to_u64(self) -> u64 {
-        crate::const_assert!(core::mem::size_of::<usize>() <= 8);
+        crate::const_assert!(
+            core::mem::size_of::<usize>() <= 8;
+            "platforms that have usize larger than 64 bits are not supported"
+        );
         self as u64
     }
 }

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -139,9 +139,15 @@ macro_rules! debug_from_display {
 /// Asserts a boolean expression at compile time.
 #[macro_export]
 macro_rules! const_assert {
-    ($x:expr) => {
-        const _: [(); 0 - !$x as usize] = [];
-    };
+    ($x:expr $(; $message:expr)?) => {
+        const _: bool = {
+            if !$x {
+                // We can't use formatting in const, only concating literals.
+                panic!(concat!("assertion ", stringify!($x), " failed" $(, ": ", $message)?))
+            }
+            $x
+        };
+    }
 }
 
 /// Derives `From<core::convert::Infallible>` for the given type.


### PR DESCRIPTION
Now that we can panic in const context we can improve the `const_assert` macro by adding a message string.

Original idea by Kix:

  https://github.com/rust-bitcoin/rust-bitcoin/pull/2972#discussion_r1726328228