### PR TITLE
CI: Use latest run_task version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 534e4977007760fafe5154bc31acae08cb535fbb
+          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 534e4977007760fafe5154bc31acae08cb535fbb
+          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 534e4977007760fafe5154bc31acae08cb535fbb
+          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 534e4977007760fafe5154bc31acae08cb535fbb
+          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 534e4977007760fafe5154bc31acae08cb535fbb
+          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 534e4977007760fafe5154bc31acae08cb535fbb
+          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -186,7 +186,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 534e4977007760fafe5154bc31acae08cb535fbb
+          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1


### PR DESCRIPTION
Recently we discovered a bug in the `run_task` script where we forgot to use `--no-default-features` in a subset of test runs (the feature matrix stuff).

Upgrade to use the latest version of `run_task.sh`.