### PR TITLE
units: Have FeeRate::from_sat_per_vb take u32 to simplify API

### DIFF
--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -41,8 +41,7 @@ pub mod fee_rate {
             let raw_tx = hex!(SOME_TX);
             let tx: Transaction = Decodable::consensus_decode(&mut raw_tx.as_slice()).unwrap();
 
-            let rate = FeeRate::from_sat_per_vb(1).expect("1 sat/byte is valid");
-
+            let rate = FeeRate::from_sat_per_vb(1);
             assert_eq!(rate.fee_vb(tx.vsize().to_u64()), rate.fee_wu(tx.weight()));
         }
     }

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -699,7 +699,7 @@ fn defult_dust_value_tests() {
     assert!(script_p2wpkh.is_p2wpkh());
     assert_eq!(script_p2wpkh.minimal_non_dust(), crate::Amount::from_sat(294));
     assert_eq!(
-        script_p2wpkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
+        script_p2wpkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb(6)),
         crate::Amount::from_sat(588)
     );
 
@@ -713,7 +713,7 @@ fn defult_dust_value_tests() {
     assert!(script_p2pkh.is_p2pkh());
     assert_eq!(script_p2pkh.minimal_non_dust(), crate::Amount::from_sat(546));
     assert_eq!(
-        script_p2pkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
+        script_p2pkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb(6)),
         crate::Amount::from_sat(1092)
     );
 }

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -129,7 +129,7 @@ impl Psbt {
     /// 1000 sats/vByte. 25k sats/vByte is obviously a mistake at this point.
     ///
     /// [`extract_tx`]: Psbt::extract_tx
-    pub const DEFAULT_MAX_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(25_000);
+    pub const DEFAULT_MAX_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb(25_000);
 
     /// An alias for [`extract_tx_fee_rate_limit`].
     ///


### PR DESCRIPTION
Personally still not 100% convinced of this change, but want to bring it out there. I have absolutely never come across a place where that unwrap made any sense. If you're dealing with user-inputted data as an amount and you get sats or so, we could still add the original methods that I PRs for `FeeRate` that use the `Amount` type in the API.

Like `FeeRate::from_per_kvb(amt: Amount)`. That API was deemed too complex at the time.