### PR TITLE
feat(bip158): compute canonical filter hash

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -149,6 +149,12 @@ impl BlockFilter {
         FilterHash(sha256d::Hash::hash(&self.content)).filter_header(previous_filter_header)
     }
 
+    /// Computes the canonical hash for the given filter.
+    pub fn filter_hash(&self) -> FilterHash {
+        let hash = sha256d::Hash::hash(&self.content);
+        FilterHash(hash)
+    }
+
     /// Returns true if any query matches against this [`BlockFilter`].
     pub fn match_any<I>(&self, block_hash: BlockHash, query: I) -> Result<bool, Error>
     where


### PR DESCRIPTION
From [BIP-157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki#filter-headers)

> The canonical hash of a block filter is the double-SHA256 of the serialized filter.

If a user forgets the "double" in double-SHA256 they will be computing a nonsensical filter hash when this is easily handled by the API.