### PR TITLE
Re-release 0.32 as v1.0.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.2"
+version = "1.0.0"
 dependencies = [
  "base58ck",
  "base64",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.2"
+version = "1.0.0"
 dependencies = [
  "base58ck",
  "base64",

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.0.0 - 2024-08-26
+
+There are no code changes between `v0.32.2` and `v1.0.0`.
+
+This release is an acknowledgement that:
+
+- We will support this version into the future.
+- We will backport security fixes and non-breaking changes.
+- We will provide a compat layer for the `primitives` release
+  so that you are not required to upgrade further if you do not wish to.
+
 # 0.32.2 - 2024-06-07
 
 - Fix a bug when parsing 256-bit numeric types [#2837](https://github.com/rust-bitcoin/rust-bitcoin/pull/2837)

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.32.2"
+version = "1.0.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
Release the current release (`v0.32.2`) as `v1.0.0`.

Turns out `rust-bitcoin v0.32` **is** the stable 1.0 release, we just didn't name it as such. Here's why:

- BDK already released their 1.0 using it.
- LDK is about to as well.
- We agreed to backport non-breaking changes as requested
- We already backport security patches.
- We have a verbal agreement from a bunch of projects to upgrade to and stay on 0.32
- We are working on a total overhaul of how things are organised (the `primitives` crate).
- Some folk are sick of upgrading, we have pushed them about as far as we can.

So, here we re-release `v.0.32.2` as `v1.0.0` with no code changes.

- BDK can bump their dependency in a patch version (hopefully).
- LDK can use the new version trivially (they are on 0.32 already).
- We can double down on backporting non-breaking functionality as other projects upgrade to 0.32 / 1.0.0
- We can continue to do security patches.

The kicker:

When we release `primitives` we release a compat layer on top of `rust-bitcoin v1` so that folk can use `primitives` without upgrading off of `v1`. We then also release `v2` for those that are ready for it.

`rust-bitcoin` can then continue working on the perfect API and release it in `v2` and because of the compat layer if you don't like the changes you don't have to use them, everyone wins!