### PR TITLE
Release tracking PR: `bitcoin-internals 0.4.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "serde",

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -19,7 +19,7 @@ alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false }
-internals = { package = "bitcoin-internals", version = "0.3.0" }
+internals = { package = "bitcoin-internals", version = "0.4.0" }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,7 +29,7 @@ base58 = { package = "base58ck", version = "0.1.0", default-features = false, fe
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc", "bitcoin-io"] }
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
+internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
 primitives = { package = "bitcoin-primitives", version = "0.100.0", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
@@ -43,7 +43,7 @@ ordered = { version = "0.2.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
 [dev-dependencies]
-internals = { package = "bitcoin-internals", version = "0.3.0", features = ["test-serde"] }
+internals = { package = "bitcoin-internals", version = "0.4.0", features = ["test-serde"] }
 serde_json = "1.0.0"
 serde_test = "1.0.19"
 bincode = "1.3.1"

--- a/internals/CHANGELOG.md
+++ b/internals/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.4.0 - 2024-09-18
+
+- Introduce `ToU64` trait [#2929](https://github.com/rust-bitcoin/rust-bitcoin/pull/2929)
+- Add macro `impl_to_hex_from_lower_hex ` [#3150](https://github.com/rust-bitcoin/rust-bitcoin/pull/3150)
+- Fix bug in `ArrayVec::extend_from_slice` [#3272](https://github.com/rust-bitcoin/rust-bitcoin/pull/3272)
+- Introduce `read_push_data_len()` and [#3293](https://github.com/rust-bitcoin/rust-bitcoin/pull/3293/)
+- Introduce new `compact_size` module [#3259](https://github.com/rust-bitcoin/rust-bitcoin/pull/3259)
+
 # 0.3.0 - 2024-03-24
 
 - Bump MSRV to Rust version 1.56.1 [#2188](https://github.com/rust-bitcoin/rust-bitcoin/pull/2188)

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-internals"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -19,7 +19,7 @@ std = ["alloc"]
 alloc = []
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.3.0" }
+internals = { package = "bitcoin-internals", version = "0.4.0" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["bitcoin-io"] }
-internals = { package = "bitcoin-internals", version = "0.3.0" }
+internals = { package = "bitcoin-internals", version = "0.4.0" }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false }
 

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -18,13 +18,13 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.3.0" }
+internals = { package = "bitcoin-internals", version = "0.4.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1", optional =true }
 
 [dev-dependencies]
-internals = { package = "bitcoin-internals", version = "0.3.0", features = ["test-serde"] }
+internals = { package = "bitcoin-internals", version = "0.4.0", features = ["test-serde"] }
 serde_test = "1.0"
 serde_json = "1.0"
 


### PR DESCRIPTION
In preparation for releasing `internals v0.4.0` bump the version number, add a changelog entry, update the lock files, and depend on the new version in all crates that depend on `internals`.