### PR TITLE
Fix ugly rustfmt

### DIFF
--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -36,11 +36,9 @@ impl fmt::LowerHex for CompactTarget {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
-impl_to_hex_from_lower_hex!(CompactTarget, |compact_target: &CompactTarget| 8 - compact_target
-    .0
-    .leading_zeros()
-    as usize
-    / 4);
+impl_to_hex_from_lower_hex!(CompactTarget, |compact_target: &CompactTarget| {
+    8 - compact_target.0.leading_zeros() as usize / 4
+});
 
 impl fmt::UpperHex for CompactTarget {
     #[inline]

--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -231,9 +231,9 @@ impl fmt::Display for Sequence {
 impl fmt::LowerHex for Sequence {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
-impl_to_hex_from_lower_hex!(Sequence, |sequence: &Sequence| 8 - sequence.0.leading_zeros()
-    as usize
-    / 4);
+impl_to_hex_from_lower_hex!(Sequence, |sequence: &Sequence| {
+    8 - sequence.0.leading_zeros() as usize / 4
+});
 
 impl fmt::UpperHex for Sequence {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }


### PR DESCRIPTION
Fix some ugly formatting introduced by the fmt bot recently.

Whitespace only, no logic changes.