### PR TITLE
hashes: Remove casts in bench code

### DIFF
--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -139,7 +139,7 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 
     #[bench]
@@ -149,7 +149,7 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 
     #[bench]
@@ -159,6 +159,6 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 }

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -333,7 +333,7 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 
     #[bench]
@@ -343,7 +343,7 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 
     #[bench]
@@ -353,6 +353,6 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 }

--- a/hashes/src/sha1.rs
+++ b/hashes/src/sha1.rs
@@ -234,7 +234,7 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 
     #[bench]
@@ -244,7 +244,7 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 
     #[bench]
@@ -254,6 +254,6 @@ mod benches {
         bh.iter(|| {
             engine.input(&bytes);
         });
-        bh.bytes = bytes.len() as u64;
+        bh.bytes = bytes.len().into();
     }
 }


### PR DESCRIPTION
Casts are hard to read because they may loose data, if `into` works it is easier to read.

Use `into` instead of casting to `u64`.