### PR TITLE
Deprecate `Transaction` `input`/`output` fields

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -473,8 +473,10 @@ pub struct Transaction {
     /// * [BIP-113 Median time-past as endpoint for lock-time calculations](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki)
     pub lock_time: absolute::LockTime,
     /// List of transaction inputs.
+    #[deprecated(since = "TBD", note = "consider using `self.inputs()`")]
     pub input: Vec<TxIn>,
     /// List of transaction outputs.
+    #[deprecated(since = "TBD", note = "consider using `self.outputs()`")]
     pub output: Vec<TxOut>,
 }
 
@@ -495,6 +497,18 @@ impl Transaction {
     // https://github.com/bitcoin/bitcoin/blob/44b05bf3fef2468783dcebf651654fdd30717e7e/src/policy/policy.h#L27
     /// Maximum transaction weight for Bitcoin Core 25.0.
     pub const MAX_STANDARD_WEIGHT: Weight = Weight::from_wu(400_000);
+
+    /// Gets a reference to the list of transaction inputs.
+    pub fn inputs(&self) -> &[TxIn] { &self.input }
+
+    /// Gets a mutable reference to the list of transaction inputs.
+    pub fn inputs_mut(&mut self) -> &mut [TxIn] { &mut self.input }
+
+    /// Gets a reference to the list of transaction outputs.
+    pub fn outputs(&self) -> &[TxOut] { &self.output }
+
+    /// Gets a mutable reference to the list of transaction outputs.
+    pub fn outputs_mut(&mut self) -> &mut [TxOut] { &mut self.output }
 
     /// Computes a "normalized TXID" which does not include any signatures.
     ///


### PR DESCRIPTION
We would like to re-name the `input` and `output` fields of the `Transaction` struct to be pluralised, however we are trying to be better library developers and not just break the world all the time.

To help transition, and also to gather feedback on the rename, add getters using the same name as the proposed new field names. Deprecate the fields.

Also add `_mut` versions of the getters for ergonomics.

Done as part of #822.

## Social Commentary

This is a really interesting PR because it succinctly illustrates the problem we face on whether to "improve" something or not and the whole 1.0 thing. The change in this PR is trivial but the decision behind if, when, how, or should we, is far from trivial. Please understand that we are taking this seriously and it feels like an extensional consideration. 