### PR TITLE
Fix bug in `ArrayVec::extend_from_slice`

### DIFF
--- a/internals/src/array_vec.rs
+++ b/internals/src/array_vec.rs
@@ -78,7 +78,7 @@ mod safety_boundary {
             assert!(new_len <= CAP, "buffer overflow");
             // SAFETY: MaybeUninit<T> has the same layout as T
             let slice = unsafe { &*(slice as *const _ as *const [MaybeUninit<T>]) };
-            self.data[self.len..].copy_from_slice(slice);
+            self.data[self.len..new_len].copy_from_slice(slice);
             self.len = new_len;
         }
     }

--- a/internals/src/array_vec.rs
+++ b/internals/src/array_vec.rs
@@ -181,4 +181,10 @@ mod tests {
         let mut av = ArrayVec::<_, 0>::new();
         av.extend_from_slice(&[42]);
     }
+
+    #[test]
+    fn extend_from_slice() {
+        let mut av = ArrayVec::<u8, 8>::new();
+        av.extend_from_slice(b"abc");
+    }
 }


### PR DESCRIPTION
Currently the source slice must be the exact length to fill the array to max capacity, this is an unnecessary restriction since an `ArrayVec` is a variable sized data structure.

Set the destination slice to be the same length as the source slice (still maintain capacity checks).