### PR TITLE
Enforce that `Hash::Bytes` is an array

### DIFF
--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -72,10 +72,11 @@ impl<T: GeneralHash> HmacEngine<T> {
 
         if key.len() > T::Engine::BLOCK_SIZE {
             let hash = <T as GeneralHash>::hash(key);
-            for (b_i, b_h) in ipad.iter_mut().zip(hash.as_ref()) {
+            let hash = hash.as_byte_array().as_ref();
+            for (b_i, b_h) in ipad.iter_mut().zip(hash) {
                 *b_i ^= *b_h;
             }
-            for (b_o, b_h) in opad.iter_mut().zip(hash.as_ref()) {
+            for (b_o, b_h) in opad.iter_mut().zip(hash) {
                 *b_o ^= *b_h;
             }
         } else {
@@ -119,7 +120,8 @@ impl<T: GeneralHash> fmt::LowerHex for Hmac<T> {
 }
 
 impl<T: GeneralHash> convert::AsRef<[u8]> for Hmac<T> {
-    fn as_ref(&self) -> &[u8] { self.0.as_ref() }
+    // Calling as_byte_array is more reliable
+    fn as_ref(&self) -> &[u8] { self.0.as_byte_array().as_ref() }
 }
 
 impl<T: GeneralHash> GeneralHash for Hmac<T> {
@@ -127,7 +129,7 @@ impl<T: GeneralHash> GeneralHash for Hmac<T> {
 
     fn from_engine(mut e: HmacEngine<T>) -> Hmac<T> {
         let ihash = T::from_engine(e.iengine);
-        e.oengine.input(ihash.as_ref());
+        e.oengine.input(ihash.as_byte_array().as_ref());
         let ohash = T::from_engine(e.oengine);
         Hmac(ohash)
     }

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -135,7 +135,6 @@ impl<T: GeneralHash> GeneralHash for Hmac<T> {
 
 impl<T: GeneralHash> Hash for Hmac<T> {
     type Bytes = T::Bytes;
-    const LEN: usize = T::LEN;
 
     fn from_slice(sl: &[u8]) -> Result<Hmac<T>, FromSliceError> { T::from_slice(sl).map(Hmac) }
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -108,7 +108,6 @@ macro_rules! hash_trait_impls {
         impl<$($gen: $gent),*> crate::Hash for Hash<$($gen),*> {
             type Bytes = [u8; $bits / 8];
 
-            const LEN: usize = $bits / 8;
             const DISPLAY_BACKWARD: bool = $reverse;
 
             fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<Hash<$($gen),*>, $crate::FromSliceError> {

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -274,10 +274,10 @@ pub trait Hash:
     + convert::AsRef<[u8]>
 {
     /// The byte array that represents the hash internally.
-    type Bytes: hex::FromHex + Copy;
+    type Bytes: hex::FromHex + Copy + IsByteArray /* <LEN={Self::LEN}> is still unsupported by Rust */;
 
     /// Length of the hash, in bytes.
-    const LEN: usize;
+    const LEN: usize = Self::Bytes::LEN;
 
     /// Copies a byte slice into a hash object.
     fn from_slice(sl: &[u8]) -> Result<Self, FromSliceError>;
@@ -295,6 +295,23 @@ pub trait Hash:
 
     /// Constructs a hash from the underlying byte array.
     fn from_byte_array(bytes: Self::Bytes) -> Self;
+}
+
+/// Ensures that a type is an array.
+pub trait IsByteArray: AsRef<[u8]> + sealed::IsByteArray {
+    /// The length of the array.
+    const LEN: usize;
+}
+
+impl<const N: usize> IsByteArray for [u8; N] {
+    const LEN: usize = N;
+}
+
+mod sealed {
+    #[doc(hidden)]
+    pub trait IsByteArray { }
+
+    impl<const N: usize> IsByteArray for [u8; N] { }
 }
 
 /// Attempted to create a hash from an invalid length slice.

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -231,7 +231,6 @@ macro_rules! hash_newtype {
         impl $crate::Hash for $newtype {
             type Bytes = <$hash as $crate::Hash>::Bytes;
 
-            const LEN: usize = <$hash as $crate::Hash>::LEN;
             const DISPLAY_BACKWARD: bool = $crate::hash_newtype_get_direction!($hash, $(#[$($type_attrs)*])*);
 
             #[inline]


### PR DESCRIPTION
This makes sure `Hash::Bytes` is an array. We've discussed this somewhere but I don't remember where.

I'm not sure if the second commit is actually valuable but hopefully shouldn't make things worse.