### PR TITLE
Show output of failed semver checks

### DIFF
--- a/.github/workflows/semver-checks-pr-label.yml
+++ b/.github/workflows/semver-checks-pr-label.yml
@@ -73,7 +73,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
-              body: ':rotating_light: API BREAKING CHANGE DETECTED'
+              body: ':rotating_light: API BREAKING CHANGE DETECTED\n\nTo see the changes click details on "Check semver breaks / PR Semver - stable toolchain" job then expand "Run semver checker script" and scroll to the end of the section.'
             });
 
             // add the label to the PR

--- a/contrib/check-semver-feature.sh
+++ b/contrib/check-semver-feature.sh
@@ -112,6 +112,7 @@ check_for_non_additive_cargo_features() {
         if grep -q "FAIL" "$file"; then
             echo "You have introduced non-additive cargo features"
             echo "FAIL found in $file"
+            cat "$file"
             # flag it as a breaking change
             # Handle the case where FAIL is found
             touch non-additive-cargo

--- a/contrib/check-semver-pr.sh
+++ b/contrib/check-semver-pr.sh
@@ -175,6 +175,7 @@ check_for_breaking_changes() {
         if grep -q "FAIL" "$file"; then
             echo "You have introduced changes to the public API"
             echo "FAIL found in $file"
+            cat "$file"
             # flag it as a breaking change
             # Handle the case where FAIL is found
             touch semver-break


### PR DESCRIPTION
Debugging the API breaks without seeing what failed is pretty much impossible. This simply prints the output when a check fails.