### PR TITLE
Protect Bip32 Numbers

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -3,7 +3,7 @@ extern crate bitcoin;
 use std::{env, process};
 
 use bitcoin::address::{Address, KnownHrp};
-use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{ChildKeyIndex, DerivationPath, Xpriv, Xpub};
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
@@ -47,7 +47,7 @@ fn main() {
 
     // generate first receiving address at m/0/0
     // manually creating indexes this time
-    let zero = ChildNumber::ZERO_NORMAL;
+    let zero = ChildKeyIndex::ZERO_NORMAL;
     let public_key = xpub.derive_xpub(&secp, &[zero, zero]).unwrap().public_key;
     let address = Address::p2wpkh(CompressedPublicKey(public_key), KnownHrp::Mainnet);
     println!("First receiving address: {}", address);

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -25,7 +25,7 @@
 use std::collections::BTreeMap;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{ChildKeyIndex, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
 use bitcoin::secp256k1::{Secp256k1, Signing};
@@ -59,10 +59,10 @@ fn get_external_address_xpriv<C: Signing>(
     index: u32,
 ) -> Xpriv {
     let derivation_path =
-        BIP84_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+        BIP84_DERIVATION_PATH.parse::<DerivationPath>().expect("valid derivation path");
     let child_xpriv = master_xpriv.derive_xpriv(secp, &derivation_path);
-    let external_index = ChildNumber::ZERO_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let external_index = ChildKeyIndex::ZERO_NORMAL;
+    let idx = ChildKeyIndex::from_normal_index(index).expect("valid index");
 
     child_xpriv.derive_xpriv(secp, &[external_index, idx])
 }
@@ -74,10 +74,10 @@ fn get_internal_address_xpriv<C: Signing>(
     index: u32,
 ) -> Xpriv {
     let derivation_path =
-        BIP84_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+        BIP84_DERIVATION_PATH.parse::<DerivationPath>().expect("valid derivation path");
     let child_xpriv = master_xpriv.derive_xpriv(secp, &derivation_path);
-    let internal_index = ChildNumber::ONE_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let internal_index = ChildKeyIndex::ONE_NORMAL;
+    let idx = ChildKeyIndex::from_normal_index(index).expect("valid index");
 
     child_xpriv.derive_xpriv(secp, &[internal_index, idx])
 }

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -32,7 +32,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{ChildKeyIndex, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::consensus::encode;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::{self, Input, Psbt, PsbtSighashType};
@@ -116,11 +116,11 @@ impl ColdStorage {
 
         // Hardened children require secret data to derive.
 
-        let path = "84h/0h/0h".into_derivation_path()?;
+        let path = "84h/0h/0h".parse::<DerivationPath>()?;
         let account_0_xpriv = master_xpriv.derive_xpriv(secp, &path);
         let account_0_xpub = Xpub::from_xpriv(secp, &account_0_xpriv);
 
-        let path = INPUT_UTXO_DERIVATION_PATH.into_derivation_path()?;
+        let path = INPUT_UTXO_DERIVATION_PATH.parse::<DerivationPath>()?;
         let input_xpriv = master_xpriv.derive_xpriv(secp, &path);
         let input_xpub = Xpub::from_xpriv(secp, &input_xpriv);
 
@@ -257,19 +257,19 @@ impl WatchOnly {
         &self,
         secp: &Secp256k1<C>,
     ) -> Result<(CompressedPublicKey, Address, DerivationPath)> {
-        let path = [ChildNumber::ONE_NORMAL, ChildNumber::ZERO_NORMAL];
+        let path = [ChildKeyIndex::ONE_NORMAL, ChildKeyIndex::ZERO_NORMAL];
         let derived = self.account_0_xpub.derive_xpub(secp, &path)?;
 
         let pk = derived.to_public_key();
         let addr = Address::p2wpkh(pk, NETWORK);
-        let path = path.into_derivation_path()?;
+        let path = DerivationPath::from(path.to_vec());
 
         Ok((pk, addr, path))
     }
 }
 
 fn input_derivation_path() -> Result<DerivationPath> {
-    let path = INPUT_UTXO_DERIVATION_PATH.into_derivation_path()?;
+    let path = INPUT_UTXO_DERIVATION_PATH.parse::<DerivationPath>()?;
     Ok(path)
 }
 

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -23,7 +23,7 @@
 use std::collections::BTreeMap;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{ChildKeyIndex, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::key::UntweakedPublicKey;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
@@ -58,10 +58,10 @@ fn get_external_address_xpriv<C: Signing>(
     index: u32,
 ) -> Xpriv {
     let derivation_path =
-        BIP86_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+        BIP86_DERIVATION_PATH.parse::<DerivationPath>().expect("valid derivation path");
     let child_xpriv = master_xpriv.derive_xpriv(secp, &derivation_path);
-    let external_index = ChildNumber::ZERO_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let external_index = ChildKeyIndex::ZERO_NORMAL;
+    let idx = ChildKeyIndex::from_normal_index(index).expect("valid index");
 
     child_xpriv.derive_xpriv(secp, &[external_index, idx])
 }
@@ -73,10 +73,10 @@ fn get_internal_address_xpriv<C: Signing>(
     index: u32,
 ) -> Xpriv {
     let derivation_path =
-        BIP86_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+        BIP86_DERIVATION_PATH.parse::<DerivationPath>().expect("valid derivation path");
     let child_xpriv = master_xpriv.derive_xpriv(secp, &derivation_path);
-    let internal_index = ChildNumber::ONE_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let internal_index = ChildKeyIndex::ONE_NORMAL;
+    let idx = ChildKeyIndex::from_normal_index(index).expect("valid index");
 
     child_xpriv.derive_xpriv(secp, &[internal_index, idx])
 }

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -3,7 +3,7 @@
 use internals::ToU64 as _;
 use io::{BufRead, Cursor, Read};
 
-use crate::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
+use crate::bip32::{ChildKeyIndex, DerivationPath, Fingerprint, Xpub};
 use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::consensus::{encode, Decodable};
 use crate::prelude::{btree_map, BTreeMap, Vec};
@@ -130,9 +130,9 @@ impl Psbt {
                                 decoder.read_exact(&mut fingerprint[..]).map_err(|_| {
                                     Error::XPubKey("can't read global xpub fingerprint")
                                 })?;
-                                let mut path = Vec::<ChildNumber>::with_capacity(child_count);
+                                let mut path = Vec::<ChildKeyIndex>::with_capacity(child_count);
                                 while let Ok(index) = u32::consensus_decode(&mut decoder) {
-                                    path.push(ChildNumber::from(index))
+                                    path.push(ChildKeyIndex::from(index))
                                 }
                                 let derivation = DerivationPath::from(path);
                                 // Keys, according to BIP-174, must be unique

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -766,7 +766,7 @@ impl GetKey for Xpriv {
                     Some(k.to_private_key())
                 } else if self.parent_fingerprint == *fingerprint
                     && !path.is_empty()
-                    && path[0] == self.child_number
+                    && path[0] == self.child_index
                 {
                     let path = DerivationPath::from_iter(path.into_iter().skip(1).copied());
                     let k = self.derive_xpriv(secp, &path);
@@ -1213,7 +1213,7 @@ mod tests {
 
     use super::*;
     use crate::address::script_pubkey::ScriptExt as _;
-    use crate::bip32::ChildNumber;
+    use crate::bip32::ChildKeyIndex;
     use crate::locktime::absolute;
     use crate::network::NetworkKind;
     use crate::psbt::serialize::{Deserialize, Serialize};
@@ -1358,15 +1358,15 @@ mod tests {
 
         let fprint = sk.fingerprint(secp);
 
-        let dpath: Vec<ChildNumber> = vec![
-            ChildNumber::ZERO_NORMAL,
-            ChildNumber::ONE_NORMAL,
-            ChildNumber::from_normal_idx(2).unwrap(),
-            ChildNumber::from_normal_idx(4).unwrap(),
-            ChildNumber::from_normal_idx(42).unwrap(),
-            ChildNumber::from_hardened_idx(69).unwrap(),
-            ChildNumber::from_normal_idx(420).unwrap(),
-            ChildNumber::from_normal_idx(31337).unwrap(),
+        let dpath: Vec<ChildKeyIndex> = vec![
+            ChildKeyIndex::ZERO_NORMAL,
+            ChildKeyIndex::ONE_NORMAL,
+            ChildKeyIndex::from_normal_index(2).unwrap(),
+            ChildKeyIndex::from_normal_index(4).unwrap(),
+            ChildKeyIndex::from_normal_index(42).unwrap(),
+            ChildKeyIndex::from_hardened_index(69),
+            ChildKeyIndex::from_normal_index(420).unwrap(),
+            ChildKeyIndex::from_normal_index(31337).unwrap(),
         ];
 
         sk = sk.derive_xpriv(secp, &dpath);

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -9,7 +9,7 @@ use hashes::{hash160, ripemd160, sha256, sha256d};
 use secp256k1::XOnlyPublicKey;
 
 use super::map::{Input, Map, Output, PsbtSighashType};
-use crate::bip32::{ChildNumber, Fingerprint, KeySource};
+use crate::bip32::{ChildKeyIndex, Fingerprint, KeySource};
 use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
@@ -218,7 +218,7 @@ impl Deserialize for KeySource {
         }
 
         let fprint: Fingerprint = bytes[0..4].try_into().expect("4 is the fingerprint length");
-        let mut dpath: Vec<ChildNumber> = Default::default();
+        let mut dpath: Vec<ChildKeyIndex> = Default::default();
 
         let mut d = &bytes[4..];
         while !d.is_empty() {

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use bitcoin::bip32::{Fingerprint, IntoDerivationPath, KeySource, Xpriv, Xpub};
+use bitcoin::bip32::{DerivationPath, Fingerprint, KeySource, Xpriv, Xpub};
 use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
 use bitcoin::opcodes::OP_0;
@@ -61,7 +61,7 @@ fn bip174_psbt_workflow() {
 
     // Strings from BIP 174 test vector.
     let test_vector = [
-        ("cP53pDbR5WtAD8dYAW9hhTjuvvTVaEiQBdrz9XPrgLBeRFiyCbQr", "0h/0h/0h"), // from_priv, into_derivation_path?
+        ("cP53pDbR5WtAD8dYAW9hhTjuvvTVaEiQBdrz9XPrgLBeRFiyCbQr", "0h/0h/0h"), // from_priv
         ("cR6SXDoyfQrcp4piaiHE97Rsgta9mNhGTen9XeonVgwsh4iSgw6d", "0h/0h/2h"),
     ];
 
@@ -276,7 +276,7 @@ fn bip32_derivation(
         let path = pk_path[i].1;
 
         let pk = pk.parse::<PublicKey>().unwrap();
-        let path = path.into_derivation_path().unwrap();
+        let path = path.parse::<DerivationPath>().unwrap();
 
         tree.insert(pk.inner, (fingerprint, path));
     }
@@ -314,7 +314,7 @@ fn parse_and_verify_keys(
         let wif_priv = PrivateKey::from_wif(secret_key).expect("failed to parse key");
 
         let path =
-            derivation_path.into_derivation_path().expect("failed to convert derivation path");
+            derivation_path.parse::<DerivationPath>().expect("failed to convert derivation path");
         let derived_priv = ext_priv.derive_xpriv(secp, &path).to_private_key();
         assert_eq!(wif_priv, derived_priv);
         let derived_pub = derived_priv.public_key(secp);

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -25,7 +25,7 @@
 use std::collections::BTreeMap;
 
 use bincode::serialize;
-use bitcoin::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
+use bitcoin::bip32::{ChildKeyIndex, KeySource, Xpriv, Xpub};
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::hex::FromHex;
@@ -194,7 +194,7 @@ fn serde_regression_control_block() {
 
 #[test]
 fn serde_regression_child_number() {
-    let num = ChildNumber::Normal { index: 0xDEADBEEF };
+    let num = ChildKeyIndex::from_raw_index(0xDEADBEEF);
     let got = serialize(&num).unwrap();
     let want = include_bytes!("data/serde/child_number_bincode") as &[_];
     assert_eq!(got, want)


### PR DESCRIPTION
Hi guys, im splitting all the features from #3036 into some PRs so we can merge it in the lib as i mentioned before closing it.

In this PR, I implemented changes to replace the use of "numbers" with "indexes" for clarity. After reviewing the discussions and the confusion surrounding the terminology, I opted for the term “index,” as it’s consistently used in Bip32. To distinguish the u32 inside the index, I introduced the term "index value," which has worked well in practice.

Another key update addresses how we handle hardened indexes when working with index values. I’ve made two constant methods, shifted_index() and unshifted_index(), to ensure proper manipulation of these values. In Bip32, was common to see the index being directly shifted in some cases and used raw in others, so this change helps standardize that behavior.

Most of the core changes are in `bitcoin/src/bip32.rs`