### PR TITLE
hashes: Hide error internals

### DIFF
--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Error code for the `hashes` crate.
+
+use core::fmt;
+
+/// Attempted to create a hash from an invalid length slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FromSliceError {
+    pub(crate) expected: usize,
+    pub(crate) got: usize,
+}
+
+impl FromSliceError {
+    /// Returns the expected slice length.
+    pub fn expected_length(&self) -> usize { self.expected }
+
+    /// Returns the invalid slice length.
+    pub fn invalid_length(&self) -> usize { self.got }
+}
+
+impl fmt::Display for FromSliceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid slice length {} (expected {})", self.got, self.expected)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FromSliceError {}

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -8,6 +8,8 @@ use core::fmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FromSliceError(pub(crate) FromSliceErrorInner);
 
+impl_from_infallible!(FromSliceError);
+
 impl FromSliceError {
     /// Returns the expected slice length.
     pub fn expected_length(&self) -> usize { self.0.expected }
@@ -23,6 +25,8 @@ pub(crate) struct FromSliceErrorInner {
     pub(crate) got: usize,
 }
 
+impl_from_infallible!(FromSliceErrorInner);
+
 impl fmt::Display for FromSliceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "invalid slice length {} (expected {})", self.0.got, self.0.expected)
@@ -31,3 +35,19 @@ impl fmt::Display for FromSliceError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for FromSliceError {}
+
+/// Derives `From<core::convert::Infallible>` for the given type.
+// This is a duplicate of `internals::impl_from_infallible`, see there for complete docs.
+#[doc(hidden)]
+macro_rules! impl_from_infallible {
+    ( $name:ident $(< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? ) => {
+        impl $(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)?
+            From<core::convert::Infallible>
+        for $name
+            $(< $( $lt ),+ >)?
+        {
+            fn from(never: core::convert::Infallible) -> Self { match never {} }
+        }
+    }
+}
+pub(crate) use impl_from_infallible;

--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -6,22 +6,26 @@ use core::fmt;
 
 /// Attempted to create a hash from an invalid length slice.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FromSliceError {
+pub struct FromSliceError(pub(crate) FromSliceErrorInner);
+
+impl FromSliceError {
+    /// Returns the expected slice length.
+    pub fn expected_length(&self) -> usize { self.0.expected }
+
+    /// Returns the invalid slice length.
+    pub fn invalid_length(&self) -> usize { self.0.got }
+}
+
+/// Attempted to create a hash from an invalid length slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FromSliceErrorInner {
     pub(crate) expected: usize,
     pub(crate) got: usize,
 }
 
-impl FromSliceError {
-    /// Returns the expected slice length.
-    pub fn expected_length(&self) -> usize { self.expected }
-
-    /// Returns the invalid slice length.
-    pub fn invalid_length(&self) -> usize { self.got }
-}
-
 impl fmt::Display for FromSliceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "invalid slice length {} (expected {})", self.got, self.expected)
+        write!(f, "invalid slice length {} (expected {})", self.0.got, self.0.expected)
     }
 }
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -129,7 +129,10 @@ macro_rules! hash_type_no_default {
                 sl: &[u8],
             ) -> $crate::_export::_core::result::Result<Hash, $crate::FromSliceError> {
                 if sl.len() != $bits / 8 {
-                    Err($crate::FromSliceError { expected: $bits / 8, got: sl.len() })
+                    Err($crate::FromSliceError($crate::error::FromSliceErrorInner {
+                        expected: $bits / 8,
+                        got: sl.len(),
+                    }))
                 } else {
                     let mut ret = [0; $bits / 8];
                     ret.copy_from_slice(sl);

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -96,6 +96,7 @@ pub mod _export {
 mod internal_macros;
 
 pub mod cmp;
+pub mod error;
 pub mod hash160;
 pub mod hkdf;
 pub mod hmac;
@@ -127,6 +128,7 @@ use core::{convert, fmt, hash};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
+    error::FromSliceError,
     hkdf::Hkdf,
     hmac::{Hmac, HmacEngine},
 };
@@ -316,30 +318,6 @@ fn incomplete_block_len<H: HashEngine>(eng: &H) -> usize {
     // After modulo operation we know cast u64 to usize as ok.
     (eng.n_bytes_hashed() % block_size) as usize
 }
-
-/// Attempted to create a hash from an invalid length slice.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FromSliceError {
-    expected: usize,
-    got: usize,
-}
-
-impl FromSliceError {
-    /// Returns the expected slice length.
-    pub fn expected_length(&self) -> usize { self.expected }
-
-    /// Returns the invalid slice length.
-    pub fn invalid_length(&self) -> usize { self.got }
-}
-
-impl fmt::Display for FromSliceError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "invalid slice length {} (expected {})", self.got, self.expected)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for FromSliceError {}
 
 #[cfg(test)]
 mod tests {

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -45,8 +45,10 @@ where
     /// Copies a byte slice into a hash object.
     #[deprecated(since = "0.15.0", note = "use `from_byte_array` instead")]
     pub fn from_slice(sl: &[u8]) -> Result<Hash<T>, FromSliceError> {
+        use crate::error::FromSliceErrorInner;
+
         if sl.len() != 32 {
-            Err(FromSliceError { expected: 32, got: sl.len() })
+            Err(FromSliceError(FromSliceErrorInner { expected: 32, got: sl.len() }))
         } else {
             let mut ret = [0; 32];
             ret.copy_from_slice(sl);


### PR DESCRIPTION
Hide the internals of the `hashes::FromSliceError`.