### PR TITLE
WIP: `primitives` compat layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,13 @@ path = "internals"
 [patch.crates-io.bitcoin-io]
 path = "io"
 
+# TEMPORARY patches for branchesh that imitate next releases.
+
+[patch.crates-io.bitcoin-primitives]
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "WIP-primitives-0.101.0"
+
 [patch.crates-io.bitcoin-units]
-path = "units"
+git = "https://github.com/tcharding/rust-bitcoin"
+branch = "WIP-units-0.1.3"
+

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -26,3 +26,6 @@ internals = { package = "bitcoin-internals", version = "0.3.0", features = ["all
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)'] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.32.2"
+version = "0.32.3"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
@@ -40,6 +40,7 @@ units = { package = "bitcoin-units", version = "0.1.0", default-features = false
 
 base64 = { version = "0.21.3", optional = true }
 ordered = { version = "0.2.0", optional = true }
+primitives = { package = "bitcoin-primitives", version = "0.101.0", default-features = false, features = ["alloc"], optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
 bitcoinconsensus = { version = "0.105.0+25.1", default-features = false, optional = true }
 
@@ -79,3 +80,6 @@ required-features = ["std", "rand-std", "bitcoinconsensus"]
 
 [[example]]
 name = "sighash"
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(mutate)', 'cfg(rust_v_1_60)'] }

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -12,7 +12,7 @@ use core::str::FromStr;
 
 use bech32::Fe32;
 use internals::write_err;
-use units::{parse, ParseIntError};
+use units::parse::{self, ParseIntError};
 
 use crate::blockdata::opcodes::all::*;
 use crate::blockdata::opcodes::Opcode;

--- a/bitcoin/src/compat.rs
+++ b/bitcoin/src/compat.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Compatibility layer.
+//!
+//! Provides compatibility between `primitives v0.100.0` and `bitcoin v0.32`.
+
+use crate::{CompactTarget, Opcode, Sequence};
+
+impl Sequence {
+    /// Converts `other` from a `primitives` type to a `rust-bitcoin v0.32` [`Sequence`] type.
+    pub fn from_compat(other: primitives::Sequence) -> Self {
+        Sequence(other.to_consensus_u32())
+    }
+
+    /// Converts `self` from a `rust-bitcoin v0.32` [`Sequence`] type to a `primitives` type.
+    pub fn to_compat(self) -> primitives::Sequence {
+        primitives::Sequence::from_consensus(self.to_consensus_u32())
+    }
+}
+
+impl Opcode {
+    /// Converts `other` from a `primitives` type to a `rust-bitcoin v0.32` [`Opcode`] type.
+    // TODO: Re-export `Opcode` from primitives crate root.
+    pub fn from_compat(other: primitives::opcodes::Opcode) -> Self {
+        Opcode::from(other.to_u8())
+    }
+
+    /// Converts `self` from a `rust-bitcoin v0.32` [`Opcode`] type to a `primitives` type.
+    pub fn to_compat(self) -> primitives::opcodes::Opcode {
+        primitives::opcodes::Opcode::from(self.to_u8())
+    }
+}
+
+impl CompactTarget {
+    /// Converts `other` from a `primitives` type to a `rust-bitcoin v0.32` [`CompactTarget`] type.
+    pub fn from_compat(other: primitives::CompactTarget) -> Self {
+        CompactTarget::from_consensus(other.to_consensus())
+    }
+
+    /// Converts `self` from a `rust-bitcoin v0.32` [`CompactTarget`] type to a `primitives` type.
+    pub fn to_compat(self) -> primitives::CompactTarget {
+        primitives::CompactTarget::from_consensus(self.to_consensus())
+    }
+}

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1521,7 +1521,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(not(feature = "std"), feature = "no-std"))]
+    #[cfg(not(feature = "std"))]
     fn private_key_debug_is_obfuscated() {
         let sk =
             PrivateKey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -83,6 +83,8 @@ pub extern crate secp256k1;
 #[macro_use]
 extern crate actual_serde as serde;
 
+#[cfg(feature = "primitives")]
+mod compat;
 #[cfg(test)]
 #[macro_use]
 mod test_macros;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -88,3 +88,7 @@ path = "fuzz_targets/hashes/sha512.rs"
 [[bin]]
 name = "units_deserialize_amount"
 path = "fuzz_targets/units/deserialize_amount.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)'] }
+

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -36,3 +36,6 @@ serde = { version = "1.0", default-features = false, optional = true }
 [dev-dependencies]
 serde_test = "1.0"
 serde_json = "1.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(hashes_fuzz)'] }

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -26,3 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = { version = "1.0.103", default-features = false, optional = true }
 
 [dev-dependencies]
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(rust_v_1_61)', 'cfg(rust_v_1_64)'] }
+

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -29,3 +29,6 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"], 
 [dev-dependencies]
 serde_test = "1.0"
 serde_json = "1.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)'] }


### PR DESCRIPTION
Example of what might be needed to implement a compat layer for `primitives` when we release it to make `primitives` types compatible with `rust-bitcoin v0.32`.

The branches used in the manifest all exist publicly on my tree if you want to play around with this.

The only thing of interest here is `bitcoin/src/compat.rs`