### PR TITLE
Show compressed public key in Debug for CompressedPublicKey

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -271,7 +271,7 @@ impl From<&PublicKey> for PubkeyHash {
 }
 
 /// An always-compressed Bitcoin ECDSA public key.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompressedPublicKey(pub secp256k1::PublicKey);
 
 impl CompressedPublicKey {
@@ -347,6 +347,12 @@ impl CompressedPublicKey {
 impl fmt::Display for CompressedPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(&self.to_bytes().as_hex(), f)
+    }
+}
+
+impl fmt::Debug for CompressedPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_fmt(format_args!("CompressedPublicKey({})", self))
     }
 }
 


### PR DESCRIPTION
Currently `CompressedPublicKey` debug produces output of form:

```
CompressedPublicKey(PublicKey(2f8b18dc0adcb73d75f7934d9523ea7347083e41c48115398cb37e295a0a6ffe86e0bf8b1ef65888c880c8d8813a30e69e466380cbe2daec18f3ed1e7a553ff2))
```

Although it shows real internal structure together with inner uncompressed public key, it is not too helpful for the purpose of debugging _compressed_ public key.

After this patch, `Debug` output will be equal to `Display` (it, in fact, delegates rendering to `Display`), prepended by the name of the struct:

```
CompressedPublicKey(02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f)
```