### PR TITLE
Rename `SigFromSliceError` to `DecodeError` for consistency with ECDSA module

### DIFF
--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -25,7 +25,7 @@ pub struct Signature {
 
 impl Signature {
     /// Deserializes the signature from a slice.
-    pub fn from_slice(sl: &[u8]) -> Result<Self, SigFromSliceError> {
+    pub fn from_slice(sl: &[u8]) -> Result<Self, DecodeError> {
         match sl.len() {
             64 => {
                 // default type
@@ -38,7 +38,7 @@ impl Signature {
                 let signature = secp256k1::schnorr::Signature::from_slice(signature)?;
                 Ok(Signature { signature, sighash_type })
             }
-            len => Err(SigFromSliceError::InvalidSignatureSize(len)),
+            len => Err(DecodeError::InvalidSignatureSize(len)),
         }
     }
 
@@ -90,7 +90,7 @@ impl Signature {
 /// [`taproot::Signature`]: crate::crypto::taproot::Signature
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum SigFromSliceError {
+pub enum DecodeError {
     /// Invalid signature hash type.
     SighashType(InvalidSighashTypeError),
     /// A secp256k1 error.
@@ -99,11 +99,11 @@ pub enum SigFromSliceError {
     InvalidSignatureSize(usize),
 }
 
-internals::impl_from_infallible!(SigFromSliceError);
+internals::impl_from_infallible!(DecodeError);
 
-impl fmt::Display for SigFromSliceError {
+impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use SigFromSliceError::*;
+        use DecodeError::*;
 
         match *self {
             SighashType(ref e) => write_err!(f, "sighash"; e),
@@ -114,9 +114,9 @@ impl fmt::Display for SigFromSliceError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for SigFromSliceError {
+impl std::error::Error for DecodeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use SigFromSliceError::*;
+        use DecodeError::*;
 
         match *self {
             Secp256k1(ref e) => Some(e),
@@ -126,10 +126,10 @@ impl std::error::Error for SigFromSliceError {
     }
 }
 
-impl From<secp256k1::Error> for SigFromSliceError {
+impl From<secp256k1::Error> for DecodeError {
     fn from(e: secp256k1::Error) -> Self { Self::Secp256k1(e) }
 }
 
-impl From<InvalidSighashTypeError> for SigFromSliceError {
+impl From<InvalidSighashTypeError> for DecodeError {
     fn from(err: InvalidSighashTypeError) -> Self { Self::SighashType(err) }
 }

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -84,7 +84,7 @@ pub enum Error {
     /// Parsing error indicating invalid ECDSA signatures
     InvalidEcdsaSignature(crate::crypto::ecdsa::DecodeError),
     /// Parsing error indicating invalid Taproot signatures
-    InvalidTaprootSignature(crate::crypto::taproot::SigFromSliceError),
+    InvalidTaprootSignature(crate::crypto::taproot::DecodeError),
     /// Parsing error indicating invalid control block
     InvalidControlBlock,
     /// Parsing error indicating invalid leaf version

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -269,7 +269,7 @@ impl Serialize for taproot::Signature {
 
 impl Deserialize for taproot::Signature {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        use taproot::SigFromSliceError::*;
+        use taproot::DecodeError::*;
 
         taproot::Signature::from_slice(bytes).map_err(|e| match e {
             SighashType(err) => Error::NonStandardSighashType(err.0),

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -24,7 +24,7 @@ use crate::{Script, ScriptBuf};
 // Re-export these so downstream only has to use one `taproot` module.
 #[rustfmt::skip]
 #[doc(inline)]
-pub use crate::crypto::taproot::{SigFromSliceError, Signature};
+pub use crate::crypto::taproot::{DecodeError, Signature};
 #[doc(inline)]
 pub use merkle_branch::TaprootMerkleBranch;
 

--- a/bitcoin/src/taproot/serialized_signature.rs
+++ b/bitcoin/src/taproot/serialized_signature.rs
@@ -11,7 +11,7 @@ use core::{fmt, ops};
 pub use into_iter::IntoIter;
 use io::Write;
 
-use super::{SigFromSliceError, Signature};
+use super::{DecodeError, Signature};
 
 pub(crate) const MAX_LEN: usize = 65; // 64 for sig, 1B sighash flag
 
@@ -117,13 +117,13 @@ impl<'a> From<&'a Signature> for SerializedSignature {
 }
 
 impl TryFrom<SerializedSignature> for Signature {
-    type Error = SigFromSliceError;
+    type Error = DecodeError;
 
     fn try_from(value: SerializedSignature) -> Result<Self, Self::Error> { value.to_signature() }
 }
 
 impl<'a> TryFrom<&'a SerializedSignature> for Signature {
-    type Error = SigFromSliceError;
+    type Error = DecodeError;
 
     fn try_from(value: &'a SerializedSignature) -> Result<Self, Self::Error> {
         value.to_signature()
@@ -155,7 +155,7 @@ impl SerializedSignature {
     /// Convert the serialized signature into the Signature struct.
     /// (This deserializes it)
     #[inline]
-    pub fn to_signature(&self) -> Result<Signature, SigFromSliceError> {
+    pub fn to_signature(&self) -> Result<Signature, DecodeError> {
         Signature::from_slice(self)
     }
 


### PR DESCRIPTION
This PR renames the `SigFromSliceError` error type to `DecodeError` in `taproot` module to maintain consistency with the naming conventions used in the `ecdsa` module. The change is aimed at improving code clarity and aligning error names across different parts of the codebase.

# Changes:

- Renamed `SigFromSliceError` to `DecodeError` in all relevant locations.

Additional Context:

This PR addresses feedback from PR #3303.
