### PR TITLE
Fix GetKey for sets (plus some related changes)

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -807,7 +807,7 @@ impl GetKey for $set<Xpriv> {
             KeyRequest::Pubkey(_) => Err(GetKeyError::NotSupported),
             KeyRequest::Bip32((fingerprint, path)) => {
                 for xpriv in self.iter() {
-                    if xpriv.parent_fingerprint == fingerprint {
+                    if xpriv.fingerprint(secp) == fingerprint {
                         let k = xpriv.derive_priv(secp, &path);
                         return Ok(Some(k.to_priv()));
                     }

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -803,18 +803,11 @@ impl GetKey for $set<Xpriv> {
         key_request: KeyRequest,
         secp: &Secp256k1<C>
     ) -> Result<Option<PrivateKey>, Self::Error> {
-        match key_request {
-            KeyRequest::Pubkey(_) => Err(GetKeyError::NotSupported),
-            KeyRequest::Bip32((fingerprint, path)) => {
-                for xpriv in self.iter() {
-                    if xpriv.fingerprint(secp) == fingerprint {
-                        let k = xpriv.derive_priv(secp, &path);
-                        return Ok(Some(k.to_priv()));
-                    }
-                }
-                Ok(None)
-            }
-        }
+        // OK to stop at the first error because Xpriv::get_key() can only fail
+        // if this isn't a KeyRequest::Bip32, which would fail for all Xprivs.
+        self.iter()
+            .find_map(|xpriv| xpriv.get_key(key_request.clone(), secp).transpose())
+            .transpose()
     }
 }}}
 impl_get_key_for_set!(BTreeSet);

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -27,12 +27,12 @@ fn psbt_sign_taproot() {
         type Error = SignError;
         fn get_key<C: Signing>(
             &self,
-            key_request: KeyRequest,
+            key_request: &KeyRequest,
             _secp: &Secp256k1<C>,
         ) -> Result<Option<PrivateKey>, Self::Error> {
             match key_request {
                 KeyRequest::Bip32((mfp, _)) =>
-                    if mfp == self.mfp {
+                    if *mfp == self.mfp {
                         Ok(Some(self.sk))
                     } else {
                         Err(SignError::KeyNotFound)


### PR DESCRIPTION
- The first commit is the simplest fix for a bug where the fingerprint wasn't compared correctly.

- The second & third commits are optional refactoring to reuse `Xpriv::get_key` for `$set<Xpriv>::get_key`, so the Xpriv matching logic only has to be maintained in one place.

- The forth commit adds support for signing with `Xpriv`s that are direct children of the `KeySource` -- possibly what the original (buggy) code author had in mind?

Of course, feel free to take just the first commit if the others seem unnecessary. The last one is kind of meh, not sure if really useful.

Note that multi-`Xpriv` signing does not actually work until #2850 is addressed too.