### PR TITLE
Move `Transaction` to `primitives` 

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -34,6 +34,7 @@ use std::fmt;
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
 use bitcoin::consensus::encode;
+use bitcoin::consensus_validation::TransactionExt as _;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::{self, Input, Psbt, PsbtSighashType};
 use bitcoin::script::ScriptBufExt as _;

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -80,6 +80,7 @@ use std::collections::BTreeMap;
 use bitcoin::address::script_pubkey::{BuilderExt as _, ScriptBufExt as _};
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::consensus::encode;
+use bitcoin::consensus_validation::TransactionExt as _;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
 use bitcoin::psbt::{self, Input, Output, Psbt, PsbtSighashType};

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -803,8 +803,8 @@ impl Address<NetworkUnchecked> {
 
     /// Parse a bech32 Address string
     pub fn from_bech32_str(s: &str) -> Result<Address<NetworkUnchecked>, Bech32Error> {
-        let (hrp, witness_version, data) = bech32::segwit::decode(s)
-            .map_err(|e| Bech32Error::ParseBech32(ParseBech32Error(e)))?;
+        let (hrp, witness_version, data) =
+            bech32::segwit::decode(s).map_err(|e| Bech32Error::ParseBech32(ParseBech32Error(e)))?;
         let version = WitnessVersion::try_from(witness_version.to_u8())?;
         let program = WitnessProgram::new(version, &data)
             .expect("bech32 guarantees valid program length for witness");

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -23,7 +23,7 @@ use crate::network::Params;
 use crate::pow::{Target, Work};
 use crate::prelude::Vec;
 use crate::script::{self, ScriptExt as _};
-use crate::transaction::{Transaction, Wtxid};
+use crate::transaction::{Transaction, TransactionExt as _, Wtxid};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -87,7 +87,10 @@ pub mod locktime {
         //! whether bit 22 of the `u32` consensus value is set.
 
         /// Re-export everything from the `primitives::locktime::relative` module.
-        pub use primitives::locktime::relative::{Height, LockTime, Time, TimeOverflowError, DisabledLockTimeError, IncompatibleHeightError, IncompatibleTimeError};
+        pub use primitives::locktime::relative::{
+            DisabledLockTimeError, Height, IncompatibleHeightError, IncompatibleTimeError,
+            LockTime, Time, TimeOverflowError,
+        };
     }
 }
 

--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -34,7 +34,7 @@ pub mod fee_rate {
             use hex::test_hex_unwrap as hex;
 
             use crate::consensus::Decodable;
-            use crate::transaction::Transaction;
+            use crate::transaction::{Transaction, TransactionExt as _};
 
             const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -340,7 +340,7 @@ impl Transaction {
     ///
     /// Hashes the transaction **including** all segwit data (i.e. the marker, flag bytes, and the
     /// witness fields themselves). For non-segwit transactions which do not have any segwit data,
-    /// this will be equal to [`Transaction::txid()`].
+    /// this will be equal to [`Transaction::compute_txid()`].
     #[doc(alias = "wtxid")]
     pub fn compute_wtxid(&self) -> Wtxid {
         let hash = hash_transaction(self, self.uses_segwit_serialization());

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -501,8 +501,8 @@ impl Transaction {
     /// This is useful in combination with [`predict_weight`] if you have the transaction already
     /// constructed with a dummy value in the fee output which you'll adjust after calculating the
     /// weight.
-    pub fn script_pubkey_lens(&self) -> impl Iterator<Item = usize> + '_ {
-        self.output.iter().map(|txout| txout.script_pubkey.len())
+    pub fn script_pubkey_lens(&self) -> TxOutToScriptPubkeyLengthIter {
+        TxOutToScriptPubkeyLengthIter { inner: self.output.iter() }
     }
 
     /// Counts the total number of sigops.
@@ -543,6 +543,18 @@ impl Transaction {
             .get(output_index)
             .ok_or(IndexOutOfBoundsError { index: output_index, length: self.output.len() }.into())
     }
+}
+
+/// Iterates over transaction outputs and for each output yields the length of the scriptPubkey.
+// This exists to hardcode the type of the closure crated by `map`.
+pub struct TxOutToScriptPubkeyLengthIter<'a> {
+    inner: core::slice::Iter<'a, TxOut>,
+}
+
+impl Iterator for TxOutToScriptPubkeyLengthIter<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> { self.inner.next().map(|txout| txout.script_pubkey.len()) }
 }
 
 impl Transaction {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -10,10 +10,8 @@
 //!
 //! This module provides the structures and functions needed to support transactions.
 
-use core::{cmp, fmt};
+use core::fmt;
 
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 use hashes::sha256d;
 use internals::{compact_size, write_err, ToU64};
 use io::{BufRead, Write};
@@ -32,7 +30,7 @@ use crate::{Amount, FeeRate, SignedAmount};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(inline)]
-pub use primitives::transaction::{OutPoint, ParseOutPointError, Txid, Wtxid, Version, TxIn, TxOut};
+pub use primitives::transaction::{OutPoint, ParseOutPointError, Transaction, Txid, Wtxid, Version, TxIn, TxOut};
 
 impl_hashencode!(Txid);
 impl_hashencode!(Wtxid);
@@ -61,6 +59,7 @@ pub trait TxIdentifier: sealed::Sealed + AsRef<[u8]> {}
 impl TxIdentifier for Txid {}
 impl TxIdentifier for Wtxid {}
 
+// Duplicated in `primitives`.
 /// The marker MUST be a 1-byte zero value: 0x00. (BIP-141)
 const SEGWIT_MARKER: u8 = 0x00;
 /// The flag MUST be a 1-byte non-zero value. Currently, 0x01 MUST be used. (BIP-141)
@@ -209,143 +208,6 @@ crate::internal_macros::define_extension_trait! {
 fn size_from_script_pubkey(script_pubkey: &Script) -> usize {
     let len = script_pubkey.len();
     Amount::SIZE + compact_size::encoded_size(len) + len
-}
-
-/// Bitcoin transaction.
-///
-/// An authenticated movement of coins.
-///
-/// See [Bitcoin Wiki: Transaction][wiki-transaction] for more information.
-///
-/// [wiki-transaction]: https://en.bitcoin.it/wiki/Transaction
-///
-/// ### Bitcoin Core References
-///
-/// * [CTtransaction definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L279)
-///
-/// ### Serialization notes
-///
-/// If any inputs have nonempty witnesses, the entire transaction is serialized
-/// in the post-BIP141 Segwit format which includes a list of witnesses. If all
-/// inputs have empty witnesses, the transaction is serialized in the pre-BIP141
-/// format.
-///
-/// There is one major exception to this: to avoid deserialization ambiguity,
-/// if the transaction has no inputs, it is serialized in the BIP141 style. Be
-/// aware that this differs from the transaction format in PSBT, which _never_
-/// uses BIP141. (Ordinarily there is no conflict, since in PSBT transactions
-/// are always unsigned and therefore their inputs have empty witnesses.)
-///
-/// The specific ambiguity is that Segwit uses the flag bytes `0001` where an old
-/// serializer would read the number of transaction inputs. The old serializer
-/// would interpret this as "no inputs, one output", which means the transaction
-/// is invalid, and simply reject it. Segwit further specifies that this encoding
-/// should *only* be used when some input has a nonempty witness; that is,
-/// witness-less transactions should be encoded in the traditional format.
-///
-/// However, in protocols where transactions may legitimately have 0 inputs, e.g.
-/// when parties are cooperatively funding a transaction, the "00 means Segwit"
-/// heuristic does not work. Since Segwit requires such a transaction be encoded
-/// in the original transaction format (since it has no inputs and therefore
-/// no input witnesses), a traditionally encoded transaction may have the `0001`
-/// Segwit flag in it, which confuses most Segwit parsers including the one in
-/// Bitcoin Core.
-///
-/// We therefore deviate from the spec by always using the Segwit witness encoding
-/// for 0-input transactions, which results in unambiguously parseable transactions.
-///
-/// ### A note on ordering
-///
-/// This type implements `Ord`, even though it contains a locktime, which is not
-/// itself `Ord`. This was done to simplify applications that may need to hold
-/// transactions inside a sorted container. We have ordered the locktimes based
-/// on their representation as a `u32`, which is not a semantically meaningful
-/// order, and therefore the ordering on `Transaction` itself is not semantically
-/// meaningful either.
-///
-/// The ordering is, however, consistent with the ordering present in this library
-/// before this change, so users should not notice any breakage (here) when
-/// transitioning from 0.29 to 0.30.
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Transaction {
-    /// The protocol version, is currently expected to be 1, 2 (BIP 68) or 3 (BIP 431).
-    pub version: Version,
-    /// Block height or timestamp. Transaction cannot be included in a block until this height/time.
-    ///
-    /// ### Relevant BIPs
-    ///
-    /// * [BIP-65 OP_CHECKLOCKTIMEVERIFY](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
-    /// * [BIP-113 Median time-past as endpoint for lock-time calculations](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki)
-    pub lock_time: absolute::LockTime,
-    /// List of transaction inputs.
-    pub input: Vec<TxIn>,
-    /// List of transaction outputs.
-    pub output: Vec<TxOut>,
-}
-
-impl cmp::PartialOrd for Transaction {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> { Some(self.cmp(other)) }
-}
-impl cmp::Ord for Transaction {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.version
-            .cmp(&other.version)
-            .then(self.lock_time.to_consensus_u32().cmp(&other.lock_time.to_consensus_u32()))
-            .then(self.input.cmp(&other.input))
-            .then(self.output.cmp(&other.output))
-    }
-}
-
-impl Transaction {
-    // https://github.com/bitcoin/bitcoin/blob/44b05bf3fef2468783dcebf651654fdd30717e7e/src/policy/policy.h#L27
-    /// Maximum transaction weight for Bitcoin Core 25.0.
-    pub const MAX_STANDARD_WEIGHT: Weight = Weight::from_wu(400_000);
-
-    /// Computes a "normalized TXID" which does not include any signatures.
-    ///
-    /// This gives a way to identify a transaction that is "the same" as
-    /// another in the sense of having same inputs and outputs.
-    #[doc(alias = "ntxid")]
-    pub fn compute_ntxid(&self) -> sha256d::Hash {
-        let cloned_tx = Transaction {
-            version: self.version,
-            lock_time: self.lock_time,
-            input: self
-                .input
-                .iter()
-                .map(|txin| TxIn {
-                    script_sig: ScriptBuf::new(),
-                    witness: Witness::default(),
-                    ..*txin
-                })
-                .collect(),
-            output: self.output.clone(),
-        };
-        cloned_tx.compute_txid().into()
-    }
-
-    /// Computes the [`Txid`].
-    ///
-    /// Hashes the transaction **excluding** the segwit data (i.e. the marker, flag bytes, and the
-    /// witness fields themselves). For non-segwit transactions which do not have any segwit data,
-    /// this will be equal to [`Transaction::compute_wtxid()`].
-    #[doc(alias = "txid")]
-    pub fn compute_txid(&self) -> Txid {
-        let hash = hash_transaction(self, false);
-        Txid::from_byte_array(hash.to_byte_array())
-    }
-
-    /// Computes the segwit version of the transaction id.
-    ///
-    /// Hashes the transaction **including** all segwit data (i.e. the marker, flag bytes, and the
-    /// witness fields themselves). For non-segwit transactions which do not have any segwit data,
-    /// this will be equal to [`Transaction::compute_txid()`].
-    #[doc(alias = "wtxid")]
-    pub fn compute_wtxid(&self) -> Wtxid {
-        let hash = hash_transaction(self, self.uses_segwit_serialization());
-        Wtxid::from_byte_array(hash.to_byte_array())
-    }
 }
 
 /// Extension functionality for the [`Transaction`] type.
@@ -704,6 +566,7 @@ impl TransactionExtPriv for Transaction {
     }
 
     /// Returns whether or not to serialize transaction as specified in BIP-144.
+    // This is duplicated in `primitives`, if you change it please do so in both places.
     fn uses_segwit_serialization(&self) -> bool {
         if self.input.iter().any(|input| !input.witness.is_empty()) {
             return true;
@@ -712,64 +575,6 @@ impl TransactionExtPriv for Transaction {
         // `Transaction` docs for full explanation).
         self.input.is_empty()
     }
-}
-
-// This is equivalent to consensus encoding but hashes the fields manually.
-fn hash_transaction(tx: &Transaction, uses_segwit_serialization: bool) -> sha256d::Hash {
-    use hashes::HashEngine as _;
-
-    let mut enc = sha256d::Hash::engine();
-    enc.input(&tx.version.0.to_le_bytes()); // Same as `encode::emit_i32`.
-
-    if uses_segwit_serialization {
-        // BIP-141 (segwit) transaction serialization also includes marker and flag.
-        enc.input(&[SEGWIT_MARKER]);
-        enc.input(&[SEGWIT_FLAG]);
-    }
-
-    // Encode inputs (excluding witness data) with leading compact size encoded int.
-    let input_len = tx.input.len();
-    enc.input(compact_size::encode(input_len).as_slice());
-    for input in &tx.input {
-        // Encode each input same as we do in `Encodable for TxIn`.
-        enc.input(input.previous_output.txid.as_byte_array());
-        enc.input(&input.previous_output.vout.to_le_bytes());
-
-        let script_sig_bytes = input.script_sig.as_bytes();
-        enc.input(compact_size::encode(script_sig_bytes.len()).as_slice());
-        enc.input(script_sig_bytes);
-
-        enc.input(&input.sequence.0.to_le_bytes())
-    }
-
-    // Encode outputs with leading compact size encoded int.
-    let output_len = tx.output.len();
-    enc.input(compact_size::encode(output_len).as_slice());
-    for output in &tx.output {
-        // Encode each output same as we do in `Encodable for TxOut`.
-        enc.input(&output.value.to_sat().to_le_bytes());
-
-        let script_pubkey_bytes = output.script_pubkey.as_bytes();
-        enc.input(compact_size::encode(script_pubkey_bytes.len()).as_slice());
-        enc.input(script_pubkey_bytes);
-    }
-
-    if uses_segwit_serialization {
-        // BIP-141 (segwit) transaction serialization also includes the witness data.
-        for input in &tx.input {
-            // Same as `Encodable for Witness`.
-            enc.input(compact_size::encode(input.witness.len()).as_slice());
-            for element in input.witness.iter() {
-                enc.input(compact_size::encode(element.len()).as_slice());
-                enc.input(element);
-            }
-        }
-    }
-
-    // Same as `Encodable for absolute::LockTime`.
-    enc.input(&tx.lock_time.to_consensus_u32().to_le_bytes());
-
-    sha256d::Hash::from_engine(enc)
 }
 
 /// Error attempting to do an out of bounds access on the transaction inputs vector.
@@ -973,22 +778,6 @@ impl Decodable for Transaction {
             })
         }
     }
