### PR TITLE
Remove bool from const_assert

### DIFF
--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -140,12 +140,11 @@ macro_rules! debug_from_display {
 #[macro_export]
 macro_rules! const_assert {
     ($x:expr $(; $message:expr)?) => {
-        const _: bool = {
+        const _: () = {
             if !$x {
                 // We can't use formatting in const, only concating literals.
                 panic!(concat!("assertion ", stringify!($x), " failed" $(, ": ", $message)?))
             }
-            $x
         };
     }
 }


### PR DESCRIPTION
It was correctly pointed out during review of #3215 (when we made `const_assert` panic) that using a `bool` added no additional information.

Remove the `bool` and just use unit.