### PR TITLE
hashes: Fix features

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -17,7 +17,6 @@ exclude = ["tests", "contrib"]
 default = ["std"]
 std = ["alloc", "bitcoin-io?/std", "hex/std"]
 alloc = ["bitcoin-io?/alloc", "hex/alloc"]
-# If you want I/O you must enable either "std" or "io".
 io = ["bitcoin-io"]
 schemars = ["dep:schemars", "alloc"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -15,11 +15,11 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hex/std", "bitcoin-io?/std"]
-alloc = ["hex/alloc"]
-schemars = ["dep:schemars", "alloc"]
+std = ["alloc", "bitcoin-io?/std", "hex/std"]
+alloc = ["bitcoin-io?/alloc", "hex/alloc"]
 # If you want I/O you must enable either "std" or "io".
 io = ["bitcoin-io"]
+schemars = ["dep:schemars", "alloc"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
 


### PR DESCRIPTION
Recently we tried to fix the features in `hashes` but during review did not notice that they were still wrong.

- Put the features in alphabetic order so it is easier to see mistakes
- Enable `bitcoin-io/alloc` conditionally from `alloc`