### PR TITLE
bip32: Backport without typo

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -38,9 +38,17 @@ const VERSION_BYTES_TESTNETS_PRIVATE: [u8; 4] = [0x04, 0x35, 0x83, 0x94];
 
 /// The old name for xpub, extended public key.
 #[deprecated(since = "0.31.0", note = "use xpub instead")]
+pub type ExtendedPubKey = Xpub;
+
+/// The old name for xpub, extended public key (with a released typo in it).
+#[deprecated(since = "0.31.0", note = "use xpub instead")]
 pub type ExtendendPubKey = Xpub;
 
 /// The old name for xpriv, extended public key.
+#[deprecated(since = "0.31.0", note = "use xpriv instead")]
+pub type ExtendedPrivKey = Xpriv;
+
+/// The old name for xpriv, extended public key (with a released typo in it).
 #[deprecated(since = "0.31.0", note = "use xpriv instead")]
 pub type ExtendendPrivKey = Xpriv;
 


### PR DESCRIPTION
In v0.31 we deprecated the long version of what became `Xpub` and `Xpriv` but we had a typo in the name so the this meant that there is no deprecated original. However now we released the typo we need to have both, the original name correctly deprecated _and_ the new typo deprecated type with the typo.

Typo fix was done on master in #2693.