### PR TITLE
Move `OutPoint` to `primitives`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -115,6 +115,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
+ "hex-conservative",
  "mutagen",
  "ordered",
  "serde",
@@ -187,6 +188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
 dependencies = [
  "arrayvec",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -114,6 +114,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
+ "hex-conservative",
  "mutagen",
  "ordered",
  "serde",
@@ -180,6 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
 dependencies = [
  "arrayvec",
+ "serde",
 ]
 
 [[package]]

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -404,6 +404,7 @@ mod test {
     use crate::consensus::encode::{deserialize, serialize};
     use crate::locktime::absolute;
     use crate::merkle_tree::TxMerkleNode;
+    use crate::transaction::OutPointExt;
     use crate::{
         transaction, Amount, CompactTarget, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Txid,
         Witness,

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -97,7 +97,9 @@ impl OutPoint {
     /// This is used as the dummy input for coinbase transactions because they don't have any
     /// previous outputs. In other words, does not point to a real transaction.
     pub const COINBASE_PREVOUT: Self = Self { txid: Txid::COINBASE_PREVOUT, vout: u32::MAX };
+}
 
+impl OutPoint {
     /// Creates a new [`OutPoint`].
     #[inline]
     #[deprecated(since = "TBD", note = "use struct initialization syntax instead")]

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -99,21 +99,20 @@ impl OutPoint {
     pub const COINBASE_PREVOUT: Self = Self { txid: Txid::COINBASE_PREVOUT, vout: u32::MAX };
 }
 
-impl OutPoint {
-    /// Creates a new [`OutPoint`].
-    #[inline]
-    #[deprecated(since = "TBD", note = "use struct initialization syntax instead")]
-    pub const fn new(txid: Txid, vout: u32) -> OutPoint { OutPoint { txid, vout } }
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`OutPoint`] type.
+    pub trait OutPointExt impl for OutPoint {
+        /// Creates a new [`OutPoint`].
+        #[inline]
+        #[deprecated(since = "TBD", note = "use struct initialization syntax instead")]
+        #[allow(clippy::new-ret-no-self)]
+        fn new(txid: Txid, vout: u32) -> Self { OutPoint { txid, vout } }
 
-    /// Creates a "null" `OutPoint`.
-    #[inline]
-    #[deprecated(since = "TBD", note = "use OutPoint::COINBASE_PREVOUT instead")]
-    pub fn null() -> OutPoint { Self::COINBASE_PREVOUT }
-
-    /// Checks if an `OutPoint` is "null".
-    #[inline]
-    #[deprecated(since = "TBD", note = "use outpoint == OutPoint::COINBASE_PREVOUT instead")]
-    pub fn is_null(&self) -> bool { *self == OutPoint::null() }
+        /// Checks if an `OutPoint` is "null".
+        #[inline]
+        #[deprecated(since = "TBD", note = "use outpoint == OutPoint::COINBASE_PREVOUT instead")]
+        fn is_null(&self) -> bool { *self == OutPoint::COINBASE_PREVOUT }
+    }
 }
 
 impl fmt::Display for OutPoint {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -111,19 +111,6 @@ impl OutPoint {
     pub fn null() -> OutPoint { Self::COINBASE_PREVOUT }
 
     /// Checks if an `OutPoint` is "null".
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use bitcoin::constants::genesis_block;
-    /// use bitcoin::params;
-    ///
-    /// let block = genesis_block(&params::MAINNET);
-    /// let tx = &block.txdata[0];
-    ///
-    /// // Coinbase transactions don't have any previous output.
-    /// assert!(tx.input[0].previous_output.is_null());
-    /// ```
     #[inline]
     #[deprecated(since = "TBD", note = "use outpoint == OutPoint::COINBASE_PREVOUT instead")]
     pub fn is_null(&self) -> bool { *self == OutPoint::null() }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,13 +16,14 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hashes/std", "internals/std", "io/std", "units/std"]
-alloc = ["hashes/alloc", "internals/alloc", "io/alloc", "units/alloc"]
-serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc"]
+std = ["alloc", "hashes/std", "hex/std", "internals/std", "io/std", "units/std"]
+alloc = ["hashes/alloc", "hex/alloc", "internals/alloc", "io/alloc", "units/alloc"]
+serde = ["dep:serde", "hashes/serde", "hex/serde", "internals/serde", "units/serde", "alloc"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["bitcoin-io"] }
+hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false }
 units = { package = "bitcoin-units", version = "0.1.0", default-features = false }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -89,7 +89,7 @@ fn parse_vout(s: &str) -> Result<u32, ParseOutPointError> {
     parse::int(s).map_err(ParseOutPointError::Vout)
 }
 
-/// An error in parsing an OutPoint.
+/// An error in parsing an [`OutPoint`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[cfg(feature = "alloc")]
@@ -156,7 +156,7 @@ impl Txid {
     /// The `Txid` used in a coinbase prevout.
     ///
     /// This is used as the "txid" of the dummy input of a coinbase transaction. This is not a real
-    /// TXID and should not be used in any other contexts. See `OutPoint::COINBASE_PREVOUT`.
+    /// TXID and should not be used in any other contexts. See [`OutPoint::COINBASE_PREVOUT`].
     pub const COINBASE_PREVOUT: Self = Self::from_byte_array([0; 32]);
 }
 


### PR DESCRIPTION
Just the minimal move of `OutPoint` to `primitives`.

The last patch closes #3347 