### PR TITLE
Use new Sequence::ENABLE_RBF_AND_LOCKTIME

### DIFF
--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -262,7 +262,7 @@ impl<'a> Arbitrary<'a> for Sequence {
             0 => Ok(Sequence::MAX),
             1 => Ok(Sequence::ZERO),
             2 => Ok(Sequence::MIN_NO_RBF),
-            3 => Ok(Sequence::ENABLE_RBF_NO_LOCKTIME),
+            3 => Ok(Sequence::ENABLE_LOCKTIME_AND_RBF),
             4 => Ok(Sequence::from_consensus(relative::Height::MIN.to_consensus_u32())),
             5 => Ok(Sequence::from_consensus(relative::Height::MAX.to_consensus_u32())),
             6 => Ok(Sequence::from_consensus(relative::Time::MIN.to_consensus_u32())),


### PR DESCRIPTION
We just renamed this and forgot to use the new name. This should have been caught by CI.