### PR TITLE
Improve docs on block hash function

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -113,7 +113,10 @@ pub struct Block {
 impl_consensus_encoding!(Block, header, txdata);
 
 impl Block {
-    /// Returns the block hash.
+    /// Computes the block hash.
+    ///
+    /// The block hash is defined as the a sha256d hash of the consensus encoding of each of the
+    /// fields of the block's header.
     pub fn block_hash(&self) -> BlockHash { self.header.block_hash() }
 
     /// Checks if Merkle root of header matches Merkle root of the transaction list.

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -48,7 +48,10 @@ impl Header {
     // Serialized length of fields (version, prev_blockhash, merkle_root, time, bits, nonce)
     pub const SIZE: usize = 4 + 32 + 32 + 4 + 4 + 4; // 80
 
-    /// Returns the block hash.
+    /// Computes the block hash.
+    ///
+    /// The block hash is defined as the a sha256d hash of the consensus encoding of each of the
+    /// fields of the header.
     // This is the same as `Encodable` but done manually because `Encodable` isn't in `primitives`.
     pub fn block_hash(&self) -> BlockHash {
         let mut engine = sha256d::Hash::engine();


### PR DESCRIPTION
The `block_hash` function is not a getter; the current docs imply `Header::block_hash` is a cheap operation but its not.

Improve the docs to include a definition of the block hash and use the word 'compute' to indicate that its not cheap.