### PR TITLE
Unify deprecated note field format

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -28,11 +28,11 @@ const VERSION_BYTES_TESTNETS_PUBLIC: [u8; 4] = [0x04, 0x35, 0x87, 0xCF];
 const VERSION_BYTES_TESTNETS_PRIVATE: [u8; 4] = [0x04, 0x35, 0x83, 0x94];
 
 /// The old name for xpub, extended public key.
-#[deprecated(since = "0.31.0", note = "use Xpub instead")]
+#[deprecated(since = "0.31.0", note = "use `Xpub` instead")]
 pub type ExtendedPubKey = Xpub;
 
 /// The old name for xpriv, extended public key.
-#[deprecated(since = "0.31.0", note = "use Xpriv instead")]
+#[deprecated(since = "0.31.0", note = "use `Xpriv` instead")]
 pub type ExtendedPrivKey = Xpriv;
 
 /// A chain code
@@ -592,7 +592,7 @@ impl Xpriv {
     }
 
     /// Constructs ECDSA compressed private key matching internal secret key representation.
-    #[deprecated(since = "TBD", note = "use `to_private_key()`")]
+    #[deprecated(since = "TBD", note = "use `to_private_key()` instead")]
     pub fn to_priv(self) -> PrivateKey { self.to_private_key() }
 
     /// Constructs ECDSA compressed private key matching internal secret key representation.
