### PR TITLE
Investigate the consenus traits

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.0-rc1"
+version = "0.33.0-alpha"
 dependencies = [
  "arbitrary",
  "base58ck",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.0-rc1"
+version = "0.33.0-alpha"
 dependencies = [
  "arbitrary",
  "base58ck",

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -515,7 +515,7 @@ the case and how we broke both `rust-miniscript` and BDK.
 - Refactor `CommandString`.
 - Refactor `Reject` message.
 - Rename `RejectReason` enum variants.
-- Refactor `encode::Error`.
+- Refactor `encode::DecodeFromReaderError`.
 - Implement `Default` for `TxIn`.
 - Implement `std::hash::Hash` for `Inventory`.
 - Implement `Copy` for `InvType` enum.
@@ -551,7 +551,7 @@ the case and how we broke both `rust-miniscript` and BDK.
     * Now supports segwit addresses with version >0.
     * Add `Address::from_script` constructor.
     * Add `Address::address_type` inspector.
-    * Parsing now returns an `address::Error` instead of `encode::Error`.
+    * Parsing now returns an `address::Error` instead of `encode::DecodeFromReaderError`.
     * Removed `bitcoin_bech32` dependency for bech32 payloads.
 * bip143: Rename `witness_script` to `script_code`
 * Rename `BlockHeader::spv_validate` to `validate_pow`

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.32.0-rc1"
+version = "0.33.0-alpha"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -40,7 +40,7 @@ fn main() {
         let mut stream_reader = BufReader::new(read_stream);
         loop {
             // Loop an retrieve new messages
-            let reply = message::RawNetworkMessage::consensus_decode(&mut stream_reader).unwrap();
+            let reply = message::RawNetworkMessage::consensus_decode_from_reader(&mut stream_reader).unwrap();
             match reply.payload() {
                 message::NetworkMessage::Version(_) => {
                     println!("Received version message: {:?}", reply.payload());

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -68,7 +68,7 @@ impl Header {
     /// Returns the block hash.
     pub fn block_hash(&self) -> BlockHash {
         let mut engine = sha256d::Hash::engine();
-        self.consensus_encode(&mut engine).expect("engines don't error");
+        self.consensus_encode_to_engine(&mut engine);
         BlockHash::from_byte_array(sha256d::Hash::from_engine(engine).to_byte_array())
     }
 
@@ -121,14 +121,14 @@ impl fmt::Debug for Header {
 }
 
 impl Encodable for Version {
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        self.to_consensus().consensus_encode(w)
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.to_consensus().consensus_encode_to_writer(w)
     }
 }
 
 impl Decodable for Version {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        Decodable::consensus_decode(r).map(Version::from_consensus)
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Decodable::consensus_decode_from_reader(r).map(Version::from_consensus)
     }
 }
 
@@ -217,7 +217,7 @@ impl Block {
         witness_reserved_value: &[u8],
     ) -> WitnessCommitment {
         let mut encoder = sha256d::Hash::engine();
-        witness_root.consensus_encode(&mut encoder).expect("engines don't error");
+        witness_root.consensus_encode_to_engine(&mut encoder);
         encoder.input(witness_reserved_value);
         WitnessCommitment::from_byte_array(sha256d::Hash::from_engine(encoder).to_byte_array())
     }

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -127,7 +127,7 @@ impl Encodable for Version {
 }
 
 impl Decodable for Version {
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         Decodable::consensus_decode_from_reader(r).map(Version::from_consensus)
     }
 }

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -39,7 +39,7 @@ pub mod fee_rate {
             const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
             let raw_tx = hex!(SOME_TX);
-            let tx: Transaction = Decodable::consensus_decode(&mut raw_tx.as_slice()).unwrap();
+            let tx: Transaction = Decodable::consensus_decode_from_reader(&mut raw_tx.as_slice()).unwrap();
 
             let rate = FeeRate::from_sat_per_vb(1).expect("1 sat/byte is valid");
 
@@ -66,16 +66,16 @@ pub mod locktime {
 
         impl Encodable for LockTime {
             #[inline]
-            fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+            fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
                 let v = self.to_consensus_u32();
-                v.consensus_encode(w)
+                v.consensus_encode_to_writer(w)
             }
         }
 
         impl Decodable for LockTime {
             #[inline]
-            fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-                u32::consensus_decode(r).map(LockTime::from_consensus)
+            fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+                u32::consensus_decode_from_reader(r).map(LockTime::from_consensus)
             }
         }
     }

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -74,7 +74,7 @@ pub mod locktime {
 
         impl Decodable for LockTime {
             #[inline]
-            fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+            fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
                 u32::consensus_decode_from_reader(r).map(LockTime::from_consensus)
             }
         }

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -398,11 +398,11 @@ crate::internal_macros::define_extension_trait! {
                 } else if self.is_witness_program() {
                     32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
                     8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
+                    self.consensus_encode_to_writer(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
                 } else {
                     32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
                     8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
+                    self.consensus_encode_to_writer(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
                 })
                 .expect("dust_relay_fee or script length should not be absurdly large")
                 / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -305,15 +305,15 @@ fn opcode_to_verify(opcode: Option<Opcode>) -> Option<Opcode> {
 
 impl Encodable for Script {
     #[inline]
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        crate::consensus::encode::consensus_encode_with_size(self.as_bytes(), w)
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        crate::consensus::encode::consensus_encode_to_writer_with_size(self.as_bytes(), w)
     }
 }
 
 impl Encodable for ScriptBuf {
     #[inline]
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        self.as_script().consensus_encode(w)
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.as_script().consensus_encode_to_writer(w)
     }
 }
 

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -321,7 +321,7 @@ impl Decodable for ScriptBuf {
     #[inline]
     fn consensus_decode_from_finite_reader<R: BufRead + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, encode::DecodeFromReaderError> {
         let v: Vec<u8> = Decodable::consensus_decode_from_finite_reader(r)?;
         Ok(ScriptBuf::from_bytes(v))
     }

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -136,7 +136,7 @@ pub struct Iter<'a> {
 }
 
 impl Decodable for Witness {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let witness_elements = r.read_compact_size()? as usize;
         // Minimum size of witness element is 1 byte, so if the count is
         // greater than MAX_VEC_SIZE we must return an error.
@@ -230,11 +230,11 @@ fn resize_if_needed(vec: &mut Vec<u8>, required_len: usize) {
 
 impl Encodable for Witness {
     // `self.content` includes the varints so encoding here includes them, as expected.
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut written = w.emit_compact_size(self.len())?;
 
         for element in self.iter() {
-            written += encode::consensus_encode_with_size(element, w)?
+            written += encode::consensus_encode_to_writer_with_size(element, w)?
         }
 
         Ok(written)

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -34,7 +34,7 @@ impl<E: fmt::Debug, I: Iterator<Item = Result<u8, E>>> IterReader<E, I> {
     }
 
     fn decode<T: Decodable>(mut self) -> Result<T, DecodeError<E>> {
-        let result = T::consensus_decode(&mut self);
+        let result = T::consensus_decode_from_reader(&mut self);
         match (result, self.error) {
             (Ok(_), None) if self.iterator.next().is_some() => Err(DecodeError::TooManyBytes),
             (Ok(value), None) => Ok(value),

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -159,7 +159,7 @@ struct DisplayWrapper<'a, T: 'a + Encodable, E>(&'a T, PhantomData<E>);
 impl<'a, T: 'a + Encodable, E: ByteEncoder> fmt::Display for DisplayWrapper<'a, T, E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut writer = IoWrapper::<'_, _, E::Encoder>::new(f, E::default().into());
-        self.0.consensus_encode(&mut writer).map_err(|error| {
+        self.0.consensus_encode_to_writer(&mut writer).map_err(|error| {
             #[cfg(debug_assertions)]
             {
                 if error.kind() != io::ErrorKind::Other
@@ -438,7 +438,7 @@ impl<E> With<E> {
             let serializer = serializer.serialize_seq(None)?;
             let mut writer = BinWriter { serializer, error: None };
 
-            let result = value.consensus_encode(&mut writer);
+            let result = value.consensus_encode_to_writer(&mut writer);
             match (result, writer.error) {
                 (Ok(_), None) => writer.serializer.end(),
                 (Ok(_), Some(error)) =>

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -23,7 +23,7 @@ macro_rules! impl_consensus_encoding {
             #[inline]
             fn consensus_decode_from_finite_reader<R: $crate::io::BufRead + ?Sized>(
                 r: &mut R,
-            ) -> core::result::Result<$thing, $crate::consensus::encode::Error> {
+            ) -> core::result::Result<$thing, $crate::consensus::encode::DecodeFromReaderError> {
                 Ok($thing {
                     $($field: $crate::consensus::Decodable::consensus_decode_from_finite_reader(r)?),+
                 })
@@ -32,7 +32,7 @@ macro_rules! impl_consensus_encoding {
             #[inline]
             fn consensus_decode_from_reader<R: $crate::io::BufRead + ?Sized>(
                 r: &mut R,
-            ) -> core::result::Result<$thing, $crate::consensus::encode::Error> {
+            ) -> core::result::Result<$thing, $crate::consensus::encode::DecodeFromReaderError> {
                 let mut r = r.take(internals::ToU64::to_u64($crate::consensus::encode::MAX_VEC_SIZE));
                 Ok($thing {
                     $($field: $crate::consensus::Decodable::consensus_decode_from_reader(&mut r)?),+
@@ -184,7 +184,7 @@ macro_rules! impl_hashencode {
         }
 
         impl $crate::consensus::Decodable for $hashtype {
-            fn consensus_decode_from_reader<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
+            fn consensus_decode_from_reader<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::DecodeFromReaderError> {
                 Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode_from_reader(r)?))
             }
         }

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -8,12 +8,12 @@ macro_rules! impl_consensus_encoding {
     ($thing:ident, $($field:ident),+) => (
         impl $crate::consensus::Encodable for $thing {
             #[inline]
-            fn consensus_encode<R: $crate::io::Write + ?Sized>(
+            fn consensus_encode_to_writer<R: $crate::io::Write + ?Sized>(
                 &self,
                 r: &mut R,
             ) -> core::result::Result<usize, $crate::io::Error> {
                 let mut len = 0;
-                $(len += self.$field.consensus_encode(r)?;)+
+                $(len += self.$field.consensus_encode_to_writer(r)?;)+
                 Ok(len)
             }
         }
@@ -30,12 +30,12 @@ macro_rules! impl_consensus_encoding {
             }
 
             #[inline]
-            fn consensus_decode<R: $crate::io::BufRead + ?Sized>(
+            fn consensus_decode_from_reader<R: $crate::io::BufRead + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$thing, $crate::consensus::encode::Error> {
                 let mut r = r.take(internals::ToU64::to_u64($crate::consensus::encode::MAX_VEC_SIZE));
                 Ok($thing {
-                    $($field: $crate::consensus::Decodable::consensus_decode(&mut r)?),+
+                    $($field: $crate::consensus::Decodable::consensus_decode_from_reader(&mut r)?),+
                 })
             }
         }
@@ -178,14 +178,14 @@ pub(crate) use impl_array_newtype_stringify;
 macro_rules! impl_hashencode {
     ($hashtype:ident) => {
         impl $crate::consensus::Encodable for $hashtype {
-            fn consensus_encode<W: $crate::io::Write + ?Sized>(&self, w: &mut W) -> core::result::Result<usize, $crate::io::Error> {
-                self.as_byte_array().consensus_encode(w)
+            fn consensus_encode_to_writer<W: $crate::io::Write + ?Sized>(&self, w: &mut W) -> core::result::Result<usize, $crate::io::Error> {
+                self.as_byte_array().consensus_encode_to_writer(w)
             }
         }
 
         impl $crate::consensus::Decodable for $hashtype {
-            fn consensus_decode<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
-                Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode(r)?))
+            fn consensus_decode_from_reader<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
+                Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode_from_reader(r)?))
             }
         }
     };

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -189,7 +189,7 @@ pub mod amount {
 
     impl Decodable for Amount {
         #[inline]
-        fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
             Ok(Amount::from_sat(Decodable::consensus_decode_from_reader(r)?))
         }
     }
@@ -229,7 +229,7 @@ mod encode_impls {
         ($ty:ident) => {
             impl Decodable for $ty {
                 #[inline]
-                fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+                fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
                     let inner = u32::consensus_decode_from_reader(r)?;
                     Ok($ty::from(inner))
                 }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -189,15 +189,15 @@ pub mod amount {
 
     impl Decodable for Amount {
         #[inline]
-        fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-            Ok(Amount::from_sat(Decodable::consensus_decode(r)?))
+        fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+            Ok(Amount::from_sat(Decodable::consensus_decode_from_reader(r)?))
         }
     }
 
     impl Encodable for Amount {
         #[inline]
-        fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-            self.to_sat().consensus_encode(w)
+        fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+            self.to_sat().consensus_encode_to_writer(w)
         }
     }
 }
@@ -229,20 +229,20 @@ mod encode_impls {
         ($ty:ident) => {
             impl Decodable for $ty {
                 #[inline]
-                fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-                    let inner = u32::consensus_decode(r)?;
+                fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+                    let inner = u32::consensus_decode_from_reader(r)?;
                     Ok($ty::from(inner))
                 }
             }
 
             impl Encodable for $ty {
                 #[inline]
-                fn consensus_encode<W: Write + ?Sized>(
+                fn consensus_encode_to_writer<W: Write + ?Sized>(
                     &self,
                     w: &mut W,
                 ) -> Result<usize, io::Error> {
                     let inner = self.to_u32();
-                    inner.consensus_encode(w)
+                    inner.consensus_encode_to_writer(w)
                 }
             }
         };

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -123,7 +123,7 @@ impl Encodable for MerkleBlock {
 }
 
 impl Decodable for MerkleBlock {
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         Ok(MerkleBlock {
             header: Decodable::consensus_decode_from_reader(r)?,
             txn: Decodable::consensus_decode_from_reader(r)?,
@@ -420,16 +420,16 @@ impl Encodable for PartialMerkleTree {
 impl Decodable for PartialMerkleTree {
     fn consensus_decode_from_finite_reader<R: BufRead + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, encode::DecodeFromReaderError> {
         let num_transactions: u32 = Decodable::consensus_decode_from_reader(r)?;
         let hashes: Vec<TxMerkleNode> = Decodable::consensus_decode_from_reader(r)?;
 
         let nb_bytes_for_bits = r.read_compact_size()? as usize;
         if nb_bytes_for_bits > MAX_VEC_SIZE {
-            return Err(encode::Error::OversizedVectorAllocation {
-                requested: nb_bytes_for_bits,
+            return Err(encode::OversizedVectorError {
+                size: nb_bytes_for_bits,
                 max: MAX_VEC_SIZE,
-            });
+            }.into());
         }
         let mut bits = vec![false; nb_bytes_for_bits * 8];
         for chunk in bits.chunks_mut(8) {

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -110,7 +110,7 @@ impl Encodable for CommandString {
 
 impl Decodable for CommandString {
     #[inline]
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         let rawbytes: [u8; 12] = Decodable::consensus_decode_from_reader(r)?;
         let rv = iter::FromIterator::from_iter(rawbytes.iter().filter_map(|&u| {
             if u > 0 {
@@ -410,7 +410,7 @@ impl Decodable for HeaderDeserializationWrapper {
     #[inline]
     fn consensus_decode_from_finite_reader<R: BufRead + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, encode::DecodeFromReaderError> {
         let len = r.read_compact_size()?;
         // should be above usual number of items to avoid
         // allocation
@@ -420,14 +420,14 @@ impl Decodable for HeaderDeserializationWrapper {
             if u8::consensus_decode_from_reader(r)? != 0u8 {
                 return Err(encode::Error::ParseFailed(
                     "Headers message should not contain transactions",
-                ));
+                ).into());
             }
         }
         Ok(HeaderDeserializationWrapper(ret))
     }
 
     #[inline]
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE.to_u64()))
     }
 }
@@ -435,7 +435,7 @@ impl Decodable for HeaderDeserializationWrapper {
 impl Decodable for RawNetworkMessage {
     fn consensus_decode_from_finite_reader<R: BufRead + ?Sized>(
         r: &mut R,
-    ) -> Result<Self, encode::Error> {
+    ) -> Result<Self, encode::DecodeFromReaderError> {
         let magic = Decodable::consensus_decode_from_finite_reader(r)?;
         let cmd = CommandString::consensus_decode_from_finite_reader(r)?;
         let checked_data = CheckedData::consensus_decode_from_finite_reader(r)?;
@@ -532,7 +532,7 @@ impl Decodable for RawNetworkMessage {
     }
 
     #[inline]
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE.to_u64()))
     }
 }

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -80,7 +80,7 @@ impl Encodable for Inventory {
 
 impl Decodable for Inventory {
     #[inline]
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         let inv_type: u32 = Decodable::consensus_decode_from_reader(r)?;
         Ok(match inv_type {
             0 => Inventory::Error,

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -59,10 +59,10 @@ impl Inventory {
 
 impl Encodable for Inventory {
     #[inline]
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         macro_rules! encode_inv {
             ($code:expr, $item:expr) => {
-                u32::consensus_encode(&$code, w)? + $item.consensus_encode(w)?
+                u32::consensus_encode_to_writer(&$code, w)? + $item.consensus_encode_to_writer(w)?
             };
         }
         Ok(match *self {
@@ -80,17 +80,17 @@ impl Encodable for Inventory {
 
 impl Decodable for Inventory {
     #[inline]
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        let inv_type: u32 = Decodable::consensus_decode(r)?;
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let inv_type: u32 = Decodable::consensus_decode_from_reader(r)?;
         Ok(match inv_type {
             0 => Inventory::Error,
-            1 => Inventory::Transaction(Decodable::consensus_decode(r)?),
-            2 => Inventory::Block(Decodable::consensus_decode(r)?),
-            4 => Inventory::CompactBlock(Decodable::consensus_decode(r)?),
-            5 => Inventory::WTx(Decodable::consensus_decode(r)?),
-            0x40000001 => Inventory::WitnessTransaction(Decodable::consensus_decode(r)?),
-            0x40000002 => Inventory::WitnessBlock(Decodable::consensus_decode(r)?),
-            tp => Inventory::Unknown { inv_type: tp, hash: Decodable::consensus_decode(r)? },
+            1 => Inventory::Transaction(Decodable::consensus_decode_from_reader(r)?),
+            2 => Inventory::Block(Decodable::consensus_decode_from_reader(r)?),
+            4 => Inventory::CompactBlock(Decodable::consensus_decode_from_reader(r)?),
+            5 => Inventory::WTx(Decodable::consensus_decode_from_reader(r)?),
+            0x40000001 => Inventory::WitnessTransaction(Decodable::consensus_decode_from_reader(r)?),
+            0x40000002 => Inventory::WitnessBlock(Decodable::consensus_decode_from_reader(r)?),
+            tp => Inventory::Unknown { inv_type: tp, hash: Decodable::consensus_decode_from_reader(r)? },
         })
     }
 }

--- a/bitcoin/src/p2p/message_bloom.rs
+++ b/bitcoin/src/p2p/message_bloom.rs
@@ -36,7 +36,7 @@ pub enum BloomFlags {
 }
 
 impl Encodable for BloomFlags {
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         w.write_all(&[match self {
             BloomFlags::None => 0,
             BloomFlags::All => 1,
@@ -47,7 +47,7 @@ impl Encodable for BloomFlags {
 }
 
 impl Decodable for BloomFlags {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(match r.read_u8()? {
             0 => BloomFlags::None,
             1 => BloomFlags::All,

--- a/bitcoin/src/p2p/message_bloom.rs
+++ b/bitcoin/src/p2p/message_bloom.rs
@@ -47,12 +47,12 @@ impl Encodable for BloomFlags {
 }
 
 impl Decodable for BloomFlags {
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         Ok(match r.read_u8()? {
             0 => BloomFlags::None,
             1 => BloomFlags::All,
             2 => BloomFlags::PubkeyOnly,
-            _ => return Err(encode::Error::ParseFailed("unknown bloom flag")),
+            _ => return Err(encode::Error::ParseFailed("unknown bloom flag").into()),
         })
     }
 }

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -109,14 +109,14 @@ pub enum RejectReason {
 }
 
 impl Encodable for RejectReason {
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         w.write_all(&[*self as u8])?;
         Ok(1)
     }
 }
 
 impl Decodable for RejectReason {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         Ok(match r.read_u8()? {
             0x01 => RejectReason::Malformed,
             0x10 => RejectReason::Invalid,

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -116,7 +116,7 @@ impl Encodable for RejectReason {
 }
 
 impl Decodable for RejectReason {
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         Ok(match r.read_u8()? {
             0x01 => RejectReason::Malformed,
             0x10 => RejectReason::Invalid,
@@ -126,7 +126,7 @@ impl Decodable for RejectReason {
             0x41 => RejectReason::Dust,
             0x42 => RejectReason::Fee,
             0x43 => RejectReason::Checkpoint,
-            _ => return Err(encode::Error::ParseFailed("unknown reject code")),
+            _ => return Err(encode::Error::ParseFailed("unknown reject code").into()),
         })
     }
 }

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -205,7 +205,7 @@ impl Encodable for ServiceFlags {
 
 impl Decodable for ServiceFlags {
     #[inline]
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         Ok(ServiceFlags(Decodable::consensus_decode_from_reader(r)?))
     }
 }
@@ -315,7 +315,7 @@ impl Encodable for Magic {
 }
 
 impl Decodable for Magic {
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(reader: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(reader: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         Ok(Magic(Decodable::consensus_decode_from_reader(reader)?))
     }
 }

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -198,15 +198,15 @@ impl ops::BitXorAssign for ServiceFlags {
 
 impl Encodable for ServiceFlags {
     #[inline]
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        self.0.consensus_encode(w)
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode_to_writer(w)
     }
 }
 
 impl Decodable for ServiceFlags {
     #[inline]
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        Ok(ServiceFlags(Decodable::consensus_decode(r)?))
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Ok(ServiceFlags(Decodable::consensus_decode_from_reader(r)?))
     }
 }
 /// Network magic bytes to identify the cryptocurrency network the message was intended for.
@@ -309,14 +309,14 @@ impl fmt::UpperHex for Magic {
 }
 
 impl Encodable for Magic {
-    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        self.0.consensus_encode(writer)
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode_to_writer(writer)
     }
 }
 
 impl Decodable for Magic {
-    fn consensus_decode<R: BufRead + ?Sized>(reader: &mut R) -> Result<Self, encode::Error> {
-        Ok(Magic(Decodable::consensus_decode(reader)?))
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(reader: &mut R) -> Result<Self, encode::Error> {
+        Ok(Magic(Decodable::consensus_decode_from_reader(reader)?))
     }
 }
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -436,15 +436,15 @@ impl From<CompactTarget> for Target {
 
 impl Encodable for CompactTarget {
     #[inline]
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        self.to_consensus().consensus_encode(w)
+    fn consensus_encode_to_writer<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.to_consensus().consensus_encode_to_writer(w)
     }
 }
 
 impl Decodable for CompactTarget {
     #[inline]
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        u32::consensus_decode(r).map(CompactTarget::from_consensus)
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        u32::consensus_decode_from_finite_reader(r).map(CompactTarget::from_consensus)
     }
 }
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -443,7 +443,7 @@ impl Encodable for CompactTarget {
 
 impl Decodable for CompactTarget {
     #[inline]
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         u32::consensus_decode_from_finite_reader(r).map(CompactTarget::from_consensus)
     }
 }

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -95,10 +95,10 @@ impl Psbt {
                                     // txs without witnesses are deserialized
                                     // properly.
                                     tx = Some(Transaction {
-                                        version: Decodable::consensus_decode(&mut decoder)?,
-                                        input: Decodable::consensus_decode(&mut decoder)?,
-                                        output: Decodable::consensus_decode(&mut decoder)?,
-                                        lock_time: Decodable::consensus_decode(&mut decoder)?,
+                                        version: Decodable::consensus_decode_from_reader(&mut decoder)?,
+                                        input: Decodable::consensus_decode_from_reader(&mut decoder)?,
+                                        output: Decodable::consensus_decode_from_reader(&mut decoder)?,
+                                        lock_time: Decodable::consensus_decode_from_reader(&mut decoder)?,
                                     });
 
                                     if decoder.position() != vlen.to_u64() {
@@ -131,7 +131,7 @@ impl Psbt {
                                     Error::XPubKey("can't read global xpub fingerprint")
                                 })?;
                                 let mut path = Vec::<ChildNumber>::with_capacity(child_count);
-                                while let Ok(index) = u32::consensus_decode(&mut decoder) {
+                                while let Ok(index) = u32::consensus_decode_from_reader(&mut decoder) {
                                     path.push(ChildNumber::from(index))
                                 }
                                 let derivation = DerivationPath::from(path);
@@ -160,7 +160,7 @@ impl Psbt {
                                             "invalid global version value length (must be 4 bytes)",
                                         ));
                                     }
-                                    version = Some(Decodable::consensus_decode(&mut decoder)?);
+                                    version = Some(Decodable::consensus_decode_from_reader(&mut decoder)?);
                                     // We only understand version 0 PSBTs. According to BIP-174 we
                                     // should throw an error if we see anything other than version 0.
                                     if version != Some(0) {

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -82,11 +82,10 @@ impl Key {
         let key_byte_size: u64 = byte_size - 1;
 
         if key_byte_size > MAX_VEC_SIZE.to_u64() {
-            return Err(encode::Error::OversizedVectorAllocation {
-                requested: key_byte_size as usize,
+            return Err(encode::DecodeFromReaderError::OversizedVector(encode::OversizedVectorError {
+                size: key_byte_size as usize,
                 max: MAX_VEC_SIZE,
-            }
-            .into());
+            }).into());
         }
 
         let type_value = r.read_compact_size()?;
@@ -155,7 +154,7 @@ impl<Subtype> Decodable for ProprietaryKey<Subtype>
 where
     Subtype: Copy + From<u64> + Into<u64>,
 {
-    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+    fn consensus_decode_from_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::DecodeFromReaderError> {
         let prefix = Vec::<u8>::consensus_decode_from_reader(r)?;
         let subtype = Subtype::from(r.read_compact_size()?);
 

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -92,8 +92,8 @@ impl TapLeafHash {
     /// Computes the leaf hash from components.
     pub fn from_script(script: &Script, ver: LeafVersion) -> TapLeafHash {
         let mut eng = sha256t::Hash::<TapLeafTag>::engine();
-        ver.to_consensus().consensus_encode(&mut eng).expect("engines don't error");
-        script.consensus_encode(&mut eng).expect("engines don't error");
+        ver.to_consensus().consensus_encode_to_engine(&mut eng);
+        script.consensus_encode_to_engine(&mut eng);
         let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
         TapLeafHash::from_byte_array(inner.to_byte_array())
     }


### PR DESCRIPTION
First a confession, I never really understood _exactly_ what the push decode stuff was aiming to fix, maybe this is somewhat related?

While trying to use `bitcoind-json-rpc` [0] and `miniscript` [1] to test `master` branch of this repo I hit a problem because one of our errors would not work with `anyhow`. This led me down a long dark session of hacking the consensus traits.

Specifically I was trying to run the `bitcoind-tests` from miniscript.

The glaring issue is that we provide `consensus::encode::deserialize` and friends that consensus decode objects from a slice yet they all return an I/O error.

Wouldn't it be better of we separated encode/decode to/from memory from doing so to/from a reader/writer? 

This demo PR just splits the errors, adds a couple of new trait methods, and gets things building. We could actually have all the I/O stuff feature gated but I think that would mean duplicating encode/decode logic all over the place. 

Here is the error:

<details>
  <summary>Error</summary>
  
```
error[E0277]: `UnsafeCell<()>` cannot be shared between threads safely
   --> /home/tobin/.cargo/git/checkouts/rust-bitcoind-json-rpc-875f1864b5a527be/bc746bd/regtest/src/lib.rs:554:55
    |
554 |         .map_err(|_| Error::NoBitcoindExecutableFound.into())
    |                                                       ^^^^ `UnsafeCell<()>` cannot be shared between threads safely
    |
    = help: within `Error`, the trait `Sync` is not implemented for `UnsafeCell<()>`, which is required by `Error: Into<_>`
    = note: required because it appears within the type `(&'static mut (), UnsafeCell<()>)`
note: required because it appears within the type `PhantomData<(&'static mut (), UnsafeCell<()>)>`
   --> /home/tobin/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/marker.rs:740:12
    |
740 | pub struct PhantomData<T: ?Sized>;
    |            ^^^^^^^^^^^
note: required because it appears within the type `client::bitcoin::bitcoin_io::Error`
   --> /home/tobin/.cargo/git/checkouts/rust-bitcoin-37ffe97e66ae7a9f/f37b573/io/src/error.rs:7:12
    |
7   | pub struct Error {
    |            ^^^^^
note: required because it appears within the type `client::bitcoin::consensus::encode::Error`
   --> /home/tobin/.cargo/git/checkouts/rust-bitcoin-37ffe97e66ae7a9f/f37b573/bitcoin/src/consensus/encode.rs:41:10
    |
41  | pub enum Error {
    |          ^^^^^
note: required because it appears within the type `client::bitcoin::consensus::DecodeError<InvalidCharError>`
   --> /home/tobin/.cargo/git/checkouts/rust-bitcoin-37ffe97e66ae7a9f/f37b573/bitcoin/src/consensus/mod.rs:108:10
    |
108 | pub enum DecodeError<E> {
    |          ^^^^^^^^^^^
note: required because it appears within the type `FromHexError`
   --> /home/tobin/.cargo/git/checkouts/rust-bitcoin-37ffe97e66ae7a9f/f37b573/bitcoin/src/consensus/encode.rs:108:10
    |
108 | pub enum FromHexError {
    |          ^^^^^^^^^^^^
note: required because it appears within the type `client::client_sync::Error`
   --> /home/tobin/.cargo/git/checkouts/rust-bitcoind-json-rpc-875f1864b5a527be/bc746bd/client/src/client_sync/error.rs:9:10
    |
9   | pub enum Error {
    |          ^^^^^
note: required because it appears within the type `Error`
   --> /home/tobin/.cargo/git/checkouts/rust-bitcoind-json-rpc-875f1864b5a527be/bc746bd/regtest/src/lib.rs:114:10
    |
114 | pub enum Error {
    |          ^^^^^
    = note: required for `anyhow::Error` to implement `From<Error>`
    = note: required for `Error` to implement `Into<anyhow::Error>`
```
</details>

The root cause is the `PhantomData` in our `io::Error` type.

This exact same problem exists also in `psbt::serialize::Error` and it has been a constant pain for me there also while trying to split the error type up.

Just for giggles this also adds an infallible `consensus_encode_to_engine` function and removes all the `expect("engines don't error")`.

[0] https://github.com/rust-bitcoin/rust-bitcoind-json-rpc/pull/43
[1] https://github.com/rust-bitcoin/rust-miniscript/pull/755
