### PR TITLE
Re-export `block::Header` as `BlockHeader`

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::{
     amount::{Amount, Denomination, SignedAmount},
     bip158::{FilterHash, FilterHeader},
     bip32::XKeyIdentifier,
-    blockdata::block::{self, Block, BlockHash, WitnessCommitment},
+    blockdata::block::{self, Block, BlockHash, Header as BlockHeader, WitnessCommitment},
     blockdata::constants,
     blockdata::fee_rate::FeeRate,
     blockdata::locktime::{self, absolute, relative},

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -55,7 +55,7 @@ pub use units::{
 
 #[doc(inline)]
 pub use self::{
-    block::{BlockHash, WitnessCommitment},
+    block::{BlockHash, Header as BlockHeader, WitnessCommitment},
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
     pow::CompactTarget,
     sequence::Sequence,


### PR DESCRIPTION
For users who want to just grab stuff from the crate root it makes total sense for there to be a `BlockHeader`.

Another nice thing, in the HMTL docs it makes BlockHeader be in the struct list right along with `Block`, `BlockHash`, and `BlockHeight`.

Close: #3548