### PR TITLE
Move `transaction::Version` to `primitives`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -946,14 +946,14 @@ impl Version {
     pub const TWO: Self = Self(2);
 }
 
-mod tmp {
-    use super::*;
-    impl Version {
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`Version`] type.
+    pub trait VersionExt impl for Version {
         /// Creates a non-standard transaction version.
-        pub fn non_standard(version: i32) -> Version { Self(version) }
+        fn non_standard(version: i32) -> Version { Self(version) }
 
         /// Returns true if this transaction version number is considered standard.
-        pub fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
+        fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
     }
 }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -944,7 +944,9 @@ impl Version {
 
     /// The second Bitcoin transaction version (post-BIP-68).
     pub const TWO: Self = Self(2);
+}
 
+impl Version {
     /// Creates a non-standard transaction version.
     pub fn non_standard(version: i32) -> Version { Self(version) }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -946,12 +946,15 @@ impl Version {
     pub const TWO: Self = Self(2);
 }
 
+mod tmp {
+use super::*;
 impl Version {
     /// Creates a non-standard transaction version.
     pub fn non_standard(version: i32) -> Version { Self(version) }
 
     /// Returns true if this transaction version number is considered standard.
     pub fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
+}
 }
 
 impl Encodable for Version {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -947,14 +947,14 @@ impl Version {
 }
 
 mod tmp {
-use super::*;
-impl Version {
-    /// Creates a non-standard transaction version.
-    pub fn non_standard(version: i32) -> Version { Self(version) }
+    use super::*;
+    impl Version {
+        /// Creates a non-standard transaction version.
+        pub fn non_standard(version: i32) -> Version { Self(version) }
 
-    /// Returns true if this transaction version number is considered standard.
-    pub fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
-}
+        /// Returns true if this transaction version number is considered standard.
+        pub fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
+    }
 }
 
 impl Encodable for Version {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -31,6 +31,10 @@ use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
 use crate::{Amount, FeeRate, SignedAmount, VarInt};
 
+#[rustfmt::skip]            // Keep public re-exports separate.
+#[doc(inline)]
+pub use primitives::transaction::*;
+
 hashes::hash_newtype! {
     /// A bitcoin transaction hash/transaction ID.
     ///
@@ -925,27 +929,6 @@ impl std::error::Error for IndexOutOfBoundsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
 
-/// The transaction version.
-///
-/// Currently, as specified by [BIP-68], only version 1 and 2 are considered standard.
-///
-/// Standardness of the inner `i32` is not an invariant because you are free to create transactions
-/// of any version, transactions with non-standard version numbers will not be relayed by the
-/// Bitcoin network.
-///
-/// [BIP-68]: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
-#[derive(Copy, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Version(pub i32);
-
-impl Version {
-    /// The original Bitcoin transaction version (pre-BIP-68).
-    pub const ONE: Self = Self(1);
-
-    /// The second Bitcoin transaction version (post-BIP-68).
-    pub const TWO: Self = Self(2);
-}
-
 crate::internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Version`] type.
     pub trait VersionExt impl for Version {
@@ -967,10 +950,6 @@ impl Decodable for Version {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Decodable::consensus_decode(r).map(Version)
     }
-}
-
-impl fmt::Display for Version {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
 impl_consensus_encoding!(TxOut, value, script_pubkey);

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -33,6 +33,7 @@ pub mod locktime;
 pub mod opcodes;
 pub mod pow;
 pub mod sequence;
+pub mod transaction;
 
 #[doc(inline)]
 pub use units::*;

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin transactions.
+//!
+//! A transaction describes a transfer of money. It consumes previously-unspent
+//! transaction outputs and produces new ones, satisfying the condition to spend
+//! the old outputs (typically a digital signature with a specific key must be
+//! provided) and defining the condition to spend the new ones. The use of digital
+//! signatures ensures that coins cannot be spent by unauthorized parties.
+//!
+//! This module provides the structures and functions needed to support transactions.
+
+use core::fmt;
+
+/// The transaction version.
+///
+/// Currently, as specified by [BIP-68], only version 1 and 2 are considered standard.
+///
+/// Standardness of the inner `i32` is not an invariant because you are free to create transactions
+/// of any version, transactions with non-standard version numbers will not be relayed by the
+/// Bitcoin network.
+///
+/// [BIP-68]: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
+#[derive(Copy, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Version(pub i32);
+
+impl Version {
+    /// The original Bitcoin transaction version (pre-BIP-68).
+    pub const ONE: Self = Self(1);
+
+    /// The second Bitcoin transaction version (post-BIP-68).
+    pub const TWO: Self = Self(2);
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}


### PR DESCRIPTION
As per title, in tiny small chunks, move the `transaction::Version` over to `primitives`. Only the type, its associated consts, and its `Display` impl are moved. The two methods are left in an extension trait.

Was originally attempted in #3253