### PR TITLE
Seal extension traits

### DIFF
--- a/bitcoin/src/address/script_pubkey.rs
+++ b/bitcoin/src/address/script_pubkey.rs
@@ -195,6 +195,13 @@ pub(super) fn new_witness_program_unchecked<T: AsRef<PushBytes>>(
     Builder::new().push_opcode(version.into()).push_slice(program).into_script()
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Script {}
+    impl Sealed for super::ScriptBuf {}
+    impl Sealed for super::Builder {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -71,6 +71,11 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Header {}
+}
+
 impl Encodable for Version {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         self.to_consensus().consensus_encode(w)

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -387,6 +387,11 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Script {}
+}
+
 crate::internal_macros::define_extension_trait! {
     pub(crate) trait ScriptExtPriv impl for Script {
         fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> crate::Amount {

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -81,6 +81,11 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::ScriptBuf {}
+}
+
 crate::internal_macros::define_extension_trait! {
     pub(crate) trait ScriptBufExtPriv impl for ScriptBuf {
         /// Pretends to convert `&mut ScriptBuf` to `&mut Vec<u8>` so that it can be modified.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -61,12 +61,6 @@ pub trait TxIdentifier: sealed::Sealed + AsRef<[u8]> {}
 impl TxIdentifier for Txid {}
 impl TxIdentifier for Wtxid {}
 
-mod sealed {
-    pub trait Sealed {}
-    impl Sealed for super::Txid {}
-    impl Sealed for super::Wtxid {}
-}
-
 /// The marker MUST be a 1-byte zero value: 0x00. (BIP-141)
 const SEGWIT_MARKER: u8 = 0x00;
 /// The flag MUST be a 1-byte non-zero value. Currently, 0x01 MUST be used. (BIP-141)
@@ -1332,6 +1326,15 @@ impl<'a> Arbitrary<'a> for Transaction {
             output: Vec::<TxOut>::arbitrary(u)?,
         })
     }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Txid {}
+    impl Sealed for super::Wtxid {}
+    impl Sealed for super::OutPoint {}
+    impl Sealed for super::TxOut {}
+    impl Sealed for super::Version {}
 }
 
 #[cfg(test)]

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -216,6 +216,11 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Witness {}
+}
+
 /// Correctness Requirements: value must always fit within u32
 // This is duplicated in `primitives::witness`, if you change it please do so over there also.
 #[inline]

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -161,6 +161,11 @@ define_extension_trait! {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Script {}
+}
+
 impl Transaction {
     /// Verifies that this transaction is able to spend its inputs.
     ///

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -252,7 +252,7 @@ macro_rules! define_extension_trait {
             fn $fn:ident$(<$($gen:ident: $gent:path),*>)?($($params:tt)*) $( -> $ret:ty )? $body:block
         )*
     }) => {
-        $(#[$($trait_attrs)*])* $trait_vis trait $trait_name {
+        $(#[$($trait_attrs)*])* $trait_vis trait $trait_name: sealed::Sealed {
             $(
                 $crate::internal_macros::only_doc_attrs! {
                     { $(#[$($fn_attrs)*])* },

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -430,6 +430,11 @@ define_extension_trait! {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::CompactTarget {}
+}
+
 impl From<CompactTarget> for Target {
     fn from(c: CompactTarget) -> Self { Target::from_compact(c) }
 }


### PR DESCRIPTION
The extension traits are temporary just while we try to stabalize `primitives`, they are not intended to be implemented by downstream.

Seal the extension traits so that downstream crates cannot implement them.

Fix: #3231