### PR TITLE
Fix unused imports, variables etc. in all remaining crate docs

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -14,6 +14,7 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(test(attr(warn(unused))))]
 // Coding conventions.
 #![warn(missing_docs)]
 // Exclude lints we don't think are valuable.

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]
+#![doc(test(attr(warn(unused))))]
 // Instead of littering the codebase for non-fuzzing and bench code just globally allow.
 #![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
 #![cfg_attr(bench, allow(dead_code, unused_imports))]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -15,16 +15,14 @@
 //! use bitcoin_hashes::Sha256;
 //!
 //! let bytes = [0u8; 5];
-//! let hash_of_bytes = Sha256::hash(&bytes);
-//! let hash_of_string = Sha256::hash("some string".as_bytes());
+//! let _hash_of_bytes = Sha256::hash(&bytes);
+//! let _hash_of_string = Sha256::hash("some string".as_bytes());
 //! ```
 //!
 //!
 //! Hashing content from a reader:
 //!
 //! ```rust
-//! use bitcoin_hashes::Sha256;
-//!
 //! #[cfg(std)]
 //! # fn main() -> std::io::Result<()> {
 //! let mut reader: &[u8] = b"hello"; // in real code, this could be a `File` or `TcpStream`
@@ -42,9 +40,6 @@
 //! Hashing content by [`std::io::Write`] on `HashEngine`:
 //!
 //! ```rust
-//! use bitcoin_hashes::Sha256;
-//! use std::io::Write;
-//!
 //! #[cfg(std)]
 //! # fn main() -> std::io::Result<()> {
 //! let mut part1: &[u8] = b"hello";
@@ -68,6 +63,7 @@
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]
+#![doc(test(attr(warn(unused))))]
 // Instead of littering the codebase for non-fuzzing and bench code just globally allow.
 #![cfg_attr(hashes_fuzz, allow(dead_code, unused_imports))]
 #![cfg_attr(bench, allow(dead_code, unused_imports))]

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
+#![doc(test(attr(warn(unused))))]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -161,34 +161,36 @@ macro_rules! const_assert {
 /// # use core::fmt::{Display, Debug};
 /// use bitcoin_internals::impl_from_infallible;
 ///
-/// enum AlphaEnum { Item }
-/// impl_from_infallible!(AlphaEnum);
+/// enum _AlphaEnum { _Item }
+/// impl_from_infallible!(_AlphaEnum);
 ///
-/// enum BetaEnum<'b> { Item(&'b usize) }
-/// impl_from_infallible!(BetaEnum<'b>);
+/// enum _BetaEnum<'b> { _Item(&'b usize) }
+/// impl_from_infallible!(_BetaEnum<'b>);
 ///
-/// enum GammaEnum<T> { Item(T) };
-/// impl_from_infallible!(GammaEnum<T>);
+/// enum _GammaEnum<T> { _Item(T) }
+/// impl_from_infallible!(_GammaEnum<T>);
 ///
-/// enum DeltaEnum<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a> {
-///     Item((&'b usize, &'a usize, T, D))
+/// enum _DeltaEnum<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a> {
+///     _Item((&'b usize, &'a usize, T, D))
 /// }
-/// impl_from_infallible!(DeltaEnum<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a>);
+/// impl_from_infallible!(_DeltaEnum<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a>);
 ///
-/// struct AlphaStruct;
-/// impl_from_infallible!(AlphaStruct);
+/// struct _AlphaStruct;
+/// impl_from_infallible!(_AlphaStruct);
 ///
 /// struct BetaStruct<'b>(&'b usize);
 /// impl_from_infallible!(BetaStruct<'b>);
+/// # let beta_struct = BetaStruct(&0);
+/// # let _ = beta_struct.0;
 ///
-/// struct GammaStruct<T>(T);
-/// impl_from_infallible!(GammaStruct<T>);
+/// struct _GammaStruct<T>(T);
+/// impl_from_infallible!(_GammaStruct<T>);
 ///
-/// struct DeltaStruct<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a> {
-///     hello: &'a T,
-///     what: &'b D,
+/// struct _DeltaStruct<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a> {
+///     _hello: &'a T,
+///     _what: &'b D,
 /// }
-/// impl_from_infallible!(DeltaStruct<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a>);
+/// impl_from_infallible!(_DeltaStruct<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a>);
 /// ```
 ///
 /// See <https://stackoverflow.com/a/61189128> for more information about this macro.

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
+#![doc(test(attr(warn(unused))))]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
+#![doc(test(attr(warn(unused))))]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.

