### PR TITLE
Deprecate `OutPoint::new` constructor

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -122,6 +122,7 @@ impl OutPoint {
 
     /// Creates a new [`OutPoint`].
     #[inline]
+    #[deprecated(since = "TBD", note = "use struct initialization syntax instead")]
     pub const fn new(txid: Txid, vout: u32) -> OutPoint { OutPoint { txid, vout } }
 
     /// Creates a "null" `OutPoint`.


### PR DESCRIPTION
The `OutPoint` type has two public fields, providing a `new` constructor that just sets these two fields adds no value.

Done after discussion in #3340 as part of `primitives` work.