### PR TITLE
Shoosh linter in bench build

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -12,8 +12,9 @@
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]
-// Instead of littering the codebase for non-fuzzing code just globally allow.
+// Instead of littering the codebase for non-fuzzing and bench code just globally allow.
 #![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
+#![cfg_attr(bench, allow(dead_code, unused_imports))]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -159,6 +159,7 @@ struct DisplayWrapper<'a, T: 'a + Encodable, E>(&'a T, PhantomData<E>);
 impl<'a, T: 'a + Encodable, E: ByteEncoder> fmt::Display for DisplayWrapper<'a, T, E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut writer = IoWrapper::<'_, _, E::Encoder>::new(f, E::default().into());
+        #[allow(unused_variables)] // When debug_assertions are not enabled.
         self.0.consensus_encode(&mut writer).map_err(|error| {
             #[cfg(debug_assertions)]
             {
@@ -199,6 +200,7 @@ impl<W: fmt::Write> ErrorTrackingWriter<W> {
     }
 
     #[track_caller]
+    #[allow(unused_variables)] // When debug_assertions are not enabled.
     fn assert_no_error(&self, fun: &str) {
         #[cfg(debug_assertions)]
         {
@@ -217,6 +219,7 @@ impl<W: fmt::Write> ErrorTrackingWriter<W> {
         }
     }
 
+    #[allow(unused_variables)] // When debug_assertions are not enabled.
     fn set_error(&mut self, was: bool) {
         #[cfg(debug_assertions)]
         {

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -30,8 +30,9 @@
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]
-// Instead of littering the codebase for non-fuzzing code just globally allow.
+// Instead of littering the codebase for non-fuzzing and bench code just globally allow.
 #![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
+#![cfg_attr(bench, allow(dead_code, unused_imports))]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -68,8 +68,9 @@
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]
-// Instead of littering the codebase for non-fuzzing code just globally allow.
+// Instead of littering the codebase for non-fuzzing and bench code just globally allow.
 #![cfg_attr(hashes_fuzz, allow(dead_code, unused_imports))]
+#![cfg_attr(bench, allow(dead_code, unused_imports))]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.


### PR DESCRIPTION
Two patches to clear the million warnings when running the bench code.