### PR TITLE
Fix clippy rustdocs warnings

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -143,6 +143,8 @@ impl Decodable for ShortId {
     }
 }
 
+/// A structure to relay a block header, short IDs, and a select few transactions.
+///
 /// A [`HeaderAndShortIds`] structure is used to relay a block header, the short
 /// transactions IDs used for matching already-available transactions, and a
 /// select few transactions which we expect a peer may be missing.

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -131,10 +131,12 @@ pub struct Input {
     pub unknown: BTreeMap<raw::Key, Vec<u8>>,
 }
 
-/// A Signature hash type for the corresponding input. As of Taproot upgrade, the signature hash
-/// type can be either [`EcdsaSighashType`] or [`TapSighashType`] but it is not possible to know
-/// directly which signature hash type the user is dealing with. Therefore, the user is responsible
-/// for converting to/from [`PsbtSighashType`] from/to the desired signature hash type they need.
+/// A Signature hash type for the corresponding input.
+///
+/// As of Taproot upgrade, the signature hash type can be either [`EcdsaSighashType`] or
+/// [`TapSighashType`] but it is not possible to know directly which signature hash type the user is
+/// dealing with. Therefore, the user is responsible for converting to/from [`PsbtSighashType`]
+/// from/to the desired signature hash type they need.
 ///
 /// # Examples
 ///

--- a/io/src/error.rs
+++ b/io/src/error.rs
@@ -116,10 +116,11 @@ impl From<Error> for std::io::Error {
 macro_rules! define_errorkind {
     ($($(#[$($attr:tt)*])* $kind:ident),*) => {
         #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-        /// A minimal subset of [`std::io::ErrorKind`] which is used for [`Error`]. Note that, as with
-        /// [`std::io`], only [`Self::Interrupted`] has defined semantics in this crate, all other
-        /// variants are provided here only to provide higher-fidelity conversions to and from
-        /// [`std::io::Error`].
+        /// A minimal subset of [`std::io::ErrorKind`] which is used for [`Error`].
+        ///
+        /// Note that, as with [`std::io`], only [`Self::Interrupted`] has defined semantics in this
+        /// crate, all other variants are provided here only to provide higher-fidelity conversions
+        /// to and from [`std::io::Error`].
         pub enum ErrorKind {
             $(
                 $(#[$($attr)*])*

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1638,6 +1638,7 @@ pub mod serde {
     #![allow(missing_docs)]
 
     //! This module adds serde serialization and deserialization support for Amounts.
+    //!
     //! Since there is not a default way to serialize and deserialize Amounts, multiple
     //! ways are supported and it's up to the user to decide which serialiation to use.
     //! The provided modules can be used as follows:


### PR DESCRIPTION
A new nightly version (`nightly-2024-08-28`) introduces a few warnings because of our rustdocs. These are valid warnings and should be fixed, thanks `clippy` team.

(The `bip152` change is a bit sloppy, open to suggestions.)