### PR TITLE
feat: remove zeroed vector by pushing front

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -18,7 +18,6 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 
-#[macro_use]
 extern crate alloc;
 
 #[cfg(bench)]
@@ -248,6 +247,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
     use hex::test_hex_unwrap as hex;
 
     use super::*;


### PR DESCRIPTION
Remove useless zeroed vector following https://github.com/rust-bitcoin/rust-bitcoin/issues/3131.
1. Init vector with capacity not to realloc when pushing.
2. If vector is empty(the first iteration), push data from the front.
3. Iterate vector from the front, and copy it from the end.