### PR TITLE
Release tracking PR: `chacha20-poly1305` v0.1.0

### DIFF
--- a/chacha20_poly1305/CHANGELOG.md
+++ b/chacha20_poly1305/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 - 2024-10-28
+
+* Initial release to create the chacha20-poly1305 crate.


### PR DESCRIPTION
The initial release for the `chacha20-poly1305` crate. No other preparation needed for release since the version, `v0.1.0`, is already set in Cargo.toml.