### PR TITLE
sequence: clarify sequence constant name and add FINAL

### DIFF
--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -38,12 +38,14 @@ pub struct Sequence(pub u32);
 impl Sequence {
     /// The maximum allowable sequence number.
     ///
-    /// This sequence number disables absolute lock time and replace-by-fee.
+    /// The sequence number that disables replace-by-fee, absolute lock time and relative lock time.
     pub const MAX: Self = Sequence(0xFFFFFFFF);
     /// Zero value sequence.
     ///
     /// This sequence number enables replace-by-fee and absolute lock time.
     pub const ZERO: Self = Sequence(0);
+    /// The sequence number that disables replace-by-fee, absolute lock time and relative lock time.
+    pub const FINAL: Self = Sequence::MAX;
     /// The sequence number that enables absolute lock time but disables replace-by-fee
     /// and relative lock time.
     pub const ENABLE_LOCKTIME_NO_RBF: Self = Sequence::MIN_NO_RBF;

--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -51,7 +51,16 @@ impl Sequence {
     pub const ENABLE_LOCKTIME_NO_RBF: Self = Sequence::MIN_NO_RBF;
     /// The sequence number that enables replace-by-fee and absolute lock time but
     /// disables relative lock time.
+    #[deprecated(
+        since = "TBD",
+        note = "This constant has ambiguous name. Please use ENABLE_LOCKTIME_AND_RBF instead."
+    )]
     pub const ENABLE_RBF_NO_LOCKTIME: Self = Sequence(0xFFFFFFFD);
+    /// The maximum sequence number that enables replace-by-fee and absolute lock time but
+    /// disables relative lock time.
+    ///
+    /// This sequence number has no meaning other than to enable RBF and the absolute locktime.
+    pub const ENABLE_LOCKTIME_AND_RBF: Self = Sequence(0xFFFFFFFD);
 
     /// The number of bytes that a sequence number contributes to the size of a transaction.
     pub const SIZE: usize = 4; // Serialized length of a u32.


### PR DESCRIPTION
c24630e7b13312ea34f0f54ed832783ced8dde3f
- `LOCKTIME` is used for both absolute and relative one without clear classification, which is confusing and could lead to an unexpected bug. Although it's API breaking change, current constant is so ambiguous unless understand the details of `LOCKTIME` semantic.

9cc5dfeef178f03ea4d0786cfbaa3b8709fed644
- Add constant `ENABLE_ALL` and `DISABLE_ALL`, which is useful for those who want to enable(disable) rbf, absolute/relative locktime.