### PR TITLE
Make changelogs more discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+
+A changelog is kept per crate, see:
+
+- [`bitcoin` CHANGELOG](bitcoin/CHANGELOG.md)
+- [`addresses` CHANGELOG](addresses/CHANGELOG.md)
+- [`base58` CHANGELOG](base58/CHANGELOG.md)
+- [`hashes` CHANGELOG](hashes/CHANGELOG.md)
+- [`internals` CHANGELOG](internals/CHANGELOG.md)
+- [`io` CHANGELOG](io/CHANGELOG.md)
+- [`primitives` CHANGELOG](primitives/CHANGELOG.md)
+- [`units` CHANGELOG](units/CHANGELOG.md)
+

--- a/README.md
+++ b/README.md
@@ -202,9 +202,14 @@ Our code is public domain so by all means fork it and go wild :)
 
 Release notes are done per crate, see:
 
-- [bitcoin CHANGELOG](bitcoin/CHANGELOG.md)
-- [hashes CHANGELOG](hashes/CHANGELOG.md)
-- [internals CHANGELOG](internals/CHANGELOG.md)
+- [`bitcoin` CHANGELOG](bitcoin/CHANGELOG.md)
+- [`addresses` CHANGELOG](addresses/CHANGELOG.md)
+- [`base58` CHANGELOG](base58/CHANGELOG.md)
+- [`hashes` CHANGELOG](hashes/CHANGELOG.md)
+- [`internals` CHANGELOG](internals/CHANGELOG.md)
+- [`io` CHANGELOG](io/CHANGELOG.md)
+- [`primitives` CHANGELOG](primitives/CHANGELOG.md)
+- [`units` CHANGELOG](units/CHANGELOG.md)
 
 
 ## Licensing


### PR DESCRIPTION
Add links to the README and also add a workspace root dummy CHANGELOG file with the same links.

This is Steven's patch from #3169 shepherded in by me.