### PR TITLE
Bug: Fix `scriptint_vec` handling of Num(0)

### DIFF
--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -161,6 +161,9 @@ pub fn write_scriptint(out: &mut [u8; 8], n: i64) -> usize {
 
 /// Returns minimally encoded scriptint as a byte vector.
 pub fn scriptint_vec(n: i64) -> Vec<u8> {
+    if n == 0 {
+        return vec![0u8];
+    }
     let mut buf = [0u8; 8];
     let len = write_scriptint(&mut buf, n);
     buf[0..len].to_vec()


### PR DESCRIPTION
This PR fixes `scriptint_vec` to ensure that Num(0) produces [0].

Ref: [BitVM/rust-bitcoin-scriptexec PR #8](https://github.com/BitVM/rust-bitcoin-scriptexec/pull/8)