### PR TITLE
units: Introduce test-infrastructure feature

### DIFF
--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -16,11 +16,14 @@ exclude = ["tests", "contrib"]
 default = ["std"]
 std = ["alloc", "internals/std"]
 alloc = ["internals/alloc"]
+# You need to enable `arbitrary` separately if you want it.
+test-infrastructure = []
 
 [dependencies]
 internals = { package = "bitcoin-internals", version = "0.3.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
+# Requires `test-infrastructure` feature to be enabled also.
 arbitrary = { version = "1", optional =true }
 
 [dev-dependencies]

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -13,8 +13,6 @@ use core::{default, fmt, ops};
 
 #[cfg(feature = "serde")]
 use ::serde::{Deserialize, Serialize};
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 use internals::error::InputString;
 use internals::write_err;
 
@@ -1072,14 +1070,6 @@ impl Amount {
     }
 }
 
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for Amount {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let a = u64::arbitrary(u)?;
-        Ok(Amount(a))
-    }
-}
-
 impl default::Default for Amount {
     fn default() -> Self { Amount::ZERO }
 }
@@ -1596,14 +1586,6 @@ impl core::iter::Sum for SignedAmount {
     }
 }
 
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for SignedAmount {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let s = i64::arbitrary(u)?;
-        Ok(SignedAmount(s))
-    }
-}
-
 /// Calculates the sum over the iterator using checked arithmetic.
 pub trait CheckedSum<R>: private::SumSeal<R> {
     /// Calculates the sum over the iterator using checked arithmetic. If an over or underflow would
@@ -2039,6 +2021,40 @@ mod verification {
                 None
             },
         );
+    }
+}
+
+/// This module holds implementations of stuff useful for writing test code.
+#[cfg(feature = "test-infrastructure")]
+mod testing_infrastructure {
+    #[cfg(feature = "arbitrary")]
+    use arbitrary::{Arbitrary, Unstructured};
+
+    use super::*;
+    use crate::testing_infrastructure::TestDummy;
+
+    #[cfg(feature = "arbitrary")]
+    impl<'a> Arbitrary<'a> for Amount {
+        fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+            let a = u64::arbitrary(u)?;
+            Ok(Amount(a))
+        }
+    }
+
+    #[cfg(feature = "arbitrary")]
+    impl<'a> Arbitrary<'a> for SignedAmount {
+        fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+            let s = i64::arbitrary(u)?;
+            Ok(SignedAmount(s))
+        }
+    }
+
+    impl TestDummy for Amount {
+        fn test_dummy() -> Amount { Amount::from_sat(100_000) }
+    }
+
+    impl TestDummy for SignedAmount {
+        fn test_dummy() -> SignedAmount { SignedAmount::from_sat(-100_000) }
     }
 }
 

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -231,6 +231,21 @@ impl ops::SubAssign<BlockInterval> for BlockInterval {
     fn sub_assign(&mut self, rhs: BlockInterval) { self.0 = self.to_u32() - rhs.to_u32(); }
 }
 