@@ -615,7 +615,7 @@ impl Xpriv {
     /// Derives an extended private key from a path.
     ///
     /// The `path` argument can be both of type `DerivationPath` or `Vec<ChildNumber>`.
-    #[deprecated(since = "TBD", note = "use `derive_xpriv()`")]
+    #[deprecated(since = "TBD", note = "use `derive_xpriv()` instead")]
     pub fn derive_priv<C: secp256k1::Signing, P: AsRef<[ChildNumber]>>(
         &self,
         secp: &Secp256k1<C>,
@@ -731,7 +731,7 @@ impl Xpriv {
 
 impl Xpub {
     /// Creates extended public key from an extended private key.
-    #[deprecated(since = "TBD", note = "use `from_xpriv()`")]
+    #[deprecated(since = "TBD", note = "use `from_xpriv()` instead")]
     pub fn from_priv<C: secp256k1::Signing>(secp: &Secp256k1<C>, sk: &Xpriv) -> Xpub {
         Self::from_xpriv(secp, sk)
     }
@@ -749,7 +749,7 @@ impl Xpub {
     }
 
     /// Constructs ECDSA compressed public key matching internal public key representation.
-    #[deprecated(since = "TBD", note = "use `to_public_key()`")]
+    #[deprecated(since = "TBD", note = "use `to_public_key()` instead")]
     pub fn to_pub(self) -> CompressedPublicKey { self.to_public_key() }
 
     /// Constructs ECDSA compressed public key matching internal public key representation.
@@ -757,7 +757,7 @@ impl Xpub {
 
     /// Constructs BIP340 x-only public key for BIP-340 signatures and Taproot use matching
     /// the internal public key representation.
-    #[deprecated(since = "TBD", note = "use `to_x_only_public_key()`")]
+    #[deprecated(since = "TBD", note = "use `to_x_only_public_key()` instead")]
     pub fn to_x_only_pub(self) -> XOnlyPublicKey { self.to_x_only_public_key() }
 
     /// Constructs BIP340 x-only public key for BIP-340 signatures and Taproot use matching
@@ -767,7 +767,7 @@ impl Xpub {
     /// Attempts to derive an extended public key from a path.
     ///
     /// The `path` argument can be any type implementing `AsRef<ChildNumber>`, such as `DerivationPath`, for instance.
-    #[deprecated(since = "TBD", note = "use `derive_xpub()`")]
+    #[deprecated(since = "TBD", note = "use `derive_xpub()` instead")]
     pub fn derive_pub<C: secp256k1::Verification, P: AsRef<[ChildNumber]>>(
         &self,
         secp: &Secp256k1<C>,

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -47,10 +47,9 @@ pub const MAX_STACK_ELEMENT_SIZE: usize = 520;
 /// How may blocks between halvings.
 pub const SUBSIDY_HALVING_INTERVAL: u32 = 210_000;
 /// Maximum allowed value for an integer in Script.
-#[deprecated(
-    since = "TBD",
-    note = "This constant has ambiguous semantics. Please carefully check your intended use-case and define a new constant reflecting that."
-)]
+/// This constant has ambiguous semantics. Please carefully check your intended use-case and define
+/// a new constant reflecting that.
+#[deprecated(since = "TBD", note = "use a more specific constant instead")]
 pub const MAX_SCRIPTNUM_VALUE: u32 = 0x80000000; // 2^31
 /// Number of blocks needed for an output from a coinbase transaction to be spendable.
 pub const COINBASE_MATURITY: u32 = 100;
@@ -200,7 +199,7 @@ impl ChainHash {
         101, 225, 90, 8, 156, 104, 214, 25, 0, 0, 0, 0, 0,
     ]);
     /// `ChainHash` for testnet3 bitcoin.
-    #[deprecated(since = "0.33.0", note = "Use TESTNET3 instead")]
+    #[deprecated(since = "0.33.0", note = "use `TESTNET3` instead")]
     pub const TESTNET: Self = Self([
         67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151,
         32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0,

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -223,10 +223,7 @@ crate::internal_macros::define_extension_trait! {
         ///
         /// This method has potentially confusing semantics and an unclear purpose, so it's going to be
         /// removed. Use `is_op_return` if you want `OP_RETURN` semantics.
-        #[deprecated(
-            since = "0.32.0",
-            note = "The method has potentially confusing semantics and is going to be removed, you might want `is_op_return`"
-        )]
+        #[deprecated(since = "0.32.0", note = "use `is_op_return` instead")]
         #[inline]
         fn is_provably_unspendable(&self) -> bool {
             use crate::opcodes::Class::{IllegalOp, ReturnOp};
@@ -263,7 +260,7 @@ crate::internal_macros::define_extension_trait! {
 
         /// Returns the minimum value an output with this script should have in order to be
         /// broadcastable on today’s Bitcoin network.
-        #[deprecated(since = "0.32.0", note = "use minimal_non_dust and friends")]
+        #[deprecated(since = "0.32.0", note = "use `minimal_non_dust` etc. instead")]
         fn dust_value(&self) -> crate::Amount { self.minimal_non_dust() }
 
         /// Returns the minimum value an output with this script should have in order to be
@@ -367,7 +364,7 @@ crate::internal_macros::define_extension_trait! {
         }
 
         /// Writes the human-readable assembly representation of the script to the formatter.
-        #[deprecated(since = "TBD", note = "use the script's Display impl instead")]
+        #[deprecated(since = "TBD", note = "use the script's `Display` impl instead")]
         fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
             write!(f, "{}", self)
         }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -41,7 +41,7 @@ crate::internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Txid`] type.
     pub trait TxidExt impl for Txid {
         /// The "all zeros" TXID.
-        #[deprecated(since = "TBD", note = "use Txid::COINBASE_PREVOUT instead")]
+        #[deprecated(since = "TBD", note = "use `Txid::COINBASE_PREVOUT` instead")]
         fn all_zeros() -> Self { Self::COINBASE_PREVOUT }
     }
 }
@@ -50,7 +50,7 @@ crate::internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Wtxid`] type.
     pub trait WtxidExt impl for Wtxid {
         /// The "all zeros" wTXID.
-        #[deprecated(since = "TBD", note = "use Wtxid::COINBASE instead")]
+        #[deprecated(since = "TBD", note = "use `Wtxid::COINBASE` instead")]
         fn all_zeros() -> Self { Self::COINBASE }
     }
 }
@@ -83,7 +83,7 @@ crate::internal_macros::define_extension_trait! {
 
         /// Checks if an `OutPoint` is "null".
         #[inline]
-        #[deprecated(since = "TBD", note = "use outpoint == OutPoint::COINBASE_PREVOUT instead")]
+        #[deprecated(since = "TBD", note = "use `outpoint == OutPoint::COINBASE_PREVOUT` instead")]
         fn is_null(&self) -> bool { *self == OutPoint::COINBASE_PREVOUT }
     }
 }
@@ -377,11 +377,9 @@ impl Transaction {
 
     /// Computes a "normalized TXID" which does not include any signatures.
     ///
-    /// This method is deprecated.  Use `compute_ntxid` instead.
-    #[deprecated(
-        since = "0.31.0",
-        note = "ntxid has been renamed to compute_ntxid to note that it's computationally expensive.  use compute_ntxid() instead."
-    )]
+    /// This method is deprecated.  `ntxid` has been renamed to `compute_ntxid` to note that it's
+    /// computationally expensive.  Use `compute_ntxid` instead.
+    #[deprecated(since = "0.31.0", note = "use `compute_ntxid()` instead")]
     pub fn ntxid(&self) -> sha256d::Hash { self.compute_ntxid() }
 
     /// Computes a "normalized TXID" which does not include any signatures.
@@ -409,11 +407,9 @@ impl Transaction {
 
     /// Computes the [`Txid`].
     ///
-    /// This method is deprecated.  Use `compute_txid` instead.
-    #[deprecated(
-        since = "0.31.0",
-        note = "txid has been renamed to compute_txid to note that it's computationally expensive.  use compute_txid() instead."
-    )]
+    /// This method is deprecated.  `txid` has been renamed to `compute_txid` to note that it's
+    /// computationally expensive.  Use `compute_txid` instead.
+    #[deprecated(since = "0.31.0", note = "use `compute_txid()` instead")]
     pub fn txid(&self) -> Txid { self.compute_txid() }
 
     /// Computes the [`Txid`].
@@ -433,11 +429,9 @@ impl Transaction {
 
     /// Computes the segwit version of the transaction id.
     ///
-    /// This method is deprecated.  Use `compute_wtxid` instead.
-    #[deprecated(
-        since = "0.31.0",
-        note = "wtxid has been renamed to compute_wtxid to note that it's computationally expensive.  use compute_wtxid() instead."
-    )]
+    /// This method is deprecated.  `wtxid` has been renamed to `compute_wtxid` to note that it's
+    /// computationally expensive.  Use `compute_wtxid` instead.
+    #[deprecated(since = "0.31.0", note = "use `compute_wtxid()` instead")]
     pub fn wtxid(&self) -> Wtxid { self.compute_wtxid() }
 
     /// Computes the segwit version of the transaction id.

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -296,7 +296,7 @@ impl Witness {
     pub fn to_bytes(&self) -> Vec<Vec<u8>> { self.iter().map(|s| s.to_vec()).collect() }
 
     /// Convenience method to create an array of byte-arrays from this witness.
-    #[deprecated(since = "TBD", note = "Use to_bytes instead")]
+    #[deprecated(since = "TBD", note = "use `to_bytes` instead")]
     pub fn to_vec(&self) -> Vec<Vec<u8>> { self.to_bytes() }
 
     /// Returns `true` if the witness contains no element.

--- a/bitcoin/src/crypto/ecdsa.rs
+++ b/bitcoin/src/crypto/ecdsa.rs
@@ -71,7 +71,7 @@ impl Signature {
     }
 
     /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) into `Vec`.
