### PR TITLE
Stop using deprecated `OutPoint` functions

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -89,7 +89,7 @@ fn bitcoin_genesis_tx() -> Transaction {
         .push_slice(b"The Times 03/Jan/2009 Chancellor on brink of second bailout for banks")
         .into_script();
     ret.input.push(TxIn {
-        previous_output: OutPoint::null(),
+        previous_output: OutPoint::COINBASE_PREVOUT,
         script_sig: in_script,
         sequence: Sequence::MAX,
         witness: Witness::default(),

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -697,7 +697,7 @@ impl Transaction {
     /// all-zeros (creates satoshis "out of thin air").
     #[doc(alias = "is_coin_base")] // method previously had this name
     pub fn is_coinbase(&self) -> bool {
-        self.input.len() == 1 && self.input[0].previous_output.is_null()
+        self.input.len() == 1 && self.input[0].previous_output == OutPoint::COINBASE_PREVOUT
     }
 
     /// Returns `true` if the transaction itself opted in to be BIP-125-replaceable (RBF).


### PR DESCRIPTION
Either our CI is failing us or `deprecated` does not work as expected, either way we should not be using the `OutPoint::null()` or `is_null` functions any more because we deprecated them already.