### PR TITLE
Change `T::from_str(s)` to `s.parse::<T>()` in examples, docs and tests

### DIFF
--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -84,7 +84,8 @@ fn get_internal_address_xpriv<C: Signing>(
 
 // The address to send to.
 fn receivers_address() -> Address {
-    "bc1q7cyrfmck2ffu2ud3rn5l5a8yv6f0chkp0zpemf".parse::<Address<_>>()
+    "bc1q7cyrfmck2ffu2ud3rn5l5a8yv6f0chkp0zpemf"
+        .parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")
@@ -92,7 +93,8 @@ fn receivers_address() -> Address {
 
 // The dummy unspent transaction outputs that we control.
 fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
-    let script_pubkey_1 = "bc1qrwuu3ydv0jfza4a0ehtfd03m9l4vw3fy0hfm50".parse::<Address<_>>()
+    let script_pubkey_1 = "bc1qrwuu3ydv0jfza4a0ehtfd03m9l4vw3fy0hfm50"
+        .parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")
@@ -105,7 +107,8 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
 
     let utxo_1 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
 
-    let script_pubkey_2 = "bc1qy7swwpejlw7a2rp774pa8rymh8tw3xvd2x2xkd".parse::<Address<_>>()
+    let script_pubkey_2 = "bc1qy7swwpejlw7a2rp774pa8rymh8tw3xvd2x2xkd"
+        .parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -184,13 +184,13 @@ fn main() {
     // information to the PSBT.
     let ty = EcdsaSighashType::All.into();
     let derivation_paths = [
-        DerivationPath::from_str("m/84'/0'/0'/0/0").expect("valid derivation path"),
-        DerivationPath::from_str("m/84'/0'/0'/1/0").expect("valid derivation path"),
+        "m/84'/0'/0'/0/0".parse::<DerivationPath>().expect("valid derivation path"),
+        "m/84'/0'/0'/1/0".parse::<DerivationPath>().expect("valid derivation path"),
     ];
     let mut bip32_derivations = Vec::new();
     for (idx, pk) in pk_inputs.iter().enumerate() {
         let mut map = BTreeMap::new();
-        let fingerprint = Fingerprint::from_str(MASTER_FINGERPRINT).expect("valid fingerprint");
+        let fingerprint = MASTER_FINGERPRINT.parse::<Fingerprint>().expect("valid fingerprint");
         map.insert(pk.0, (fingerprint, derivation_paths[idx].clone()));
         bip32_derivations.push(map);
     }

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -23,7 +23,6 @@
 //!
 //! The miner's fee will be 10,000 satoshis.
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
@@ -85,7 +84,7 @@ fn get_internal_address_xpriv<C: Signing>(
 
 // The address to send to.
 fn receivers_address() -> Address {
-    Address::from_str("bc1q7cyrfmck2ffu2ud3rn5l5a8yv6f0chkp0zpemf")
+    "bc1q7cyrfmck2ffu2ud3rn5l5a8yv6f0chkp0zpemf".parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")
@@ -93,7 +92,7 @@ fn receivers_address() -> Address {
 
 // The dummy unspent transaction outputs that we control.
 fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
-    let script_pubkey_1 = Address::from_str("bc1qrwuu3ydv0jfza4a0ehtfd03m9l4vw3fy0hfm50")
+    let script_pubkey_1 = "bc1qrwuu3ydv0jfza4a0ehtfd03m9l4vw3fy0hfm50".parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")
@@ -106,7 +105,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
 
     let utxo_1 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
 
-    let script_pubkey_2 = Address::from_str("bc1qy7swwpejlw7a2rp774pa8rymh8tw3xvd2x2xkd")
+    let script_pubkey_2 = "bc1qy7swwpejlw7a2rp774pa8rymh8tw3xvd2x2xkd".parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -112,7 +112,7 @@ impl ColdStorage {
     ///
     /// The newly created signer along with the data needed to configure a watch-only wallet.
     fn new<C: Signing>(secp: &Secp256k1<C>, xpriv: &str) -> Result<ExportData> {
-        let master_xpriv = Xpriv::from_str(xpriv)?;
+        let master_xpriv = xpriv.parse::<Xpriv>()?;
         let master_xpub = Xpub::from_priv(secp, &master_xpriv);
 
         // Hardened children require secret data to derive.
@@ -176,10 +176,10 @@ impl WatchOnly {
     /// Creates the PSBT, in BIP174 parlance this is the 'Creator'.
     fn create_psbt<C: Verification>(&self, secp: &Secp256k1<C>) -> Result<Psbt> {
         let to_address = Address::from_str(RECEIVE_ADDRESS)?.require_network(Network::Regtest)?;
-        let to_amount = Amount::from_str(OUTPUT_AMOUNT_BTC)?;
+        let to_amount = OUTPUT_AMOUNT_BTC.parse::<Amount>()?;
 
         let (_, change_address, _) = self.change_address(secp)?;
-        let change_amount = Amount::from_str(CHANGE_AMOUNT_BTC)?;
+        let change_amount = CHANGE_AMOUNT_BTC.parse::<Amount>()?;
 
         let tx = Transaction {
             version: transaction::Version::TWO,
@@ -217,7 +217,7 @@ impl WatchOnly {
         map.insert(pk.0, (fingerprint, path));
         input.bip32_derivation = map;
 
-        let ty = PsbtSighashType::from_str("SIGHASH_ALL")?;
+        let ty = "SIGHASH_ALL".parse::<PsbtSighashType>()?;
         input.sighash_type = Some(ty);
 
         psbt.inputs = vec![input];
@@ -276,7 +276,7 @@ fn input_derivation_path() -> Result<DerivationPath> {
 fn previous_output() -> TxOut {
     let script_pubkey = ScriptBuf::from_hex(INPUT_UTXO_SCRIPT_PUBKEY)
         .expect("failed to parse input utxo scriptPubkey");
-    let amount = Amount::from_str(INPUT_UTXO_VALUE).expect("failed to parse input utxo value");
+    let amount = INPUT_UTXO_VALUE.parse::<Amount>().expect("failed to parse input utxo value");
 
     TxOut { value: amount, script_pubkey }
 }

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -30,7 +30,6 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::str::FromStr;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
@@ -175,7 +174,7 @@ impl WatchOnly {
 
     /// Creates the PSBT, in BIP174 parlance this is the 'Creator'.
     fn create_psbt<C: Verification>(&self, secp: &Secp256k1<C>) -> Result<Psbt> {
-        let to_address = Address::from_str(RECEIVE_ADDRESS)?.require_network(Network::Regtest)?;
+        let to_address = RECEIVE_ADDRESS.parse::<Address<_>>()?.require_network(Network::Regtest)?;
         let to_amount = OUTPUT_AMOUNT_BTC.parse::<Amount>()?;
 
         let (_, change_address, _) = self.change_address(secp)?;

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -2,8 +2,6 @@
 
 //! Demonstrate creating a transaction that spends to and from p2wpkh outputs.
 
-use std::str::FromStr;
-
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
@@ -102,7 +100,7 @@ fn senders_keys<C: Signing>(secp: &Secp256k1<C>) -> (SecretKey, WPubkeyHash) {
 ///
 /// (FWIW this is a random mainnet address from block 80219.)
 fn receivers_address() -> Address {
-    Address::from_str("bc1q7cyrfmck2ffu2ud3rn5l5a8yv6f0chkp0zpemf")
+    "bc1q7cyrfmck2ffu2ud3rn5l5a8yv6f0chkp0zpemf".parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -2,8 +2,6 @@
 
 //! Demonstrate creating a transaction that spends to and from p2tr outputs.
 
-use std::str::FromStr;
-
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
 use bitcoin::key::{Keypair, TapTweak, TweakedKeypair, UntweakedPublicKey};
 use bitcoin::locktime::absolute;
@@ -99,7 +97,7 @@ fn senders_keys<C: Signing>(secp: &Secp256k1<C>) -> Keypair {
 ///
 /// (FWIW this is an arbitrary mainnet address from block 805222.)
 fn receivers_address() -> Address {
-    Address::from_str("bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va")
+    "bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va".parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -151,13 +151,13 @@ fn main() {
     // Map of tap root X-only keys to origin info and leaf hashes contained in it.
     let origin_input_1 = get_tap_key_origin(
         pk_input_1,
-        Fingerprint::from_str(MASTER_FINGERPRINT).unwrap(),
-        DerivationPath::from_str("m/86'/0'/0'/0/0").unwrap(),
+        MASTER_FINGERPRINT.parse::<Fingerprint>().unwrap(),
+        "m/86'/0'/0'/0/0".parse::<DerivationPath>().unwrap(),
     );
     let origin_input_2 = get_tap_key_origin(
         pk_input_2,
-        Fingerprint::from_str(MASTER_FINGERPRINT).unwrap(),
-        DerivationPath::from_str("m/86'/0'/0'/1/0").unwrap(),
+        MASTER_FINGERPRINT.parse::<Fingerprint>().unwrap(),
+        "m/86'/0'/0'/1/0".parse::<DerivationPath>().unwrap(),
     );
     let origins = [origin_input_1, origin_input_2];
 

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -21,7 +21,6 @@
 //!
 //! The miner's fee will be 10,000 satoshis.
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
@@ -95,7 +94,7 @@ fn get_tap_key_origin(
 
 // The address to send to.
 fn receivers_address() -> Address {
-    Address::from_str("bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va")
+    "bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va".parse::<Address<_>>()
         .expect("a valid address")
         .require_network(Network::Bitcoin)
         .expect("valid address for mainnet")
@@ -104,7 +103,7 @@ fn receivers_address() -> Address {
 // The dummy unspent transaction outputs that we control.
 fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
     let script_pubkey_1 =
-        Address::from_str("bc1p80lanj0xee8q667aqcnn0xchlykllfsz3gu5skfv9vjsytaujmdqtv52vu")
+        "bc1p80lanj0xee8q667aqcnn0xchlykllfsz3gu5skfv9vjsytaujmdqtv52vu".parse::<Address<_>>()
             .unwrap()
             .require_network(Network::Bitcoin)
             .unwrap()
@@ -118,7 +117,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
     let utxo_1 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
 
     let script_pubkey_2 =
-        Address::from_str("bc1pfd0jmmdnp278vppcw68tkkmquxtq50xchy7f6wdmjtjm7fgsr8dszdcqce")
+        "bc1pfd0jmmdnp278vppcw68tkkmquxtq50xchy7f6wdmjtjm7fgsr8dszdcqce".parse::<Address<_>>()
             .unwrap()
             .require_network(Network::Bitcoin)
             .unwrap()

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -116,7 +116,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tx_hex_string = encode::serialize_hex(&generate_bip86_key_spend_tx(
         &secp,
         // The master extended private key from the descriptor in step 4
-        Xpriv::from_str(BENEFACTOR_XPRIV_STR)?,
+        BENEFACTOR_XPRIV_STR.parse::<Xpriv>()?,
         // Set these fields with valid data for the UTXO from step 5 above
         UTXO_1,
         vec![
@@ -135,10 +135,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("START EXAMPLE 2 - Script path spending of inheritance UTXO\n");
 
     {
-        let beneficiary = BeneficiaryWallet::new(Xpriv::from_str(BENEFICIARY_XPRIV_STR)?)?;
+        let beneficiary = BeneficiaryWallet::new(BENEFICIARY_XPRIV_STR.parse::<Xpriv>()?)?;
 
         let mut benefactor = BenefactorWallet::new(
-            Xpriv::from_str(BENEFACTOR_XPRIV_STR)?,
+            BENEFACTOR_XPRIV_STR.parse::<Xpriv>()?,
             beneficiary.master_xpub(),
         )?;
         let (tx, psbt) = benefactor.create_inheritance_funding_tx(
@@ -173,10 +173,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("START EXAMPLE 3 - Key path spending of inheritance UTXO\n");
 
     {
-        let beneficiary = BeneficiaryWallet::new(Xpriv::from_str(BENEFICIARY_XPRIV_STR)?)?;
+        let beneficiary = BeneficiaryWallet::new(BENEFICIARY_XPRIV_STR.parse::<Xpriv>()?)?;
 
         let mut benefactor = BenefactorWallet::new(
-            Xpriv::from_str(BENEFACTOR_XPRIV_STR)?,
+            BENEFACTOR_XPRIV_STR.parse::<Xpriv>()?,
             beneficiary.master_xpub(),
         )?;
         let (tx, _) = benefactor.create_inheritance_funding_tx(
@@ -227,7 +227,7 @@ fn generate_bip86_key_spend_tx(
     outputs: Vec<TxOut>,
 ) -> Result<Transaction, Box<dyn std::error::Error>> {
     let from_amount = input_utxo.amount_in_sats;
-    let input_pubkey = XOnlyPublicKey::from_str(input_utxo.pubkey)?;
+    let input_pubkey = input_utxo.pubkey.parse::<XOnlyPublicKey>()?;
 
     // CREATOR + UPDATER
     let tx1 = Transaction {
@@ -249,8 +249,8 @@ fn generate_bip86_key_spend_tx(
         (
             vec![],
             (
-                Fingerprint::from_str(input_utxo.master_fingerprint)?,
-                DerivationPath::from_str(input_utxo.derivation_path)?,
+                input_utxo.master_fingerprint.parse::<Fingerprint>()?,
+                input_utxo.derivation_path.parse::<DerivationPath>()?,
             ),
         ),
     );
@@ -264,7 +264,7 @@ fn generate_bip86_key_spend_tx(
         tap_key_origins: origins,
         ..Default::default()
     };
-    let ty = PsbtSighashType::from_str("SIGHASH_ALL")?;
+    let ty = "SIGHASH_ALL".parse::<PsbtSighashType>()?;
     input.sighash_type = Some(ty);
     input.tap_internal_key = Some(input_pubkey);
     psbt.inputs = vec![input];
@@ -391,7 +391,7 @@ impl BenefactorWallet {
         }
         // We use some other derivation path in this example for our inheritance protocol. The important thing is to ensure
         // that we use an unhardened path so we can make use of xpubs.
-        let derivation_path = DerivationPath::from_str(&format!("101/1/0/0/{}", self.next))?;
+        let derivation_path = format!("101/1/0/0/{}", self.next).parse::<DerivationPath>()?;
         let internal_keypair =
             self.master_xpriv.derive_priv(&self.secp, &derivation_path).to_keypair(&self.secp);
         let beneficiary_key =
@@ -443,7 +443,7 @@ impl BenefactorWallet {
             internal_keypair.x_only_public_key().0,
             (vec![], (self.master_xpriv.fingerprint(&self.secp), derivation_path)),
         );
-        let ty = PsbtSighashType::from_str("SIGHASH_ALL")?;
+        let ty = "SIGHASH_ALL".parse::<PsbtSighashType>()?;
         let mut tap_scripts = BTreeMap::new();
         tap_scripts.insert(
             taproot_spend_info.control_block(&(script.clone(), LeafVersion::TapScript)).unwrap(),
@@ -480,7 +480,7 @@ impl BenefactorWallet {
             // We use some other derivation path in this example for our inheritance protocol. The important thing is to ensure
             // that we use an unhardened path so we can make use of xpubs.
             let new_derivation_path =
-                DerivationPath::from_str(&format!("101/1/0/0/{}", self.next))?;
+                format!("101/1/0/0/{}", self.next).parse::<DerivationPath>()?;
             let new_internal_keypair = self
                 .master_xpriv
                 .derive_priv(&self.secp, &new_derivation_path)
@@ -582,7 +582,7 @@ impl BenefactorWallet {
                 beneficiary_key,
                 (vec![leaf_hash], (self.beneficiary_xpub.fingerprint(), new_derivation_path)),
             );
-            let ty = PsbtSighashType::from_str("SIGHASH_ALL")?;
+            let ty = "SIGHASH_ALL".parse::<PsbtSighashType>()?;
             let mut tap_scripts = BTreeMap::new();
             tap_scripts.insert(
                 taproot_spend_info

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -76,7 +76,6 @@ const UTXO_3: P2trUtxo = P2trUtxo {
 };
 
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 use bitcoin::address::script_pubkey::{BuilderExt as _, ScriptBufExt as _};
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
@@ -101,10 +100,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Just some addresses for outputs from our wallets. Not really important.
     let to_address =
-        Address::from_str("bcrt1p0p3rvwww0v9znrclp00uneq8ytre9kj922v8fxhnezm3mgsmn9usdxaefc")?
+        "bcrt1p0p3rvwww0v9znrclp00uneq8ytre9kj922v8fxhnezm3mgsmn9usdxaefc".parse::<Address<_>>()?
             .require_network(Network::Regtest)?;
     let change_address =
-        Address::from_str("bcrt1pz449kexzydh2kaypatup5ultru3ej284t6eguhnkn6wkhswt0l7q3a7j76")?
+        "bcrt1pz449kexzydh2kaypatup5ultru3ej284t6eguhnkn6wkhswt0l7q3a7j76".parse::<Address<_>>()?
             .require_network(Network::Regtest)?;
     let amount_to_send_in_sats = Amount::ONE_BTC;
     let change_amount = UTXO_1

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -898,7 +898,7 @@ mod tests {
 
     fn roundtrips(addr: &Address, network: Network) {
         assert_eq!(
-            Address::from_str(&addr.to_string()).unwrap().assume_checked(),
+            addr.to_string().parse::<Address<_>>().unwrap().assume_checked(),
             *addr,
             "string round-trip failed for {}",
             addr,
@@ -1051,7 +1051,7 @@ mod tests {
         }
 
         let addr_str = "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k";
-        let unchecked = Address::from_str(addr_str).unwrap();
+        let unchecked = addr_str.parse::<Address<_>>().unwrap();
 
         assert_eq!(
             format!("{:?}", Test { address: unchecked.clone() }),
@@ -1085,7 +1085,8 @@ mod tests {
             ("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", None),
         ];
         for (address, expected_type) in &addresses {
-            let addr = Address::from_str(address)
+            let addr = address
+                .parse::<Address<_>>()
                 .unwrap()
                 .require_network(Network::Bitcoin)
                 .expect("mainnet");
@@ -1099,7 +1100,7 @@ mod tests {
         use serde_json;
 
         let addr =
-            Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM").unwrap().assume_checked();
+            "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>().unwrap().assume_checked();
         let json = serde_json::to_value(&addr).unwrap();
         assert_eq!(
             json,
@@ -1113,7 +1114,7 @@ mod tests {
         );
 
         let addr =
-            Address::from_str("33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k").unwrap().assume_checked();
+            "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k".parse::<Address<_>>().unwrap().assume_checked();
         let json = serde_json::to_value(&addr).unwrap();
         assert_eq!(
             json,
@@ -1127,7 +1128,8 @@ mod tests {
         );
 
         let addr: Address<NetworkUnchecked> =
-            Address::from_str("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
+            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"
+                .parse::<Address<_>>()
                 .unwrap();
         let json = serde_json::to_value(addr).unwrap();
         assert_eq!(
@@ -1137,10 +1139,10 @@ mod tests {
             )
         );
 
-        let addr =
-            Address::from_str("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
-                .unwrap()
-                .assume_checked();
+        let addr = "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"
+            .parse::<Address<_>>()
+            .unwrap()
+            .assume_checked();
         let json = serde_json::to_value(&addr).unwrap();
         assert_eq!(
             json,
@@ -1158,7 +1160,8 @@ mod tests {
             .unwrap()
         );
 
-        let addr = Address::from_str("bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl")
+        let addr = "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl"
+            .parse::<Address<_>>()
             .unwrap()
             .assume_checked();
         let json = serde_json::to_value(&addr).unwrap();
@@ -1179,8 +1182,11 @@ mod tests {
         for el in
             ["132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM", "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k"].iter()
         {
-            let addr =
-                Address::from_str(el).unwrap().require_network(Network::Bitcoin).expect("mainnet");
+            let addr = el
+                .parse::<Address<_>>()
+                .unwrap()
+                .require_network(Network::Bitcoin)
+                .expect("mainnet");
             assert_eq!(addr.to_qr_uri(), format!("bitcoin:{}", el));
         }
 
@@ -1190,7 +1196,7 @@ mod tests {
         ]
         .iter()
         {
-            let addr = Address::from_str(el).unwrap().assume_checked();
+            let addr = el.parse::<Address<_>>().unwrap().assume_checked();
             assert_eq!(addr.to_qr_uri(), format!("bitcoin:{}", el.to_ascii_uppercase()));
         }
     }
@@ -1198,10 +1204,9 @@ mod tests {
     #[test]
     fn p2tr_from_untweaked() {
         //Test case from BIP-086
-        let internal_key = XOnlyPublicKey::from_str(
-            "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115",
-        )
-        .unwrap();
+        let internal_key = "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115"
+            .parse::<XOnlyPublicKey>()
+            .unwrap();
         let secp = Secp256k1::verification_only();
         let address = Address::p2tr(&secp, internal_key, None, KnownHrp::Mainnet);
         assert_eq!(
@@ -1215,98 +1220,99 @@ mod tests {
     #[test]
     fn test_is_related_to_pubkey_p2wpkh() {
         let address_string = "bc1qhvd6suvqzjcu9pxjhrwhtrlj85ny3n2mqql5w4";
-        let address = Address::from_str(address_string)
+        let address = address_string
+            .parse::<Address<_>>()
             .expect("address")
             .require_network(Network::Bitcoin)
             .expect("mainnet");
 
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = pubkey_string.parse::<PublicKey>().expect("pubkey");
 
         let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
-            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
-        )
-        .expect("pubkey");
+        let unused_pubkey = "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c"
+            .parse::<PublicKey>()
+            .expect("pubkey");
         assert!(!address.is_related_to_pubkey(unused_pubkey))
     }
 
     #[test]
     fn test_is_related_to_pubkey_p2shwpkh() {
         let address_string = "3EZQk4F8GURH5sqVMLTFisD17yNeKa7Dfs";
-        let address = Address::from_str(address_string)
+        let address = address_string
+            .parse::<Address<_>>()
             .expect("address")
             .require_network(Network::Bitcoin)
             .expect("mainnet");
 
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = pubkey_string.parse::<PublicKey>().expect("pubkey");
 
         let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
-            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
-        )
-        .expect("pubkey");
+        let unused_pubkey = "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c"
+            .parse::<PublicKey>()
+            .expect("pubkey");
         assert!(!address.is_related_to_pubkey(unused_pubkey))
     }
 
     #[test]
     fn test_is_related_to_pubkey_p2pkh() {
         let address_string = "1J4LVanjHMu3JkXbVrahNuQCTGCRRgfWWx";
-        let address = Address::from_str(address_string)
+        let address = address_string
+            .parse::<Address<_>>()
             .expect("address")
             .require_network(Network::Bitcoin)
             .expect("mainnet");
 
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = pubkey_string.parse::<PublicKey>().expect("pubkey");
 
         let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
-            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
-        )
-        .expect("pubkey");
+        let unused_pubkey = "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c"
+            .parse::<PublicKey>()
+            .expect("pubkey");
         assert!(!address.is_related_to_pubkey(unused_pubkey))
     }
 
     #[test]
     fn test_is_related_to_pubkey_p2pkh_uncompressed_key() {
         let address_string = "msvS7KzhReCDpQEJaV2hmGNvuQqVUDuC6p";
-        let address = Address::from_str(address_string)
+        let address = address_string
+            .parse::<Address<_>>()
             .expect("address")
             .require_network(Network::Testnet)
             .expect("testnet");
 
         let pubkey_string = "04e96e22004e3db93530de27ccddfdf1463975d2138ac018fc3e7ba1a2e5e0aad8e424d0b55e2436eb1d0dcd5cb2b8bcc6d53412c22f358de57803a6a655fbbd04";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = pubkey_string.parse::<PublicKey>().expect("pubkey");
 
         let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
-            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
-        )
-        .expect("pubkey");
+        let unused_pubkey = "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c"
+            .parse::<PublicKey>()
+            .expect("pubkey");
         assert!(!address.is_related_to_pubkey(unused_pubkey))
     }
 
     #[test]
     fn test_is_related_to_pubkey_p2tr() {
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = pubkey_string.parse::<PublicKey>().expect("pubkey");
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
         let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(xonly_pubkey);
         let address = Address::p2tr_tweaked(tweaked_pubkey, KnownHrp::Mainnet);
 
         assert_eq!(
             address,
-            Address::from_str("bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e")
+            "bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e"
+                .parse::<Address<_>>()
                 .expect("address")
                 .require_network(Network::Bitcoin)
                 .expect("mainnet")
@@ -1315,24 +1321,24 @@ mod tests {
         let result = address.is_related_to_pubkey(pubkey);
         assert!(result);
 
-        let unused_pubkey = PublicKey::from_str(
-            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
-        )
-        .expect("pubkey");
+        let unused_pubkey = "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c"
+            .parse::<PublicKey>()
+            .expect("pubkey");
         assert!(!address.is_related_to_pubkey(unused_pubkey));
     }
 
     #[test]
     fn test_is_related_to_xonly_pubkey() {
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
-        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+        let pubkey = pubkey_string.parse::<PublicKey>().expect("pubkey");
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
         let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(xonly_pubkey);
         let address = Address::p2tr_tweaked(tweaked_pubkey, KnownHrp::Mainnet);
 
         assert_eq!(
             address,
-            Address::from_str("bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e")
+            "bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e"
+                .parse::<Address<_>>()
                 .expect("address")
                 .require_network(Network::Bitcoin)
                 .expect("mainnet")
@@ -1365,13 +1371,13 @@ mod tests {
 
     #[test]
     fn valid_address_parses_correctly() {
-        let addr = AddressType::from_str("p2tr").expect("false negative while parsing address");
+        let addr = "p2tr".parse::<AddressType>().expect("false negative while parsing address");
         assert_eq!(addr, AddressType::P2tr);
     }
 
     #[test]
     fn invalid_address_parses_error() {
-        let got = AddressType::from_str("invalid");
+        let got = "invalid".parse::<AddressType>();
         let want = Err(UnknownAddressTypeError("invalid".to_string()));
         assert_eq!(got, want);
     }
@@ -1389,10 +1395,14 @@ mod tests {
             "bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e",
         ];
         for addr in &addresses {
-            let addr = Address::from_str(addr).unwrap().require_network(Network::Bitcoin).unwrap();
+            let addr =
+                addr.parse::<Address<_>>().unwrap().require_network(Network::Bitcoin).unwrap();
             for another in &addresses {
-                let another =
-                    Address::from_str(another).unwrap().require_network(Network::Bitcoin).unwrap();
+                let another = another
+                    .parse::<Address<_>>()
+                    .unwrap()
+                    .require_network(Network::Bitcoin)
+                    .unwrap();
                 assert_eq!(addr.matches_script_pubkey(&another.script_pubkey()), addr == another);
             }
         }

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -309,7 +309,7 @@ pub enum AddressData {
 /// ```
 /// # use std::str::FromStr;
 /// # use bitcoin::address::{Address, NetworkChecked};
-/// let address: Address<NetworkChecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")
+/// let address: Address<NetworkChecked> = "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>()
 ///                .unwrap().assume_checked();
 /// assert_eq!(address.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
 /// ```
@@ -317,7 +317,7 @@ pub enum AddressData {
 /// ```ignore
 /// # use std::str::FromStr;
 /// # use bitcoin::address::{Address, NetworkChecked};
-/// let address: Address<NetworkUnchecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")
+/// let address: Address<NetworkUnchecked> = "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>()
 ///                .unwrap();
 /// let s = address.to_string(); // does not compile
 /// ```
@@ -329,7 +329,7 @@ pub enum AddressData {
 /// ```
 /// # use std::str::FromStr;
 /// # use bitcoin::address::{Address, NetworkUnchecked};
-/// let address: Address<NetworkUnchecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")
+/// let address: Address<NetworkUnchecked> = "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>()
 ///                .unwrap();
 /// assert_eq!(format!("{:?}", address), "Address<NetworkUnchecked>(132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM)");
 /// ```
@@ -337,7 +337,7 @@ pub enum AddressData {
 /// ```
 /// # use std::str::FromStr;
 /// # use bitcoin::address::{Address, NetworkChecked};
-/// let address: Address<NetworkChecked> = Address::from_str("132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM")
+/// let address: Address<NetworkChecked> = "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>()
 ///                .unwrap().assume_checked();
 /// assert_eq!(format!("{:?}", address), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
 /// ```

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -924,30 +924,30 @@ mod tests {
 
     #[test]
     fn test_parse_derivation_path() {
-        assert_eq!(DerivationPath::from_str("n/0'/0"), Err(Error::InvalidChildNumberFormat));
-        assert_eq!(DerivationPath::from_str("4/m/5"), Err(Error::InvalidChildNumberFormat));
-        assert_eq!(DerivationPath::from_str("//3/0'"), Err(Error::InvalidChildNumberFormat));
-        assert_eq!(DerivationPath::from_str("0h/0x"), Err(Error::InvalidChildNumberFormat));
+        assert_eq!("n/0'/0".parse::<DerivationPath>(), Err(Error::InvalidChildNumberFormat));
+        assert_eq!("4/m/5".parse::<DerivationPath>(), Err(Error::InvalidChildNumberFormat));
+        assert_eq!("//3/0'".parse::<DerivationPath>(), Err(Error::InvalidChildNumberFormat));
+        assert_eq!("0h/0x".parse::<DerivationPath>(), Err(Error::InvalidChildNumberFormat));
         assert_eq!(
-            DerivationPath::from_str("2147483648"),
+            "2147483648".parse::<DerivationPath>(),
             Err(Error::InvalidChildNumber(2147483648))
         );
 
-        assert_eq!(DerivationPath::master(), DerivationPath::from_str("").unwrap());
+        assert_eq!(DerivationPath::master(), "".parse::<DerivationPath>().unwrap());
         assert_eq!(DerivationPath::master(), DerivationPath::default());
 
         // Acceptable forms for a master path.
-        assert_eq!(DerivationPath::from_str("m").unwrap(), DerivationPath(vec![]));
-        assert_eq!(DerivationPath::from_str("m/").unwrap(), DerivationPath(vec![]));
-        assert_eq!(DerivationPath::from_str("").unwrap(), DerivationPath(vec![]));
+        assert_eq!("m".parse::<DerivationPath>().unwrap(), DerivationPath(vec![]));
+        assert_eq!("m/".parse::<DerivationPath>().unwrap(), DerivationPath(vec![]));
+        assert_eq!("".parse::<DerivationPath>().unwrap(), DerivationPath(vec![]));
 
-        assert_eq!(DerivationPath::from_str("0'"), Ok(vec![ChildNumber::ZERO_HARDENED].into()));
+        assert_eq!("0'".parse::<DerivationPath>(), Ok(vec![ChildNumber::ZERO_HARDENED].into()));
         assert_eq!(
-            DerivationPath::from_str("0'/1"),
+            "0'/1".parse::<DerivationPath>(),
             Ok(vec![ChildNumber::ZERO_HARDENED, ChildNumber::ONE_NORMAL].into())
         );
         assert_eq!(
-            DerivationPath::from_str("0h/1/2'"),
+            "0h/1/2'".parse::<DerivationPath>(),
             Ok(vec![
                 ChildNumber::ZERO_HARDENED,
                 ChildNumber::ONE_NORMAL,
@@ -956,7 +956,7 @@ mod tests {
             .into())
         );
         assert_eq!(
-            DerivationPath::from_str("0'/1/2h/2"),
+            "0'/1/2h/2".parse::<DerivationPath>(),
             Ok(vec![
                 ChildNumber::ZERO_HARDENED,
                 ChildNumber::ONE_NORMAL,
@@ -972,27 +972,27 @@ mod tests {
             ChildNumber::from_normal_idx(2).unwrap(),
             ChildNumber::from_normal_idx(1000000000).unwrap(),
         ]);
-        assert_eq!(DerivationPath::from_str("0'/1/2'/2/1000000000").unwrap(), want);
-        assert_eq!(DerivationPath::from_str("m/0'/1/2'/2/1000000000").unwrap(), want);
+        assert_eq!("0'/1/2'/2/1000000000".parse::<DerivationPath>().unwrap(), want);
+        assert_eq!("m/0'/1/2'/2/1000000000".parse::<DerivationPath>().unwrap(), want);
 
         let s = "0'/50/3'/5/545456";
-        assert_eq!(DerivationPath::from_str(s), s.into_derivation_path());
-        assert_eq!(DerivationPath::from_str(s), s.to_string().into_derivation_path());
+        assert_eq!(s.parse::<DerivationPath>(), s.into_derivation_path());
+        assert_eq!(s.parse::<DerivationPath>(), s.to_string().into_derivation_path());
 
         let s = "m/0'/50/3'/5/545456";
-        assert_eq!(DerivationPath::from_str(s), s.into_derivation_path());
-        assert_eq!(DerivationPath::from_str(s), s.to_string().into_derivation_path());
+        assert_eq!(s.parse::<DerivationPath>(), s.into_derivation_path());
+        assert_eq!(s.parse::<DerivationPath>(), s.to_string().into_derivation_path());
     }
 
     #[test]
     fn test_derivation_path_conversion_index() {
-        let path = DerivationPath::from_str("0h/1/2'").unwrap();
+        let path = "0h/1/2'".parse::<DerivationPath>().unwrap();
         let numbers: Vec<ChildNumber> = path.clone().into();
         let path2: DerivationPath = numbers.into();
         assert_eq!(path, path2);
         assert_eq!(&path[..2], &[ChildNumber::ZERO_HARDENED, ChildNumber::ONE_NORMAL]);
         let indexed: DerivationPath = path[..2].into();
-        assert_eq!(indexed, DerivationPath::from_str("0h/1").unwrap());
+        assert_eq!(indexed, "0h/1".parse::<DerivationPath>().unwrap());
         assert_eq!(indexed.child(ChildNumber::from_hardened_idx(2).unwrap()), path);
     }
 
@@ -1038,8 +1038,8 @@ mod tests {
         assert_eq!(&sk.to_string()[..], expected_sk);
         assert_eq!(&pk.to_string()[..], expected_pk);
         // Check decoded base58 against result
-        let decoded_sk = Xpriv::from_str(expected_sk);
-        let decoded_pk = Xpub::from_str(expected_pk);
+        let decoded_sk = expected_sk.parse::<Xpriv>();
+        let decoded_pk = expected_pk.parse::<Xpub>();
         assert_eq!(Ok(sk), decoded_sk);
         assert_eq!(Ok(pk), decoded_pk);
     }
@@ -1059,29 +1059,29 @@ mod tests {
         assert_eq!(cn.increment().err(), Some(Error::InvalidChildNumber(1 << 31)));
 
         let cn = ChildNumber::from_normal_idx(350).unwrap();
-        let path = DerivationPath::from_str("42'").unwrap();
+        let path = "42'".parse::<DerivationPath>().unwrap();
         let mut iter = path.children_from(cn);
         assert_eq!(iter.next(), Some("42'/350".parse().unwrap()));
         assert_eq!(iter.next(), Some("42'/351".parse().unwrap()));
 
-        let path = DerivationPath::from_str("42'/350'").unwrap();
+        let path = "42'/350'".parse::<DerivationPath>().unwrap();
         let mut iter = path.normal_children();
         assert_eq!(iter.next(), Some("42'/350'/0".parse().unwrap()));
         assert_eq!(iter.next(), Some("42'/350'/1".parse().unwrap()));
 
-        let path = DerivationPath::from_str("42'/350'").unwrap();
+        let path = "42'/350'".parse::<DerivationPath>().unwrap();
         let mut iter = path.hardened_children();
         assert_eq!(iter.next(), Some("42'/350'/0'".parse().unwrap()));
         assert_eq!(iter.next(), Some("42'/350'/1'".parse().unwrap()));
 
         let cn = ChildNumber::from_hardened_idx(42350).unwrap();
-        let path = DerivationPath::from_str("42'").unwrap();
+        let path = "42'".parse::<DerivationPath>().unwrap();
         let mut iter = path.children_from(cn);
         assert_eq!(iter.next(), Some("42'/42350'".parse().unwrap()));
         assert_eq!(iter.next(), Some("42'/42351'".parse().unwrap()));
 
         let cn = ChildNumber::from_hardened_idx(max).unwrap();
-        let path = DerivationPath::from_str("42'").unwrap();
+        let path = "42'".parse::<DerivationPath>().unwrap();
         let mut iter = path.children_from(cn);
         assert!(iter.next().is_some());
         assert!(iter.next().is_none());
@@ -1246,7 +1246,7 @@ mod tests {
 
         // Xpriv having secret key set to all zeros
         let xpriv_str = "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx";
-        Xpriv::from_str(xpriv_str).unwrap();
+        xpriv_str.parse::<Xpriv>().unwrap();
     }
 
     #[test]
@@ -1254,6 +1254,6 @@ mod tests {
     fn schnorr_broken_privkey_ffs() {
         // Xpriv having secret key set to all 0xFF's
         let xpriv_str = "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fENZ3QzxW";
-        Xpriv::from_str(xpriv_str).unwrap();
+        xpriv_str.parse::<Xpriv>().unwrap();
     }
 }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -421,11 +421,10 @@ impl DerivationPath {
     ///
     /// ```
     /// use bitcoin::bip32::{DerivationPath, ChildNumber};
-    /// use std::str::FromStr;
     ///
-    /// let base = DerivationPath::from_str("m/42").unwrap();
+    /// let base = "m/42".parse::<DerivationPath>().unwrap();
     ///
-    /// let deriv_1 = base.extend(DerivationPath::from_str("0/1").unwrap());
+    /// let deriv_1 = base.extend("0/1".parse::<DerivationPath>().unwrap());
     /// let deriv_2 = base.extend(&[
     ///     ChildNumber::ZERO_NORMAL,
     ///     ChildNumber::ONE_NORMAL
@@ -447,7 +446,7 @@ impl DerivationPath {
     /// use bitcoin::bip32::DerivationPath;
     /// use std::str::FromStr;
     ///
-    /// let path = DerivationPath::from_str("m/84'/0'/0'/0/1").unwrap();
+    /// let path = "m/84'/0'/0'/0/1".parse::<DerivationPath>().unwrap();
     /// const HARDENED: u32 = 0x80000000;
     /// assert_eq!(path.to_u32_vec(), vec![84 + HARDENED, HARDENED, HARDENED, 0, 1]);
     /// ```

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -209,8 +209,6 @@ impl ChainHash {
 
 #[cfg(test)]
 mod test {
-    use core::str::FromStr;
-
     use hex::test_hex_unwrap as hex;
 
     use super::*;
@@ -233,7 +231,7 @@ mod test {
         assert_eq!(gen.output.len(), 1);
         assert_eq!(serialize(&gen.output[0].script_pubkey),
                    hex!("434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"));
-        assert_eq!(gen.output[0].value, Amount::from_str("50 BTC").unwrap());
+        assert_eq!(gen.output[0].value, "50 BTC".parse::<Amount>().unwrap());
         assert_eq!(gen.lock_time, absolute::LockTime::ZERO);
 
         assert_eq!(

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use core::str::FromStr;
-
 use hex_lit::hex;
 
 use super::*;
@@ -38,10 +36,10 @@ fn script() {
 
     // keys
     const KEYSTR1: &str = "21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";
-    let key = PublicKey::from_str(&KEYSTR1[2..]).unwrap();
+    let key = KEYSTR1[2..].parse::<PublicKey>().unwrap();
     script = script.push_key(key); comp.extend_from_slice(&hex!(KEYSTR1)); assert_eq!(script.as_bytes(), &comp[..]);
     const KEYSTR2: &str = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
-    let key = PublicKey::from_str(&KEYSTR2[2..]).unwrap();
+    let key = KEYSTR2[2..].parse::<PublicKey>().unwrap();
     script = script.push_key(key); comp.extend_from_slice(&hex!(KEYSTR2)); assert_eq!(script.as_bytes(), &comp[..]);
 
     // opcodes
@@ -52,7 +50,7 @@ fn script() {
 #[test]
 fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = key_str.parse::<PublicKey>().unwrap();
     let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
     assert_eq!(actual.to_vec(), key.to_bytes());
@@ -61,7 +59,7 @@ fn p2pk_pubkey_bytes_valid_key_and_valid_script_returns_expected_key() {
 #[test]
 fn p2pk_pubkey_bytes_no_checksig_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = key_str.parse::<PublicKey>().unwrap();
     let no_checksig = Script::builder().push_key(key).into_script();
     assert_eq!(no_checksig.p2pk_pubkey_bytes(), None);
 }
@@ -82,7 +80,7 @@ fn p2pk_pubkey_bytes_no_key_returns_none() {
 #[test]
 fn p2pk_pubkey_bytes_different_op_code_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = key_str.parse::<PublicKey>().unwrap();
     let different_op_code = Script::builder().push_key(key).push_opcode(OP_NOP).into_script();
     assert!(different_op_code.p2pk_pubkey_bytes().is_none());
 }
@@ -107,7 +105,7 @@ fn p2pk_pubkey_bytes_invalid_key_returns_some() {
 #[test]
 fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
     let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
-    let key = PublicKey::from_str(compressed_key_str).unwrap();
+    let key = compressed_key_str.parse::<PublicKey>().unwrap();
     let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_pubkey_bytes().unwrap();
     assert_eq!(actual.to_vec(), key.to_bytes());
@@ -116,7 +114,7 @@ fn p2pk_pubkey_bytes_compressed_key_returns_expected_key() {
 #[test]
 fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = key_str.parse::<PublicKey>().unwrap();
     let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_public_key().unwrap();
     assert_eq!(actual, key);
@@ -125,7 +123,7 @@ fn p2pk_public_key_valid_key_and_valid_script_returns_expected_key() {
 #[test]
 fn p2pk_public_key_no_checksig_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = key_str.parse::<PublicKey>().unwrap();
     let no_checksig = Script::builder().push_key(key).into_script();
     assert_eq!(no_checksig.p2pk_public_key(), None);
 }
@@ -145,7 +143,7 @@ fn p2pk_public_key_no_key_returns_none() {
 #[test]
 fn p2pk_public_key_different_op_code_returns_none() {
     let key_str = "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3";
-    let key = PublicKey::from_str(key_str).unwrap();
+    let key = key_str.parse::<PublicKey>().unwrap();
     let different_op_code = Script::builder().push_key(key).push_opcode(OP_NOP).into_script();
     assert!(different_op_code.p2pk_public_key().is_none());
 }
@@ -169,7 +167,7 @@ fn p2pk_public_key_invalid_key_returns_none() {
 #[test]
 fn p2pk_public_key_compressed_key_returns_some() {
     let compressed_key_str = "0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c";
-    let key = PublicKey::from_str(compressed_key_str).unwrap();
+    let key = compressed_key_str.parse::<PublicKey>().unwrap();
     let p2pk = Script::builder().push_key(key).push_opcode(OP_CHECKSIG).into_script();
     let actual = p2pk.p2pk_public_key().unwrap();
     assert_eq!(actual, key);
@@ -181,7 +179,7 @@ fn script_x_only_key() {
     // to our script in order to give a heads up to the script compiler that it should add the next 32 bytes to the stack.
     // From: https://github.com/bitcoin-core/btcdeb/blob/e8c2750c4a4702768c52d15640ed03bf744d2601/doc/tapscript-example.md?plain=1#L43
     const KEYSTR: &str = "209997a497d964fc1a62885b05a51166a65a90df00492c8d7cf61d6accf54803be";
-    let x_only_key = XOnlyPublicKey::from_str(&KEYSTR[2..]).unwrap();
+    let x_only_key = KEYSTR[2..].parse::<XOnlyPublicKey>().unwrap();
     let script = Builder::new().push_x_only_key(x_only_key);
     assert_eq!(script.into_bytes(), &hex!(KEYSTR) as &[u8]);
 }
@@ -201,9 +199,9 @@ fn script_builder() {
 
 #[test]
 fn script_generators() {
-    let pubkey =
-        PublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e")
-            .unwrap();
+    let pubkey = "0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e"
+        .parse::<PublicKey>()
+        .unwrap();
     assert!(ScriptBuf::new_p2pk(pubkey).is_p2pk());
 
     let pubkey_hash = pubkey.pubkey_hash();

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1438,8 +1438,6 @@ impl InputWeightPrediction {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
     use hex::{test_hex_unwrap as hex, FromHex};
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;
@@ -1464,43 +1462,38 @@ mod tests {
 
     #[test]
     fn outpoint() {
-        assert_eq!(OutPoint::from_str("i don't care"), Err(ParseOutPointError::Format));
+        assert_eq!("i don't care".parse::<OutPoint>(), Err(ParseOutPointError::Format));
         assert_eq!(
-            OutPoint::from_str(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:1:1"
-            ),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:1:1"
+                .parse::<OutPoint>(),
             Err(ParseOutPointError::Format)
         );
         assert_eq!(
-            OutPoint::from_str("5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:"),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:".parse::<OutPoint>(),
             Err(ParseOutPointError::Format)
         );
         assert_eq!(
-            OutPoint::from_str(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:11111111111"
-            ),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:11111111111"
+                .parse::<OutPoint>(),
             Err(ParseOutPointError::TooLong)
         );
         assert_eq!(
-            OutPoint::from_str(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:01"
-            ),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:01"
+                .parse::<OutPoint>(),
             Err(ParseOutPointError::VoutNotCanonical)
         );
         assert_eq!(
-            OutPoint::from_str(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:+42"
-            ),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:+42"
+                .parse::<OutPoint>(),
             Err(ParseOutPointError::VoutNotCanonical)
         );
         assert_eq!(
-            OutPoint::from_str("i don't care:1"),
+            "i don't care:1".parse::<OutPoint>(),
             Err(ParseOutPointError::Txid("i don't care".parse::<Txid>().unwrap_err()))
         );
         assert_eq!(
-            OutPoint::from_str(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X:1"
-            ),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X:1"
+                .parse::<OutPoint>(),
             Err(ParseOutPointError::Txid(
                 "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c945X"
                     .parse::<Txid>()
@@ -1508,16 +1501,14 @@ mod tests {
             ))
         );
         assert_eq!(
-            OutPoint::from_str(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:lol"
-            ),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:lol"
+                .parse::<OutPoint>(),
             Err(ParseOutPointError::Vout(parse::int::<u32, _>("lol").unwrap_err()))
         );
 
         assert_eq!(
-            OutPoint::from_str(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:42"
-            ),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:42"
+                .parse::<OutPoint>(),
             Ok(OutPoint {
                 txid: "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456"
                     .parse()
@@ -1526,9 +1517,8 @@ mod tests {
             })
         );
         assert_eq!(
-            OutPoint::from_str(
-                "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:0"
-            ),
+            "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:0"
+                .parse::<OutPoint>(),
             Ok(OutPoint {
                 txid: "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456"
                     .parse()
@@ -1824,7 +1814,7 @@ mod tests {
         ];
         for (s, sht) in sighashtypes {
             assert_eq!(sht.to_string(), s);
-            assert_eq!(EcdsaSighashType::from_str(s).unwrap(), sht);
+            assert_eq!(s.parse::<EcdsaSighashType>().unwrap(), sht);
         }
         let sht_mistakes = [
             "SIGHASH_ALL | SIGHASH_ANYONECANPAY",
@@ -1840,7 +1830,7 @@ mod tests {
         ];
         for s in sht_mistakes {
             assert_eq!(
-                EcdsaSighashType::from_str(s).unwrap_err().to_string(),
+                s.parse::<EcdsaSighashType>().unwrap_err().to_string(),
                 format!("unrecognized SIGHASH string '{}'", s)
             );
         }
@@ -1975,13 +1965,13 @@ mod tests {
 
     #[test]
     fn effective_value_happy_path() {
-        let value = Amount::from_str("1 cBTC").unwrap();
+        let value = "1 cBTC".parse::<Amount>().unwrap();
         let fee_rate = FeeRate::from_sat_per_kwu(10);
         let satisfaction_weight = Weight::from_wu(204);
         let effective_value = effective_value(fee_rate, satisfaction_weight, value).unwrap();
 
         // 10 sat/kwu * (204wu + BASE_WEIGHT) = 4 sats
-        let expected_fee = SignedAmount::from_str("4 sats").unwrap();
+        let expected_fee = "4 sats".parse::<SignedAmount>().unwrap();
         let expected_effective_value = value.to_signed().unwrap() - expected_fee;
         assert_eq!(effective_value, expected_effective_value);
     }

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -134,10 +134,9 @@ impl PublicKey {
     /// # Example: Using with `sort_unstable_by_key`
     ///
     /// ```rust
-    /// use std::str::FromStr;
     /// use bitcoin::PublicKey;
     ///
-    /// let pk = |s| PublicKey::from_str(s).unwrap();
+    /// let pk = |s: &str| s.parse::<PublicKey>().unwrap();
     ///
     /// let mut unsorted = [
     ///     pk("04c4b0bbb339aa236bff38dbe6a451e111972a7909a126bc424013cba2ec33bc38e98ac269ffe028345c31ac8d0a365f29c8f7e7cfccac72f84e1acd02bc554f35"),

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1151,7 +1151,7 @@ mod tests {
         // test string conversion
         assert_eq!(&sk.to_string(), "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy");
         let sk_str =
-            PrivateKey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+            "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy".parse::<PrivateKey>().unwrap();
         assert_eq!(&sk.to_wif(), &sk_str.to_wif());
 
         // mainnet uncompressed
@@ -1165,7 +1165,8 @@ mod tests {
         let mut pk = sk.public_key(&secp);
         assert!(!pk.compressed);
         assert_eq!(&pk.to_string(), "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133");
-        assert_eq!(pk, PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap());
+        assert_eq!(pk, "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133"
+        .parse::<PublicKey>().unwrap());
         let addr = Address::p2pkh(pk, sk.network);
         assert_eq!(&addr.to_string(), "1GhQvF6dL8xa6wBxLnWmHcQsurx9RxiMc8");
         pk.compressed = true;
@@ -1175,31 +1176,29 @@ mod tests {
         );
         assert_eq!(
             pk,
-            PublicKey::from_str(
-                "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
-            )
-            .unwrap()
+            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
+                .parse::<PublicKey>()
+                .unwrap()
         );
     }
 
     #[test]
     fn test_pubkey_hash() {
-        let pk = PublicKey::from_str(
-            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
-        )
-        .unwrap();
-        let upk = PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap();
+        let pk = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
+            .parse::<PublicKey>()
+            .unwrap();
+        let upk = "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133"
+        .parse::<PublicKey>().unwrap();
         assert_eq!(pk.pubkey_hash().to_string(), "9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4");
         assert_eq!(upk.pubkey_hash().to_string(), "ac2e7daf42d2c97418fd9f78af2de552bb9c6a7a");
     }
 
     #[test]
     fn test_wpubkey_hash() {
-        let pk = PublicKey::from_str(
-            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
-        )
-        .unwrap();
-        let upk = PublicKey::from_str("042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133").unwrap();
+        let pk = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af"
+            .parse::<PublicKey>()
+            .unwrap();
+        let upk = "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133".parse::<PublicKey>().unwrap();
         assert_eq!(
             pk.wpubkey_hash().unwrap().to_string(),
             "9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4"
@@ -1241,7 +1240,7 @@ mod tests {
         ];
 
         let s = Secp256k1::new();
-        let sk = PrivateKey::from_str(KEY_WIF).unwrap();
+        let sk = KEY_WIF.parse::<PrivateKey>().unwrap();
         let pk = PublicKey::from_private_key(&s, sk);
         let pk_u = PublicKey { inner: pk.inner, compressed: false };
 
@@ -1303,10 +1302,9 @@ mod tests {
 
     #[test]
     fn pubkey_to_sort_key() {
-        let key1 = PublicKey::from_str(
-            "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8",
-        )
-        .unwrap();
+        let key1 = "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8"
+            .parse::<PublicKey>()
+            .unwrap();
         let key2 = PublicKey { inner: key1.inner, compressed: false };
         let arrayvec1 = ArrayVec::from_slice(
             &<[u8; 33]>::from_hex(
@@ -1329,8 +1327,9 @@ mod tests {
             input: Vec<PublicKey>,
             expect: Vec<PublicKey>,
         }
-        let fmt =
-            |v: Vec<_>| v.into_iter().map(|s| PublicKey::from_str(s).unwrap()).collect::<Vec<_>>();
+        let fmt = |v: Vec<_>| {
+            v.into_iter().map(|s: &str| s.parse::<PublicKey>().unwrap()).collect::<Vec<_>>()
+        };
         let vectors = vec![
             // Start BIP67 vectors
             // Vector 1
@@ -1449,15 +1448,15 @@ mod tests {
         // Sanity checks, we accept string length 130 digits.
         let s = "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
         assert_eq!(s.len(), 130);
-        assert!(PublicKey::from_str(s).is_ok());
+        assert!(s.parse::<PublicKey>().is_ok());
         // And 66 digits.
         let s = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af";
         assert_eq!(s.len(), 66);
-        assert!(PublicKey::from_str(s).is_ok());
+        assert!(s.parse::<PublicKey>().is_ok());
 
         let s = "aoeusthb";
         assert_eq!(s.len(), 8);
-        let res = PublicKey::from_str(s);
+        let res = s.parse::<PublicKey>();
         assert!(res.is_err());
         assert_eq!(res.unwrap_err(), ParsePublicKeyError::InvalidHexLength(8));
     }
@@ -1467,7 +1466,7 @@ mod tests {
         // Ensuring test cases fail when PublicKey::from_str is used on invalid keys
         let s = "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b142";
         assert_eq!(s.len(), 130);
-        let res = PublicKey::from_str(s);
+        let res = s.parse::<PublicKey>();
         assert!(res.is_err());
         assert_eq!(
             res.unwrap_err(),
@@ -1478,7 +1477,7 @@ mod tests {
 
         let s = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd169";
         assert_eq!(s.len(), 66);
-        let res = PublicKey::from_str(s);
+        let res = s.parse::<PublicKey>();
         assert!(res.is_err());
         assert_eq!(
             res.unwrap_err(),
@@ -1489,7 +1488,7 @@ mod tests {
 
         let s = "062e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
         assert_eq!(s.len(), 130);
-        let res = PublicKey::from_str(s);
+        let res = s.parse::<PublicKey>();
         assert!(res.is_err());
         assert_eq!(
             res.unwrap_err(),
@@ -1498,13 +1497,13 @@ mod tests {
 
         let s = "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b13g";
         assert_eq!(s.len(), 130);
-        let res = PublicKey::from_str(s);
+        let res = s.parse::<PublicKey>();
         assert!(res.is_err());
         assert_eq!(res.unwrap_err(), ParsePublicKeyError::InvalidChar(103));
 
         let s = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1ag";
         assert_eq!(s.len(), 66);
-        let res = PublicKey::from_str(s);
+        let res = s.parse::<PublicKey>();
         assert!(res.is_err());
         assert_eq!(res.unwrap_err(), ParsePublicKeyError::InvalidChar(103));
     }
@@ -1513,7 +1512,7 @@ mod tests {
     #[cfg(feature = "std")]
     fn private_key_debug_is_obfuscated() {
         let sk =
-            PrivateKey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+            "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy".parse::<PrivateKey>().unwrap();
         let want =
             "PrivateKey { compressed: true, network: Test, inner: SecretKey(#32014e414fdce702) }";
         let got = format!("{:?}", sk);
@@ -1524,7 +1523,7 @@ mod tests {
     #[cfg(not(feature = "std"))]
     fn private_key_debug_is_obfuscated() {
         let sk =
-            PrivateKey::from_str("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+            "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy".parse::<PrivateKey>().unwrap();
         // Why is this not shortened? In rust-secp256k1/src/secret it is printed with "#{:016x}"?
         let want = "PrivateKey { compressed: true, network: Test, inner: SecretKey(#7217ac58fbad8880a91032107b82cb6c5422544b426c350ee005cf509f3dbf7b) }";
         let got = format!("{:?}", sk);

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -302,7 +302,6 @@ impl ToSocketAddrs for AddrV2Message {
 
 #[cfg(test)]
 mod test {
-    use core::str::FromStr;
     use std::net::IpAddr;
 
     use hex::{test_hex_unwrap as hex, FromHex};
@@ -384,7 +383,7 @@ mod test {
     #[test]
     fn onion_test() {
         let onionaddr = SocketAddr::new(
-            IpAddr::V6(Ipv6Addr::from_str("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").unwrap()),
+            IpAddr::V6("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca".parse::<Ipv6Addr>().unwrap()),
             1111,
         );
         let addr = Address::new(&onionaddr, ServiceFlags::NONE);
@@ -399,7 +398,7 @@ mod test {
         assert_eq!(serialize(&ip), hex!("010401020304"));
 
         let ip =
-            AddrV2::Ipv6(Ipv6Addr::from_str("1a1b:2a2b:3a3b:4a4b:5a5b:6a6b:7a7b:8a8b").unwrap());
+            AddrV2::Ipv6("1a1b:2a2b:3a3b:4a4b:5a5b:6a6b:7a7b:8a8b".parse::<Ipv6Addr>().unwrap());
         assert_eq!(serialize(&ip), hex!("02101a1b2a2b3a3b4a4b5a5b6a6b7a7b8a8b"));
 
         let ip = AddrV2::TorV2(FromHex::from_hex("f1f2f3f4f5f6f7f8f9fa").unwrap());
@@ -423,7 +422,7 @@ mod test {
             hex!("0520a2894dabaec08c0051a481a6dac88b64f98232ae42d4b6fd2fa81952dfe36a87")
         );
 
-        let ip = AddrV2::Cjdns(Ipv6Addr::from_str("fc01:1:2:3:4:5:6:7").unwrap());
+        let ip = AddrV2::Cjdns("fc01:1:2:3:4:5:6:7".parse::<Ipv6Addr>().unwrap());
         assert_eq!(serialize(&ip), hex!("0610fc010001000200030004000500060007"));
 
         let ip = AddrV2::Unknown(170, hex!("01020304"));
@@ -451,7 +450,7 @@ mod test {
         let ip: AddrV2 = deserialize(&hex!("02100102030405060708090a0b0c0d0e0f10")).unwrap();
         assert_eq!(
             ip,
-            AddrV2::Ipv6(Ipv6Addr::from_str("102:304:506:708:90a:b0c:d0e:f10").unwrap())
+            AddrV2::Ipv6("102:304:506:708:90a:b0c:d0e:f10".parse::<Ipv6Addr>().unwrap())
         );
 
         // Invalid IPv6, with bogus length.
@@ -508,7 +507,7 @@ mod test {
 
         // Valid CJDNS.
         let ip: AddrV2 = deserialize(&hex!("0610fc000001000200030004000500060007")).unwrap();
-        assert_eq!(ip, AddrV2::Cjdns(Ipv6Addr::from_str("fc00:1:2:3:4:5:6:7").unwrap()));
+        assert_eq!(ip, AddrV2::Cjdns("fc00:1:2:3:4:5:6:7".parse::<Ipv6Addr>().unwrap()));
 
         // Invalid CJDNS, incorrect marker
         assert!(deserialize::<AddrV2>(&hex!("0610fd000001000200030004000500060007")).is_err());

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -433,7 +433,7 @@ mod tests {
         ];
 
         for (magic_str, network) in &known_network_magic_strs {
-            let magic: Magic = Magic::from_str(magic_str).unwrap();
+            let magic: Magic = magic_str.parse::<Magic>().unwrap();
             assert_eq!(Network::try_from(magic).unwrap(), *network);
             assert_eq!(&magic.to_string(), magic_str);
         }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1865,11 +1865,9 @@ mod tests {
 
     #[test]
     fn target_is_met_by_for_target_equals_hash() {
-        use std::str::FromStr;
-
-        let hash =
-            BlockHash::from_str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")
-                .expect("failed to parse block hash");
+        let hash = "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"
+            .parse::<BlockHash>()
+            .expect("failed to parse block hash");
         let target = Target(U256::from_le_bytes(hash.to_byte_array()));
         assert!(target.is_met_by(hash));
     }

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -523,7 +523,7 @@ mod test {
         ] {
             let sighash = PsbtSighashType::from(*ecdsa);
             let s = format!("{}", sighash);
-            let back = PsbtSighashType::from_str(&s).unwrap();
+            let back = s.parse::<PsbtSighashType>().unwrap();
             assert_eq!(back, sighash);
             assert_eq!(back.ecdsa_hash_ty().unwrap(), *ecdsa);
         }
@@ -542,7 +542,7 @@ mod test {
         ] {
             let sighash = PsbtSighashType::from(*tap);
             let s = format!("{}", sighash);
-            let back = PsbtSighashType::from_str(&s).unwrap();
+            let back = s.parse::<PsbtSighashType>().unwrap();
             assert_eq!(back, sighash);
             assert_eq!(back.taproot_hash_ty().unwrap(), *tap);
         }
@@ -553,7 +553,7 @@ mod test {
         let nonstd = 0xdddddddd;
         let sighash = PsbtSighashType { inner: nonstd };
         let s = format!("{}", sighash);
-        let back = PsbtSighashType::from_str(&s).unwrap();
+        let back = s.parse::<PsbtSighashType>().unwrap();
 
         assert_eq!(back, sighash);
         assert_eq!(back.ecdsa_hash_ty(), Err(NonStandardSighashTypeError(nonstd)));

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1569,9 +1569,6 @@ mod tests {
     }
 
     mod bip_vectors {
-        #[cfg(feature = "base64")]
-        use std::str::FromStr;
-
         use super::*;
         use crate::psbt::map::Map;
 
@@ -1585,7 +1582,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "InvalidMagic")]
         fn invalid_vector_1_base64() {
-            Psbt::from_str("AgAAAAEmgXE3Ht/yhek3re6ks3t4AAwFZsuzrWRkFxPKQhcb9gAAAABqRzBEAiBwsiRRI+a/R01gxbUMBD1MaRpdJDXwmjSnZiqdwlF5CgIgATKcqdrPKAvfMHQOwDkEIkIsgctFg5RXrrdvwS7dlbMBIQJlfRGNM1e44PTCzUbbezn22cONmnCry5st5dyNv+TOMf7///8C09/1BQAAAAAZdqkU0MWZA8W6woaHYOkP1SGkZlqnZSCIrADh9QUAAAAAF6kUNUXm4zuDLEcFDyTT7rk8nAOUi8eHsy4TAA==").unwrap();
+            "AgAAAAEmgXE3Ht/yhek3re6ks3t4AAwFZsuzrWRkFxPKQhcb9gAAAABqRzBEAiBwsiRRI+a/R01gxbUMBD1MaRpdJDXwmjSnZiqdwlF5CgIgATKcqdrPKAvfMHQOwDkEIkIsgctFg5RXrrdvwS7dlbMBIQJlfRGNM1e44PTCzUbbezn22cONmnCry5st5dyNv+TOMf7///8C09/1BQAAAAAZdqkU0MWZA8W6woaHYOkP1SGkZlqnZSCIrADh9QUAAAAAF6kUNUXm4zuDLEcFDyTT7rk8nAOUi8eHsy4TAA==".parse::<Psbt>().unwrap();
         }
 
         #[test]
@@ -1599,7 +1596,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "ConsensusEncoding")]
         fn invalid_vector_2_base64() {
-            Psbt::from_str("cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAA==")
+            "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAA==".parse::<Psbt>()
                 .unwrap();
         }
 
@@ -1613,7 +1610,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "UnsignedTxHasScriptSigs")]
         fn invalid_vector_3_base64() {
-            Psbt::from_str("cHNidP8BAP0KAQIAAAACqwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QAAAAAakcwRAIgR1lmF5fAGwNrJZKJSGhiGDR9iYZLcZ4ff89X0eURZYcCIFMJ6r9Wqk2Ikf/REf3xM286KdqGbX+EhtdVRs7tr5MZASEDXNxh/HupccC1AaZGoqg7ECy0OIEhfKaC3Ibi1z+ogpL+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAABASAA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHhwEEFgAUhdE1N/LiZUBaNNuvqePdoB+4IwgAAAA=").unwrap();
+            "cHNidP8BAP0KAQIAAAACqwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QAAAAAakcwRAIgR1lmF5fAGwNrJZKJSGhiGDR9iYZLcZ4ff89X0eURZYcCIFMJ6r9Wqk2Ikf/REf3xM286KdqGbX+EhtdVRs7tr5MZASEDXNxh/HupccC1AaZGoqg7ECy0OIEhfKaC3Ibi1z+ogpL+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAABASAA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHhwEEFgAUhdE1N/LiZUBaNNuvqePdoB+4IwgAAAA=".parse::<Psbt>().unwrap();
         }
 
         #[test]
@@ -1626,7 +1623,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "MustHaveUnsignedTx")]
         fn invalid_vector_4_base64() {
-            Psbt::from_str("cHNidP8AAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAA==").unwrap();
+            "cHNidP8AAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAA==".parse::<Psbt>().unwrap();
         }
 
         #[test]
@@ -1639,7 +1636,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "DuplicateKey(Key { type_value: 0, key_data: [] })")]
         fn invalid_vector_5_base64() {
-            Psbt::from_str("cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAQA/AgAAAAH//////////////////////////////////////////wAAAAAA/////wEAAAAAAAAAAANqAQAAAAAAAAAA").unwrap();
+            "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAQA/AgAAAAH//////////////////////////////////////////wAAAAAA/////wEAAAAAAAAAAANqAQAAAAAAAAAA".parse::<Psbt>().unwrap();
         }
 
         #[test]
@@ -1738,9 +1735,9 @@ mod tests {
             #[cfg(feature = "base64")]
             {
                 let base64str = "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAAAA";
-                assert_eq!(Psbt::from_str(base64str).unwrap(), unserialized);
+                assert_eq!(base64str.parse::<Psbt>().unwrap(), unserialized);
                 assert_eq!(base64str, unserialized.to_string());
-                assert_eq!(Psbt::from_str(base64str).unwrap(), hex_psbt(base16str).unwrap());
+                assert_eq!(base64str.parse::<Psbt>().unwrap(), hex_psbt(base16str).unwrap());
             }
         }
 

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -222,8 +222,6 @@ mod tests {
     #[test]
     #[cfg(all(feature = "secp-recovery", feature = "base64", feature = "rand-std"))]
     fn test_message_signature() {
-        use core::str::FromStr;
-
         use secp256k1;
 
         use crate::{Address, AddressType, Network, NetworkKind};
@@ -237,7 +235,7 @@ mod tests {
         let signature = super::MessageSignature { signature: secp_sig, compressed: true };
 
         assert_eq!(signature.to_base64(), signature.to_string());
-        let signature2 = super::MessageSignature::from_str(&signature.to_string()).unwrap();
+        let signature2 = &signature.to_string().parse::<super::MessageSignature>().unwrap();
         let pubkey = signature2
             .recover_pubkey(&secp, msg_hash)
             .unwrap()

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -1,7 +1,6 @@
 #![cfg(not(feature = "rand-std"))]
 
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 use bitcoin::bip32::{DerivationPath, Fingerprint};
 use bitcoin::consensus::encode::serialize_hex;
@@ -77,7 +76,7 @@ fn psbt_sign_taproot() {
 
     // m/86'/1'/0'/0/7
     let to_address = "tb1pyfv094rr0vk28lf8v9yx3veaacdzg26ztqk4ga84zucqqhafnn5q9my9rz";
-    let to_address = Address::from_str(to_address).unwrap().assume_checked();
+    let to_address = to_address.parse::<Address<_>>().unwrap().assume_checked();
 
     // key path spend
     {
@@ -94,7 +93,7 @@ fn psbt_sign_taproot() {
         // Step 2: sign psbt.
         //
         let keystore = Keystore {
-            mfp: Fingerprint::from_str(mfp).unwrap(),
+            mfp: mfp.parse::<Fingerprint>().unwrap(),
             sk: PrivateKey::new(kp.secret_key(), Network::Testnet),
         };
         let _ = psbt_key_path_spend.sign(&keystore, secp);
@@ -124,7 +123,7 @@ fn psbt_sign_taproot() {
         let signing_key_path = sk_path[1].1;
 
         let keystore = Keystore {
-            mfp: Fingerprint::from_str(mfp).unwrap(),
+            mfp: mfp.parse::<Fingerprint>().unwrap(),
             sk: PrivateKey::new(kp.secret_key(), Network::Testnet),
         };
 
@@ -234,8 +233,8 @@ fn create_psbt_for_taproot_key_path_spend(
         (
             vec![],
             (
-                Fingerprint::from_str(mfp).unwrap(),
-                DerivationPath::from_str(internal_key_path).unwrap(),
+                mfp.parse::<Fingerprint>().unwrap(),
+                internal_key_path.parse::<DerivationPath>().unwrap(),
             ),
         ),
     );
@@ -249,7 +248,7 @@ fn create_psbt_for_taproot_key_path_spend(
         tap_key_origins: origins,
         ..Default::default()
     };
-    let ty = PsbtSighashType::from_str("SIGHASH_DEFAULT").unwrap();
+    let ty = "SIGHASH_DEFAULT".parse::<PsbtSighashType>().unwrap();
     input.sighash_type = Some(ty);
     input.tap_internal_key = Some(tree.internal_key());
     input.tap_merkle_root = tree.merkle_root();
@@ -308,8 +307,8 @@ fn create_psbt_for_taproot_script_path_spend(
         (
             vec![use_script.tapscript_leaf_hash()],
             (
-                Fingerprint::from_str(mfp).unwrap(),
-                DerivationPath::from_str(signing_key_path).unwrap(),
+                mfp.parse::<Fingerprint>().unwrap(),
+                signing_key_path.parse::<DerivationPath>().unwrap(),
             ),
         ),
     );
@@ -329,7 +328,7 @@ fn create_psbt_for_taproot_script_path_spend(
         tap_scripts,
         ..Default::default()
     };
-    let ty = PsbtSighashType::from_str("SIGHASH_ALL").unwrap();
+    let ty = "SIGHASH_ALL".parse::<PsbtSighashType>().unwrap();
     input.sighash_type = Some(ty);
     input.tap_internal_key = Some(tree.internal_key());
     input.tap_merkle_root = tree.merkle_root();

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -23,7 +23,6 @@
 #![cfg(feature = "serde")]
 
 use std::collections::BTreeMap;
-use std::str::FromStr;
 
 use bincode::serialize;
 use bitcoin::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
@@ -144,7 +143,7 @@ fn serde_regression_witness() {
 #[test]
 fn serde_regression_address() {
     let s = include_str!("data/serde/public_key_hex");
-    let pk = PublicKey::from_str(s.trim()).unwrap();
+    let pk = s.trim().parse::<PublicKey>().unwrap();
     let addr = Address::p2pkh(pk, NetworkKind::Main);
 
     let got = serialize(&addr).unwrap();
@@ -155,7 +154,7 @@ fn serde_regression_address() {
 #[test]
 fn serde_regression_extended_priv_key() {
     let s = include_str!("data/serde/extended_priv_key");
-    let key = Xpriv::from_str(s.trim()).unwrap();
+    let key = s.trim().parse::<Xpriv>().unwrap();
     let got = serialize(&key).unwrap();
     let want = include_bytes!("data/serde/extended_priv_key_bincode") as &[_];
     assert_eq!(got, want)
@@ -164,7 +163,7 @@ fn serde_regression_extended_priv_key() {
 #[test]
 fn serde_regression_extended_pub_key() {
     let s = include_str!("data/serde/extended_pub_key");
-    let key = Xpub::from_str(s.trim()).unwrap();
+    let key = s.trim().parse::<Xpub>().unwrap();
     let got = serialize(&key).unwrap();
     let want = include_bytes!("data/serde/extended_pub_key_bincode") as &[_];
     assert_eq!(got, want)
@@ -174,7 +173,7 @@ fn serde_regression_extended_pub_key() {
 fn serde_regression_ecdsa_sig() {
     let s = include_str!("data/serde/ecdsa_sig_hex");
     let sig = ecdsa::Signature {
-        signature: secp256k1::ecdsa::Signature::from_str(s.trim()).unwrap(),
+        signature: s.trim().parse::<secp256k1::ecdsa::Signature>().unwrap(),
         sighash_type: EcdsaSighashType::All,
     };
 
@@ -212,7 +211,7 @@ fn serde_regression_private_key() {
 #[test]
 fn serde_regression_public_key() {
     let s = include_str!("data/serde/public_key_hex");
-    let pk = PublicKey::from_str(s.trim()).unwrap();
+    let pk = s.trim().parse::<PublicKey>().unwrap();
     let got = serialize(&pk).unwrap();
     let want = include_bytes!("data/serde/public_key_bincode") as &[_];
     assert_eq!(got, want)
@@ -271,7 +270,7 @@ fn serde_regression_psbt() {
         version: 0,
         xpub: {
             let s = include_str!("data/serde/extended_pub_key");
-            let xpub = Xpub::from_str(s.trim()).unwrap();
+            let xpub = s.trim().parse::<Xpub>().unwrap();
             vec![(xpub, key_source)].into_iter().collect()
         },
         unsigned_tx: {
@@ -289,7 +288,7 @@ fn serde_regression_psbt() {
                 value: Amount::from_sat(190_303_501_938),
                 script_pubkey: ScriptBuf::from_hex("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587").unwrap(),
             }),
-            sighash_type: Some(PsbtSighashType::from(EcdsaSighashType::from_str("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY").unwrap())),
+            sighash_type: Some(PsbtSighashType::from("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY".parse::<EcdsaSighashType>().unwrap())),
             redeem_script: Some(vec![0x51].into()),
             witness_script: None,
             partial_sigs: vec![(
@@ -350,7 +349,7 @@ fn serde_regression_proprietary_key() {
 fn serde_regression_taproot_sig() {
     let s = include_str!("data/serde/taproot_sig_hex");
     let sig = taproot::Signature {
-        signature: secp256k1::schnorr::Signature::from_str(s.trim()).unwrap(),
+        signature: s.trim().parse::<secp256k1::schnorr::Signature>().unwrap(),
         sighash_type: TapSighashType::All,
     };
 

--- a/fuzz/fuzz_targets/bitcoin/deserialize_address.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_address.rs
@@ -1,10 +1,8 @@
-use std::str::FromStr;
-
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
-    let addr = match bitcoin::address::Address::from_str(&data_str) {
+    let addr = match data_str.parse::<bitcoin::address::Address<_>>() {
         Ok(addr) => addr.assume_checked(),
         Err(_) => return,
     };

--- a/fuzz/fuzz_targets/bitcoin/outpoint_string.rs
+++ b/fuzz/fuzz_targets/bitcoin/outpoint_string.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use bitcoin::consensus::encode;
 use bitcoin::transaction::OutPoint;
 use honggfuzz::fuzz;
@@ -21,7 +19,7 @@ fn do_test(data: &[u8]) {
         Err(_) => return,
         Ok(s) => s,
     };
-    match OutPoint::from_str(&data_str) {
+    match data_str.parse::<OutPoint>() {
         Ok(op) => {
             assert_eq!(op.to_string().as_bytes(), data_str.as_bytes());
         }
@@ -32,7 +30,7 @@ fn do_test(data: &[u8]) {
                 let ser = encode::serialize(&deser);
                 assert_eq!(ser, data);
                 let string = deser.to_string();
-                match OutPoint::from_str(&string) {
+                match string.parse::<OutPoint>() {
                     Ok(destring) => assert_eq!(destring, deser),
                     Err(_) => panic!(),
                 }

--- a/fuzz/fuzz_targets/units/deserialize_amount.rs
+++ b/fuzz/fuzz_targets/units/deserialize_amount.rs
@@ -1,27 +1,25 @@
-use std::str::FromStr;
-
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
 
     // signed
-    let samt = match bitcoin::amount::SignedAmount::from_str(&data_str) {
+    let samt = match data_str.parse::<bitcoin::amount::SignedAmount>() {
         Ok(amt) => amt,
         Err(_) => return,
     };
-    let samt_roundtrip = match bitcoin::amount::SignedAmount::from_str(&samt.to_string()) {
+    let samt_roundtrip = match samt.to_string().parse::<bitcoin::amount::SignedAmount>() {
         Ok(amt) => amt,
         Err(_) => return,
     };
     assert_eq!(samt, samt_roundtrip);
 
     // unsigned
-    let amt = match bitcoin::amount::Amount::from_str(&data_str) {
+    let amt = match data_str.parse::<bitcoin::amount::Amount>() {
         Ok(amt) => amt,
         Err(_) => return,
     };
-    let amt_roundtrip = match bitcoin::amount::Amount::from_str(&amt.to_string()) {
+    let amt_roundtrip = match amt.to_string().parse::<bitcoin::amount::Amount>() {
         Ok(amt) => amt,
         Err(_) => return,
     };

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -37,15 +37,14 @@ use arbitrary::{Arbitrary, Unstructured};
 /// # Examples
 ///
 /// ```
-/// # use core::str::FromStr;
 /// # use bitcoin_units::Amount;
 ///
-/// assert_eq!(Amount::from_str("1 BTC").unwrap(), Amount::from_sat(100_000_000));
-/// assert_eq!(Amount::from_str("1 cBTC").unwrap(), Amount::from_sat(1_000_000));
-/// assert_eq!(Amount::from_str("1 mBTC").unwrap(), Amount::from_sat(100_000));
-/// assert_eq!(Amount::from_str("1 uBTC").unwrap(), Amount::from_sat(100));
-/// assert_eq!(Amount::from_str("1 bit").unwrap(), Amount::from_sat(100));
-/// assert_eq!(Amount::from_str("1 sat").unwrap(), Amount::from_sat(1));
+/// assert_eq!("1 BTC".parse::<Amount>().unwrap(), Amount::from_sat(100_000_000));
+/// assert_eq!("1 cBTC".parse::<Amount>().unwrap(), Amount::from_sat(1_000_000));
+/// assert_eq!("1 mBTC".parse::<Amount>().unwrap(), Amount::from_sat(100_000));
+/// assert_eq!("1 uBTC".parse::<Amount>().unwrap(), Amount::from_sat(100));
+/// assert_eq!("1 bit".parse::<Amount>().unwrap(), Amount::from_sat(100));
+/// assert_eq!("1 sat".parse::<Amount>().unwrap(), Amount::from_sat(1));
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[non_exhaustive]

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -2046,21 +2046,21 @@ mod tests {
         for denom in denoms {
             for v in &["0", "000"] {
                 let s = format!("{} {}", v, denom);
-                match Amount::from_str(&s) {
+                match s.parse::<Amount>() {
                     Err(e) => panic!("failed to crate amount from {}: {:?}", s, e),
                     Ok(amount) => assert_eq!(amount, Amount::from_sat(0)),
                 }
             }
 
             let s = format!("-0 {}", denom);
-            match Amount::from_str(&s) {
+            match s.parse::<Amount>() {
                 Err(e) => assert_eq!(
                     e,
                     ParseError::Amount(ParseAmountError::OutOfRange(OutOfRangeError::negative()))
                 ),
                 Ok(_) => panic!("unsigned amount from {}", s),
             }
-            match SignedAmount::from_str(&s) {
+            match s.parse::<SignedAmount>() {
                 Err(e) => panic!("failed to crate amount from {}: {:?}", s, e),
                 Ok(amount) => assert_eq!(amount, SignedAmount::from_sat(0)),
             }
@@ -2514,50 +2514,50 @@ mod tests {
         use super::ParseAmountError as E;
 
         assert_eq!(
-            Amount::from_str("x BTC"),
+            "x BTC".parse::<Amount>(),
             Err(InvalidCharacterError { invalid_char: 'x', position: 0 }.into())
         );
         assert_eq!(
-            Amount::from_str("xBTC"),
+            "xBTC".parse::<Amount>(),
             Err(Unknown(UnknownDenominationError("xBTC".into())).into()),
         );
         assert_eq!(
-            Amount::from_str("5 BTC BTC"),
+            "5 BTC BTC".parse::<Amount>(),
             Err(Unknown(UnknownDenominationError("BTC BTC".into())).into()),
         );
         assert_eq!(
-            Amount::from_str("5BTC BTC"),
+            "5BTC BTC".parse::<Amount>(),
             Err(E::from(InvalidCharacterError { invalid_char: 'B', position: 1 }).into())
         );
         assert_eq!(
-            Amount::from_str("5 5 BTC"),
+            "5 5 BTC".parse::<Amount>(),
             Err(Unknown(UnknownDenominationError("5 BTC".into())).into()),
         );
 
         #[track_caller]
         fn ok_case(s: &str, expected: Amount) {
-            assert_eq!(Amount::from_str(s).unwrap(), expected);
-            assert_eq!(Amount::from_str(&s.replace(' ', "")).unwrap(), expected);
+            assert_eq!(s.parse::<Amount>().unwrap(), expected);
+            assert_eq!(s.replace(' ', "").parse::<Amount>().unwrap(), expected);
         }
 
         #[track_caller]
         fn case(s: &str, expected: Result<Amount, impl Into<ParseError>>) {
             let expected = expected.map_err(Into::into);
-            assert_eq!(Amount::from_str(s), expected);
-            assert_eq!(Amount::from_str(&s.replace(' ', "")), expected);
+            assert_eq!(s.parse::<Amount>(), expected);
+            assert_eq!(s.replace(' ', "").parse::<Amount>(), expected);
         }
 
         #[track_caller]
         fn ok_scase(s: &str, expected: SignedAmount) {
-            assert_eq!(SignedAmount::from_str(s).unwrap(), expected);
-            assert_eq!(SignedAmount::from_str(&s.replace(' ', "")).unwrap(), expected);
+            assert_eq!(s.parse::<SignedAmount>().unwrap(), expected);
+            assert_eq!(s.replace(' ', "").parse::<SignedAmount>().unwrap(), expected);
         }
 
         #[track_caller]
         fn scase(s: &str, expected: Result<SignedAmount, impl Into<ParseError>>) {
             let expected = expected.map_err(Into::into);
-            assert_eq!(SignedAmount::from_str(s), expected);
-            assert_eq!(SignedAmount::from_str(&s.replace(' ', "")), expected);
+            assert_eq!(s.parse::<SignedAmount>(), expected);
+            assert_eq!(s.replace(' ', "").parse::<SignedAmount>(), expected);
         }
 
         case("5 BCH", Err(Unknown(UnknownDenominationError("BCH".into()))));
@@ -2647,18 +2647,18 @@ mod tests {
 
         let amt = Amount::from_sat(42);
         let denom = Amount::to_string_with_denomination;
-        assert_eq!(Amount::from_str(&denom(amt, D::Bitcoin)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(amt, D::MilliBitcoin)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(amt, D::MicroBitcoin)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(amt, D::Bit)), Ok(amt));
-        assert_eq!(Amount::from_str(&denom(amt, D::Satoshi)), Ok(amt));
+        assert_eq!(denom(amt, D::Bitcoin).parse::<Amount>(), Ok(amt));
+        assert_eq!(denom(amt, D::MilliBitcoin).parse::<Amount>(), Ok(amt));
+        assert_eq!(denom(amt, D::MicroBitcoin).parse::<Amount>(), Ok(amt));
+        assert_eq!(denom(amt, D::Bit).parse::<Amount>(), Ok(amt));
+        assert_eq!(denom(amt, D::Satoshi).parse::<Amount>(), Ok(amt));
 
         assert_eq!(
-            Amount::from_str("42 satoshi BTC"),
+            "42 satoshi BTC".parse::<Amount>(),
             Err(Unknown(UnknownDenominationError("satoshi BTC".into())).into()),
         );
         assert_eq!(
-            SignedAmount::from_str("-42 satoshi BTC"),
+            "-42 satoshi BTC".parse::<SignedAmount>(),
             Err(Unknown(UnknownDenominationError("satoshi BTC".into())).into()),
         );
     }
@@ -2868,7 +2868,7 @@ mod tests {
             "satoshis", "SAT", "sat", "SATS", "sats", "bit", "bits",
         ];
         for denom in valid.iter() {
-            assert!(Denomination::from_str(denom).is_ok());
+            assert!(denom.parse::<Denomination>().is_ok());
         }
     }
 
@@ -2876,7 +2876,7 @@ mod tests {
     fn disallow_confusing_forms() {
         let confusing = ["CBTC", "Cbtc", "MBTC", "Mbtc", "UBTC", "Ubtc"];
         for denom in confusing.iter() {
-            match Denomination::from_str(denom) {
+            match denom.parse::<Denomination>() {
                 Ok(_) => panic!("from_str should error for {}", denom),
                 Err(ParseDenominationError::PossiblyConfusing(_)) => {}
                 Err(e) => panic!("unexpected error: {}", e),
@@ -2889,7 +2889,7 @@ mod tests {
         // Non-exhaustive list of unknown forms.
         let unknown = ["NBTC", "ABC", "abc", "mSat", "msat"];
         for denom in unknown.iter() {
-            match Denomination::from_str(denom) {
+            match denom.parse::<Denomination>() {
                 Ok(_) => panic!("from_str should error for {}", denom),
                 Err(ParseDenominationError::Unknown(_)) => (),
                 Err(e) => panic!("unexpected error: {}", e),


### PR DESCRIPTION
Following on from #3265 `T::from_str(s)` to `s.parse::<T>()` has been changed in the rest of the repository, i.e. in examples, docs and tests that were not done in the previous PR.

Address was done in a separate patch because the formatting was different and required a different macro to make the change.  Also in the rustdocs it also gives 3 variants for parsing strings to addresses (`bitcoin/src/address/mod.rs` ll266-301) and I chose variant 3, but I can change to 1 if preferred.
``` rust

// variant 1
let address: Address<NetworkUnchecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse().unwrap();
let address: Address<NetworkChecked> = address.require_network(Network::Bitcoin).unwrap();

// variant 2
 let address: Address = Address::from_str("32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf").unwrap()
                .require_network(Network::Bitcoin).unwrap();

// variant 3
let address: Address<NetworkChecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse::<Address<_>>()
               .unwrap().require_network(Network::Bitcoin).unwrap();
```