### PR TITLE
fix: deprecate wrong and unused max script num

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -47,6 +47,7 @@ pub const MAX_STACK_ELEMENT_SIZE: usize = 520;
 /// How may blocks between halvings.
 pub const SUBSIDY_HALVING_INTERVAL: u32 = 210_000;
 /// Maximum allowed value for an integer in Script.
+#[deprecated(since = "TBD", note = "This constant has ambiguous semantics. Please carefully check your intended use-case and define a new constant reflecting that.")]
 pub const MAX_SCRIPTNUM_VALUE: u32 = 0x80000000; // 2^31
 /// Number of blocks needed for an output from a coinbase transaction to be spendable.
 pub const COINBASE_MATURITY: u32 = 100;


### PR DESCRIPTION
~~Script number can be up to 2^39 - 1 to encode locktime.~~
~~If it's only for the integer operation besides locktime, it must be 2^31 - 1, not 2^31.~~

I agree with apoelstra  opinion to deprecate this value.