### PR TITLE
Move `block::Header` to `primitives`

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -66,9 +66,16 @@ impl Header {
     pub const SIZE: usize = 4 + 32 + 32 + 4 + 4 + 4; // 80
 
     /// Returns the block hash.
+    // This is the same as `Encodable` but done manually because `Encodable` isn't in `primitives`.
     pub fn block_hash(&self) -> BlockHash {
         let mut engine = sha256d::Hash::engine();
-        self.consensus_encode(&mut engine).expect("engines don't error");
+        engine.input(&self.version.to_consensus().to_le_bytes());
+        engine.input(self.prev_blockhash.as_byte_array());
+        engine.input(self.merkle_root.as_byte_array());
+        engine.input(&self.time.to_le_bytes());
+        engine.input(&self.bits.to_consensus().to_le_bytes());
+        engine.input(&self.nonce.to_le_bytes());
+
         BlockHash::from_byte_array(sha256d::Hash::from_engine(engine).to_byte_array())
     }
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -574,14 +574,25 @@ mod tests {
         }
     }
 
+    fn header() -> Header {
+        let header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
+        deserialize(&header).expect("can't deserialize correct block header")
+    }
+
     #[test]
     fn compact_roundrtip_test() {
-        let some_header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
-
-        let header: Header =
-            deserialize(&some_header).expect("can't deserialize correct block header");
-
+        let header = header();
         assert_eq!(header.bits, header.target().to_compact_lossy());
+    }
+
+    #[test]
+    fn header_block_hash_regression() {
+        let header = header();
+        let block_hash = "00000000b0c5a240b2a61d2e75692224efd4cbecdf6eaf4cc2cf477ca7c270e7";
+
+        let want = block_hash.parse::<BlockHash>().unwrap();
+        let got = header.block_hash();
+        assert_eq!(got, want)
     }
 
     #[test]

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -27,7 +27,7 @@ use crate::transaction::{Transaction, Wtxid};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use primitives::block::*;
+pub use primitives::block::{Version, BlockHash, WitnessCommitment};
 
 impl_hashencode!(BlockHash);
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -254,7 +254,7 @@ impl Target {
     /// Panics if `self` is zero (divide by zero).
     ///
     /// [max]: Target::max
-    /// [target]: crate::block::Header::target
+    /// [target]: crate::block::HeaderExt::target
     #[cfg_attr(all(test, mutate), mutate)]
     pub fn difficulty(&self, params: impl AsRef<Params>) -> u128 {
         // Panic here may be eaiser to debug than during the actual division.


### PR DESCRIPTION
- Patch 1: Trivial preparation. 
- Patch 2 and 3: Reduce the API surface in a disappointing way due to the orphan rule.
- Patch 4: Do the move.