### PR TITLE
refactor push_int_unchecked and test push_int overflow

### DIFF
--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -916,3 +916,9 @@ fn instruction_script_num_parse() {
         Some(Ok(Instruction::PushBytes(PushBytes::empty()))),
     );
 }
+
+#[test]
+fn script_push_int_overflow() {
+    // Only errors if `data == i32::MIN` (CScriptNum cannot have value -2^31).
+    assert_eq!(Builder::new().push_int(i32::MIN), Err(Error::NumericOverflow));
+}


### PR DESCRIPTION
Follow up https://github.com/rust-bitcoin/rust-bitcoin/pull/3392

c9988ba8cb352d4a4c37d23083345e05de665a89
- refactor `push_int_unchecked` with match expression for cleaner code(many thanks for @tcharding https://github.com/rust-bitcoin/rust-bitcoin/issues/3407).

a33bcd3654640ec7aa1cbf13fc9cd8b1be0d757d
- ensure newly introduced safe `push_int` function as expected, testing if returns `Error::NumericOverflow` when `n` is `i32::MIN`