### PR TITLE
Remove needless_borrows_for_generic_args

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -21,7 +21,6 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
-#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
 extern crate alloc;
 

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -459,7 +459,7 @@ impl Address {
         network: impl Into<NetworkKind>,
     ) -> Result<Address, WitnessScriptSizeError> {
         let hash = witness_script.wscript_hash()?;
-        let builder = script::Builder::new().push_int_unchecked(0).push_slice(&hash);
+        let builder = script::Builder::new().push_int_unchecked(0).push_slice(hash);
         let script_hash = builder.as_script().script_hash().expect("script is less than 520 bytes");
         Ok(Address::p2sh_from_hash(script_hash, network))
     }

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -296,7 +296,7 @@ mod test {
         // This is the best.
         let _ = genesis_block(&params::MAINNET);
         // this works and is ok too.
-        let _ = genesis_block(&Network::Bitcoin);
+        let _ = genesis_block(Network::Bitcoin);
         let _ = genesis_block(Network::Bitcoin);
         // This works too, but is suboptimal because it inlines the const.
         let _ = genesis_block(Params::MAINNET);

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -244,7 +244,7 @@ mod test {
         let mut witness = Witness::default();
         for i in 0..5 {
             assert_eq!(witness.iter().len(), i);
-            witness.push(&vec![0u8]);
+            witness.push([0u8]);
         }
         let mut iter = witness.iter();
         for i in (0..=5).rev() {

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -39,7 +39,6 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
-#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
 // We only support machines with index size of 4 bytes or more.
 //

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -64,7 +64,6 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
-#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -15,7 +15,6 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
-#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -17,7 +17,6 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
-#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -18,7 +18,6 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
-#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -478,7 +478,7 @@ mod test {
     #[test]
     fn witness_single_empty_element() {
         let mut got = Witness::new();
-        got.push(&[]);
+        got.push([]);
         let want = single_empty_element();
         assert_eq!(got, want)
     }
@@ -497,7 +497,7 @@ mod test {
 
         // Push a single byte element onto the witness stack.
         let push = [0_u8];
-        witness.push(&push);
+        witness.push(push);
 
         let elements = [1u8, 0];
         let expected = Witness {
@@ -520,7 +520,7 @@ mod test {
 
         // Now push 2 byte element onto the witness stack.
         let push = [2u8, 3u8];
-        witness.push(&push);
+        witness.push(push);
 
         let elements = [1u8, 0, 2, 2, 3];
         let expected = Witness {
@@ -543,7 +543,7 @@ mod test {
 
         // Now push another 2 byte element onto the witness stack.
         let push = [4u8, 5u8];
-        witness.push(&push);
+        witness.push(push);
 
         let elements = [1u8, 0, 2, 2, 3, 2, 4, 5];
         let expected = Witness {
@@ -574,7 +574,7 @@ mod test {
 
         for i in 0..num_pushes {
             assert_eq!(witness.iter().len(), i);
-            witness.push(&arbitrary_element);
+            witness.push(arbitrary_element);
         }
 
         let mut iter = witness.iter();
@@ -600,9 +600,9 @@ mod test {
     fn arbitrary_witness() -> Witness {
         let mut witness = Witness::default();
 
-        witness.push(&[0_u8]);
-        witness.push(&[1_u8; 32]);
-        witness.push(&[2_u8; 72]);
+        witness.push([0_u8]);
+        witness.push([1_u8; 32]);
+        witness.push([2_u8; 72]);
 
         witness
     }

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -13,7 +13,6 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
-#![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
 #![no_std]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
This has been fixed and we use nightly to lint so we have access to the merged fix.