### PR TITLE
Replace `Amount` with `Value`

### DIFF
--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -31,8 +31,8 @@ use bitcoin::psbt::Input;
 use bitcoin::secp256k1::{Secp256k1, Signing};
 use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
-    consensus, transaction, Address, Amount, EcdsaSighashType, Network, OutPoint, Psbt, ScriptBuf,
-    Sequence, Transaction, TxIn, TxOut, Txid, WPubkeyHash, Witness,
+    consensus, transaction, Address, EcdsaSighashType, Network, OutPoint, Psbt, ScriptBuf,
+    Sequence, Transaction, TxIn, TxOut, Txid, Value, WPubkeyHash, Witness,
 };
 
 // The master xpriv, from which we derive the keys we control.
@@ -45,13 +45,13 @@ const BIP84_DERIVATION_PATH: &str = "m/84'/0'/0'";
 // The master fingerprint of the master xpriv.
 const MASTER_FINGERPRINT: &str = "9680603f";
 
-// The dummy UTXO amounts we are spending.
-const DUMMY_UTXO_AMOUNT_INPUT_1: Amount = Amount::from_sat(20_000_000);
-const DUMMY_UTXO_AMOUNT_INPUT_2: Amount = Amount::from_sat(10_000_000);
+// The dummy UTXO values we are spending.
+const DUMMY_UTXO_VALUE_INPUT_1: Value = Value::from_sat(20_000_000);
+const DUMMY_UTXO_VALUE_INPUT_2: Value = Value::from_sat(10_000_000);
 
-// The amounts we are sending to someone, and receiving back as change.
-const SPEND_AMOUNT: Amount = Amount::from_sat(25_000_000);
-const CHANGE_AMOUNT: Amount = Amount::from_sat(4_990_000); // 10_000 sat fee.
+// The values we are sending to someone, and receiving back as change.
+const SPEND_VALUE: Value = Value::from_sat(25_000_000);
+const CHANGE_VALUE: Value = Value::from_sat(4_990_000); // 10_000 sat fee.
 
 // Derive the external address xpriv.
 fn get_external_address_xpriv<C: Signing>(
@@ -106,7 +106,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
         vout: 0,
     };
 
-    let utxo_1 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
+    let utxo_1 = TxOut { value: DUMMY_UTXO_VALUE_INPUT_1, script_pubkey: script_pubkey_1 };
 
     let script_pubkey_2 = "bc1qy7swwpejlw7a2rp774pa8rymh8tw3xvd2x2xkd"
         .parse::<Address<_>>()
@@ -120,7 +120,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
         vout: 1,
     };
 
-    let utxo_2 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_2, script_pubkey: script_pubkey_2 };
+    let utxo_2 = TxOut { value: DUMMY_UTXO_VALUE_INPUT_2, script_pubkey: script_pubkey_2 };
     vec![(out_point_1, utxo_1), (out_point_2, utxo_2)]
 }
 
@@ -162,11 +162,11 @@ fn main() {
         .collect();
 
     // The spend output is locked to a key controlled by the receiver.
-    let spend = TxOut { value: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
+    let spend = TxOut { value: SPEND_VALUE, script_pubkey: address.script_pubkey() };
 
     // The change output is locked to a key controlled by us.
     let change = TxOut {
-        value: CHANGE_AMOUNT,
+        value: CHANGE_VALUE,
         script_pubkey: ScriptBuf::new_p2wpkh(pk_change.wpubkey_hash()), // Change comes back to us.
     };
 

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -1,7 +1,7 @@
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
 use bitcoin::script::ScriptExt as _;
 use bitcoin::{
-    consensus, ecdsa, sighash, Amount, CompressedPublicKey, Script, ScriptBuf, Transaction,
+    consensus, ecdsa, sighash, CompressedPublicKey, Script, ScriptBuf, Transaction, Value,
 };
 use hex_lit::hex;
 
@@ -43,7 +43,7 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, value: u64) {
 
     let mut cache = sighash::SighashCache::new(&tx);
     let sighash = cache
-        .p2wpkh_signature_hash(inp_idx, &spk, Amount::from_sat(value), sig.sighash_type)
+        .p2wpkh_signature_hash(inp_idx, &spk, Value::from_sat(value), sig.sighash_type)
         .expect("failed to compute sighash");
     println!("Segwit p2wpkh sighash: {:x}", sighash);
     let msg = secp256k1::Message::from(sighash);
@@ -125,12 +125,7 @@ fn compute_sighash_p2wsh(raw_tx: &[u8], inp_idx: usize, value: u64) {
         assert!((70..=72).contains(&sig_len), "signature length {} out of bounds", sig_len);
         //here we assume that all sighash_flags are the same. Can they be different?
         let sighash = cache
-            .p2wsh_signature_hash(
-                inp_idx,
-                witness_script,
-                Amount::from_sat(value),
-                sig.sighash_type,
-            )
+            .p2wsh_signature_hash(inp_idx, witness_script, Value::from_sat(value), sig.sighash_type)
             .expect("failed to compute sighash");
         println!("Segwit p2wsh sighash: {:x} ({})", sighash, sig.sighash_type);
     }

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -8,13 +8,13 @@ use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};
 use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
-    transaction, Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
-    Txid, WPubkeyHash, Witness,
+    transaction, Address, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
+    Value, WPubkeyHash, Witness,
 };
 
