### PR TITLE
Ignore doc example that has a compile error

### DIFF
--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1127,7 +1127,8 @@ impl<R: BorrowMut<Transaction>> SighashCache<R> {
     ///
     /// # Examples
     ///
-    /// ```compile_fail
+    /// ```ignore
+    /// # // Example is an incomplete section of code that does not compile by itself
     /// let mut sighasher = SighashCache::new(&mut tx_to_sign);
     /// let sighash = sighasher.p2wpkh_signature_hash(input_index, &utxo.script_pubkey, amount, sighash_type)?;
     ///


### PR DESCRIPTION
With the stricter doc tests required to pick up unused imports etc. the code under the `compile_fail` tag also creates an Error.

Changed `compile_fail` to `ignore` to remove the Error.