+/// This module holds implementations of stuff useful for writing test code.
+#[cfg(feature = "test-infrastructure")]
+mod testing_infrastructure {
+    use super::*;
+    use crate::testing_infrastructure::TestDummy;
+
+    impl TestDummy for BlockHeight {
+        fn test_dummy() -> BlockHeight { BlockHeight(800_000) }
+    }
+
+    impl TestDummy for BlockInterval {
+        fn test_dummy() -> BlockInterval { BlockInterval(100) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -5,8 +5,6 @@
 use core::fmt;
 use core::ops::{Div, Mul};
 
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -109,14 +107,6 @@ impl FeeRate {
     }
 }
 
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for FeeRate {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let f = u64::arbitrary(u)?;
-        Ok(FeeRate(f))
-    }
-}
-
 /// Alternative will display the unit.
 impl fmt::Display for FeeRate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -154,6 +144,23 @@ impl Div<Weight> for Amount {
 }
 
 crate::impl_parse_str_from_int_infallible!(FeeRate, u64, from_sat_per_kwu);
+
+/// This module holds implementations of stuff useful for writing test code.
+#[cfg(feature = "test-infrastructure")]
+mod testing_infrastructure {
+    #[cfg(feature = "arbitrary")]
+    use arbitrary::{Arbitrary, Unstructured};
+
+    use super::*;
+
+    #[cfg(feature = "arbitrary")]
+    impl<'a> Arbitrary<'a> for FeeRate {
+        fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+            let f = u64::arbitrary(u)?;
+            Ok(FeeRate(f))
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -42,3 +42,17 @@ pub use self::{
     fee_rate::FeeRate,
     weight::Weight
 };
+
+/// This module holds stuff useful for writing test code.
+#[cfg(feature = "test-infrastructure")]
+#[allow(dead_code)]             // FIXME(tcharding): Not sure right now why this is needed.
+pub mod testing_infrastructure {
+    /// Trait for creating dummy test case data.
+    pub trait TestDummy {
+        /// Generates a "dummy" instance of the type suitable for use in unit tests.
+        ///
+        /// Useful when the exact data is not important and saves one from looking up docs to find a
+        /// constructor and writing `Foo::from_bar(b); // Arbitrary data.`
+        fn test_dummy() -> Self;
+    }
+}

--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -153,7 +153,7 @@ impl Time {
     /// ```rust
     /// use bitcoin_units::locktime::absolute::Time;
     ///
-    /// let t: u32 = 1653195600; // May 22nd, 5am UTC.
+    /// let t: u32 = 1653195600; // Sunday, 22 May 2022 05:00:00
     /// let time = Time::from_consensus(t).expect("invalid time value");
     /// assert_eq!(time.to_consensus_u32(), t);
     /// ```
@@ -368,6 +368,21 @@ impl From<ParseIntError> for ParseError {
 
 impl From<ConversionError> for ParseError {
     fn from(value: ConversionError) -> Self { Self::Conversion(value.input.into()) }
+}
+
+/// This module holds implementations of stuff useful for writing test code.
+#[cfg(feature = "test-infrastructure")]
+mod testing_infrastructure {
+    use super::*;
+    use crate::testing_infrastructure::TestDummy;
+
+    impl TestDummy for Height {
+        fn test_dummy() -> Height { Height(800_000) }
+    }
+
+    impl TestDummy for Time {
+        fn test_dummy() -> Height { Time(1653195600) } // Sunday, 22 May 2022 05:00:00
+    }
 }
 
 #[cfg(test)]

--- a/units/src/locktime/relative.rs
+++ b/units/src/locktime/relative.rs
@@ -153,6 +153,21 @@ impl fmt::Display for TimeOverflowError {
 #[cfg(feature = "std")]
 impl std::error::Error for TimeOverflowError {}
 
+/// This module holds implementations of stuff useful for writing test code.
+#[cfg(feature = "test-infrastructure")]
+mod testing_infrastructure {
+    use super::*;
+    use crate::testing_infrastructure::TestDummy;
+
+    impl TestDummy for Height {
+        fn test_dummy() -> Height { Height(6) }
+    }
+
+    impl TestDummy for Time {
+        fn test_dummy() -> Height { Time::from_seconds_floor(3600) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
CI is red as expected because this only touches `units` but changes how the `arbitrary` feature works. Looking for a concept ACK, especially around the feature gating and module structure, also is the module useful at the crate root or should the trait definition either not be in a module or be re-exported?

Add a `test-infrastructure` feature, enabling this feature gives users stuff that is useful for writing test code.

- Create a module structure that keeps all the test infrastructure stuff together inside each module.
- Move `abitrary` stuff into the new module. This helps with code organisation and also allows users to get at test infra with or without the `arbitrary` dependency.
- Add a `TestDummy` trait (note for now only has one method)
- Implement `TestDummy` for all types in the crate.

The idea for this came out of #3341.