### PR TITLE
Soften wording on MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For more information please see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features on **Rust 1.63.0**.
+This library should compile with any combination of features on **Rust 1.63.0**.
 
 Use `Cargo-minimal.lock` to build the MSRV by copying to `Cargo.lock` and building.
 


### PR DESCRIPTION
Currently we use the word "always" in the MSRV docs, we mean to say "there are no set of features that will break the build" but this usage of "always" may be interpreted as "always, for all time" which is definitely not what we mean.

Soften the wording on MSRV by removing the word always.