### PR TITLE
Add doc comment detailing fee calculation

### DIFF
--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -86,6 +86,9 @@ impl FeeRate {
     /// Checked weight multiplication.
     ///
     /// Computes the absolute fee amount for a given [`Weight`] at this fee rate.
+    /// When the resulting fee is a non-integer amount, the amount is rounded up,
+    /// ensuring that the transaction fee is enough instead of falling short if
+    /// rounded down.
     ///
     /// [`None`] is returned if an overflow occurred.
     pub fn checked_mul_by_weight(self, rhs: Weight) -> Option<Amount> {


### PR DESCRIPTION
Update doc comment to make clear that the ceiling is computed instead of the default behavior for integer division.