### PR TITLE
Release tracking PR: `primitives 0.101.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.100.0"
+version = "0.101.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.100.0"
+version = "0.101.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -31,7 +31,7 @@ hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = fa
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false, features = ["alloc"] }
-primitives = { package = "bitcoin-primitives", version = "0.100.0", default-features = false, features = ["alloc"] }
+primitives = { package = "bitcoin-primitives", version = "0.101.0", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false, features = ["alloc"] }
 

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 0.101.0 - 2024-11-15
+
+This is the first "real" release of the `primitives` crate, as such it
+includes a lot of work. Search GitHub with the following filter to see
+all related PRs: `is:pr label:C-primitives merged:<=2024-11-15`
+
+Move the following modules and types from `rust-bitcoin` to `bitcoin-primitives`:
+
+- `block`: `Block`, `Header`, `Version`, `BlockHash`, `WitnessCommitment`, `Validation`, `Checked`, `Unchecked`
+- `locktime`: `absolute::LockTime`, `relative::LockTime`
+- `merkle_tree`: `TxMerkleNode`, `WitnessMerkleNode`
+- `opcodes`: `Opcode`
+- `pow`: `CompactTarget`
+- `sequence`: `Sequence`
+- `taproot`: `TapBranchTag`, `TapLeafHash`, `TapLeafTag`, `TapNodeHash`, `TapTweakHash`, `TapTweakTag`
+- `transaction`: `Transaction`, `TxIn`, `TxOut`, `OutPoint`, `Txid`, `Wtxid`, `Version`
+- `witness`: `Witness`, `Iter`
+
+And various error types. See re-exports at the crate root and also in `rust-bitcoin` at the crate
+root and from the respective module.
+
+We hope to very soon release `primitives 1.0` - please raise any and all issues you come across no
+matter how small so we can fix them for the stable release.
+
+Enjoy!
+
 # 0.100.0 - 2024-07-01
 
 * Initial release of the `github.com/rust-bitcoin/rust-bitcoin/primitives` crate as

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitcoin-primitives"
 # Arbitrary high version number so as to not clash with the original
 # `bitcoin-primitives` crate that we replaced `v0.1.16-alpha`.
-version = "0.100.0"
+version = "0.101.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -46,14 +46,13 @@ pub mod witness;
 
 #[doc(inline)]
 pub use units::amount::{self, Amount, SignedAmount};
-#[cfg(feature = "alloc")]
 #[doc(inline)]
+#[cfg(feature = "alloc")]
 pub use units::{
     block::{BlockHeight, BlockInterval},
     fee_rate::{self, FeeRate},
     weight::{self, Weight},
 };
-
 #[doc(inline)]
 #[cfg(feature = "alloc")]
 pub use self::{

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -4,7 +4,8 @@
 //!
 //! Primitive data types that are used throughout the [`rust-bitcoin`] ecosystem.
 //!
-//! This crate can be used in a no-std environment but requires an allocator.
+//! This crate can be used in a no-std environment but a lot of the functionality requires an
+//! allocator i.e., requires the `alloc` feature to be enabled.
 //!
 //! [`rust-bitcoin`]: <https://github.com/rust-bitcoin>
 


### PR DESCRIPTION
Its 00:02 on the 15th UTC now, I'm hoping this merges within 24 hours - then the date is correct.