-}
-
-impl From<Transaction> for Txid {
-    fn from(tx: Transaction) -> Txid { tx.compute_txid() }
-}
-
-impl From<&Transaction> for Txid {
-    fn from(tx: &Transaction) -> Txid { tx.compute_txid() }
-}
-
-impl From<Transaction> for Wtxid {
-    fn from(tx: Transaction) -> Wtxid { tx.compute_wtxid() }
-}
-
-impl From<&Transaction> for Wtxid {
-    fn from(tx: &Transaction) -> Wtxid { tx.compute_wtxid() }
 }
 
 /// Computes the value of an output accounting for the cost of spending it.
@@ -1355,20 +1144,6 @@ impl InputWeightPrediction {
     /// not counting the prevout (txid, index), sequence, potential witness flag bytes or the witness count varint.
     pub const fn weight(&self) -> Weight {
         Weight::from_wu_usize(self.script_size * 4 + self.witness_size)
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for Transaction {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        use primitives::absolute::LockTime;
-
-        Ok(Transaction {
-            version: Version::arbitrary(u)?,
-            lock_time: LockTime::arbitrary(u)?,
-            input: Vec::<TxIn>::arbitrary(u)?,
-            output: Vec::<TxOut>::arbitrary(u)?,
-        })
     }
 }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -2146,7 +2146,7 @@ mod benches {
     use io::sink;
     use test::{black_box, Bencher};
 
-    use super::Transaction;
+    use super::*;
     use crate::consensus::{deserialize, Encodable};
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -304,13 +304,6 @@ impl Transaction {
 
     /// Computes a "normalized TXID" which does not include any signatures.
     ///
-    /// This method is deprecated.  `ntxid` has been renamed to `compute_ntxid` to note that it's
-    /// computationally expensive.  Use `compute_ntxid` instead.
-    #[deprecated(since = "0.31.0", note = "use `compute_ntxid()` instead")]
-    pub fn ntxid(&self) -> sha256d::Hash { self.compute_ntxid() }
-
-    /// Computes a "normalized TXID" which does not include any signatures.
-    ///
     /// This gives a way to identify a transaction that is "the same" as
     /// another in the sense of having same inputs and outputs.
     #[doc(alias = "ntxid")]
@@ -334,13 +327,6 @@ impl Transaction {
 
     /// Computes the [`Txid`].
     ///
-    /// This method is deprecated.  `txid` has been renamed to `compute_txid` to note that it's
-    /// computationally expensive.  Use `compute_txid` instead.
-    #[deprecated(since = "0.31.0", note = "use `compute_txid()` instead")]
-    pub fn txid(&self) -> Txid { self.compute_txid() }
-
-    /// Computes the [`Txid`].
-    ///
     /// Hashes the transaction **excluding** the segwit data (i.e. the marker, flag bytes, and the
     /// witness fields themselves). For non-segwit transactions which do not have any segwit data,
     /// this will be equal to [`Transaction::compute_wtxid()`].
@@ -352,13 +338,6 @@ impl Transaction {
 
     /// Computes the segwit version of the transaction id.
     ///
-    /// This method is deprecated.  `wtxid` has been renamed to `compute_wtxid` to note that it's
-    /// computationally expensive.  Use `compute_wtxid` instead.
-    #[deprecated(since = "0.31.0", note = "use `compute_wtxid()` instead")]
-    pub fn wtxid(&self) -> Wtxid { self.compute_wtxid() }
-
-    /// Computes the segwit version of the transaction id.
-    ///
     /// Hashes the transaction **including** all segwit data (i.e. the marker, flag bytes, and the
     /// witness fields themselves). For non-segwit transactions which do not have any segwit data,
     /// this will be equal to [`Transaction::txid()`].
@@ -367,6 +346,29 @@ impl Transaction {
         let hash = hash_transaction(self, self.uses_segwit_serialization());
         Wtxid::from_byte_array(hash.to_byte_array())
     }
+}
+
+impl Transaction {
+    /// Computes a "normalized TXID" which does not include any signatures.
+    ///
+    /// This method is deprecated.  `ntxid` has been renamed to `compute_ntxid` to note that it's
+    /// computationally expensive.  Use `compute_ntxid` instead.
+    #[deprecated(since = "0.31.0", note = "use `compute_ntxid()` instead")]
+    pub fn ntxid(&self) -> sha256d::Hash { self.compute_ntxid() }
+
+    /// Computes the [`Txid`].
+    ///
+    /// This method is deprecated.  `txid` has been renamed to `compute_txid` to note that it's
+    /// computationally expensive.  Use `compute_txid` instead.
+    #[deprecated(since = "0.31.0", note = "use `compute_txid()` instead")]
+    pub fn txid(&self) -> Txid { self.compute_txid() }
+
+    /// Computes the segwit version of the transaction id.
+    ///
+    /// This method is deprecated.  `wtxid` has been renamed to `compute_wtxid` to note that it's
+    /// computationally expensive.  Use `compute_wtxid` instead.
+    #[deprecated(since = "0.31.0", note = "use `compute_wtxid()` instead")]
+    pub fn wtxid(&self) -> Wtxid { self.compute_wtxid() }
 
     /// Returns the weight of this transaction, as defined by BIP-141.
     ///
@@ -526,6 +528,24 @@ impl Transaction {
         cost.saturating_add(self.count_witness_sigops(&mut spent))
     }
 
+    /// Returns a reference to the input at `input_index` if it exists.
+    #[inline]
+    pub fn tx_in(&self, input_index: usize) -> Result<&TxIn, InputsIndexError> {
+        self.input
+            .get(input_index)
+            .ok_or(IndexOutOfBoundsError { index: input_index, length: self.input.len() }.into())
+    }
+
+    /// Returns a reference to the output at `output_index` if it exists.
+    #[inline]
+    pub fn tx_out(&self, output_index: usize) -> Result<&TxOut, OutputsIndexError> {
+        self.output
+            .get(output_index)
+            .ok_or(IndexOutOfBoundsError { index: output_index, length: self.output.len() }.into())
+    }
+}
+
+impl Transaction {
     /// Gets the sigop count.
     ///
     /// Counts sigops for this transaction's input scriptSigs and output scriptPubkeys i.e., doesn't
@@ -627,22 +647,6 @@ impl Transaction {
         // To avoid serialization ambiguity, no inputs means we use BIP141 serialization (see
         // `Transaction` docs for full explanation).
         self.input.is_empty()
-    }
-
-    /// Returns a reference to the input at `input_index` if it exists.
-    #[inline]
-    pub fn tx_in(&self, input_index: usize) -> Result<&TxIn, InputsIndexError> {
-        self.input
-            .get(input_index)
-            .ok_or(IndexOutOfBoundsError { index: input_index, length: self.input.len() }.into())
-    }
-
-    /// Returns a reference to the output at `output_index` if it exists.
-    #[inline]
-    pub fn tx_out(&self, output_index: usize) -> Result<&TxOut, OutputsIndexError> {
-        self.output
-            .get(output_index)
-            .ok_or(IndexOutOfBoundsError { index: output_index, length: self.output.len() }.into())
     }
 }
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1509,7 +1509,6 @@ mod tests {
     use crate::consensus::deserialize;
     use crate::locktime::absolute;
     use crate::script::ScriptBufExt as _;
-    use crate::taproot::TapTweakHashExt as _;
 
     extern crate serde_json;
 
@@ -1826,6 +1825,8 @@ mod tests {
     #[test]
     fn bip_341_sighash_tests() {
         use hex::DisplayHex;
+
+        use crate::taproot::TapTweakHashExt as _;
 
         fn sighash_deser_numeric<'de, D>(deserializer: D) -> Result<TapSighashType, D::Error>
         where

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -23,6 +23,7 @@ use crate::address::script_pubkey::ScriptExt as _;
 use crate::consensus::{encode, Encodable};
 use crate::prelude::{Borrow, BorrowMut, String, ToOwned, Vec};
 use crate::taproot::{LeafVersion, TapLeafHash, TapLeafTag, TAPROOT_ANNEX_PREFIX};
+use crate::transaction::TransactionExt as _;
 use crate::witness::Witness;
 use crate::{transaction, Amount, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut};
 

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -27,7 +27,7 @@ use crate::key::{TapTweak, XOnlyPublicKey};
 use crate::prelude::{btree_map, BTreeMap, BTreeSet, Borrow, Box, Vec};
 use crate::script::ScriptExt as _;
 use crate::sighash::{self, EcdsaSighashType, Prevouts, SighashCache};
-use crate::transaction::{self, Transaction, TxOut};
+use crate::transaction::{self, Transaction, TransactionExt as _, TxOut};
 use crate::{Amount, FeeRate, TapLeafHash, TapSighashType};
 
 #[rustfmt::skip]                // Keep public re-exports separate.

--- a/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
@@ -1,3 +1,4 @@
+use bitcoin::transaction::TransactionExt as _;
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: CC0-1.0
 
 //! SipHash 2-4 implementation.

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -51,7 +51,7 @@ pub use units::amount::{Amount, SignedAmount};
 pub use units::{
     block::{BlockHeight, BlockInterval},
     fee_rate::FeeRate,
-    weight::Weight
+    weight::Weight,
 };
 
 #[doc(inline)]


### PR DESCRIPTION
First introduce the `Transaction` extension traits manually (without using the `define_extension_trait` macro) then move the `Transaction` to `primitives`.

Note please patch 5, ugly due to language requirements.