### PR TITLE
Fix fuzztest failure

### DIFF
--- a/hashes/src/ripemd160.rs
+++ b/hashes/src/ripemd160.rs
@@ -37,7 +37,7 @@ fn from_engine(mut e: HashEngine) -> Hash {
 #[cfg(hashes_fuzz)]
 fn from_engine(e: HashEngine) -> Hash {
     let mut res = e.midstate();
-    res[0] ^= (e.length & 0xff) as u8;
+    res[0] ^= (e.bytes_hashed & 0xff) as u8;
     Hash(res)
 }
 

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -91,7 +91,7 @@ macro_rules! engine_input_impl(
             for c in inp {
                 self.buffer[0] ^= *c;
             }
-            self.length += inp.len();
+            self.bytes_hashed += inp.len();
         }
     )
 );

--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -91,7 +91,7 @@ macro_rules! engine_input_impl(
             for c in inp {
                 self.buffer[0] ^= *c;
             }
-            self.bytes_hashed += inp.len();
+            self.bytes_hashed += inp.len() as u64;
         }
     )
 );


### PR DESCRIPTION
In #3298 `HashEngine.length` was changed to `HashEngine.bytes_hashed` and changed from `usize` to `u64`.  

Behind a `hashes_fuzz` feature gate there were a couple of occurrences of length that had not been updated and caused a fuzztest failure.  These have been updated to the new name and type.

Fix #3448