### PR TITLE
Bump units version

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arbitrary",
  "bitcoin-internals",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arbitrary",
  "bitcoin-internals",

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
The master branch version of units is behind that of crates: https://crates.io/crates/bitcoin-units

This breaks the ability for those of us trying to patch and work off of master since Cargo ignores the patched version 0.1.1 which is technically ahead.

I'm not sure how this got out of sync and if there's a preferable way/commit to fix this.

closes https://github.com/rust-bitcoin/rust-bitcoin/issues/3171