### PR TITLE
hashes: Wrap `hex` error

### DIFF
--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -8,6 +8,8 @@ use core::fmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FromSliceError(pub(crate) FromSliceErrorInner);
 
+impl_from_infallible!(FromSliceError);
+
 impl FromSliceError {
     /// Returns the expected slice length.
     pub fn expected_length(&self) -> usize { self.0.expected }
@@ -23,6 +25,8 @@ pub(crate) struct FromSliceErrorInner {
     pub(crate) got: usize,
 }
 
+impl_from_infallible!(FromSliceErrorInner);
+
 impl fmt::Display for FromSliceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "invalid slice length {} (expected {})", self.0.got, self.0.expected)
@@ -31,3 +35,62 @@ impl fmt::Display for FromSliceError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for FromSliceError {}
+
+/// Derives `From<core::convert::Infallible>` for the given type.
+///
+/// Supports types with arbitrary combinations of lifetimes and type parameters.
+///
+/// Note: Paths are not supported (for ex. impl_from_infallible!(Hello<D: std::fmt::Display>).
+///
+/// # Examples
+///
+/// ```rust
+/// # #[allow(unused)]
+/// # fn main() {
+/// # use core::fmt::{Display, Debug};
+/// use bitcoin_internals::impl_from_infallible;
+///
+/// enum AlphaEnum { Item }
+/// impl_from_infallible!(AlphaEnum);
+///
+/// enum BetaEnum<'b> { Item(&'b usize) }
+/// impl_from_infallible!(BetaEnum<'b>);
+///
+/// enum GammaEnum<T> { Item(T) }
+/// impl_from_infallible!(GammaEnum<T>);
+///
+/// enum DeltaEnum<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a> {
+///     Item((&'b usize, &'a usize, T, D))
+/// }
+/// impl_from_infallible!(DeltaEnum<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a>);
+///
+/// struct AlphaStruct;
+/// impl_from_infallible!(AlphaStruct);
+///
+/// struct BetaStruct<'b>(&'b usize);
+/// impl_from_infallible!(BetaStruct<'b>);
+///
+/// struct GammaStruct<T>(T);
+/// impl_from_infallible!(GammaStruct<T>);
+///
+/// struct DeltaStruct<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a> {
+///     hello: &'a T,
+///     what: &'b D,
+/// }
+/// impl_from_infallible!(DeltaStruct<'b, 'a: 'static + 'b, T: 'a, D: Debug + Display + 'a>);
+/// # }
+/// ```
+///
+/// See <https://stackoverflow.com/a/61189128> for more information about this macro.
+macro_rules! impl_from_infallible {
+    ( $name:ident $(< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? ) => {
+        impl $(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)?
+            From<core::convert::Infallible>
+        for $name
+            $(< $( $lt ),+ >)?
+        {
+            fn from(never: core::convert::Infallible) -> Self { match never {} }
+        }
+    }
+}
+pub(crate) use impl_from_infallible;

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Error code for the `hashes` crate.
+
+use core::fmt;
+
+/// Attempted to create a hash from an invalid length slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FromSliceError {
+    pub(crate) expected: usize,
+    pub(crate) got: usize,
+}
+
+impl FromSliceError {
+    /// Returns the expected slice length.
+    pub fn expected_length(&self) -> usize { self.expected }
+
+    /// Returns the invalid slice length.
+    pub fn invalid_length(&self) -> usize { self.got }
+}
+
+impl fmt::Display for FromSliceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid slice length {} (expected {})", self.got, self.expected)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromSliceError {}

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -6,22 +6,26 @@ use core::fmt;
 
 /// Attempted to create a hash from an invalid length slice.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FromSliceError {
+pub struct FromSliceError(pub(crate) FromSliceErrorInner);
+
+impl FromSliceError {
+    /// Returns the expected slice length.
+    pub fn expected_length(&self) -> usize { self.0.expected }
+
+    /// Returns the invalid slice length.
+    pub fn invalid_length(&self) -> usize { self.0.got }
+}
+
+/// Attempted to create a hash from an invalid length slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FromSliceErrorInner {
     pub(crate) expected: usize,
     pub(crate) got: usize,
 }
 
