### PR TITLE
Add ArbitraryInRange to Amount

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -10,9 +10,8 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "arbitrary"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
+version = "1.3.2"
+source = "git+https://github.com/sivizius/arbitrary.git?rev=c28e5fa123d6410cf810373bed5335386e45dae7#c28e5fa123d6410cf810373bed5335386e45dae7"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -11,8 +11,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "arbitrary"
 version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+source = "git+https://github.com/sivizius/arbitrary.git?rev=c28e5fa123d6410cf810373bed5335386e45dae7#c28e5fa123d6410cf810373bed5335386e45dae7"
 
 [[package]]
 name = "arrayvec"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -35,7 +35,7 @@ primitives = { package = "bitcoin-primitives", version = "0.100.0", default-feat
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false, features = ["alloc"] }
 
-arbitrary = { version = "1.0.1", optional = true }
+arbitrary = { git = "https://github.com/sivizius/arbitrary.git", optional = true, rev = "c28e5fa123d6410cf810373bed5335386e45dae7" }
 base64 = { version = "0.22.0", optional = true }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -28,7 +28,7 @@ internals = { package = "bitcoin-internals", version = "0.4.0" }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
-arbitrary = { version = "1", optional = true }
+arbitrary = { git = "https://github.com/sivizius/arbitrary.git", optional = true, rev = "c28e5fa123d6410cf810373bed5335386e45dae7" }
 ordered = { version = "0.2.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
 

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["internals/alloc"]
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
-arbitrary = { version = "1", optional =true }
+arbitrary = { git = "https://github.com/sivizius/arbitrary.git", optional = true, rev = "c28e5fa123d6410cf810373bed5335386e45dae7" }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", version = "0.4.0", features = ["test-serde"] }

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -14,7 +14,7 @@ use core::{default, fmt, ops};
 #[cfg(feature = "serde")]
 use ::serde::{Deserialize, Serialize};
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary, ArbitraryInRange, Unstructured};
 use internals::error::InputString;
 use internals::write_err;
 
@@ -1096,6 +1096,19 @@ impl<'a> Arbitrary<'a> for Amount {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let a = u64::arbitrary(u)?;
         Ok(Amount(a))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> ArbitraryInRange<'a> for Amount {
+    type Bound = u64;
+
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> arbitrary::Result<Self>
+    where
+        R: ops::RangeBounds<Self::Bound>,
+    {
+        let sat = u64::arbitrary_in_range(u, range)?;
+        Ok(Amount::from_sat(sat))
     }
 }
 

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary, ArbitraryInRange, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -126,6 +126,19 @@ impl FeeRate {
 impl<'a> Arbitrary<'a> for FeeRate {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let f = u64::arbitrary(u)?;
+        Ok(FeeRate(f))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> ArbitraryInRange<'a> for FeeRate {
+    type Bound = u64;
+
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> arbitrary::Result<Self>
+    where
+        R: core::ops::RangeBounds<Self::Bound>,
+    {
+        let f = u64::arbitrary_in_range(u, range)?;
         Ok(FeeRate(f))
     }
 }

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary, ArbitraryInRange, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -210,6 +210,19 @@ crate::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);
 impl<'a> Arbitrary<'a> for Weight {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let w = u64::arbitrary(u)?;
+        Ok(Weight(w))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> ArbitraryInRange<'a> for Weight {
+    type Bound = u64;
+
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> arbitrary::Result<Self>
+    where
+        R: core::ops::RangeBounds<Self::Bound>,
+    {
+        let w = u64::arbitrary_in_range(u, range)?;
         Ok(Weight(w))
     }
 }


### PR DESCRIPTION
Leaving this in draft since it's not yet merged into Arbitrary.

Allows for creating Arbitrary Amount in range such as:
```rust
let a: Amount = Amount::arbitrary_in_range(u, &(minimal_non_dust..=effective_value_max)).unwrap();
```

This can also be used for building an Arbitrary Utxo pool such that any Arbitrary subset will not overflow u64 by setting the maximum bound.