### PR TITLE
Deprecate `Transaction` fields

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -679,8 +679,10 @@ pub struct Transaction {
     /// * [BIP-113 Median time-past as endpoint for lock-time calculations](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki)
     pub lock_time: absolute::LockTime,
     /// List of transaction inputs.
+    #[deprecated(since = "0.32.3", note = "use inputs() getter function instead")]
     pub input: Vec<TxIn>,
     /// List of transaction outputs.
+    #[deprecated(since = "0.32.3", note = "use outputs() getter function instead")]
     pub output: Vec<TxOut>,
 }
 
@@ -701,6 +703,12 @@ impl Transaction {
     // https://github.com/bitcoin/bitcoin/blob/44b05bf3fef2468783dcebf651654fdd30717e7e/src/policy/policy.h#L27
     /// Maximum transaction weight for Bitcoin Core 25.0.
     pub const MAX_STANDARD_WEIGHT: Weight = Weight::from_wu(400_000);
+
+    /// Gets a reference to the list of inputs.
+    pub fn inputs(&self) -> &[TxIn] { &self.input }
+
+    /// Gets a reference to the list of outputs.
+    pub fn outputs(&self) -> &[TxOut] { &self.output }
 
     /// Computes a "normalized TXID" which does not include any signatures.
     ///

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -41,6 +41,8 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
+// For 0.32.x releases only.
+#![allow(deprecated)]
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]


### PR DESCRIPTION
Draft because on top of #3379, I thought that one was controversial enough to get its own PR.

This is an alternate approach to #2360

We would like to rename the transaction fields to use plural form but doing so is a real pain for upgraders. In an attempt to ease the upgrade path deprecated the `input` and `output` fields in a point release of `0.32.x`. Add read only getters `inputs()` and `outputs()`.

Intentionally do not add a full API (mutable getters, setters etc.) because this API will likely not stay around for ever and users can still use the `input` and `output` field and shoosh the linter with `allow(deprecated)`.
