### PR TITLE
Fix unused lint warnings in hashes rustdocs

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -24,12 +24,12 @@
 //!
 //! ```
 //! #[cfg(feature = "std")] {
-//! # fn main() -> std::io::Result<()> {
-//! use bitcoin_hashes::{Hash as _, Sha256};
+//! # fn _example() -> std::io::Result<()> {
+//! use bitcoin_hashes::Sha256;
 //! let mut reader: &[u8] = b"hello"; // in real code, this could be a `File` or `TcpStream`
 //! let mut engine = Sha256::engine();
 //! std::io::copy(&mut reader, &mut engine)?;
-//! let hash = Sha256::from_engine(engine);
+//! let _hash = Sha256::from_engine(engine);
 //! # Ok(())
 //! # }}
 //! ```
@@ -39,17 +39,17 @@
 //!
 //! ```
 //! #[cfg(feature = "std")] {
-//! # fn main() -> std::io::Result<()> {
+//! # fn _example() -> std::io::Result<()> {
 //! use std::io::Write as _; // Or `bitcoin-io::Write` if `bitcoin-io` feature is enabled.
 //! use bitcoin_hashes::Sha256;
-//! let mut part1: &[u8] = b"hello";
-//! let mut part2: &[u8] = b" ";
-//! let mut part3: &[u8] = b"world";
+//! let part1: &[u8] = b"hello";
+//! let part2: &[u8] = b" ";
+//! let part3: &[u8] = b"world";
 //! let mut engine = Sha256::engine();
 //! engine.write_all(part1)?;
 //! engine.write_all(part2)?;
 //! engine.write_all(part3)?;
-//! let hash = Sha256::from_engine(engine);
+//! let _hash = Sha256::from_engine(engine);
 //! # Ok(())
 //! # }}
 //! ```

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! Hashing a single byte slice or a string:
 //!
-//! ```rust
+//! ```
 //! use bitcoin_hashes::Sha256;
 //!
 //! let bytes = [0u8; 5];
@@ -22,26 +22,26 @@
 //!
 //! Hashing content from a reader:
 //!
-//! ```rust
-//! #[cfg(std)]
+//! ```
+//! #[cfg(feature = "std")] {
 //! # fn main() -> std::io::Result<()> {
+//! use bitcoin_hashes::{Hash as _, Sha256};
 //! let mut reader: &[u8] = b"hello"; // in real code, this could be a `File` or `TcpStream`
 //! let mut engine = Sha256::engine();
 //! std::io::copy(&mut reader, &mut engine)?;
 //! let hash = Sha256::from_engine(engine);
 //! # Ok(())
-//! # }
-//!
-//! #[cfg(not(std))]
-//! # fn main() {}
+//! # }}
 //! ```
 //!
 //!
 //! Hashing content by [`std::io::Write`] on `HashEngine`:
 //!
-//! ```rust
-//! #[cfg(std)]
+//! ```
+//! #[cfg(feature = "std")] {
 //! # fn main() -> std::io::Result<()> {
+//! use std::io::Write as _; // Or `bitcoin-io::Write` if `bitcoin-io` feature is enabled.
+//! use bitcoin_hashes::Sha256;
 //! let mut part1: &[u8] = b"hello";
 //! let mut part2: &[u8] = b" ";
 //! let mut part3: &[u8] = b"world";
@@ -51,10 +51,7 @@
 //! engine.write_all(part3)?;
 //! let hash = Sha256::from_engine(engine);
 //! # Ok(())
-//! # }
-//!
-//! #[cfg(not(std))]
-//! # fn main() {}
+//! # }}
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
Draft because on top of #3410

The example code in `hashes/src/lib.rs` was not linted because of an incorrectly applied feature gate.  Now that this is fixed in #3410 the example code causes warnings for unused code.

Unused variables and functions have been prefixed with`_` and `mut` removed from the variables that do not need to be mutable.