### PR TITLE
CI: Whitelist WASM job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -280,6 +280,7 @@ jobs:
 
   WASM:                         # hashes crate only.
     name: WASM - stable toolchain
+    continue-on-error: true     # wasm-bindgen-test is not currently working.
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The WASM job is not working. `wasm-pack build` works fine but `wasm-pack test` doesn't compile.

For now just whitelist the job.