### PR TITLE
Use `doc(notable_trait)`

### DIFF
--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -252,6 +252,7 @@ macro_rules! define_extension_trait {
             fn $fn:ident$(<$($gen:ident: $gent:path),*>)?($($params:tt)*) $( -> $ret:ty )? $body:block
         )*
     }) => {
+        #[cfg_attr(docsrs, doc(notable_trait))]
         $(#[$($trait_attrs)*])* $trait_vis trait $trait_name: sealed::Sealed {
             $(
                 $crate::internal_macros::only_doc_attrs! {

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -27,6 +27,7 @@
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_notable_trait))]
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]


### PR DESCRIPTION
There is an unstable feature that puts up a little 'i' in a circle next to any function that returns a type that implements an notable trait. For us this means we can make the extension traits more discoverable.

ref: https://doc.rust-lang.org/unstable-book/language-features/doc-notable-trait.html

Close: #3232