### PR TITLE
Fix lint errors

### DIFF
--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -6,6 +6,7 @@
 //! library is used with the `secp-recovery` feature.
 
 use hashes::{sha256d, HashEngine};
+#[cfg(feature = "secp-recovery")]
 use secp256k1::SecretKey;
 
 use crate::consensus::encode::WriteExt;

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -98,7 +98,7 @@ pub struct Take<'a, R: Read + ?Sized> {
     remaining: u64,
 }
 
-impl<'a, R: Read + ?Sized> Take<'a, R> {
+impl<R: Read + ?Sized> Take<'_, R> {
     /// Reads all bytes until EOF from the underlying reader into `buf`.
     #[cfg(feature = "alloc")]
     #[inline]
@@ -120,7 +120,7 @@ impl<'a, R: Read + ?Sized> Take<'a, R> {
     }
 }
 
-impl<'a, R: Read + ?Sized> Read for Take<'a, R> {
+impl<R: Read + ?Sized> Read for Take<'_, R> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let len = cmp::min(buf.len(), self.remaining.try_into().unwrap_or(buf.len()));
@@ -131,7 +131,7 @@ impl<'a, R: Read + ?Sized> Read for Take<'a, R> {
 }
 
 // Impl copied from Rust stdlib.
-impl<'a, R: BufRead + ?Sized> BufRead for Take<'a, R> {
+impl<R: BufRead + ?Sized> BufRead for Take<'_, R> {
     #[inline]
     fn fill_buf(&mut self) -> Result<&[u8]> {
         // Don't call into inner reader at all at EOF because it may still block
@@ -299,7 +299,7 @@ impl Write for alloc::vec::Vec<u8> {
     fn flush(&mut self) -> Result<()> { Ok(()) }
 }
 
-impl<'a> Write for &'a mut [u8] {
+impl Write for &mut [u8] {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         let cnt = core::cmp::min(self.len(), buf.len());

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -163,7 +163,7 @@ impl Add<&FeeRate> for FeeRate {
     fn add(self, other: &FeeRate) -> <FeeRate as Add>::Output { FeeRate(self.0 + other.0) }
 }
 
-impl<'a, 'b> Add<&'a FeeRate> for &'b FeeRate {
+impl<'a> Add<&'a FeeRate> for &FeeRate {
     type Output = FeeRate;
 
     fn add(self, other: &'a FeeRate) -> <FeeRate as Add>::Output { FeeRate(self.0 + other.0) }
@@ -187,7 +187,7 @@ impl Sub<&FeeRate> for FeeRate {
     fn sub(self, other: &FeeRate) -> <FeeRate as Add>::Output { FeeRate(self.0 - other.0) }
 }
 
-impl<'a, 'b> Sub<&'a FeeRate> for &'b FeeRate {
+impl<'a> Sub<&'a FeeRate> for &FeeRate {
     type Output = FeeRate;
 
     fn sub(self, other: &'a FeeRate) -> <FeeRate as Add>::Output { FeeRate(self.0 - other.0) }


### PR DESCRIPTION
New lint warnings from a recent nightly toolchain show some explicit lifetimes that can be omitted.

The unnecessary lifetimes have been removed.

An unused import warning has also been fixed by placing the use statement behind the relevant feature gate.