-const DUMMY_UTXO_AMOUNT: Amount = Amount::from_sat(20_000_000);
-const SPEND_AMOUNT: Amount = Amount::from_sat(5_000_000);
-const CHANGE_AMOUNT: Amount = Amount::from_sat(14_999_000); // 1000 sat fee.
+const DUMMY_UTXO_VALUE: Value = Value::from_sat(20_000_000);
+const SPEND_VALUE: Value = Value::from_sat(5_000_000);
+const CHANGE_VALUE: Value = Value::from_sat(14_999_000); // 1000 sat fee.
 
 fn main() {
     let secp = Secp256k1::new();
@@ -39,11 +39,11 @@ fn main() {
     };
 
     // The spend output is locked to a key controlled by the receiver.
-    let spend = TxOut { value: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
+    let spend = TxOut { value: SPEND_VALUE, script_pubkey: address.script_pubkey() };
 
     // The change output is locked to a key controlled by us.
     let change = TxOut {
-        value: CHANGE_AMOUNT,
+        value: CHANGE_VALUE,
         script_pubkey: ScriptBuf::new_p2wpkh(wpkh), // Change comes back to us.
     };
 
@@ -63,7 +63,7 @@ fn main() {
         .p2wpkh_signature_hash(
             input_index,
             &dummy_utxo.script_pubkey,
-            DUMMY_UTXO_AMOUNT,
+            DUMMY_UTXO_VALUE,
             sighash_type,
         )
         .expect("failed to create sighash");
@@ -124,7 +124,7 @@ fn dummy_unspent_transaction_output(wpkh: WPubkeyHash) -> (OutPoint, TxOut) {
         vout: 0,
     };
 
-    let utxo = TxOut { value: DUMMY_UTXO_AMOUNT, script_pubkey };
+    let utxo = TxOut { value: DUMMY_UTXO_VALUE, script_pubkey };
 
     (out_point, utxo)
 }

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -9,13 +9,13 @@ use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing, Verificat
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
 use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
-    transaction, Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
-    Txid, Witness,
+    transaction, Address, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
+    Value, Witness,
 };
 
-const DUMMY_UTXO_AMOUNT: Amount = Amount::from_sat(20_000_000);
-const SPEND_AMOUNT: Amount = Amount::from_sat(5_000_000);
-const CHANGE_AMOUNT: Amount = Amount::from_sat(14_999_000); // 1000 sat fee.
+const DUMMY_UTXO_VALUE: Value = Value::from_sat(20_000_000);
+const SPEND_VALUE: Value = Value::from_sat(5_000_000);
+const CHANGE_VALUE: Value = Value::from_sat(14_999_000); // 1000 sat fee.
 
 fn main() {
     let secp = Secp256k1::new();
@@ -40,11 +40,11 @@ fn main() {
     };
 
     // The spend output is locked to a key controlled by the receiver.
-    let spend = TxOut { value: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
+    let spend = TxOut { value: SPEND_VALUE, script_pubkey: address.script_pubkey() };
 
     // The change output is locked to a key controlled by us.
     let change = TxOut {
-        value: CHANGE_AMOUNT,
+        value: CHANGE_VALUE,
         script_pubkey: ScriptBuf::new_p2tr(&secp, internal_key, None), // Change comes back to us.
     };
 
@@ -124,7 +124,7 @@ fn dummy_unspent_transaction_output<C: Verification>(
         vout: 0,
     };
 
-    let utxo = TxOut { value: DUMMY_UTXO_AMOUNT, script_pubkey };
+    let utxo = TxOut { value: DUMMY_UTXO_VALUE, script_pubkey };
 
     (out_point, utxo)
 }

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -30,8 +30,8 @@ use bitcoin::psbt::Input;
 use bitcoin::secp256k1::{Secp256k1, Signing};
 use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
-    consensus, transaction, Address, Amount, Network, OutPoint, Psbt, ScriptBuf, Sequence,
-    TapLeafHash, TapSighashType, Transaction, TxIn, TxOut, Txid, Witness, XOnlyPublicKey,
+    consensus, transaction, Address, Network, OutPoint, Psbt, ScriptBuf, Sequence, TapLeafHash,
+    TapSighashType, Transaction, TxIn, TxOut, Txid, Value, Witness, XOnlyPublicKey,
 };
 
 // The master xpriv, from which we derive the keys we control.
@@ -44,13 +44,13 @@ const BIP86_DERIVATION_PATH: &str = "m/86'/0'/0'";
 // The master fingerprint of the master xpriv.
 const MASTER_FINGERPRINT: &str = "9680603f";
 
-// The dummy UTXO amounts we are spending.
-const DUMMY_UTXO_AMOUNT_INPUT_1: Amount = Amount::from_sat(20_000_000);
-const DUMMY_UTXO_AMOUNT_INPUT_2: Amount = Amount::from_sat(10_000_000);
+// The dummy UTXO values we are spending.
+const DUMMY_UTXO_VALUE_INPUT_1: Value = Value::from_sat(20_000_000);
+const DUMMY_UTXO_VALUE_INPUT_2: Value = Value::from_sat(10_000_000);
 
-// The amounts we are sending to someone, and receiving back as change.
-const SPEND_AMOUNT: Amount = Amount::from_sat(25_000_000);
-const CHANGE_AMOUNT: Amount = Amount::from_sat(4_990_000); // 10_000 sat fee.
+// The values we are sending to someone, and receiving back as change.
+const SPEND_VALUE: Value = Value::from_sat(25_000_000);
+const CHANGE_VALUE: Value = Value::from_sat(4_990_000); // 10_000 sat fee.
 
 // Derive the external address xpriv.
 fn get_external_address_xpriv<C: Signing>(
@@ -116,7 +116,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
         vout: 0,
     };
 
-    let utxo_1 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
+    let utxo_1 = TxOut { value: DUMMY_UTXO_VALUE_INPUT_1, script_pubkey: script_pubkey_1 };
 
     let script_pubkey_2 = "bc1pfd0jmmdnp278vppcw68tkkmquxtq50xchy7f6wdmjtjm7fgsr8dszdcqce"
         .parse::<Address<_>>()
@@ -130,7 +130,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
         vout: 1,
     };
 
-    let utxo_2 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_2, script_pubkey: script_pubkey_2 };
+    let utxo_2 = TxOut { value: DUMMY_UTXO_VALUE_INPUT_2, script_pubkey: script_pubkey_2 };
     vec![(out_point_1, utxo_1), (out_point_2, utxo_2)]
 }
 
