### PR TITLE
transaction: Add plural field getters

### DIFF
--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -113,6 +113,18 @@ impl Transaction {
     /// Maximum transaction weight for Bitcoin Core 25.0.
     pub const MAX_STANDARD_WEIGHT: Weight = Weight::from_wu(400_000);
 
+    /// Returns a reference to the transaction inputs.
+    pub fn inputs(&self) -> &[TxIn] { &self.input }
+
+    /// Returns a mutable reference to the transaction inputs.
+    pub fn inputs_mut(&mut self) -> &mut [TxIn] { &mut self.input }
+
+    /// Returns a reference to the transaction outputs.
+    pub fn outputs(&self) -> &[TxOut] { &self.output }
+
+    /// Returns a mutable reference to the transaction outputs.
+    pub fn outputs_mut(&mut self) -> &mut [TxOut] { &mut self.output }
+
     /// Computes a "normalized TXID" which does not include any signatures.
     ///
     /// This gives a way to identify a transaction that is "the same" as


### PR DESCRIPTION
The `Transaction` type was created way back when, and the field names were named using singular (`input` and `output`). In hindsite plural probably should have been used since its more idiomatic Rust but the fields have been around so long now that re-naming them is going annoy a whole bunch of people.

As a compromise add getters that use plural, immutable and mutable versions, for both the `input` and `output` fields.

Close: #822