### PR TITLE
Change `T::from_str(s)` to `s.parse::<T>()`

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -1,6 +1,5 @@
 extern crate bitcoin;
 
-use std::str::FromStr;
 use std::{env, process};
 
 use bitcoin::address::{Address, KnownHrp};
@@ -40,7 +39,7 @@ fn main() {
     println!("Root key: {}", root);
 
     // derive child xpub
-    let path = DerivationPath::from_str("84h/0h/0h").unwrap();
+    let path = "84h/0h/0h".parse::<DerivationPath>().unwrap();
     let child = root.derive_priv(&secp, &path);
     println!("Child at {}: {}", path, child);
     let xpub = Xpub::from_priv(&secp, &child);

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -538,7 +538,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKey {
                 E: serde::de::Error,
             {
                 if let Ok(s) = core::str::from_utf8(v) {
-                    PrivateKey::from_str(s).map_err(E::custom)
+                    s.parse::<PrivateKey>().map_err(E::custom)
                 } else {
                     Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
                 }
@@ -548,7 +548,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKey {
             where
                 E: serde::de::Error,
             {
-                PrivateKey::from_str(v).map_err(E::custom)
+                v.parse::<PrivateKey>().map_err(E::custom)
             }
         }
 
@@ -586,7 +586,7 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
                     E: serde::de::Error,
                 {
                     if let Ok(hex) = core::str::from_utf8(v) {
-                        PublicKey::from_str(hex).map_err(E::custom)
+                        hex.parse::<PublicKey>().map_err(E::custom)
                     } else {
                         Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
                     }
@@ -596,7 +596,7 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
                 where
                     E: serde::de::Error,
                 {
-                    PublicKey::from_str(v).map_err(E::custom)
+                    v.parse::<PublicKey>().map_err(E::custom)
                 }
             }
             d.deserialize_str(HexVisitor)
@@ -652,7 +652,7 @@ impl<'de> serde::Deserialize<'de> for CompressedPublicKey {
                     E: serde::de::Error,
                 {
                     if let Ok(hex) = core::str::from_utf8(v) {
-                        CompressedPublicKey::from_str(hex).map_err(E::custom)
+                        hex.parse::<CompressedPublicKey>().map_err(E::custom)
                     } else {
                         Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self))
                     }
@@ -662,7 +662,7 @@ impl<'de> serde::Deserialize<'de> for CompressedPublicKey {
                 where
                     E: serde::de::Error,
                 {
-                    CompressedPublicKey::from_str(v).map_err(E::custom)
+                    v.parse::<CompressedPublicKey>().map_err(E::custom)
                 }
             }
             d.deserialize_str(HexVisitor)

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -170,7 +170,7 @@ impl FromStr for PsbtSighashType {
         // NB: some of Taproot sighash types are non-standard for pre-Taproot
         // inputs. We also do not support SIGHASH_RESERVED in verbatim form
         // ("0xFF" string should be used instead).
-        if let Ok(ty) = TapSighashType::from_str(s) {
+        if let Ok(ty) = s.parse::<TapSighashType>() {
             return Ok(ty.into());
         }
 

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -2,7 +2,6 @@
 //! defined at <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#test-vectors>
 
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 use bitcoin::bip32::{Fingerprint, IntoDerivationPath, KeySource, Xpriv, Xpub};
 use bitcoin::consensus::encode::{deserialize, serialize_hex};
@@ -118,7 +117,7 @@ fn build_extended_private_key() -> Xpriv {
     let extended_private_key = "tprv8ZgxMBicQKsPd9TeAdPADNnSyH9SSUUbTVeFszDE23Ki6TBB5nCefAdHkK8Fm3qMQR6sHwA56zqRmKmxnHk37JkiFzvncDqoKmPWubu7hDF";
     let seed = "cUkG8i1RFfWGWy5ziR11zJ5V4U4W3viSFCfyJmZnvQaUsd1xuF3T";
 
-    let xpriv = Xpriv::from_str(extended_private_key).unwrap();
+    let xpriv = extended_private_key.parse::<Xpriv>().unwrap();
 
     let sk = PrivateKey::from_wif(seed).unwrap();
     let seeded = Xpriv::new_master(NetworkKind::Test, &sk.inner.secret_bytes()).unwrap();
@@ -276,7 +275,7 @@ fn bip32_derivation(
         let pk = pk_path[i].0;
         let path = pk_path[i].1;
 
-        let pk = PublicKey::from_str(pk).unwrap();
+        let pk = pk.parse::<PublicKey>().unwrap();
         let path = path.into_derivation_path().unwrap();
 
         tree.insert(pk.inner, (fingerprint, path));
@@ -290,7 +289,7 @@ fn update_psbt_with_sighash_all(mut psbt: Psbt) -> Psbt {
     let expected_psbt_hex = include_str!("data/update_2_psbt_hex");
     let expected_psbt: Psbt = hex_psbt(expected_psbt_hex);
 
-    let ty = PsbtSighashType::from_str("SIGHASH_ALL").unwrap();
+    let ty = "SIGHASH_ALL".parse::<PsbtSighashType>().unwrap();
 
     let mut input_0 = psbt.inputs[0].clone();
     input_0.sighash_type = Some(ty);

--- a/hashes/embedded/src/main.rs
+++ b/hashes/embedded/src/main.rs
@@ -49,7 +49,7 @@ fn check_result(engine: sha256::HashEngine) {
     let hash = TestType(sha256::Hash::from_engine(engine));
 
     let hash_check =
-        TestType::from_str("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".parse::<TestType>()
             .unwrap();
     hprintln!("hash:{} hash_check:{}", hash, hash_check).unwrap();
     if hash != hash_check {

--- a/hashes/src/serde_macros.rs
+++ b/hashes/src/serde_macros.rs
@@ -29,7 +29,7 @@ pub mod serde_details {
             E: de::Error,
         {
             if let Ok(hex) = str::from_utf8(v) {
-                Self::Value::from_str(hex).map_err(E::custom)
+                hex.parse::<Self::Value>().map_err(E::custom)
             } else {
                 return Err(E::invalid_value(de::Unexpected::Bytes(v), &self));
             }
@@ -39,7 +39,7 @@ pub mod serde_details {
         where
             E: de::Error,
         {
-            Self::Value::from_str(v).map_err(E::custom)
+            v.parse::<Self::Value>().map_err(E::custom)
         }
     }
 

--- a/internals/src/serde.rs
+++ b/internals/src/serde.rs
@@ -135,7 +135,6 @@ macro_rules! serde_struct_human_string_impl {
             {
                 if deserializer.is_human_readable() {
                     use core::fmt::Formatter;
-                    use core::str::FromStr;
 
                     struct Visitor;
                     impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
@@ -149,7 +148,7 @@ macro_rules! serde_struct_human_string_impl {
                         where
                             E: $crate::serde::de::Error,
                         {
-                            $name::from_str(v).map_err(E::custom)
+                            v.parse::<$name>().map_err(E::custom)
                         }
 
                     }

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -935,7 +935,7 @@ impl Amount {
     /// Please be aware of the risk of using floating-point numbers.
     #[cfg(feature = "alloc")]
     pub fn to_float_in(self, denom: Denomination) -> f64 {
-        f64::from_str(&self.to_string_in(denom)).unwrap()
+        self.to_string_in(denom).parse::<f64>().unwrap()
     }
 
     /// Expresses this [`Amount`] as a floating-point value in Bitcoin.
@@ -1308,7 +1308,7 @@ impl SignedAmount {
     /// Please be aware of the risk of using floating-point numbers.
     #[cfg(feature = "alloc")]
     pub fn to_float_in(self, denom: Denomination) -> f64 {
-        f64::from_str(&self.to_string_in(denom)).unwrap()
+        self.to_string_in(denom).parse::<f64>().unwrap()
     }
 
     /// Express this [`SignedAmount`] as a floating-point value in Bitcoin.


### PR DESCRIPTION
As mentioned in issue #3234 `s.parse::<T>()` is more idiomatic and produces more helpful error messages.

This has been changed in the main codebase, not including examples, rustdocs, and in the `test` modules.

`use std::str::FromStr;` has been removed where this change makes it unnecessary.

To close the issue it may also need to be changed in the examples and the `test` modules and `contributing.md` updated.
