### PR TITLE
bitcoin: Allow deprecated

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -41,6 +41,8 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
+// For 0.32.x releases only.
+#![allow(deprecated)]
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]


### PR DESCRIPTION
We are trying to make our upgrade path as painless as possible, as such we are deprecating things and leaving them in for ages. Some things are hard to deprecated (e.g. struct field re-names). A solution is to deprecated in a point release to `0.32.x` so that when users eventually upgrade to use `primitives` they will already have done a bunch of the changes (or preparations).

As an example, we want to change the transaction field names. If we deprecated them in a `0.32.x` point release and add getter functions then in `primitives` we can use the new names (and eventually deprecate the original getters if we want to).

To try and keep the diff between `0.32.x` and master as small as possible lets just allow deprecated things on the `0.32.x` branch. This way we can have some chance of getting the linter to pass in CI on backport patches. This also helps with dev so one can run the linter if backporting a patch that requires substantial changes to the original.