### PR TITLE
Improve documentation test in merkle_tree

### DIFF
--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -7,11 +7,11 @@
 //! ```
 //! # use bitcoin::Txid;
 //! # use bitcoin::merkle_tree::{MerkleNode as _, TxMerkleNode};
-//! # use bitcoin::hashes::Hash;
 //! # let tx1 = Txid::from_byte_array([0xAA; 32]);  // Arbitrary dummy hash values.
 //! # let tx2 = Txid::from_byte_array([0xFF; 32]);
-//! let tx_hashes = vec![tx1, tx2]; // All the hashes we wish to merkelize.
+//! let tx_hashes = [tx1, tx2]; // All the hashes we wish to merkelize.
 //! let root = TxMerkleNode::calculate_root(tx_hashes.into_iter());
+//! assert!(root.is_some());
 //! ```
 
 mod block;


### PR DESCRIPTION
Removes unnecessary usage of vector and adds a missing assert. Closes #3353.

Note: Kixunil in the [referred comment](https://github.com/rust-bitcoin/rust-bitcoin/pull/3288#discussion_r1756514494) wondered about missing 'unused variable' warning. It seems that rustdoc [adds](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#pre-processing-examples) allows to the documentation tests. However, these warnings [can be enabled](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#showing-warnings-in-doctests) on module level. Do we want that? I tried to enable and there are already some occurrences of unused variables and imports. Caveat: it seems that we can't deny warnings on that, only print the warnings to stdout with `--show-output`.