### PR TITLE
psbt: Fix bug in Subtype consensus_encode

### DIFF
--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -143,8 +143,8 @@ where
     Subtype: Copy + From<u64> + Into<u64>,
 {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        let mut len = self.prefix.consensus_encode(w)? + 1;
-        w.emit_compact_size(self.subtype.into())?;
+        let mut len = self.prefix.consensus_encode(w)?;
+        len += w.emit_compact_size(self.subtype.into())?;
         w.write_all(&self.key)?;
         len += self.key.len();
         Ok(len)


### PR DESCRIPTION
In #2906 we switched from using a `u8` for type keys to using a `u64` and encoding as a compact int (inline with the spec). Note that a `u8` encodes to the same bytes as a `u64` when the value is < 252.

In that patch, I introduced a bug because the length returned by `PoprietaryKey::consensus_encode` uses a hard code 1 for the length of the encoding (because of single byte) instead of the variable length for the new compact encoding.

Bug showed up in fuzzing, and was isolated by Jamil - mad props.

Fix: #3501