### PR TITLE
Explicitly re-export stuff from crates down the stack

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -28,6 +28,8 @@ use crate::transaction::{Transaction, Wtxid};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use primitives::block::{Version, BlockHash, Header, WitnessCommitment};
+#[doc(inline)]
+pub use units::block::{BlockHeight, BlockInterval, TooBigForRelativeBlockHeightError};
 
 impl_hashencode!(BlockHash);
 

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -21,7 +21,7 @@ pub use self::{
 /// Implements `FeeRate` and assoctiated features.
 pub mod fee_rate {
     /// Re-export everything from the [`units::fee_rate`] module.
-    pub use units::fee_rate::*;
+    pub use units::fee_rate::FeeRate;
 
     #[cfg(test)]
     mod tests {
@@ -62,7 +62,7 @@ pub mod locktime {
 
         /// Re-export everything from the `primitives::locktime::absolute` module.
         #[rustfmt::skip]        // Keep public re-exports separate.
-        pub use primitives::locktime::absolute::*;
+        pub use primitives::locktime::absolute::{ConversionError, Height, LockTime, ParseHeightError, ParseTimeError, Time};
 
         impl Encodable for LockTime {
             #[inline]
@@ -87,7 +87,7 @@ pub mod locktime {
         //! whether bit 22 of the `u32` consensus value is set.
 
         /// Re-export everything from the `primitives::locktime::relative` module.
-        pub use primitives::locktime::relative::*;
+        pub use primitives::locktime::relative::{Height, LockTime, Time, TimeOverflowError, DisabledLockTimeError, IncompatibleHeightError, IncompatibleTimeError};
     }
 }
 
@@ -100,5 +100,5 @@ pub mod opcodes {
 /// Implements `Weight` and associated features.
 pub mod weight {
     /// Re-export everything from the [`units::weight`] module.
-    pub use units::weight::*;
+    pub use units::weight::Weight;
 }

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -18,7 +18,7 @@ use crate::Script;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use primitives::witness::{Witness, Iter};
+pub use primitives::witness::{Iter, Witness};
 
 impl Decodable for Witness {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -182,7 +182,10 @@ pub mod amount {
     #[rustfmt::skip]            // Keep public re-exports separate.
     #[doc(inline)]
     pub use units::amount::{
-        Amount, CheckedSum, Denomination, Display, ParseAmountError, ParseError, SignedAmount,
+        Amount, CheckedSum, Denomination, Display, InvalidCharacterError, MissingDenominationError,
+        MissingDigitsError, OutOfRangeError, ParseAmountError, ParseDenominationError, ParseError,
+        PossiblyConfusingDenominationError, SignedAmount, TooPreciseError,
+        UnknownDenominationError,
     };
     #[cfg(feature = "serde")]
     pub use units::amount::serde;

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -26,7 +26,7 @@ use crate::{Txid, Wtxid};
 #[rustfmt::skip]
 #[doc(inline)]
 pub use self::block::{MerkleBlock, MerkleBlockError, PartialMerkleTree};
-pub use primitives::merkle_tree::*;
+pub use primitives::merkle_tree::{TxMerkleNode, WitnessMerkleNode};
 
 impl_hashencode!(TxMerkleNode);
 impl_hashencode!(WitnessMerkleNode);

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -45,7 +45,14 @@ pub mod transaction;
 pub mod witness;
 
 #[doc(inline)]
-pub use units::*;
+pub use units::amount::{Amount, SignedAmount};
+#[cfg(feature = "alloc")]
+#[doc(inline)]
+pub use units::{
+    block::{BlockHeight, BlockInterval},
+    fee_rate::FeeRate,
+    weight::Weight
+};
 
 #[doc(inline)]
 pub use self::{

--- a/primitives/src/locktime/absolute.rs
+++ b/primitives/src/locktime/absolute.rs
@@ -19,7 +19,7 @@ use crate::absolute;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use units::locktime::absolute::*;
+pub use units::locktime::absolute::{ConversionError, Height, ParseHeightError, ParseTimeError, Time, LOCK_TIME_THRESHOLD};
 
 /// An absolute lock time value, representing either a block height or a UNIX timestamp (seconds
 /// since epoch).

--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -18,7 +18,7 @@ use crate::Sequence;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use units::locktime::relative::*;
+pub use units::locktime::relative::{Height, Time, TimeOverflowError};
 
 /// A relative lock time value, representing either a block height or time (512 second intervals).
 ///


### PR DESCRIPTION
Up until recently we were using wildcard re-exports for types moved to `units` and `primitives`. We have decided against doing so in favour of explicit re-exports.
    
Audit `units` and `primitives` using `git grep 'pub enum'` (and `struct`) and explicitly re-export all types.
    
Remove all wildcards except for the re-exports from `opcodes`, there are too many opcodes, explicitly re-exporting them does not aid clarity.
 
