### PR TITLE
Move `Arbitrary` impls

### DIFF
--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -3,6 +3,8 @@
 #[cfg(doc)]
 use core::ops::Deref;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 use hex::FromHex;
 use internals::ToU64 as _;
 
@@ -10,9 +12,6 @@ use super::{opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptExt
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
-
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 
 /// An owned, growable script.
 ///

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -157,14 +157,6 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for ScriptBuf {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let v = Vec::<u8>::arbitrary(u)?;
-        Ok(ScriptBuf(v))
-    }
-}
-
 crate::internal_macros::define_extension_trait! {
     pub(crate) trait ScriptBufExtPriv impl for ScriptBuf {
         /// Pretends to convert `&mut ScriptBuf` to `&mut Vec<u8>` so that it can be modified.
@@ -300,5 +292,13 @@ impl<'a> Drop for ScriptBufAsVec<'a> {
     fn drop(&mut self) {
         let vec = core::mem::take(&mut self.1);
         *(self.0) = ScriptBuf::from_bytes(vec);
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for ScriptBuf {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let v = Vec::<u8>::arbitrary(u)?;
+        Ok(ScriptBuf(v))
     }
 }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -12,6 +12,8 @@
 
 use core::{cmp, fmt, str};
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 use hashes::sha256d;
 use internals::{write_err, ToU64 as _};
 use io::{BufRead, Write};
@@ -28,9 +30,6 @@ use crate::script::{Script, ScriptBuf, ScriptExt as _, ScriptExtPriv as _};
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
 use crate::{Amount, FeeRate, SignedAmount, VarInt};
-
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 
 hashes::hash_newtype! {
     /// A bitcoin transaction hash/transaction ID.
@@ -411,10 +410,7 @@ crate::internal_macros::define_extension_trait! {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for TxOut {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(TxOut {
-            value: Amount::arbitrary(u)?,
-            script_pubkey: ScriptBuf::arbitrary(u)?,
-        })
+        Ok(TxOut { value: Amount::arbitrary(u)?, script_pubkey: ScriptBuf::arbitrary(u)? })
     }
 }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -407,17 +407,17 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
+/// Returns the total number of bytes that this script pubkey would contribute to a transaction.
+fn size_from_script_pubkey(script_pubkey: &Script) -> usize {
+    let len = script_pubkey.len();
+    Amount::SIZE + VarInt::from(len).size() + len
+}
+
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for TxOut {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(TxOut { value: Amount::arbitrary(u)?, script_pubkey: ScriptBuf::arbitrary(u)? })
     }
-}
-
-/// Returns the total number of bytes that this script pubkey would contribute to a transaction.
-fn size_from_script_pubkey(script_pubkey: &Script) -> usize {
-    let len = script_pubkey.len();
-    Amount::SIZE + VarInt::from(len).size() + len
 }
 
 /// Bitcoin transaction.

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -15,7 +15,6 @@ use core::{default, fmt, ops};
 use ::serde::{Deserialize, Serialize};
 use internals::error::InputString;
 use internals::write_err;
-
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 
@@ -1074,14 +1073,6 @@ impl Amount {
     }
 }
 
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for Amount {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let a = u64::arbitrary(u)?;
-        Ok(Amount(a))
-    }
-}
-
 impl default::Default for Amount {
     fn default() -> Self { Amount::ZERO }
 }
@@ -1172,6 +1163,14 @@ impl core::iter::Sum for Amount {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         let sats: u64 = iter.map(|amt| amt.0).sum();
         Amount::from_sat(sats)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for Amount {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let a = u64::arbitrary(u)?;
+        Ok(Amount(a))
     }
 }
 

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -5,14 +5,13 @@
 use core::fmt;
 use core::ops::{Div, Mul};
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::amount::Amount;
 use crate::weight::Weight;
-
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 
 /// Represents fee rate.
 ///

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -109,14 +109,6 @@ impl FeeRate {
     }
 }
 
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for FeeRate {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let f = u64::arbitrary(u)?;
-        Ok(FeeRate(f))
-    }
-}
-
 /// Alternative will display the unit.
 impl fmt::Display for FeeRate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -154,6 +146,14 @@ impl Div<Weight> for Amount {
 }
 
 crate::impl_parse_str_from_int_infallible!(FeeRate, u64, from_sat_per_kwu);
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for FeeRate {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let f = u64::arbitrary(u)?;
+        Ok(FeeRate(f))
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR may seem overly trivial so please let me explain.

- In #3257 the original author (cc'd below) kindly put the `Arbitrary` stuff at the bottom for another type during review
- There will likely be a bunch more of these impls and its easy enough code to write so we might get newer contributors who will just follow what is already done

Move the `Arbitrary` impls to the bottom of the type or file because its test code, more or less, and not needed to be read that much.
