### PR TITLE
Do trivial docs cleanup

### DIFF
--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -46,7 +46,7 @@ impl Height {
         parse_hex(s, Self::from_consensus)
     }
 
-    /// Constructs a new block height.
+    /// Creates a [`Height`] from a consensus `u32`.
     ///
     /// # Errors
     ///
@@ -142,7 +142,7 @@ impl Time {
     /// The input string may or may not contain a typical hex prefix e.g., `0x`.
     pub fn from_hex(s: &str) -> Result<Self, ParseTimeError> { parse_hex(s, Self::from_consensus) }
 
-    /// Constructs a new block time.
+    /// Creates a [`Time`] from a consensus `u32`.
     ///
     /// # Errors
     ///

--- a/units/src/locktime/relative.rs
+++ b/units/src/locktime/relative.rs
@@ -22,7 +22,7 @@ impl Height {
     /// The maximum relative block height.
     pub const MAX: Self = Height(u16::MAX);
 
-    /// Create a [`Height`] using a count of blocks.
+    /// Creates [`Height`] using a count of blocks.
     #[inline]
     pub const fn from_height(blocks: u16) -> Self { Height(blocks) }
 


### PR DESCRIPTION
We are trying to stabalise `units`; do a few trivial docs cleanups.