### PR TITLE
Rename Midstate::into_parts to Midstate::to_parts since it derives Copy

### DIFF
--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -198,7 +198,7 @@ impl Midstate {
     pub const fn as_parts(&self) -> (&[u8; 32], u64) { (&self.bytes, self.bytes_hashed) }
 
     /// Deconstructs the [`Midstate`], returning the underlying byte array and number of bytes hashed.
-    pub const fn into_parts(self) -> ([u8; 32], u64) { (self.bytes, self.bytes_hashed) }
+    pub const fn to_parts(self) -> ([u8; 32], u64) { (self.bytes, self.bytes_hashed) }
 
     /// Creates midstate for tagged hashes.
     ///


### PR DESCRIPTION
This is a follow up to #3010

Fixes #3079