### PR TITLE
Fix: Proper relative::locktime validation and wrong link to bip68

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -47,7 +47,10 @@ pub const MAX_STACK_ELEMENT_SIZE: usize = 520;
 /// How may blocks between halvings.
 pub const SUBSIDY_HALVING_INTERVAL: u32 = 210_000;
 /// Maximum allowed value for an integer in Script.
-#[deprecated(since = "TBD", note = "This constant has ambiguous semantics. Please carefully check your intended use-case and define a new constant reflecting that.")]
+#[deprecated(
+    since = "TBD",
+    note = "This constant has ambiguous semantics. Please carefully check your intended use-case and define a new constant reflecting that."
+)]
 pub const MAX_SCRIPTNUM_VALUE: u32 = 0x80000000; // 2^31
 /// Number of blocks needed for an output from a coinbase transaction to be spendable.
 pub const COINBASE_MATURITY: u32 = 100;

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -174,7 +174,8 @@ impl fmt::LowerHex for SerializedSignature {
         fmt::LowerHex::fmt(&(**self).as_hex(), f)
     }
 }
-impl_to_hex_from_lower_hex!(SerializedSignature, |signature: &SerializedSignature| signature.len * 2);
+impl_to_hex_from_lower_hex!(SerializedSignature, |signature: &SerializedSignature| signature.len
+    * 2);
 
 impl fmt::UpperHex for SerializedSignature {
     #[inline]

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -22,6 +22,7 @@ pub mod message_network;
 
 use core::str::FromStr;
 use core::{fmt, ops};
+
 use hex::FromHex;
 use internals::{debug_from_display, impl_to_hex_from_lower_hex, write_err};
 use io::{BufRead, Write};
@@ -122,7 +123,8 @@ impl ServiceFlags {
 impl fmt::LowerHex for ServiceFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
-impl_to_hex_from_lower_hex!(ServiceFlags, |service_flags: &ServiceFlags| 16 - service_flags.0.leading_zeros() as usize / 4);
+impl_to_hex_from_lower_hex!(ServiceFlags, |service_flags: &ServiceFlags| 16
+    - service_flags.0.leading_zeros() as usize / 4);
 
 impl fmt::UpperHex for ServiceFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -7,6 +7,7 @@
 
 use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 use core::{cmp, fmt};
+
 use internals::impl_to_hex_from_lower_hex;
 use io::{BufRead, Write};
 #[cfg(all(test, mutate))]

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -73,7 +73,7 @@ fn serde_regression_absolute_lock_time_time() {
 
 #[test]
 fn serde_regression_relative_lock_time_height() {
-    let t = relative::LockTime::from(relative::Height::from(0xCAFE_u16));
+    let t = relative::LockTime::from(relative::HeightSpan::from(0xCAFE_u16));
     let got = serialize(&t).unwrap();
 
     let want = include_bytes!("data/serde/relative_lock_time_blocks_bincode") as &[_];
@@ -82,7 +82,7 @@ fn serde_regression_relative_lock_time_height() {
 
 #[test]
 fn serde_regression_relative_lock_time_time() {
-    let t = relative::LockTime::from(relative::Time::from_512_second_intervals(0xFACE_u16));
+    let t = relative::LockTime::from(relative::TimeSpan::from_512_second_intervals(0xFACE_u16));
     let got = serialize(&t).unwrap();
 
     let want = include_bytes!("data/serde/relative_lock_time_seconds_bincode") as &[_];

--- a/hashes/src/hkdf.rs
+++ b/hashes/src/hkdf.rs
@@ -79,8 +79,11 @@ where
             let t = Hmac::from_engine(hmac_engine);
             let start_index = (counter as usize - 1) * T::Bytes::LEN;
             // Last block might not take full hash length.
-            let end_index =
-                if counter == (total_blocks as u8) { okm.len() } else { counter as usize * T::Bytes::LEN };
+            let end_index = if counter == (total_blocks as u8) {
+                okm.len()
+            } else {
+                counter as usize * T::Bytes::LEN
+            };
 
             okm[start_index..end_index].copy_from_slice(&t.as_ref()[0..(end_index - start_index)]);
 

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -274,7 +274,7 @@ pub trait Hash:
     + convert::AsRef<[u8]>
 {
     /// The byte array that represents the hash internally.
-    type Bytes: hex::FromHex + Copy + IsByteArray /* <LEN={Self::LEN}> is still unsupported by Rust */;
+    type Bytes: hex::FromHex + Copy + IsByteArray;
 
     /// Length of the hash, in bytes.
     const LEN: usize = Self::Bytes::LEN;
@@ -309,9 +309,9 @@ impl<const N: usize> IsByteArray for [u8; N] {
 
 mod sealed {
     #[doc(hidden)]
-    pub trait IsByteArray { }
+    pub trait IsByteArray {}
 
-    impl<const N: usize> IsByteArray for [u8; N] { }
+    impl<const N: usize> IsByteArray for [u8; N] {}
 }
 
 /// Attempted to create a hash from an invalid length slice.

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -227,7 +227,5 @@ macro_rules! impl_to_hex_from_lower_hex {
 #[macro_export]
 #[cfg(not(feature = "alloc"))]
 macro_rules! impl_to_hex_from_lower_hex {
-    ($t:ident, $hex_len_fn:expr) => {
-
-    };
+    ($t:ident, $hex_len_fn:expr) => {};
 }

--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -34,7 +34,7 @@ pub use units::locktime::relative::*;
 ///
 /// ### Relevant BIPs
 ///
-/// * [BIP 68 Relative lock-time using consensus-enforced sequence numbers](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
+/// * [BIP 68 Relative lock-time using consensus-enforced sequence numbers](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki)
 /// * [BIP 112 CHECKSEQUENCEVERIFY](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -3,6 +3,7 @@
 //! Proof-of-work related integer types.
 
 use core::fmt;
+
 use internals::impl_to_hex_from_lower_hex;
 
 /// Encoding of 256-bit target as 32-bit float.
@@ -35,7 +36,11 @@ impl fmt::LowerHex for CompactTarget {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
-impl_to_hex_from_lower_hex!(CompactTarget, |compact_target: &CompactTarget| 8 - compact_target.0.leading_zeros() as usize / 4);
+impl_to_hex_from_lower_hex!(CompactTarget, |compact_target: &CompactTarget| 8 - compact_target
+    .0
+    .leading_zeros()
+    as usize
+    / 4);
 
 impl fmt::UpperHex for CompactTarget {
     #[inline]

--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -171,6 +171,13 @@ impl Sequence {
         }
     }
 
+    /// Gets the u16 value of the last 16 bits of the sequence number.
+    /// Ideally the Block or Time lock.
+    ///
+    /// Note: Calling this on a sequence lower than [`MIN_NO_RBF`] will give you an undefined value.
+    #[inline]
+    pub const fn get_raw_value(&self) -> u16 { ((self.0 << 16) >> 16) as u16 }
+
     /// Creates a sequence from a u32 value.
     #[inline]
     pub fn from_consensus(n: u32) -> Self { Sequence(n) }

--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -16,6 +16,7 @@
 //! [BIP-125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki>
 
 use core::fmt;
+
 use internals::impl_to_hex_from_lower_hex;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use units::locktime::relative::TimeOverflowError;
 #[cfg(feature = "alloc")]
 use units::parse::{self, PrefixedHexError, UnprefixedHexError};
+
 #[cfg(feature = "alloc")]
 use crate::locktime::relative;
 
@@ -181,7 +183,7 @@ impl Sequence {
     #[inline]
     #[cfg(feature = "alloc")]
     pub fn to_relative_lock_time(&self) -> Option<relative::LockTime> {
-        use crate::locktime::relative::{Height, LockTime, Time};
+        use crate::locktime::relative::{HeightSpan, LockTime, TimeSpan};
 
         if !self.is_relative_lock_time() {
             return None;
@@ -190,9 +192,9 @@ impl Sequence {
         let lock_value = self.low_u16();
 
         if self.is_time_locked() {
-            Some(LockTime::from(Time::from_512_second_intervals(lock_value)))
+            Some(LockTime::from(TimeSpan::from_512_second_intervals(lock_value)))
         } else {
-            Some(LockTime::from(Height::from(lock_value)))
+            Some(LockTime::from(HeightSpan::from(lock_value)))
         }
     }
 
@@ -219,7 +221,9 @@ impl fmt::Display for Sequence {
 impl fmt::LowerHex for Sequence {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
-impl_to_hex_from_lower_hex!(Sequence, |sequence: &Sequence| 8 - sequence.0.leading_zeros() as usize / 4);
+impl_to_hex_from_lower_hex!(Sequence, |sequence: &Sequence| 8 - sequence.0.leading_zeros()
+    as usize
+    / 4);
 
 impl fmt::UpperHex for Sequence {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -131,15 +131,15 @@ impl From<BlockInterval> for u32 {
     fn from(height: BlockInterval) -> Self { height.to_u32() }
 }
 
-impl From<relative::Height> for BlockInterval {
+impl From<relative::HeightSpan> for BlockInterval {
     /// Converts a [`locktime::relative::Height`] to a [`BlockInterval`].
     ///
     /// A relative locktime block height has a maximum value of `u16::MAX` where as a
     /// [`BlockInterval`] is a thin wrapper around a `u32`, the two types are not interchangeable.
-    fn from(h: relative::Height) -> Self { Self::from_u32(h.value().into()) }
+    fn from(h: relative::HeightSpan) -> Self { Self::from_u32(h.value().into()) }
 }
 
-impl TryFrom<BlockInterval> for relative::Height {
+impl TryFrom<BlockInterval> for relative::HeightSpan {
     type Error = TooBigForRelativeBlockHeightError;
 
     /// Converts a [`BlockInterval`] to a [`locktime::relative::Height`].
@@ -151,7 +151,7 @@ impl TryFrom<BlockInterval> for relative::Height {
         if h > u16::MAX as u32 {
             return Err(TooBigForRelativeBlockHeightError(h));
         }
-        Ok(relative::Height::from(h as u16)) // Cast ok, value checked above
+        Ok(relative::HeightSpan::from(h as u16)) // Cast ok, value checked above
     }
 }
 
@@ -165,7 +165,7 @@ impl fmt::Display for TooBigForRelativeBlockHeightError {
             f,
             "block interval is too big to be used as a relative lock time: {} (max: {})",
             self.0,
-            relative::Height::MAX
+            relative::HeightSpan::MAX
         )
     }
 }


### PR DESCRIPTION
Hi, was implementing Relative Lock Time validation on [Floresta](https://github.com/vinteumorg/Floresta) and noticed that `rust-bitcoin`s implementation had some issue.

The link in the documentation was wrong, the link was pointing to Bip65 and not Bip68.

The check if the relative locktime was satisfied was literally the copy of the `absolute::Locktime`, they work in different ways and need different data to it.
I tried to be clear in what concern implementation and bip declaration. But here`s a little resume about:

The relative locktime is extracted directly from the sequence field in the input, independently if is time or height, the check is done by getting this value and checking if the spam + the committed accordingly value of the **prevout** is less than the actual.

by example: A time-locked Relative LockTime  will get the intervals inside the sequence, sum with the mtp of the prevout and will be valid if that sum is equal or less than the actual mtp of the chain.

Heres some info sources:
[Bip68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki).
[learnme a bitcoin sequence explaining](https://learnmeabitcoin.com/technical/transaction/input/sequence/).