### PR TITLE
Remove unnecessary lifetime

### DIFF
--- a/internals/src/error/input_string.rs
+++ b/internals/src/error/input_string.rs
@@ -102,7 +102,7 @@ pub struct CannotParse<'a, T: fmt::Display + ?Sized> {
     what: &'a T,
 }
 
-impl<'a, T: fmt::Display + ?Sized> fmt::Display for CannotParse<'a, T> {
+impl<T: fmt::Display + ?Sized> fmt::Display for CannotParse<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         storage::cannot_parse(&self.input.0, &self.what, f)
     }


### PR DESCRIPTION
Found by `rustc` after update to recent nightly version to `nightly-2024-10-06`.