### PR TITLE
CI: Run the nightly update job at 5 past midnight

### DIFF
--- a/.github/workflows/cron-semi-weekly-update-nightly.yml
+++ b/.github/workflows/cron-semi-weekly-update-nightly.yml
@@ -1,7 +1,7 @@
 name: Update Nightly rustc
 on:
   schedule:
-    - cron: "0 0 * * 1,4" # runs every Monday and Thursday at 00:00
+    - cron: "5 0 * * 1,4" # runs every Monday and Thursday at 00:05
   workflow_dispatch: # allows manual triggering
 jobs:
   format:


### PR DESCRIPTION
Currently we run the job at midnight here and in `sepc256k1`, this led recently to one using the nightly toolchain from the 10th of Sep and the other using the toolchain from 11th of Sep.

Update to run at 5 past so this doesn't happen again.