### PR TITLE
Remove unused import

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1342,8 +1342,6 @@ impl<'a> Arbitrary<'a> for Transaction {
 
 #[cfg(test)]
 mod tests {
-    use core::str;
-
     use hex::{test_hex_unwrap as hex, FromHex};
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;


### PR DESCRIPTION
Ran `./maintainer-tools/ci/run_task.sh stable` without error locally, so I don't think this import is needed.