--- a/primitives/src/locktime/absolute.rs
+++ b/primitives/src/locktime/absolute.rs
@@ -46,7 +46,7 @@ pub use units::locktime::absolute::*;
 /// # let n = LockTime::from_consensus(741521);          // n OP_CHECKLOCKTIMEVERIFY
 /// # let lock_time = LockTime::from_consensus(741521);  // nLockTime
 /// // To compare absolute lock times there are various `is_satisfied_*` methods, you may also use:
-/// let is_satisfied = match (n, lock_time) {
+/// let _is_satisfied = match (n, lock_time) {
 ///     (Blocks(n), Blocks(lock_time)) => n <= lock_time,
 ///     (Seconds(n), Seconds(lock_time)) => n <= lock_time,
 ///     _ => panic!("handle invalid comparison error"),
@@ -108,7 +108,6 @@ impl LockTime {
     ///
     /// ```rust
     /// # use bitcoin_primitives::absolute::LockTime;
-    /// # let n = LockTime::from_consensus(741521); // n OP_CHECKLOCKTIMEVERIFY
     ///
     /// // `from_consensus` roundtrips as expected with `to_consensus_u32`.
     /// let n_lock_time: u32 = 741521;
@@ -237,7 +236,7 @@ impl LockTime {
     /// # Examples
     ///
     /// ```rust
-    /// # use bitcoin_primitives::absolute::{LockTime, LockTime::*};
+    /// # use bitcoin_primitives::absolute::LockTime;
     /// let lock_time = LockTime::from_consensus(741521);
     /// let check = LockTime::from_consensus(741521 + 1);
     /// assert!(lock_time.is_implied_by(check));
@@ -270,7 +269,7 @@ impl LockTime {
     /// # let n = LockTime::from_consensus(741521);              // n OP_CHECKLOCKTIMEVERIFY
     /// # let lock_time = LockTime::from_consensus(741521 + 1);  // nLockTime
     ///
-    /// let is_satisfied = match (n, lock_time) {
+    /// let _is_satisfied = match (n, lock_time) {
     ///     (Blocks(n), Blocks(lock_time)) => n <= lock_time,
     ///     (Seconds(n), Seconds(lock_time)) => n <= lock_time,
     ///     _ => panic!("invalid comparison"),

--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -165,7 +165,7 @@ impl LockTime {
     ///
     /// ```rust
     /// # use bitcoin_primitives::Sequence;
-    /// # use bitcoin_primitives::locktime::relative::{LockTime, Height, Time};
+    /// # use bitcoin_primitives::locktime::relative::{Height, Time};
     ///
     /// # let required_height = 100;       // 100 blocks.
     /// # let intervals = 70;     // Approx 10 hours.
@@ -204,7 +204,6 @@ impl LockTime {
     ///
     /// ```rust
     /// # use bitcoin_primitives::Sequence;
-    /// # use bitcoin_primitives::locktime::relative::{LockTime, Height, Time};
     ///
     /// # let required_height = 100;       // 100 blocks.
     /// # let lock = Sequence::from_height(required_height).to_relative_lock_time().expect("valid height");
@@ -252,7 +251,7 @@ impl LockTime {
     ///
     /// ```rust
     /// # use bitcoin_primitives::Sequence;
-    /// # use bitcoin_primitives::locktime::relative::{LockTime, Height, Time};
+    /// # use bitcoin_primitives::locktime::relative::Height;
     ///
     /// let required_height: u16 = 100;
     /// let lock = Sequence::from_height(required_height).to_relative_lock_time().expect("valid height");
@@ -279,7 +278,7 @@ impl LockTime {
     ///
     /// ```rust
     /// # use bitcoin_primitives::Sequence;
-    /// # use bitcoin_primitives::locktime::relative::{LockTime, Height, Time};
+    /// # use bitcoin_primitives::locktime::relative::Time;
     ///
     /// let intervals: u16 = 70; // approx 10 hours;
     /// let lock = Sequence::from_512_second_intervals(intervals).to_relative_lock_time().expect("valid time");

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
+#![doc(test(attr(warn(unused))))]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.


### PR DESCRIPTION
Building on #3362 which only addressed the `bitcoin` crate, all other crates have been fixed.

`#![doc(test(attr(warn(unused))))]` has been added to all `lib.rs` files

In all docs:
- Unused imports have been removed
- Unused variables have been prefixed with `_`

`macro.rs` is a separate patch since the solution is not ideal with all the added `_`, and having to create an instance of `BetaStruct`.  Someone might have a better idea?


