### PR TITLE
Add stricter doc test to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,6 +12,8 @@ check:
 # Lint everything.
 lint:
   cargo +$(cat ./nightly-version) clippy --workspace --all-targets --all-features -- --deny warnings
+  # lint warnings get inhibited unless we use `--nocapture`
+  cargo test --quiet --workspace --doc -- --nocapture
 
 # Run cargo fmt
 fmt:
@@ -30,9 +32,6 @@ sane: lint
   cargo test --quiet --workspace --all-targets --no-default-features > /dev/null || exit 1
   cargo test --quiet --workspace --all-targets > /dev/null || exit 1
   cargo test --quiet --workspace --all-targets --all-features > /dev/null || exit 1
-
-  # doctests don't get run from workspace root with `cargo test`.
-  cargo test --quiet --workspace --doc || exit 1
 
   # Make an attempt to catch feature gate problems in doctests
   cargo test --manifest-path bitcoin/Cargo.toml --doc --no-default-features > /dev/null || exit 1


### PR DESCRIPTION
In order to show warnings for unused imports etc. in doc examples as mentioned in #3362, an extra test has been added to the justfile for `just lint` and the doc test in `just sane` has been removed since it calls `just lint`.