### PR TITLE
Add version three variant to transaction version

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -343,7 +343,7 @@ fn size_from_script_pubkey(script_pubkey: &Script) -> usize {
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Transaction {
-    /// The protocol version, is currently expected to be 1 or 2 (BIP 68).
+    /// The protocol version, is currently expected to be 1, 2 (BIP 68) or 3 (BIP 431).
     pub version: Version,
     /// Block height or timestamp. Transaction cannot be included in a block until this height/time.
     ///
@@ -797,7 +797,7 @@ crate::internal_macros::define_extension_trait! {
         fn non_standard(version: i32) -> Version { Self(version) }
 
         /// Returns true if this transaction version number is considered standard.
-        fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO }
+        fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO || *self == Version::THREE }
     }
 }
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -171,13 +171,14 @@ impl Wtxid {
 
 /// The transaction version.
 ///
-/// Currently, as specified by [BIP-68], only version 1 and 2 are considered standard.
+/// Currently, as specified by [BIP-68] and [BIP-431], version 1, 2, and 3 are considered standard.
 ///
 /// Standardness of the inner `i32` is not an invariant because you are free to create transactions
 /// of any version, transactions with non-standard version numbers will not be relayed by the
 /// Bitcoin network.
 ///
 /// [BIP-68]: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
+/// [BIP-431]: https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki
 #[derive(Copy, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Version(pub i32);
@@ -188,6 +189,9 @@ impl Version {
 
     /// The second Bitcoin transaction version (post-BIP-68).
     pub const TWO: Self = Self(2);
+
+    /// The third Bitcoin transaction version (post-BIP-431).
+    pub const THREE: Self = Self(3);
 }
 
 impl fmt::Display for Version {
@@ -208,10 +212,11 @@ impl<'a> Arbitrary<'a> for OutPoint {
 impl<'a> Arbitrary<'a> for Version {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         // Equally weight the case of normal version numbers
-        let choice = u.int_in_range(0..=2)?;
+        let choice = u.int_in_range(0..=3)?;
         match choice {
             0 => Ok(Version::ONE),
             1 => Ok(Version::TWO),
+            2 => Ok(Version::THREE),
             _ => Ok(Version(u.arbitrary()?)),
         }
     }


### PR DESCRIPTION
Topologically restricted transactions are now considered standard as of Bitcoin 28.0. 