### PR TITLE
Deprecate `from_slice` methods in favor of arrays

### DIFF
--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -71,13 +71,14 @@ where
     pub fn from_engine(e: HashEngine) -> Hash<T> { from_engine(e) }
 
     /// Copies a byte slice into a hash object.
+    #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
     pub fn from_slice(sl: &[u8]) -> Result<Hash<T>, FromSliceError> {
         if sl.len() != 32 {
             Err(FromSliceError { expected: 32, got: sl.len() })
         } else {
             let mut ret = [0; 32];
             ret.copy_from_slice(sl);
-            Ok(Self::internal_new(ret))
+            Ok(Self::from_byte_array(ret))
         }
     }
 


### PR DESCRIPTION
As brought up in issue #3102 support for Rust arrays is now much better so slice-accepting methods that require a fixed length can be replaced with a method that accepts an array.

`from_slice()` methods that require a fixed length have been deprecated and where needed a `from_byte_array()` method created that accepts an array.

There are still `from_slice` methods that rely on changes to external crates before they can be changed to arrays.