### PR TITLE
CI: Hobble WASM job

### DIFF
--- a/hashes/contrib/wasm.sh
+++ b/hashes/contrib/wasm.sh
@@ -8,5 +8,6 @@ clang --version &&
     CARGO_TARGET_DIR=wasm cargo install --force wasm-pack &&
     printf '\n[target.wasm32-unknown-unknown.dev-dependencies]\nwasm-bindgen-test = "0.3"\n' >> Cargo.toml &&
     printf '\n[lib]\ncrate-type = ["cdylib", "rlib"]\n' >> Cargo.toml &&
-    CC=clang-9 wasm-pack build &&
-    CC=clang-9 wasm-pack test --node;
+    CC=clang-9 wasm-pack build;
+# wasm-pack test isn't currently working.
+#    CC=clang-9 wasm-pack test --node;


### PR DESCRIPTION
The WASM job is not working. `wasm-pack build` works fine but `wasm-pack test` doesn't compile.

Comment out the line that runs `wasm-pack test`.