### PR TITLE
Prepare `Witness`

### DIFF
--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -231,7 +231,7 @@ impl Encodable for Witness {
     // `self.content` includes the varints so encoding here includes them, as expected.
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let content_with_indices_len = self.content.len();
-        let indices_size = self.witness_elements * 4;
+        let indices_size = self.len() * 4;
         let content_len = content_with_indices_len - indices_size;
         Ok(w.emit_compact_size(self.witness_elements)? + w.emit_slice(&self.content[..content_len])?)
     }

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -252,15 +252,15 @@ impl Witness {
     /// It is expected that `pubkey` is related to the secret key used to create `signature`.
     pub fn p2wpkh(signature: ecdsa::Signature, pubkey: secp256k1::PublicKey) -> Witness {
         let mut witness = Witness::new();
-        witness.push_slice(&signature.serialize());
-        witness.push_slice(&pubkey.serialize());
+        witness.push(signature.serialize());
+        witness.push(pubkey.serialize());
         witness
     }
 
     /// Creates a witness required to do a key path spend of a P2TR output.
     pub fn p2tr_key_spend(signature: &taproot::Signature) -> Witness {
         let mut witness = Witness::new();
-        witness.push_slice(&signature.serialize());
+        witness.push(signature.serialize());
         witness
     }
 
@@ -363,7 +363,7 @@ impl Witness {
     ///
     /// Pushes the DER encoded signature + sighash_type, requires an allocation.
     pub fn push_ecdsa_signature(&mut self, signature: ecdsa::Signature) {
-        self.push_slice(&signature.serialize())
+        self.push(signature.serialize())
     }
 
     /// Note `index` is the index into the `content` vector and should be the result of calling

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -12,8 +12,8 @@ use arbitrary::{Arbitrary, Unstructured};
 use internals::compact_size;
 use io::{BufRead, Write};
 
-use crate::consensus::encode::{Error, ReadExt, MAX_VEC_SIZE};
-use crate::consensus::{Decodable, Encodable, WriteExt};
+use crate::consensus::encode::{self, Error, MAX_VEC_SIZE, ReadExt, WriteExt};
+use crate::consensus::{Decodable, Encodable};
 use crate::crypto::ecdsa;
 use crate::prelude::Vec;
 #[cfg(doc)]
@@ -230,10 +230,13 @@ fn resize_if_needed(vec: &mut Vec<u8>, required_len: usize) {
 impl Encodable for Witness {
     // `self.content` includes the varints so encoding here includes them, as expected.
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        let content_with_indices_len = self.content.len();
-        let indices_size = self.len() * 4;
-        let content_len = content_with_indices_len - indices_size;
-        Ok(w.emit_compact_size(self.witness_elements)? + w.emit_slice(&self.content[..content_len])?)
+        let mut written = w.emit_compact_size(self.len())?;
+
+        for element in self.iter() {
+            written += encode::consensus_encode_with_size(element, w)?
+        }
+
+        Ok(written)
     }
 }
 


### PR DESCRIPTION
Prepare `Witness` to be moved to `primitives`.

This is the first three patches out of #3406. Patch 1 and 2 are internal changes, path 3 is also internal but introduces a slight perf hit by doing multiple writes.