### PR TITLE
io: Bump version to 0.1.3

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "bitcoin-units"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "bitcoin-units"

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.3 - 2024-11-02
+
+* Backport IO improvements [#3181](https://github.com/rust-bitcoin/rust-bitcoin/pull/3181)
+  (Original PR: [#3176](https://github.com/rust-bitcoin/rust-bitcoin/pull/3176))
+
 # 0.1.2 - 2024-03-14
 
 * Implement `From<core::convert::Infallible>` for Errors [#2516](https://github.com/rust-bitcoin/rust-bitcoin/pull/2516)

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-io"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"


### PR DESCRIPTION
In preparation for release bump the version, add a changeloge entry, and update the lock files.