### PR TITLE
Move easy things from `transaction` to `primitives`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -113,6 +113,7 @@ dependencies = [
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
+ "bitcoin_hashes",
  "mutagen",
  "ordered",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -112,6 +112,7 @@ dependencies = [
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
+ "bitcoin_hashes",
  "mutagen",
  "ordered",
  "serde",

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -897,31 +897,15 @@ impl std::error::Error for IndexOutOfBoundsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
 
-/// The transaction version.
-///
-/// Currently, as specified by [BIP-68], only version 1 and 2 are considered standard.
-///
-/// Standardness of the inner `i32` is not an invariant because you are free to create transactions
-/// of any version, transactions with non-standard version numbers will not be relayed by the
-/// Bitcoin network.
-///
-/// [BIP-68]: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
-#[derive(Copy, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Version(pub i32);
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`Version`] type.
+    pub trait VersionExt impl for Version {
+        /// Creates a non-standard transaction version.
+        fn non_standard(version: i32) -> Version { Self(version) }
 
-impl Version {
-    /// The original Bitcoin transaction version (pre-BIP-68).
-    pub const ONE: Self = Self(1);
-
-    /// The second Bitcoin transaction version (post-BIP-68).
-    pub const TWO: Self = Self(2);
-
-    /// Creates a non-standard transaction version.
-    pub fn non_standard(version: i32) -> Version { Self(version) }
-
-    /// Returns true if this transaction version number is considered standard.
-    pub fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
+        /// Returns true if this transaction version number is considered standard.
+        fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
+    }
 }
 
 impl Encodable for Version {
@@ -934,10 +918,6 @@ impl Decodable for Version {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Decodable::consensus_decode(r).map(Version)
     }
-}
-
-impl fmt::Display for Version {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
 impl_consensus_encoding!(TxOut, value, script_pubkey);

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -31,40 +31,9 @@ use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
 use crate::{Amount, FeeRate, SignedAmount, VarInt};
 
-hashes::hash_newtype! {
-    /// A bitcoin transaction hash/transaction ID.
-    ///
-    /// For compatibility with the existing Bitcoin infrastructure and historical and current
-    /// versions of the Bitcoin Core software itself, this and other [`sha256d::Hash`] types, are
-    /// serialized in reverse byte order when converted to a hex string via [`std::fmt::Display`]
-    /// trait operations.
-    ///
-    /// See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
-    pub struct Txid(sha256d::Hash);
-
-    /// A bitcoin witness transaction ID.
-    pub struct Wtxid(sha256d::Hash);
-}
-impl_hashencode!(Txid);
-impl_hashencode!(Wtxid);
-
-impl Txid {
-    /// The "all zeros" TXID.
-    ///
-    /// This is used as the "txid" of the dummy input of a coinbase transaction. It is
-    /// not a real TXID and should not be used in other contexts.
-    pub fn all_zeros() -> Self { Self::from_byte_array([0; 32]) }
-}
-
-impl Wtxid {
-    /// The "all zeros" wTXID.
-    ///
-    /// This is used as the wTXID for the coinbase transaction when constructing blocks,
-    /// since the coinbase transaction contains a commitment to all transactions' wTXIDs
-    /// but naturally cannot commit to its own. It is not a real wTXID and should not be
-    /// used in other contexts.
-    pub fn all_zeros() -> Self { Self::from_byte_array([0; 32]) }
-}
+#[rustfmt::skip]            // Keep public re-exports separate.
+#[doc(inline)]
+pub use primitives::transaction::*;
 
 /// Trait that abstracts over a transaction identifier i.e., `Txid` and `Wtxid`.
 pub trait TxIdentifier: sealed::Sealed + AsRef<[u8]> {}
@@ -77,6 +46,9 @@ mod sealed {
     impl Sealed for super::Txid {}
     impl Sealed for super::Wtxid {}
 }
+
+impl_hashencode!(Txid);
+impl_hashencode!(Wtxid);
 
 /// The marker MUST be a 1-byte zero value: 0x00. (BIP-141)
 const SEGWIT_MARKER: u8 = 0x00;
@@ -564,7 +536,7 @@ impl Transaction {
         self.input.consensus_encode(&mut enc).expect("engines don't error");
         self.output.consensus_encode(&mut enc).expect("engines don't error");
         self.lock_time.consensus_encode(&mut enc).expect("engines don't error");
-        Txid(sha256d::Hash::from_engine(enc))
+        Txid::from_byte_array(sha256d::Hash::from_engine(enc).to_byte_array())
     }
 
     /// Computes the segwit version of the transaction id.
@@ -585,7 +557,7 @@ impl Transaction {
     pub fn compute_wtxid(&self) -> Wtxid {
         let mut enc = sha256d::Hash::engine();
         self.consensus_encode(&mut enc).expect("engines don't error");
-        Wtxid(sha256d::Hash::from_engine(enc))
+        Wtxid::from_byte_array(sha256d::Hash::from_engine(enc).to_byte_array())
     }
 
     /// Returns the weight of this transaction, as defined by BIP-141.

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -181,7 +181,7 @@ macro_rules! impl_hashencode {
     ($hashtype:ident) => {
         impl $crate::consensus::Encodable for $hashtype {
             fn consensus_encode<W: $crate::io::Write + ?Sized>(&self, w: &mut W) -> core::result::Result<usize, $crate::io::Error> {
-                self.0.consensus_encode(w)
+                self.as_byte_array().consensus_encode(w)
             }
         }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,11 +16,12 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "internals/std", "io/std", "units/std"]
-alloc = ["internals/alloc", "io/alloc", "units/alloc"]
-serde = ["dep:serde", "internals/serde", "units/serde", "alloc"]
+std = ["alloc", "hashes/std", "internals/std", "io/std", "units/std"]
+alloc = ["hashes/alloc", "internals/alloc", "io/alloc", "units/alloc"]
+serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc"]
 
 [dependencies]
+hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["io"] }
 internals = { package = "bitcoin-internals", version = "0.3.0" }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -33,6 +33,7 @@ pub mod locktime;
 pub mod opcodes;
 pub mod pow;
 pub mod sequence;
+pub mod transaction;
 
 #[doc(inline)]
 pub use units::*;

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin transactions.
+//!
+//! A transaction describes a transfer of money. It consumes previously-unspent
+//! transaction outputs and produces new ones, satisfying the condition to spend
+//! the old outputs (typically a digital signature with a specific key must be
+//! provided) and defining the condition to spend the new ones. The use of digital
+//! signatures ensures that coins cannot be spent by unauthorized parties.
+//!
+//! This module provides the structures and functions needed to support transactions.
+
+use hashes::sha256d;
+
+hashes::hash_newtype! {
+    /// A bitcoin transaction hash/transaction ID.
+    ///
+    /// For compatibility with the existing Bitcoin infrastructure and historical and current
+    /// versions of the Bitcoin Core software itself, this and other [`sha256d::Hash`] types, are
+    /// serialized in reverse byte order when converted to a hex string via [`std::fmt::Display`]
+    /// trait operations.
+    ///
+    /// See [`hashes::Hash::DISPLAY_BACKWARD`] for more details.
+    pub struct Txid(sha256d::Hash);
+
+    /// A bitcoin witness transaction ID.
+    pub struct Wtxid(sha256d::Hash);
+}
+
+impl Txid {
+    /// The "all zeros" TXID.
+    ///
+    /// This is used as the "txid" of the dummy input of a coinbase transaction. It is
+    /// not a real TXID and should not be used in other contexts.
+    pub fn all_zeros() -> Self { Self::from_byte_array([0; 32]) }
+}
+
+impl Wtxid {
+    /// The "all zeros" wTXID.
+    ///
+    /// This is used as the wTXID for the coinbase transaction when constructing blocks,
+    /// since the coinbase transaction contains a commitment to all transactions' wTXIDs
+    /// but naturally cannot commit to its own. It is not a real wTXID and should not be
+    /// used in other contexts.
+    pub fn all_zeros() -> Self { Self::from_byte_array([0; 32]) }
+}

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -10,6 +10,8 @@
 //!
 //! This module provides the structures and functions needed to support transactions.
 
+use core::fmt;
+
 use hashes::sha256d;
 
 hashes::hash_newtype! {
@@ -43,4 +45,29 @@ impl Wtxid {
     /// but naturally cannot commit to its own. It is not a real wTXID and should not be
     /// used in other contexts.
     pub fn all_zeros() -> Self { Self::from_byte_array([0; 32]) }
+}
+
+/// The transaction version.
+///
+/// Currently, as specified by [BIP-68], only version 1 and 2 are considered standard.
+///
+/// Standardness of the inner `i32` is not an invariant because you are free to create transactions
+/// of any version, transactions with non-standard version numbers will not be relayed by the
+/// Bitcoin network.
+///
+/// [BIP-68]: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
+#[derive(Copy, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Version(pub i32);
+
+impl Version {
+    /// The original Bitcoin transaction version (pre-BIP-68).
+    pub const ONE: Self = Self(1);
+
+    /// The second Bitcoin transaction version (post-BIP-68).
+    pub const TWO: Self = Self(2);
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }


### PR DESCRIPTION
Move hash wrapper types and `transaction::Version`.