-impl FromSliceError {
-    /// Returns the expected slice length.
-    pub fn expected_length(&self) -> usize { self.expected }
-
-    /// Returns the invalid slice length.
-    pub fn invalid_length(&self) -> usize { self.got }
-}
-
 impl fmt::Display for FromSliceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "invalid slice length {} (expected {})", self.got, self.expected)
+        write!(f, "invalid slice length {} (expected {})", self.0.got, self.0.expected)
     }
 }
 

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -4,6 +4,142 @@
 
 use core::fmt;
 
+/// Hex decoding error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HexError(pub(crate) HexToArrayErrorInner);
+
+impl HexToArrayError {
+    /// Constructs a new invalid char error.
+    pub fn new_invalid_char(invalid: u8, pos: usize) -> Self {
+        Self(HexToArrayErrorInner::InvalidChar(InvalidCharError {
+            invalid, pos,
+        }))
+    }
+
+    /// Constructs a new invalid length error.
+    pub fn new_invalid_length(invalid: usize, expected: usize) -> Self {
+        Self(HexToArrayErrorInner::InvalidLength(InvalidLengthError {
+            expected, invalid
+        }))
+    }
+
+    /// Returns the invalid character if this was an invalid char error.
+    pub fn invalid_char(&self) -> Option<u8> {
+        use HexToArrayErrorInner::*;
+
+        match self.0 {
+            InvalidChar(ref e) => Some(e.invalid_char()),
+            InvalidLength(_) => None,
+        }
+    }
+
+    /// Returns the position of the invalid character if this was an invalid char error.
+    pub fn invalid_char_pos(&self) -> Option<usize> {
+        use HexToArrayErrorInner::*;
+
+        match self.0 {
+            InvalidChar(ref e) => Some(e.pos()),
+            InvalidLength(_) => None,
+        }
+    }
+
+    /// Returns (invalid_length, expected_length) if this was an invalid length error.
+    pub fn invalid_length(&self) -> Option<(usize, usize)> {
+        use HexToArrayErrorInner::*;
+
+        match self.0 {
+            InvalidChar(_) => None,
+            InvalidLength(ref e) => Some((e.invalid, e.expected)),
+        }
+    }
+}
+
+impl_from_infallible!(HexToArrayError);
+
+/// Hex decoding error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HexToArrayErrorInner {
+    /// Non-hexadecimal character.
+    InvalidChar(InvalidCharError),
+    /// Tried to parse fixed-length hash from a string with the wrong length.
+    InvalidLength(InvalidLengthError),
+}
+
+impl_from_infallible!(HexToArrayErrorInner);
+
+impl fmt::Display for HexToArrayError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use HexToArrayErrorInner::*;
+
+        match self.0 {
+            InvalidChar(ref e) => write_err!(f, "failed to parse hex digit"; e),
+            InvalidLength(ref e) => write_err!(f, "failed to parse hex"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HexToArrayError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use HexToArrayErrorInner::*;
+
+        match self.0 {
+            InvalidChar(ref e) => Some(e),
+            InvalidLength(ref e) => Some(e),
+        }
+    }
+}
+
+/// Invalid hex character.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InvalidCharError {
+    pub(crate) invalid: u8,
+    pub(crate) pos: usize,
+}
+
+impl InvalidCharError {
+    /// Returns the invalid character byte.
+    pub(crate) fn invalid_char(&self) -> u8 { self.invalid }
+    /// Returns the position of the invalid character byte.
+    pub(crate) fn pos(&self) -> usize { self.pos }
+}
+
+impl_from_infallible!(InvalidCharError);
+
+impl fmt::Display for InvalidCharError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid hex char {} at pos {}", self.invalid, self.pos)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidCharError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+/// Tried to parse fixed-length hash from a string with the wrong length.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) struct InvalidLengthError {
+    /// The expected length.
+    pub(crate) expected: usize,
+    /// The invalid length.
+    pub(crate) invalid: usize,
+}
+
+impl_from_infallible!(InvalidLengthError);
+
+impl fmt::Display for InvalidLengthError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invilad hex string length {} (expected {})", self.invalid, self.expected)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidLengthError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
 /// Attempted to create a hash from an invalid length slice.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FromSliceError(pub(crate) FromSliceErrorInner);
