### PR TITLE
Add Arbitrary to SignedAmount type

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1594,6 +1594,14 @@ impl core::iter::Sum for SignedAmount {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for SignedAmount {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let s = i64::arbitrary(u)?;
+        Ok(SignedAmount(s))
+    }
+}
+
 /// Calculates the sum over the iterator using checked arithmetic.
 pub trait CheckedSum<R>: private::SumSeal<R> {
     /// Calculates the sum over the iterator using checked arithmetic. If an over or underflow would


### PR DESCRIPTION
While proptesting, I've found Arbitrary for SingedAmount to be useful.  Would appreciate adding this as well.