### PR TITLE
internals: Fix lint warnings on macro

### DIFF
--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -205,7 +205,10 @@ macro_rules! impl_from_infallible {
     }
 }
 
-/// Implements `to_hex` for functions that have implemented [`core::fmt::LowerHex`]
+/// Adds an implementation of `pub fn to_hex(&self) -> String` if `alloc` feature is enabled.
+///
+/// The added function allocates a `String` then calls through to [`core::fmt::LowerHex`].
+/// Calling this macro without the `alloc` feature enabled is a noop.
 #[macro_export]
 #[cfg(feature = "alloc")]
 macro_rules! impl_to_hex_from_lower_hex {
@@ -224,6 +227,10 @@ macro_rules! impl_to_hex_from_lower_hex {
     };
 }
 
+/// Adds an implementation of `pub fn to_hex(&self) -> String` if `alloc` feature is enabled.
+///
+/// The added function allocates a `String` then calls through to [`core::fmt::LowerHex`].
+/// Calling this macro without the `alloc` feature enabled is a noop.
 #[macro_export]
 #[cfg(not(feature = "alloc"))]
 macro_rules! impl_to_hex_from_lower_hex {


### PR DESCRIPTION
The new `impl_to_hex_from_lower_hex` macro causes build warnings when `internals` is built without the `alloc` feature.

There are two macro implementations depending on feature gates, duplicate the rustdocs from the other one.

While we are at it reduce the lines of code for the empty case.