### PR TITLE
Remove unused import

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -8,7 +8,6 @@
 //!
 
 use hashes::{sha256d, Hash};
-use hex_lit::hex;
 use internals::impl_array_newtype;
 
 use crate::blockdata::block::{self, Block};


### PR DESCRIPTION
This is not a direct backport but we did this fix on master already. Just remove the import statement to shoosh the linter.