### PR TITLE
Add no_std flag to the chacha20-poly1305 crate

### DIFF
--- a/chacha20_poly1305/src/chacha20.rs
+++ b/chacha20_poly1305/src/chacha20.rs
@@ -326,6 +326,7 @@ fn keystream_at_slice(key: Key, nonce: Nonce, count: u32, seek: usize) -> [u8; 6
 #[cfg(test)]
 #[cfg(feature = "alloc")]
 mod tests {
+    use alloc::vec::Vec;
     use hex::prelude::*;
 
     use super::*;

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -2,6 +2,12 @@
 
 //! Combine the ChaCha20 stream cipher with the Poly1305 message authentication code
 //! to form an authenticated encryption with additional data (AEAD) algorithm.
+#![no_std]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod chacha20;
 pub mod poly1305;
@@ -143,6 +149,7 @@ fn encode_lengths(aad_len: u64, content_len: u64) -> [u8; 16] {
 #[cfg(test)]
 #[cfg(feature = "alloc")]
 mod tests {
+    use alloc::vec::Vec;
     use hex::prelude::*;
 
     use super::*;

--- a/chacha20_poly1305/src/poly1305.rs
+++ b/chacha20_poly1305/src/poly1305.rs
@@ -223,6 +223,7 @@ fn _print_acc(num: &[u32; 5]) {
 #[cfg(test)]
 #[cfg(feature = "alloc")]
 mod tests {
+    use alloc::vec::Vec;
     use hex::prelude::*;
 
     use super::*;


### PR DESCRIPTION
I unfortunately forgot to copy over the `no_std` configuration when I promoted the chacha20_poly1305 from an internal module (where it inherited the setting) to the main module of the new crate.

This crate is using a slightly simpler no_std pattern than some other crates in the org. I like the simple approach, but can update it if consistency is valued in this case.