### PR TITLE
fix(p2p): `ServiceFlags::remove` cannot alter unused service

### DIFF
--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -109,7 +109,9 @@ impl ServiceFlags {
     ///
     /// Returns itself.
     pub fn remove(&mut self, other: ServiceFlags) -> ServiceFlags {
-        self.0 &= !other.0;
+        if self.has(other) {
+            self.0 &= !other.0;
+        }
         *self
     }
 


### PR DESCRIPTION
Attempting to remove a service that does not exist within `ServiceFlags` completely mangles the bits and makes the `ServiceFlags` unusable. An additional check can just ignore the request to remove a flag if the service isn't present. This was discovered by trying to remove an unrecognized flag `0xfffffffffffff3b0`, which I am struggling to find in the `bitcoin` `protocol.h`.