@@ -35,6 +171,28 @@ impl fmt::Display for FromSliceError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for FromSliceError {}
+
+/// Formats error.
+///
+/// If `std` feature is OFF appends error source (delimited by `: `). We do this because
+/// `e.source()` is only available in std builds, without this macro the error source is lost for
+/// no-std builds.
+macro_rules! write_err {
+    ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
+        {
+            #[cfg(feature = "std")]
+            {
+                let _ = &$source;   // Prevents clippy warnings.
+                write!($writer, $string $(, $args)*)
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
+            }
+        }
+    }
+}
+pub(crate) use write_err;
 
 /// Derives `From<core::convert::Infallible>` for the given type.
 ///

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -129,7 +129,10 @@ macro_rules! hash_type_no_default {
                 sl: &[u8],
             ) -> $crate::_export::_core::result::Result<Hash, $crate::FromSliceError> {
                 if sl.len() != $bits / 8 {
-                    Err($crate::FromSliceError { expected: $bits / 8, got: sl.len() })
+                    Err($crate::FromSliceError($crate::error::FromSliceErrorInner {
+                        expected: $bits / 8,
+                        got: sl.len(),
+                    }))
                 } else {
                     let mut ret = [0; $bits / 8];
                     ret.copy_from_slice(sl);

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -128,7 +128,7 @@ use core::{convert, fmt, hash};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    error::FromSliceError,
+    error::{FromSliceError, HexToArrayError},
     hkdf::Hkdf,
     hmac::{Hmac, HmacEngine},
 };

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -96,6 +96,7 @@ pub mod _export {
 mod internal_macros;
 
 pub mod cmp;
+pub mod error;
 pub mod hash160;
 pub mod hkdf;
 pub mod hmac;
@@ -127,6 +128,7 @@ use core::{convert, fmt, hash};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
+    error::FromSliceError,
     hkdf::Hkdf,
     hmac::{Hmac, HmacEngine},
 };
@@ -316,30 +318,6 @@ fn incomplete_block_len<H: HashEngine>(eng: &H) -> usize {
     // After modulo operation we know cast u64 to usize as ok.
     (eng.n_bytes_hashed() % block_size) as usize
 }
-
-/// Attempted to create a hash from an invalid length slice.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FromSliceError {
-    expected: usize,
-    got: usize,
-}
-
-impl FromSliceError {
-    /// Returns the expected slice length.
-    pub fn expected_length(&self) -> usize { self.expected }
-
-    /// Returns the invalid slice length.
-    pub fn invalid_length(&self) -> usize { self.got }
-}
-
-impl fmt::Display for FromSliceError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "invalid slice length {} (expected {})", self.got, self.expected)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for FromSliceError {}
 
 #[cfg(test)]
 mod tests {

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -45,8 +45,10 @@ where
     /// Copies a byte slice into a hash object.
     #[deprecated(since = "0.15.0", note = "use `from_byte_array` instead")]
     pub fn from_slice(sl: &[u8]) -> Result<Hash<T>, FromSliceError> {
+        use crate::error::FromSliceErrorInner;
+
         if sl.len() != 32 {
-            Err(FromSliceError { expected: 32, got: sl.len() })
+            Err(FromSliceError(FromSliceErrorInner { expected: 32, got: sl.len() }))
         } else {
             let mut ret = [0; 32];
             ret.copy_from_slice(sl);

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -419,7 +419,7 @@ fn parse_vout(s: &str) -> Result<u32, ParseOutPointError> {
 #[cfg(feature = "alloc")]
 pub enum ParseOutPointError {
     /// Error in TXID part.
-    Txid(hex::HexToArrayError),
+    Txid(hashes::HexToArrayError),
     /// Error in vout part.
     Vout(parse::ParseIntError),
     /// Error in general format.


### PR DESCRIPTION
Draft because on top of https://github.com/rust-bitcoin/rust-bitcoin/pull/3579, this one is just the last patch.

We would like to make `hex` an optional dependency. In order to do so we must not expose the `hex::HexToArrayError` in the public API.
    
Add a new `HexError` type (with hidden innards) and convert the `hex` error to the new error. This is complicated by the fact that the error is converted in public code (via a macro) so we cannot access the innards of the new error. As such we add a bunch of ugly as hell constructors (and getters).
 
