### PR TITLE
Release tracking PR: `bitcoin-io v0.2.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
 ]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -30,7 +30,7 @@ bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc", "bitcoin-io"] }
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc"] }
-io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
+io = { package = "bitcoin-io", version = "0.2.0", default-features = false, features = ["alloc"] }
 primitives = { package = "bitcoin-primitives", version = "0.100.0", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -23,7 +23,7 @@ small-hash = []
 [dependencies]
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
 
-bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
+bitcoin-io = { version = "0.2.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.0 - 2024-09-18
+
+* Add blanket impl of io traits for `&mut T` [#3188](https://github.com/rust-bitcoin/rust-bitcoin/pull/3188)
+* Add `std` bridge [#3176](https://github.com/rust-bitcoin/rust-bitcoin/pull/3176)
+* Bump MSRV to Rust `v1.63.0` [#3100](https://github.com/rust-bitcoin/rust-bitcoin/pull/3100)
+* Remove blanket trait impls [#2453](https://github.com/rust-bitcoin/rust-bitcoin/pull/2453)
+
 # 0.1.2 - 2024-03-14
 
 * Implement `From<core::convert::Infallible>` for Errors [#2516](https://github.com/rust-bitcoin/rust-bitcoin/pull/2516)

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-io"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["bitcoin-io"] }
 hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
-io = { package = "bitcoin-io", version = "0.1.1", default-features = false }
+io = { package = "bitcoin-io", version = "0.2.0", default-features = false }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1", optional = true }


### PR DESCRIPTION
In preparation for releasing `io v0.2.0` bump the version number, add a changelog entry, update the lock files, and depend on the new version in all crates that depend on `io`.
 
