### PR TITLE
primitives: Add rustdoc links back in

### DIFF
--- a/primitives/src/locktime/absolute.rs
+++ b/primitives/src/locktime/absolute.rs
@@ -14,8 +14,8 @@ use arbitrary::{Arbitrary, Unstructured};
 use mutagen::mutate;
 use units::parse::{self, PrefixedHexError, UnprefixedHexError};
 
-#[cfg(doc)]
-use crate::absolute;
+#[cfg(all(doc, feature = "alloc"))]
+use crate::{absolute, Transaction};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -24,14 +24,14 @@ pub use units::locktime::absolute::{ConversionError, Height, ParseHeightError, P
 /// An absolute lock time value, representing either a block height or a UNIX timestamp (seconds
 /// since epoch).
 ///
-/// Used for transaction lock time (`nLockTime` in Bitcoin Core and `Transaction::lock_time`
+/// Used for transaction lock time (`nLockTime` in Bitcoin Core and [`Transaction::lock_time`]
 /// in this library) and also for the argument to opcode 'OP_CHECKLOCKTIMEVERIFY`.
 ///
 /// ### Note on ordering
 ///
 /// Locktimes may be height- or time-based, and these metrics are incommensurate; there is no total
 /// ordering on locktimes. We therefore have implemented [`PartialOrd`] but not [`Ord`].
-/// For `Transaction`, which has a locktime field, we implement a total ordering to make
+/// For [`Transaction`], which has a locktime field, we implement a total ordering to make
 /// it easy to store transactions in sorted data structures, and use the locktime's 32-bit integer
 /// consensus encoding to order it. We also implement [`ordered::ArbitraryOrd`] if the "ordered"
 /// feature is enabled.
@@ -85,7 +85,7 @@ pub enum LockTime {
 }
 
 impl LockTime {
-    /// If `Transaction::lock_time` is set to zero it is ignored, in other words a
+    /// If [`Transaction::lock_time`] is set to zero it is ignored, in other words a
     /// transaction with nLocktime==0 is able to be included immediately in any block.
     pub const ZERO: LockTime = LockTime::Blocks(Height::ZERO);
 
@@ -197,7 +197,7 @@ impl LockTime {
     /// blocktime based lock it is checked against `time`.
     ///
     /// A 'timelock constraint' refers to the `n` from `n OP_CHEKCLOCKTIMEVERIFY`, this constraint
-    /// is satisfied if a transaction with nLockTime (`Transaction::lock_time`) set to
+    /// is satisfied if a transaction with nLockTime ([`Transaction::lock_time`]) set to
     /// `height`/`time` is valid.
     ///
     /// # Examples

--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -12,8 +12,8 @@ use core::{cmp, convert, fmt};
 #[cfg(all(test, mutate))]
 use mutagen::mutate;
 
-#[cfg(doc)]
-use crate::relative;
+#[cfg(all(doc, feature = "alloc"))]
+use crate::{relative, TxIn};
 use crate::Sequence;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -22,7 +22,7 @@ pub use units::locktime::relative::{Height, Time, TimeOverflowError};
 
 /// A relative lock time value, representing either a block height or time (512 second intervals).
 ///
-/// Used for sequence numbers (`nSequence` in Bitcoin Core and `TxIn::sequence`
+/// Used for sequence numbers (`nSequence` in Bitcoin Core and [`TxIn::sequence`]
 /// in this library) and also for the argument to opcode 'OP_CHECKSEQUENCEVERIFY`.
 ///
 /// ### Note on ordering

--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -3,8 +3,7 @@
 //! Bitcoin transaction input sequence number.
 //!
 //! The sequence field is used for:
-//! - Indicating whether absolute lock-time (specified in `lock_time` field of `Transaction`)
-//!   is enabled.
+//! - Indicating whether absolute lock-time (specified in `lock_time` field of [`Transaction`]) is enabled.
 //! - Indicating and encoding [BIP-68] relative lock-times.
 //! - Indicating whether a transaction opts-in to [BIP-125] replace-by-fee.
 //!
@@ -28,6 +27,8 @@ use units::parse::{self, PrefixedHexError, UnprefixedHexError};
 
 #[cfg(feature = "alloc")]
 use crate::locktime::relative;
+#[cfg(all(doc, feature = "alloc"))]
+use crate::transaction::Transaction;
 
 /// Bitcoin transaction input sequence number.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -74,7 +75,7 @@ impl Sequence {
     /// BIP-68 relative lock time type flag mask.
     const LOCK_TYPE_MASK: u32 = 0x00400000;
 
-    /// Returns `true` if the sequence number enables absolute lock-time (`Transaction::lock_time`).
+    /// Returns `true` if the sequence number enables absolute lock-time ([`Transaction::lock_time`]).
     #[inline]
     pub fn enables_absolute_lock_time(&self) -> bool { *self != Sequence::MAX }
 


### PR DESCRIPTION
During move of code to `primitives` we removed a few links to types that were not yet moved, we can now put these back in.

Close: #2997