### PR TITLE
hashes: Rename length field and use u64

### DIFF
--- a/hashes/src/hash160.rs
+++ b/hashes/src/hash160.rs
@@ -34,7 +34,7 @@ impl Default for HashEngine {
 impl crate::HashEngine for HashEngine {
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
     fn input(&mut self, data: &[u8]) { self.0.input(data) }
-    fn n_bytes_hashed(&self) -> usize { self.0.n_bytes_hashed() }
+    fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
 }
 
 fn from_engine(e: HashEngine) -> Hash {

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -102,7 +102,7 @@ impl<T: GeneralHash> HmacEngine<T> {
 impl<T: GeneralHash> HashEngine for HmacEngine<T> {
     const BLOCK_SIZE: usize = T::Engine::BLOCK_SIZE;
 
-    fn n_bytes_hashed(&self) -> usize { self.iengine.n_bytes_hashed() }
+    fn n_bytes_hashed(&self) -> u64 { self.iengine.n_bytes_hashed() }
 
     fn input(&mut self, buf: &[u8]) { self.iengine.input(buf) }
 }

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -187,8 +187,8 @@ pub trait HashEngine: Clone {
     /// Add data to the hash engine.
     fn input(&mut self, data: &[u8]);
 
-    /// Return the number of bytes already n_bytes_hashed(inputted).
-    fn n_bytes_hashed(&self) -> usize;
+    /// Return the number of bytes already input into the engine.
+    fn n_bytes_hashed(&self) -> u64;
 }
 
 /// Trait describing hash digests which can be constructed by hashing arbitrary data.
@@ -312,6 +312,13 @@ mod sealed {
     pub trait IsByteArray { }
 
     impl<const N: usize> IsByteArray for [u8; N] { }
+}
+
+fn incomplete_block_len<H: HashEngine>(eng: &H) -> usize {
+    let block_size = <H as HashEngine>::BLOCK_SIZE as u64; // Cast usize to u64 is ok.
+
+    // After modulo operation we know cast u64 to usize as ok.
+    (eng.n_bytes_hashed() % block_size) as usize
 }
 
 /// Attempted to create a hash from an invalid length slice.

--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -6,7 +6,7 @@ use core::cmp;
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::HashEngine as _;
+use crate::{incomplete_block_len, HashEngine as _};
 
 crate::internal_macros::hash_type! {
     160,
@@ -17,19 +17,19 @@ crate::internal_macros::hash_type! {
 #[cfg(not(hashes_fuzz))]
 fn from_engine(mut e: HashEngine) -> Hash {
     // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
-    let data_len = e.length as u64;
+    let n_bytes_hashed = e.bytes_hashed;
 
     let zeroes = [0; BLOCK_SIZE - 8];
     e.input(&[0x80]);
-    if e.length % BLOCK_SIZE > zeroes.len() {
+    if crate::incomplete_block_len(&e) > zeroes.len() {
         e.input(&zeroes);
     }
-    let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
+    let pad_length = zeroes.len() - incomplete_block_len(&e);
     e.input(&zeroes[..pad_length]);
-    debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
+    debug_assert_eq!(incomplete_block_len(&e), zeroes.len());
 
-    e.input(&(8 * data_len).to_le_bytes());
-    debug_assert_eq!(e.length % BLOCK_SIZE, 0);
+    e.input(&(8 * n_bytes_hashed).to_le_bytes());
+    debug_assert_eq!(incomplete_block_len(&e), 0);
 
     Hash(e.midstate())
 }
@@ -48,7 +48,7 @@ const BLOCK_SIZE: usize = 64;
 pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],
-    length: usize,
+    bytes_hashed: u64,
 }
 
 impl HashEngine {
@@ -56,7 +56,7 @@ impl HashEngine {
     pub const fn new() -> Self {
         Self {
             h: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
-            length: 0,
+            bytes_hashed: 0,
             buffer: [0; BLOCK_SIZE],
         }
     }
@@ -85,7 +85,7 @@ impl Default for HashEngine {
 impl crate::HashEngine for HashEngine {
     const BLOCK_SIZE: usize = 64;
 
-    fn n_bytes_hashed(&self) -> usize { self.length }
+    fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
 
     engine_input_impl!();
 }

--- a/hashes/src/sha256d.rs
+++ b/hashes/src/sha256d.rs
@@ -29,7 +29,7 @@ impl Default for HashEngine {
 impl crate::HashEngine for HashEngine {
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
     fn input(&mut self, data: &[u8]) { self.0.input(data) }
-    fn n_bytes_hashed(&self) -> usize { self.0.n_bytes_hashed() }
+    fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
 }
 
 fn from_engine(e: HashEngine) -> Hash {

--- a/hashes/src/sha384.rs
+++ b/hashes/src/sha384.rs
@@ -35,7 +35,7 @@ impl Default for HashEngine {
 impl crate::HashEngine for HashEngine {
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
 
-    fn n_bytes_hashed(&self) -> usize { self.0.n_bytes_hashed() }
+    fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
 
     fn input(&mut self, inp: &[u8]) { self.0.input(inp); }
 }

--- a/hashes/src/sha512_256.rs
+++ b/hashes/src/sha512_256.rs
@@ -45,7 +45,7 @@ impl Default for HashEngine {
 impl crate::HashEngine for HashEngine {
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
 
-    fn n_bytes_hashed(&self) -> usize { self.0.n_bytes_hashed() }
+    fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
 
     fn input(&mut self, inp: &[u8]) { self.0.input(inp); }
 }

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -70,15 +70,16 @@ macro_rules! engine_input_impl(
     () => (
         #[cfg(not(hashes_fuzz))]
         fn input(&mut self, mut inp: &[u8]) {
+
             while !inp.is_empty() {
-                let buf_idx = self.length % <Self as crate::HashEngine>::BLOCK_SIZE;
+                let buf_idx = $crate::incomplete_block_len(self);
                 let rem_len = <Self as crate::HashEngine>::BLOCK_SIZE - buf_idx;
                 let write_len = cmp::min(rem_len, inp.len());
 
                 self.buffer[buf_idx..buf_idx + write_len]
                     .copy_from_slice(&inp[..write_len]);
-                self.length += write_len;
-                if self.length % <Self as crate::HashEngine>::BLOCK_SIZE == 0 {
+                self.bytes_hashed += write_len as u64;
+                if $crate::incomplete_block_len(self) == 0 {
                     self.process_block();
                 }
                 inp = &inp[write_len..];


### PR DESCRIPTION
The hash engine types have a `length` field that is used to cache the number of bytes hashed so far, as such it is an arbitrary number and could use a `u64` instead of `usize`.

While we are at it rename `length` to `bytes_hashed` to remove any ambiguity of what this field is. Note this field is private, we already have the public getter `n_bytes_hashes` to get the value.

Introduce a private function `incomplete_block_size`, the purpose of this function is to put all the casts in one place so they can be well documented and easily understood.

Fix: #3016