@@ -182,11 +182,11 @@ fn main() {
         .collect();
 
     // The spend output is locked to a key controlled by the receiver.
-    let spend = TxOut { value: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
+    let spend = TxOut { value: SPEND_VALUE, script_pubkey: address.script_pubkey() };
 
     // The change output is locked to a key controlled by us.
     let change = TxOut {
-        value: CHANGE_AMOUNT,
+        value: CHANGE_VALUE,
         script_pubkey: ScriptBuf::new_p2tr(&secp, pk_change, None), // Change comes back to us.
     };
 

--- a/bitcoin/src/amount.rs
+++ b/bitcoin/src/amount.rs
@@ -2,10 +2,21 @@
 
 //! Bitcoin amounts.
 //!
-//! This module mainly introduces the [`Amount`] and [`SignedAmount`] types.
+//! Bitcoin amounts are useful for interacting with humans i.e., displaying and reading strings.
+//! Machines (and robots) are better off using sats, hence the type used in transaction outputs is
+//! `Value` not [`Amount`]. Also a UTXO can never have negative value however the [`SignedAmount`]
+//! is at times useful, so we provide it.
+//!
+//! # Examples
+//!
+//! ````
+//! # use bitcoin::Amount;
+//! let _ = "1 BTC".parse::<Amount>().unwrap();
+//! let _ = format!("{}", Amount::ONE_BTC);
+//! ````
+//!
 //! We refer to the documentation on the types for more information.
 
-#[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
 use core::cmp::Ordering;
 use core::str::FromStr;
@@ -18,7 +29,6 @@ use arbitrary::{Arbitrary, Unstructured};
 use internals::error::InputString;
 use internals::write_err;
 
-#[cfg(feature = "alloc")]
 use crate::{FeeRate, Weight};
 
 /// A set of denominations in which amounts can be expressed.
@@ -39,7 +49,7 @@ use crate::{FeeRate, Weight};
 /// # Examples
 ///
 /// ```
-/// # use bitcoin_units::Amount;
+/// # use bitcoin::Amount;
 ///
 /// assert_eq!("1 BTC".parse::<Amount>().unwrap(), Amount::from_sat(100_000_000));
 /// assert_eq!("1 cBTC".parse::<Amount>().unwrap(), Amount::from_sat(1_000_000));
@@ -890,7 +900,6 @@ impl Amount {
     pub const fn to_sat(self) -> u64 { self.0 }
 
     /// Converts from a value expressing bitcoins to an [`Amount`].
-    #[cfg(feature = "alloc")]
     pub fn from_btc(btc: f64) -> Result<Amount, ParseAmountError> {
         Amount::from_float_in(btc, Denomination::Bitcoin)
     }
@@ -934,7 +943,6 @@ impl Amount {
     /// Expresses this [`Amount`] as a floating-point value in the given denomination.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    #[cfg(feature = "alloc")]
     pub fn to_float_in(self, denom: Denomination) -> f64 {
         self.to_string_in(denom).parse::<f64>().unwrap()
     }
@@ -946,11 +954,10 @@ impl Amount {
     /// # Examples
     ///
     /// ```
-    /// # use bitcoin_units::amount::{Amount, Denomination};
+    /// # use bitcoin::amount::{Amount, Denomination};
     /// let amount = Amount::from_sat(100_000);
     /// assert_eq!(amount.to_btc(), amount.to_float_in(Denomination::Bitcoin))
     /// ```
-    #[cfg(feature = "alloc")]
     pub fn to_btc(self) -> f64 { self.to_float_in(Denomination::Bitcoin) }
 
     /// Converts this [`Amount`] in floating-point notation with a given
@@ -961,7 +968,6 @@ impl Amount {
     /// If the amount is too big, too precise or negative.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    #[cfg(feature = "alloc")]
     pub fn from_float_in(value: f64, denom: Denomination) -> Result<Amount, ParseAmountError> {
         if value < 0.0 {
             return Err(OutOfRangeError::negative().into());
@@ -1004,12 +1010,10 @@ impl Amount {
     /// Returns a formatted string of this [`Amount`] in the given denomination.
     ///
     /// Does not include the denomination.
-    #[cfg(feature = "alloc")]
     pub fn to_string_in(self, denom: Denomination) -> String { self.display_in(denom).to_string() }
 
     /// Returns a formatted string of this [`Amount`] in the given denomination,
     /// suffixed with the abbreviation for the denomination.
-    #[cfg(feature = "alloc")]
     pub fn to_string_with_denomination(self, denom: Denomination) -> String {
         self.display_in(denom).show_denomination().to_string()
     }
@@ -1049,7 +1053,6 @@ impl Amount {
     /// sufficient.  If you wish to round-down, use the unchecked version instead.
     ///
     /// [`None`] is returned if an overflow occurred.
-    #[cfg(feature = "alloc")]
     pub fn checked_div_by_weight(self, rhs: Weight) -> Option<FeeRate> {
         let sats = self.0.checked_mul(1000)?;
         let wu = rhs.to_wu();
@@ -1316,7 +1319,6 @@ impl SignedAmount {
     pub const fn to_sat(self) -> i64 { self.0 }
 
     /// Convert from a value expressing bitcoins to an [`SignedAmount`].
-    #[cfg(feature = "alloc")]
     pub fn from_btc(btc: f64) -> Result<SignedAmount, ParseAmountError> {
         SignedAmount::from_float_in(btc, Denomination::Bitcoin)
     }
@@ -1350,7 +1352,6 @@ impl SignedAmount {
     /// Express this [`SignedAmount`] as a floating-point value in the given denomination.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    #[cfg(feature = "alloc")]
     pub fn to_float_in(self, denom: Denomination) -> f64 {
         self.to_string_in(denom).parse::<f64>().unwrap()
     }
@@ -1360,7 +1361,6 @@ impl SignedAmount {
     /// Equivalent to `to_float_in(Denomination::Bitcoin)`.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    #[cfg(feature = "alloc")]
     pub fn to_btc(self) -> f64 { self.to_float_in(Denomination::Bitcoin) }
 
     /// Convert this [`SignedAmount`] in floating-point notation with a given
@@ -1371,7 +1371,6 @@ impl SignedAmount {
     /// If the amount is too big, too precise or negative.
     ///
     /// Please be aware of the risk of using floating-point numbers.
-    #[cfg(feature = "alloc")]
     pub fn from_float_in(
         value: f64,
         denom: Denomination,
@@ -1414,12 +1413,10 @@ impl SignedAmount {
     /// Get a string number of this [`SignedAmount`] in the given denomination.
     ///
     /// Does not include the denomination.
-    #[cfg(feature = "alloc")]
     pub fn to_string_in(self, denom: Denomination) -> String { self.display_in(denom).to_string() }
 
     /// Get a formatted string of this [`SignedAmount`] in the given denomination,
     /// suffixed with the abbreviation for the denomination.
-    #[cfg(feature = "alloc")]
     pub fn to_string_with_denomination(self, denom: Denomination) -> String {
         self.display_in(denom).show_denomination().to_string()
     }
@@ -1721,11 +1718,11 @@ pub mod serde {
     //!
     //! ```rust,ignore
     //! use serde::{Serialize, Deserialize};
-    //! use bitcoin_units::Amount;
+    //! use bitcoin::Amount;
     //!
     //! #[derive(Serialize, Deserialize)]
     //! pub struct HasAmount {
-    //!     #[serde(with = "bitcoin_units::amount::serde::as_btc")]
+    //!     #[serde(with = "bitcoin::amount::serde::as_btc")]
     //!     pub amount: Amount,
     //! }
     //! ```
@@ -1734,18 +1731,14 @@ pub mod serde {
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    #[cfg(feature = "alloc")]
-    use super::Denomination;
-    use super::{Amount, ParseAmountError, SignedAmount};
+    use super::{Amount, Denomination, ParseAmountError, SignedAmount};
 
     /// This trait is used only to avoid code duplication and naming collisions
     /// of the different serde serialization crates.
     pub trait SerdeAmount: Copy + Sized {
         fn ser_sat<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error>;
         fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error>;
-        #[cfg(feature = "alloc")]
         fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error>;
-        #[cfg(feature = "alloc")]
         fn des_btc<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error>;
     }
 
@@ -1758,7 +1751,6 @@ pub mod serde {
     pub trait SerdeAmountForOpt: Copy + Sized + SerdeAmount {
         fn type_prefix(_: private::Token) -> &'static str;
         fn ser_sat_opt<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error>;
-        #[cfg(feature = "alloc")]
         fn ser_btc_opt<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error>;
     }
 
@@ -1791,11 +1783,9 @@ pub mod serde {
         fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
             Ok(Amount::from_sat(u64::deserialize(d)?))
         }
-        #[cfg(feature = "alloc")]
         fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {
             f64::serialize(&self.to_float_in(Denomination::Bitcoin), s)
         }
-        #[cfg(feature = "alloc")]
         fn des_btc<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
             use serde::de::Error;
             Amount::from_btc(f64::deserialize(d)?)
@@ -1809,7 +1799,6 @@ pub mod serde {
         fn ser_sat_opt<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {
             s.serialize_some(&self.to_sat())
         }
-        #[cfg(feature = "alloc")]
         fn ser_btc_opt<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {
             s.serialize_some(&self.to_btc())
         }
@@ -1822,11 +1811,9 @@ pub mod serde {
         fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
             Ok(SignedAmount::from_sat(i64::deserialize(d)?))
         }
-        #[cfg(feature = "alloc")]
         fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {
             f64::serialize(&self.to_float_in(Denomination::Bitcoin), s)
         }
-        #[cfg(feature = "alloc")]
         fn des_btc<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
             use serde::de::Error;
             SignedAmount::from_btc(f64::deserialize(d)?)
@@ -1840,7 +1827,6 @@ pub mod serde {
         fn ser_sat_opt<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {
             s.serialize_some(&self.to_sat())
         }
-        #[cfg(feature = "alloc")]
         fn ser_btc_opt<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {
             s.serialize_some(&self.to_btc())
         }
@@ -1864,7 +1850,7 @@ pub mod serde {
         }
 
         pub mod opt {
-            //! Serialize and deserialize [`Option<Amount>`](crate::Amount) as real numbers denominated in satoshi.
+            //! Serialize and deserialize [`Option<Amount>`] as real numbers denominated in satoshi.
             //! Use with `#[serde(default, with = "amount::serde::as_sat::opt")]`.
 
             use core::fmt;
@@ -1915,7 +1901,6 @@ pub mod serde {
         }
     }
 
-    #[cfg(feature = "alloc")]
     pub mod as_btc {
         //! Serialize and deserialize [`Amount`](crate::Amount) as JSON numbers denominated in BTC.
         //! Use with `#[serde(with = "amount::serde::as_btc")]`.
@@ -2109,7 +2094,6 @@ mod verification {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "alloc")]
     use alloc::format;
     #[cfg(feature = "std")]
     use std::panic;
@@ -2117,7 +2101,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(feature = "alloc")]
     fn from_str_zero() {
         let denoms = ["BTC", "mBTC", "uBTC", "bits", "sats"];
         for denom in denoms {
@@ -2238,7 +2221,6 @@ mod tests {
         assert_eq!(ssat(-6).checked_div(2), Some(ssat(-3)));
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn amount_checked_div_by_weight() {
         let weight = Weight::from_kwu(1).unwrap();
@@ -2287,7 +2269,6 @@ mod tests {
         assert_eq!(signed_amt, SignedAmount::MAX);
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn floating_point() {
         use super::Denomination as D;
@@ -2365,9 +2346,7 @@ mod tests {
             p("0.000.000", btc),
             Err(E::from(InvalidCharacterError { invalid_char: '.', position: 5 }))
         );
-        #[cfg(feature = "alloc")]
         let more_than_max = format!("1{}", Amount::MAX);
-        #[cfg(feature = "alloc")]
         assert_eq!(p(&more_than_max, btc), Err(OutOfRangeError::too_big(false).into()));
         assert_eq!(p("0.000000042", btc), Err(TooPreciseError { position: 10 }.into()));
         assert_eq!(p("1.0000000", sat), Ok(Amount::from_sat(1)));
@@ -2378,7 +2357,6 @@ mod tests {
 
         assert_eq!(p("1", btc), Ok(Amount::from_sat(1_000_000_00)));
         assert_eq!(sp("-.5", btc), Ok(SignedAmount::from_sat(-500_000_00)));
-        #[cfg(feature = "alloc")]
         assert_eq!(sp(&i64::MIN.to_string(), sat), Ok(SignedAmount::from_sat(i64::MIN)));
         assert_eq!(p("1.1", btc), Ok(Amount::from_sat(1_100_000_00)));
         assert_eq!(p("100", sat), Ok(Amount::from_sat(100)));
@@ -2392,7 +2370,6 @@ mod tests {
         );
 
         // make sure satoshi > i64::MAX is checked.
-        #[cfg(feature = "alloc")]
         {
             let amount = Amount::from_sat(i64::MAX as u64);
             assert_eq!(Amount::from_str_in(&amount.to_string_in(sat), sat), Ok(amount));
@@ -2415,7 +2392,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
     fn to_string() {
         use super::Denomination as D;
 
@@ -2438,7 +2414,6 @@ mod tests {
     }
 
     // May help identify a problem sooner
-    #[cfg(feature = "alloc")]
     #[test]
     fn test_repeat_char() {
         let mut buf = String::new();
@@ -2454,7 +2429,6 @@ mod tests {
         ($denom:ident; $($test_name:ident, $val:literal, $format_string:literal, $expected:literal);* $(;)?) => {
             $(
                 #[test]
-                #[cfg(feature = "alloc")]
                 fn $test_name() {
                     assert_eq!(format!($format_string, Amount::from_sat($val).display_in(Denomination::$denom)), $expected);
                     assert_eq!(format!($format_string, SignedAmount::from_sat($val as i64).display_in(Denomination::$denom)), $expected);
@@ -2467,7 +2441,6 @@ mod tests {
         ($denom:ident, $denom_suffix:literal; $($test_name:ident, $val:literal, $format_string:literal, $expected:literal);* $(;)?) => {
             $(
                 #[test]
-                #[cfg(feature = "alloc")]
                 fn $test_name() {
                     assert_eq!(format!($format_string, Amount::from_sat($val).display_in(Denomination::$denom).show_denomination()), concat!($expected, $denom_suffix));
                     assert_eq!(format!($format_string, SignedAmount::from_sat($val as i64).display_in(Denomination::$denom).show_denomination()), concat!($expected, $denom_suffix));
@@ -2694,11 +2667,9 @@ mod tests {
         ok_scase("-5 satoshi", SignedAmount::from_sat(-5));
         ok_case("0.10000000 BTC", Amount::from_sat(100_000_00));
         ok_scase("-100 bits", SignedAmount::from_sat(-10_000));
-        #[cfg(feature = "alloc")]
         ok_scase(&format!("{} SAT", i64::MIN), SignedAmount::from_sat(i64::MIN));
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
     fn to_from_string_in() {
@@ -2755,7 +2726,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn to_string_with_denomination_from_str_roundtrip() {
         use ParseDenominationError::*;
@@ -2805,7 +2775,6 @@ mod tests {
     }
 
     #[cfg(feature = "serde")]
-    #[cfg(feature = "alloc")]
     #[test]
     #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
     fn serde_as_btc() {
@@ -2844,7 +2813,6 @@ mod tests {
     }
 
     #[cfg(feature = "serde")]
-    #[cfg(feature = "alloc")]
     #[test]
     #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
     fn serde_as_btc_opt() {
@@ -2886,7 +2854,6 @@ mod tests {
     }
 
     #[cfg(feature = "serde")]
-    #[cfg(feature = "alloc")]
     #[test]
     #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
     fn serde_as_sat_opt() {
@@ -3015,7 +2982,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
     fn trailing_zeros_for_amount() {
         assert_eq!(format!("{}", Amount::from_sat(1000000)), "0.01 BTC");
         assert_eq!(format!("{}", Amount::ONE_SAT), "0.00000001 BTC");

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -407,9 +407,9 @@ mod test {
     use crate::locktime::absolute;
     use crate::merkle_tree::TxMerkleNode;
     use crate::transaction::OutPointExt;
+    use crate::value::ONE_SAT;
     use crate::{
-        transaction, Amount, CompactTarget, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Txid,
-        Witness,
+        transaction, CompactTarget, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Txid, Witness,
     };
 
     fn dummy_tx(nonce: &[u8]) -> Transaction {
@@ -423,7 +423,7 @@ mod test {
                 sequence: Sequence(1),
                 witness: Witness::new(),
             }],
-            output: vec![TxOut { value: Amount::ONE_SAT, script_pubkey: ScriptBuf::new() }],
+            output: vec![TxOut { value: ONE_SAT, script_pubkey: ScriptBuf::new() }],
         }
     }
 

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -17,7 +17,7 @@ use crate::opcodes::all::*;
 use crate::pow::CompactTarget;
 use crate::transaction::{self, OutPoint, Transaction, TxIn, TxOut};
 use crate::witness::Witness;
-use crate::{script, Amount, BlockHash, Sequence, TestnetVersion};
+use crate::{script, BlockHash, Sequence, TestnetVersion, Value};
 
 /// How many seconds between blocks we expect on average.
 pub const TARGET_BLOCK_SPACING: u32 = 600;
@@ -113,7 +113,7 @@ fn bitcoin_genesis_tx(params: &Params) -> Transaction {
         witness: Witness::default(),
     });
 
-    ret.output.push(TxOut { value: Amount::from_sat(50 * 100_000_000), script_pubkey: out_script });
+    ret.output.push(TxOut { value: Value::from_sat(50 * 100_000_000), script_pubkey: out_script });
 
     // end
     ret
@@ -266,6 +266,7 @@ mod test {
     use super::*;
     use crate::consensus::encode::serialize;
     use crate::network::params;
+    use crate::value::FIFTY_BTC;
     use crate::Txid;
 
     #[test]
@@ -283,7 +284,7 @@ mod test {
         assert_eq!(gen.output.len(), 1);
         assert_eq!(serialize(&gen.output[0].script_pubkey),
                    hex!("434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"));
-        assert_eq!(gen.output[0].value, "50 BTC".parse::<Amount>().unwrap());
+        assert_eq!(gen.output[0].value, FIFTY_BTC);
         assert_eq!(gen.lock_time, absolute::LockTime::ZERO);
 
         assert_eq!(

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -15,7 +15,7 @@ use crate::opcodes::{self, Opcode};
 use crate::policy::DUST_RELAY_TX_FEE;
 use crate::prelude::{sink, DisplayHex, String, ToString};
 use crate::taproot::{LeafVersion, TapLeafHash, TapLeafHashExt as _};
-use crate::FeeRate;
+use crate::{FeeRate, Value};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(inline)]
@@ -261,7 +261,7 @@ crate::internal_macros::define_extension_trait! {
         /// Returns the minimum value an output with this script should have in order to be
         /// broadcastable on today’s Bitcoin network.
         #[deprecated(since = "0.32.0", note = "use `minimal_non_dust` etc. instead")]
-        fn dust_value(&self) -> crate::Amount { self.minimal_non_dust() }
+        fn dust_value(&self) -> Value { self.minimal_non_dust() }
 
         /// Returns the minimum value an output with this script should have in order to be
         /// broadcastable on today's Bitcoin network.
@@ -272,7 +272,7 @@ crate::internal_macros::define_extension_trait! {
         /// To use a custom value, use [`minimal_non_dust_custom`].
         ///
         /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
-        fn minimal_non_dust(&self) -> crate::Amount {
+        fn minimal_non_dust(&self) -> Value {
             self.minimal_non_dust_internal(DUST_RELAY_TX_FEE.into())
         }
 
@@ -287,7 +287,7 @@ crate::internal_macros::define_extension_trait! {
         /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
         ///
         /// [`minimal_non_dust`]: Script::minimal_non_dust
-        fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
+        fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> Value {
             self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu() * 4)
         }
 
@@ -394,7 +394,7 @@ mod sealed {
 
 crate::internal_macros::define_extension_trait! {
     pub(crate) trait ScriptExtPriv impl for Script {
-        fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> crate::Amount {
+        fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> Value {
             // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
             // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
             let sats = dust_relay_fee
@@ -414,7 +414,7 @@ crate::internal_macros::define_extension_trait! {
                         // Note: We ensure the division happens at the end, since Core performs the division at the end.
                         //       This will make sure none of the implicit floor operations mess with the value.
 
-            crate::Amount::from_sat(sats)
+            Value::from_sat(sats)
         }
 
         fn count_sigops_internal(&self, accurate: bool) -> usize {

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -9,7 +9,7 @@ use crate::address::script_pubkey::{
 };
 use crate::consensus::encode::{deserialize, serialize};
 use crate::crypto::key::{PublicKey, XOnlyPublicKey};
-use crate::FeeRate;
+use crate::{FeeRate, Value};
 
 #[test]
 #[rustfmt::skip]
@@ -678,7 +678,7 @@ fn test_bitcoinconsensus() {
     let spent_bytes = hex!("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d");
     let spent = Script::from_bytes(&spent_bytes);
     let spending = hex!("010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000");
-    spent.verify(0, crate::Amount::from_sat(18393430), &spending).unwrap();
+    spent.verify(0, Value::from_sat(18393430), &spending).unwrap();
 }
 
 #[test]
@@ -687,10 +687,10 @@ fn defult_dust_value_tests() {
     // well-known scriptPubKey types.
     let script_p2wpkh = Builder::new().push_int_unchecked(0).push_slice([42; 20]).into_script();
     assert!(script_p2wpkh.is_p2wpkh());
-    assert_eq!(script_p2wpkh.minimal_non_dust(), crate::Amount::from_sat(294));
+    assert_eq!(script_p2wpkh.minimal_non_dust(), Value::from_sat(294));
     assert_eq!(
         script_p2wpkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
-        crate::Amount::from_sat(588)
+        Value::from_sat(588)
     );
 
     let script_p2pkh = Builder::new()
@@ -701,10 +701,10 @@ fn defult_dust_value_tests() {
         .push_opcode(OP_CHECKSIG)
         .into_script();
     assert!(script_p2pkh.is_p2pkh());
-    assert_eq!(script_p2pkh.minimal_non_dust(), crate::Amount::from_sat(546));
+    assert_eq!(script_p2pkh.minimal_non_dust(), Value::from_sat(546));
     assert_eq!(
         script_p2pkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
-        crate::Amount::from_sat(1092)
+        Value::from_sat(1092)
     );
 }
 

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -20,8 +20,10 @@ use hashes::{sha256, sha256d, GeneralHash, Hash};
 use hex::DisplayHex as _;
 use internals::{compact_size, ToU64};
 use io::{BufRead, Cursor, Read, Write};
+use units::Value;
 
 use super::IterReader;
+use crate::amount::Amount;
 use crate::bip152::{PrefilledTransaction, ShortId};
 use crate::bip158::{FilterHash, FilterHeader};
 use crate::block::{self, BlockHash};
@@ -722,6 +724,32 @@ tuple_encode!(T0, T1, T2, T3, T4);
 tuple_encode!(T0, T1, T2, T3, T4, T5);
 tuple_encode!(T0, T1, T2, T3, T4, T5, T6);
 tuple_encode!(T0, T1, T2, T3, T4, T5, T6, T7);
+
+impl Decodable for Amount {
+    #[inline]
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        Ok(Amount::from_sat(Decodable::consensus_decode(r)?))
+    }
+}
+
+impl Encodable for Amount {
+    #[inline]
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.to_sat().consensus_encode(w)
+    }
+}
+
+impl Encodable for Value {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.to_sat().consensus_encode(w)
+    }
+}
+
+impl Decodable for Value {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
+        Ok(Self::from_sat(<u64>::consensus_decode(r)?))
+    }
+}
 
 impl Encodable for sha256d::Hash {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -7,8 +7,8 @@
 use core::fmt;
 
 use internals::write_err;
+use units::Value;
 
-use crate::amount::Amount;
 use crate::consensus::encode;
 #[cfg(doc)]
 use crate::consensus_validation;
@@ -31,7 +31,7 @@ use crate::transaction::{OutPoint, Transaction, TxOut};
 pub fn verify_script(
     script: &Script,
     index: usize,
-    amount: Amount,
+    amount: Value,
     spending_tx: &[u8],
 ) -> Result<(), BitcoinconsensusError> {
     verify_script_with_flags(
@@ -56,7 +56,7 @@ pub fn verify_script(
 pub fn verify_script_with_flags<F: Into<u32>>(
     script: &Script,
     index: usize,
-    amount: Amount,
+    amount: Value,
     spending_tx: &[u8],
     flags: F,
 ) -> Result<(), BitcoinconsensusError> {
@@ -133,7 +133,7 @@ define_extension_trait! {
         fn verify(
             &self,
             index: usize,
-            amount: crate::Amount,
+            amount: Value,
             spending_tx: &[u8],
         ) -> Result<(), BitcoinconsensusError> {
             verify_script(self, index, amount, spending_tx)
@@ -152,7 +152,7 @@ define_extension_trait! {
         fn verify_with_flags(
             &self,
             index: usize,
-            amount: crate::Amount,
+            amount: Value,
             spending_tx: &[u8],
             flags: impl Into<u32>,
         ) -> Result<(), BitcoinconsensusError> {

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -96,6 +96,7 @@ mod serde_utils;
 #[macro_use]
 pub mod p2p;
 pub mod address;
+pub mod amount;
 pub mod bip152;
 pub mod bip158;
 pub mod bip32;
@@ -113,6 +114,7 @@ pub mod pow;
 pub mod psbt;
 pub mod sign_message;
 pub mod taproot;
+pub mod value;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -142,6 +144,7 @@ pub use crate::{
     psbt::Psbt,
     sighash::{EcdsaSighashType, TapSighashType},
     taproot::{TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash, TapTweakHash, TapTweakTag},
+    value::Value,
 };
 #[doc(inline)]
 pub use primitives::Sequence;
@@ -168,41 +171,6 @@ mod prelude {
     pub use crate::io::sink;
 
     pub use hex::DisplayHex;
-}
-
-pub mod amount {
-    //! Bitcoin amounts.
-    //!
-    //! This module mainly introduces the [Amount] and [SignedAmount] types.
-    //! We refer to the documentation on the types for more information.
-
-    use crate::consensus::{encode, Decodable, Encodable};
-    use crate::io::{BufRead, Write};
-
-    #[rustfmt::skip]            // Keep public re-exports separate.
-    #[doc(inline)]
-    pub use units::amount::{
-        Amount, CheckedSum, Denomination, Display, InvalidCharacterError, MissingDenominationError,
-        MissingDigitsError, OutOfRangeError, ParseAmountError, ParseDenominationError, ParseError,
-        PossiblyConfusingDenominationError, SignedAmount, TooPreciseError,
-        UnknownDenominationError,
-    };
-    #[cfg(feature = "serde")]
-    pub use units::amount::serde;
-
-    impl Decodable for Amount {
-        #[inline]
-        fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-            Ok(Amount::from_sat(Decodable::consensus_decode(r)?))
-        }
-    }
-
-    impl Encodable for Amount {
-        #[inline]
-        fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-            self.to_sat().consensus_encode(w)
-        }
-    }
 }
 
 /// Unit parsing utilities.

--- a/bitcoin/src/value.rs
+++ b/bitcoin/src/value.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin value.
+//!
+//! Provides the [`Value`] type, this is mainly for machine usage. If you are interacting with
+//! humans consider using the [`Amount`] type.
+//!
+//! [`Amount`]: crate::Amount
+
+use crate::{FeeRate, Weight};
+
+#[rustfmt::skip]            // Keep public re-exports separate.
+#[doc(inline)]
+pub use units::value::{Value, ZERO, ONE_SAT, ONE_BTC, FIFTY_BTC};
+
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`Value`] type.
+    pub trait ValueExt impl for Value {
+        /// Checked addition.
+        ///
+        /// Returns [`None`] if overflow occurred.
+        fn checked_add(self, rhs: Value) -> Option<Value> {
+            self.to_sat().checked_add(rhs.to_sat()).map(Value::from_sat)
+        }
+
+        /// Checked subtraction.
+        ///
+        /// Returns [`None`] if overflow occurred.
+        fn checked_sub(self, rhs: Value) -> Option<Value> {
+            self.to_sat().checked_sub(rhs.to_sat()).map(Value::from_sat)
+        }
+
+        /// Checked multiplication.
+        ///
+        /// Returns [`None`] if overflow occurred.
+        fn checked_mul(self, rhs: u64) -> Option<Value> { self.to_sat().checked_mul(rhs).map(Value::from_sat) }
+
+        /// Checked integer division.
+        ///
+        /// Be aware that integer division loses the remainder if no exact division
+        /// can be made.
+        /// Returns [`None`] if overflow occurred.
+        fn checked_div(self, rhs: u64) -> Option<Value> { self.to_sat().checked_div(rhs).map(Value::from_sat) }
+
+        /// Checked weight division.
+        ///
+        /// Be aware that integer division loses the remainder if no exact division
+        /// can be made.  This method rounds up ensuring the transaction fee-rate is
+        /// sufficient.  If you wish to round-down, use the unchecked version instead.
+        ///
+        /// [`None`] is returned if an overflow occurred.
+        #[cfg(feature = "alloc")]
+        fn checked_div_by_weight(self, rhs: Weight) -> Option<FeeRate> {
+            let sats = self.to_sat().checked_mul(1000)?;
+            let wu = rhs.to_wu();
+
+            let fee_rate = sats.checked_add(wu.checked_sub(1)?)?.checked_div(wu)?;
+            Some(FeeRate::from_sat_per_kwu(fee_rate))
+        }
+
+        /// Checked remainder.
+        ///
+        /// Returns [`None`] if overflow occurred.
+        fn checked_rem(self, rhs: u64) -> Option<Value> { self.to_sat().checked_rem(rhs).map(Value::from_sat) }
+
+        /// Unchecked addition.
+        ///
+        /// Computes `self + rhs`.
+        ///
+        /// # Panics
+        ///
+        /// On overflow, panics in debug mode, wraps in release mode.
+        fn unchecked_add(self, rhs: Value) -> Value { Value::from_sat(self.to_sat() + rhs.to_sat()) }
+
+        /// Unchecked subtraction.
+        ///
+        /// Computes `self - rhs`.
+        ///
+        /// # Panics
+        ///
+        /// On overflow, panics in debug mode, wraps in release mode.
+        fn unchecked_sub(self, rhs: Value) -> Value { Value::from_sat(self.to_sat() - rhs.to_sat()) }
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Value {}
+}

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -12,7 +12,7 @@ use bitcoin::script::{PushBytes, ScriptBufExt as _};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{
     absolute, script, transaction, Amount, Denomination, NetworkKind, OutPoint, PrivateKey,
-    PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Value, Witness,
 };
 
 #[track_caller]
@@ -179,14 +179,20 @@ fn create_transaction() -> Transaction {
         ],
         output: vec![
             TxOut {
-                value: Amount::from_str_in(output_0.amount, Denomination::Bitcoin)
-                    .expect("failed to parse amount"),
+                value: Value::from_sat(
+                    Amount::from_str_in(output_0.amount, Denomination::Bitcoin)
+                        .expect("failed to parse amount")
+                        .to_sat(),
+                ),
                 script_pubkey: ScriptBuf::from_hex(output_0.script_pubkey)
                     .expect("failed to parse script"),
             },
             TxOut {
-                value: Amount::from_str_in(output_1.amount, Denomination::Bitcoin)
-                    .expect("failed to parse amount"),
+                value: Value::from_sat(
+                    Amount::from_str_in(output_1.amount, Denomination::Bitcoin)
+                        .expect("failed to parse amount")
+                        .to_sat(),
+                ),
                 script_pubkey: ScriptBuf::from_hex(output_1.script_pubkey)
                     .expect("failed to parse script"),
             },

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -11,10 +11,9 @@ use bitcoin::taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::transaction::Version;
 use bitcoin::{
     absolute, script, Address, Network, OutPoint, PrivateKey, Psbt, ScriptBuf, Sequence,
-    Transaction, TxIn, TxOut, Witness,
+    Transaction, TxIn, TxOut, Value, Witness,
 };
 use secp256k1::{Keypair, Secp256k1, Signing, XOnlyPublicKey};
-use units::Amount;
 
 #[test]
 fn psbt_sign_taproot() {
@@ -205,7 +204,7 @@ fn create_psbt_for_taproot_key_path_spend(
 ) -> Psbt {
     let send_value = 6400;
     let out_puts = vec![TxOut {
-        value: Amount::from_sat(send_value),
+        value: Value::from_sat(send_value),
         script_pubkey: to_address.script_pubkey(),
     }];
     let prev_tx_id = "06980ca116f74c7845a897461dd0e1d15b114130176de5004957da516b4dee3a";
@@ -243,7 +242,7 @@ fn create_psbt_for_taproot_key_path_spend(
     let mut input = Input {
         witness_utxo: {
             let script_pubkey = from_address.script_pubkey();
-            Some(TxOut { value: Amount::from_sat(utxo_value), script_pubkey })
+            Some(TxOut { value: Value::from_sat(utxo_value), script_pubkey })
         },
         tap_key_origins: origins,
         ..Default::default()
@@ -283,7 +282,7 @@ fn create_psbt_for_taproot_script_path_spend(
     let mfp = "73c5da0a";
 
     let out_puts = vec![TxOut {
-        value: Amount::from_sat(send_value),
+        value: Value::from_sat(send_value),
         script_pubkey: to_address.script_pubkey(),
     }];
     let prev_tx_id = "9d7c6770fca57285babab60c51834cfcfd10ad302119cae842d7216b4ac9a376";
@@ -322,7 +321,7 @@ fn create_psbt_for_taproot_script_path_spend(
     let mut input = Input {
         witness_utxo: {
             let script_pubkey = from_address.script_pubkey();
-            Some(TxOut { value: Amount::from_sat(utxo_value), script_pubkey })
+            Some(TxOut { value: Value::from_sat(utxo_value), script_pubkey })
         },
         tap_key_origins: origins,
         tap_scripts,

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -37,8 +37,8 @@ use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapTree, TaprootBuilder};
 use bitcoin::witness::Witness;
 use bitcoin::{
-    ecdsa, transaction, Address, Amount, Block, NetworkKind, OutPoint, PrivateKey, PublicKey,
-    ScriptBuf, Sequence, Target, Transaction, TxIn, TxOut, Txid, Work,
+    ecdsa, transaction, Address, Block, NetworkKind, OutPoint, PrivateKey, PublicKey, ScriptBuf,
+    Sequence, Target, Transaction, TxIn, TxOut, Txid, Value, Work,
 };
 
 /// Implicitly does regression test for `BlockHeader` also.
@@ -110,7 +110,7 @@ fn serde_regression_txin() {
 #[test]
 fn serde_regression_txout() {
     let txout = TxOut {
-        value: Amount::from_sat(0xDEADBEEFCAFEBABE),
+        value: Value::from_sat(0xDEADBEEFCAFEBABE),
         script_pubkey: ScriptBuf::from(vec![0u8, 1u8, 2u8]),
     };
     let got = serialize(&txout).unwrap();
@@ -238,7 +238,7 @@ fn serde_regression_psbt() {
             .unwrap()]),
         }],
         output: vec![TxOut {
-            value: Amount::from_sat(190_303_501_938),
+            value: Value::from_sat(190_303_501_938),
             script_pubkey: ScriptBuf::from_hex("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587")
                 .unwrap(),
         }],
@@ -285,7 +285,7 @@ fn serde_regression_psbt() {
         inputs: vec![Input {
             non_witness_utxo: Some(tx),
             witness_utxo: Some(TxOut {
-                value: Amount::from_sat(190_303_501_938),
+                value: Value::from_sat(190_303_501_938),
                 script_pubkey: ScriptBuf::from_hex("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587").unwrap(),
             }),
             sighash_type: Some(PsbtSighashType::from("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY".parse::<EcdsaSighashType>().unwrap())),

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -44,8 +44,6 @@ pub mod transaction;
 #[cfg(feature = "alloc")]
 pub mod witness;
 
-#[doc(inline)]
-pub use units::amount::{Amount, SignedAmount};
 #[cfg(feature = "alloc")]
 #[doc(inline)]
 pub use units::{

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -18,7 +18,7 @@ use hashes::sha256d;
 #[cfg(feature = "alloc")]
 use internals::write_err;
 #[cfg(feature = "alloc")]
-use units::{parse, Amount};
+use units::{parse, Value};
 
 #[cfg(feature = "alloc")]
 use crate::script::ScriptBuf;
@@ -85,7 +85,7 @@ impl TxIn {
 #[cfg(feature = "alloc")]
 pub struct TxOut {
     /// The value of the output, in satoshis.
-    pub value: Amount,
+    pub value: Value,
     /// The script which must be satisfied for the output to be spent.
     pub script_pubkey: ScriptBuf,
 }
@@ -94,7 +94,7 @@ pub struct TxOut {
 impl TxOut {
     /// This is used as a "null txout" in consensus signing code.
     pub const NULL: Self =
-        TxOut { value: Amount::from_sat(0xffffffffffffffff), script_pubkey: ScriptBuf::new() };
+        TxOut { value: Value::from_sat(0xffffffffffffffff), script_pubkey: ScriptBuf::new() };
 }
 
 /// A reference to a transaction output.
@@ -293,7 +293,7 @@ impl<'a> Arbitrary<'a> for TxIn {
 #[cfg(feature = "alloc")]
 impl<'a> Arbitrary<'a> for TxOut {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(TxOut { value: Amount::arbitrary(u)?, script_pubkey: ScriptBuf::arbitrary(u)? })
+        Ok(TxOut { value: Value::arbitrary(u)?, script_pubkey: ScriptBuf::arbitrary(u)? })
     }
 }
 

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -22,7 +22,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub mod amount;
 #[cfg(feature = "alloc")]
 pub mod block;
 #[cfg(feature = "alloc")]
@@ -31,11 +30,12 @@ pub mod fee_rate;
 pub mod locktime;
 #[cfg(feature = "alloc")]
 pub mod parse;
+pub mod value;
 #[cfg(feature = "alloc")]
 pub mod weight;
 
 #[doc(inline)]
-pub use self::amount::{Amount, SignedAmount};
+pub use self::value::Value;
 #[cfg(feature = "alloc")]
 #[doc(inline)]
 #[rustfmt::skip]

--- a/units/src/value.rs
+++ b/units/src/value.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin has value, and that value is denominated in sats - period.
+
+use core::fmt;
+
+#[cfg(feature = "serde")]
+use ::serde::{Deserialize, Serialize};
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
+
+/// Abstraction over Bitcoin value - denominated in Satoshis.
+///
+/// Value can never be negative and has nothing to do with floats.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Value(u64);
+
+/// Zero value.
+pub const ZERO: Value = Value(0);
+/// Exactly one satoshi.
+pub const ONE_SAT: Value = Value(1);
+/// Exactly one bitcoin.
+pub const ONE_BTC: Value = Value(100_000_000);
+/// Exactly fifty bitcoin.
+pub const FIFTY_BTC: Value = Value(50 * 100_000_000);
+
+impl Value {
+    /// Zero value.
+    pub const ZERO: Value = Value(0);
+    /// The maximum value allowed as an amount. Useful for sanity checking.
+    pub const MAX_MONEY: Value = Value(21_000_000 * ONE_BTC.0);
+    /// The minimum possible value.
+    pub const MIN: Value = Value(u64::MIN);
+    /// The maximum possible value.
+    pub const MAX: Value = Value(u64::MAX);
+    /// The number of bytes that a value type contributes to the size of a transaction.
+    pub const SIZE: usize = 8; // Serialized length of a u64.
+
+    /// Creates a [`Value`] from a `u64` (you can also just use `from`).
+    pub const fn from_sat(sat: u64) -> Value { Value(sat) }
+
+    /// Gets the satoshi value as a `u64`.
+    pub const fn to_sat(self) -> u64 { self.0 }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+macro_rules! impl_from_uint {
+    ($($uint:ty),*) => {
+        $(
+            impl From<$uint> for Value {
+                fn from(v: $uint) -> Self { Self(v.into())}
+            }
+        )*
+    }
+}
+impl_from_uint!(u8, u16, u32, u64);
+
+impl From<Value> for u64 {
+    fn from(v: Value) -> u64 { v.0 }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for Value {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let a = u64::arbitrary(u)?;
+        Ok(Value(a))
+    }
+}


### PR DESCRIPTION
Our `Amount` type is doing two things and these are at odds with each other.

1. A UTXO has a value.
2. Humans read and write in both sats and BTC

For (1) we can and should have a simple type, this type can and should be stable.

For (2) there is much more nuance e.g., is "1 BTC" a valid representation?

Note also that we have buckley's chance of stabilising the current `units::amount` module with the extremely strict bar we have set ourselves.

To solve all these problems this patch introduces a `Value` type. This is for the usecase described by (1). It is a dumb wrapper type that can be easily stabalized.

For (2) we move the current `amount` module to `bitcoin` and leave it as is (with some additional module docs).