### PR TITLE
Improve `witness` unit tests

### DIFF
--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -645,14 +645,31 @@ mod test {
         v
     }
 
-    #[test]
-    fn witness_debug_can_display_empty_instruction() {
-        let witness = Witness {
+    // A witness with a single element that is empty (zero length).
+    fn single_empty_element() -> Witness {
+        // The first is 0 serialized as a compact size integer.
+        // The last four bytes represent start at index 0.
+        let content = [0_u8; 5];
+
+        Witness {
             witness_elements: 1,
-            content: append_u32_vec(vec![], &[0]),
-            indices_start: 2,
-        };
+            content: content.to_vec(),
+            indices_start: 1,
+        }
+    }
+
+    #[test]
+    fn witness_debug_can_display_empty_element() {
+        let witness = single_empty_element();
         println!("{:?}", witness);
+    }
+
+    #[test]
+    fn witness_single_empty_element() {
+        let mut got = Witness::new();
+        got.push(&[]);
+        let want = single_empty_element();
+        assert_eq!(got, want)
     }
 
     #[test]

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -757,7 +757,7 @@ mod test {
     }
 
     #[test]
-    fn test_iter_len() {
+    fn exact_sized_iterator() {
         let mut witness = Witness::default();
         for i in 0..5 {
             assert_eq!(witness.iter().len(), i);


### PR DESCRIPTION
In preparation for moving the `Witness` type over to `primitives` refactor and improve all the unit tests that will be moved, do not touch the ones that will stay behind.

The first five patches are from #3406, the last is just a re-name of the test function I tried to refactor in https://github.com/rust-bitcoin/rust-bitcoin/commit/ac6fe3a8815127e8c4df5fbe3f8a7241679e7c48