### PR TITLE
Add API for extracting the inner payload of RawNetworkMessage

### DIFF
--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -311,6 +311,11 @@ impl RawNetworkMessage {
         Self { magic, payload, payload_len, checksum }
     }
 
+    /// Consumes the [RawNetworkMessage] instance and returns the inner payload.
+    pub fn into_payload(self) -> NetworkMessage {
+        self.payload
+    }
+
     /// The actual message data
     pub fn payload(&self) -> &NetworkMessage { &self.payload }
 


### PR DESCRIPTION
> I'd like to take out the `payload` of RawNetworkMessage and then send it to the actual network message processor, but finds there is no way to do it. This commit adds such an API to expose the owned value of inner `payload`.

Quoted from original author, but as they said this would be a nice-to-have