-    #[deprecated(since = "TBD", note = "Use to_bytes instead")]
+    #[deprecated(since = "TBD", note = "use `to_bytes` instead")]
     pub fn to_vec(self) -> Vec<u8> { self.to_bytes() }
 
     /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) to a `writer`.

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -58,7 +58,7 @@ impl Signature {
     }
 
     /// Serializes the signature.
-    #[deprecated(since = "TBD", note = "Use to_bytes instead")]
+    #[deprecated(since = "TBD", note = "use `to_bytes` instead")]
     pub fn to_vec(self) -> Vec<u8> { self.to_bytes() }
 
     /// Serializes the signature to `writer`.

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -4,7 +4,7 @@
 //!
 //! This module is deprecated. You can find hash types in their respective, hopefully obvious, modules.
 
-#[deprecated(since = "TBD", note = "use crate::T instead")]
+#[deprecated(since = "TBD", note = "use `crate::T` instead")]
 pub use crate::{
     BlockHash, FilterHash, FilterHeader, TxMerkleNode, Txid, WitnessCommitment, WitnessMerkleNode,
     Wtxid,

--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -96,7 +96,7 @@ pub struct Params {
     /// Number of blocks with the same set of rules.
     pub miner_confirmation_window: BlockInterval,
     /// Proof of work limit value. It contains the lowest possible difficulty.
-    #[deprecated(since = "0.32.0", note = "field renamed to max_attainable_target")]
+    #[deprecated(since = "0.32.0", note = "use `max_attainable_target` instead")]
     pub pow_limit: Target,
     /// The maximum **attainable** target value for these params.
     ///
@@ -129,7 +129,7 @@ pub struct Params {
 /// [using-statics-or-consts]: <https://doc.rust-lang.org/reference/items/static-items.html#using-statics-or-consts>
 pub static MAINNET: Params = Params::MAINNET;
 /// The testnet3 parameters.
-#[deprecated(since = "0.33.0", note = "Use TESTNET3 instead")]
+#[deprecated(since = "0.33.0", note = "use `TESTNET3` instead")]
 pub static TESTNET: Params = Params::TESTNET3;
 /// The testnet3 parameters.
 pub static TESTNET3: Params = Params::TESTNET3;
@@ -163,7 +163,7 @@ impl Params {
     };
 
     /// The testnet3 parameters.
-    #[deprecated(since = "0.33.0", note = "Use TESTNET3 instead")]
+    #[deprecated(since = "0.33.0", note = "use `TESTNET3` instead")]
     pub const TESTNET: Params = Params {
         network: Network::Testnet(TestnetVersion::V3),
         bip16_time: 1333238400,                      // Apr 1 2012

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -217,7 +217,7 @@ impl Magic {
     /// Bitcoin mainnet network magic bytes.
     pub const BITCOIN: Self = Self([0xF9, 0xBE, 0xB4, 0xD9]);
     /// Bitcoin testnet3 network magic bytes.
-    #[deprecated(since = "0.33.0", note = "Use TESTNET3 instead")]
+    #[deprecated(since = "0.33.0", note = "use `TESTNET3` instead")]
     pub const TESTNET: Self = Self([0x0B, 0x11, 0x09, 0x07]);
     /// Bitcoin testnet3 network magic bytes.
     pub const TESTNET3: Self = Self([0x0B, 0x11, 0x09, 0x07]);

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -286,12 +286,12 @@ impl Target {
 
     /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
     /// adjustment occurs.
-    #[deprecated(since = "0.32.0", note = "use min_transition_threshold instead")]
+    #[deprecated(since = "0.32.0", note = "use `min_transition_threshold` instead")]
     pub fn min_difficulty_transition_threshold(&self) -> Self { self.min_transition_threshold() }
 
     /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
     /// adjustment occurs.
-    #[deprecated(since = "0.32.0", note = "use max_transition_threshold instead")]
+    #[deprecated(since = "0.32.0", note = "use `max_transition_threshold` instead")]
     pub fn max_difficulty_transition_threshold(&self) -> Self {
         self.max_transition_threshold_unchecked()
     }

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -123,7 +123,7 @@ mod message_signing {
         }
 
         /// Create a `MessageSignature` from a byte slice.
-        #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
+        #[deprecated(since = "TBD", note = "use `from_byte_array` instead")]
         pub fn from_slice(bytes: &[u8]) -> Result<MessageSignature, MessageSignatureError> {
             let byte_array: [u8; 65] =
                 bytes.try_into().map_err(|_| MessageSignatureError::InvalidLength)?;

--- a/bitcoin/src/taproot/merkle_branch.rs
+++ b/bitcoin/src/taproot/merkle_branch.rs
@@ -19,7 +19,7 @@ pub struct TaprootMerkleBranch(Vec<TapNodeHash>);
 
 impl TaprootMerkleBranch {
     /// Returns a reference to the slice of hashes.
-    #[deprecated(since = "0.32.0", note = "Use `as_slice` instead")]
+    #[deprecated(since = "0.32.0", note = "use `as_slice` instead")]
     #[inline]
     pub fn as_inner(&self) -> &[TapNodeHash] { &self.0 }
 
@@ -106,7 +106,7 @@ impl TaprootMerkleBranch {
     }
 
     /// Returns the inner list of hashes.
-    #[deprecated(since = "0.32.0", note = "Use `into_vec` instead")]
+    #[deprecated(since = "0.32.0", note = "use `into_vec` instead")]
     #[inline]
     pub fn into_inner(self) -> Vec<TapNodeHash> { self.0 }
 

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -144,7 +144,7 @@ impl Hash {
     /// Computes hash from `bytes` in `const` context.
     ///
     /// Warning: this function is inefficient. It should be only used in `const` context.
-    #[deprecated(since = "TBD", note = "use Self::hash_unoptimized")]
+    #[deprecated(since = "TBD", note = "use `Self::hash_unoptimized` instead")]
     pub const fn const_hash(bytes: &[u8]) -> Self { Hash::hash_unoptimized(bytes) }
 
     /// Computes hash from `bytes` in `const` context.

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -46,7 +46,7 @@ where
     pub fn from_engine(e: HashEngine) -> Hash<T> { from_engine(e) }
 
     /// Copies a byte slice into a hash object.
-    #[deprecated(since = "TBD", note = "Use `from_byte_array` instead.")]
+    #[deprecated(since = "TBD", note = "use `from_byte_array` instead")]
     pub fn from_slice(sl: &[u8]) -> Result<Hash<T>, FromSliceError> {
         if sl.len() != 32 {
             Err(FromSliceError { expected: 32, got: sl.len() })
@@ -211,7 +211,7 @@ macro_rules! sha256t_tag {
 ///
 /// [`hash_newtype`]: crate::hash_newtype
 #[macro_export]
-#[deprecated(since = "TBD", note = "use `sha256_tag!` combined with `hash_newtype!`")]
+#[deprecated(since = "TBD", note = "use `sha256_tag!` combined with `hash_newtype!` instead")]
 macro_rules! sha256t_hash_newtype {
     ($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+); $(#[$($hash_attr:tt)*])* $hash_vis:vis struct $hash_name:ident($(#[$($field_attr:tt)*])* _);) => {
         $crate::sha256t_tag_struct!($tag_vis, $tag, stringify!($hash_name), $(#[$($tag_attr)*])*);

--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -51,10 +51,7 @@ impl Sequence {
     pub const ENABLE_LOCKTIME_NO_RBF: Self = Sequence::MIN_NO_RBF;
     /// The sequence number that enables replace-by-fee and absolute lock time but
     /// disables relative lock time.
-    #[deprecated(
-        since = "TBD",
-        note = "This constant has ambiguous name. Please use ENABLE_LOCKTIME_AND_RBF instead."
-    )]
+    #[deprecated(since = "TBD", note = "use `ENABLE_LOCKTIME_AND_RBF` instead")]
     pub const ENABLE_RBF_NO_LOCKTIME: Self = Sequence(0xFFFFFFFD);
     /// The maximum sequence number that enables replace-by-fee and absolute lock time but
     /// disables relative lock time.

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -996,7 +996,7 @@ impl Amount {
     ///
     /// Does not include the denomination.
     #[rustfmt::skip]
-    #[deprecated(since = "TBD", note = "Use `display_in()` instead")]
+    #[deprecated(since = "TBD", note = "use `display_in()` instead")]
     pub fn fmt_value_in(self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.to_sat(), false, f, denom, false, FormatOptions::default())
     }
@@ -1406,7 +1406,7 @@ impl SignedAmount {
     ///
     /// Does not include the denomination.
     #[rustfmt::skip]
-    #[deprecated(since = "TBD", note = "Use `display_in()` instead")]
+    #[deprecated(since = "TBD", note = "use `display_in()` instead")]
     pub fn fmt_value_in(self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.unsigned_abs().to_sat(), self.is_negative(), f, denom, false, FormatOptions::default())
     }


### PR DESCRIPTION
Following the suggestion in Issue #3306 all the deprecated note fields have been changed to be lower case and in the format "use `abc` instead".