### PR TITLE
Fix re-exports and (manually) format the codebase

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -249,12 +249,15 @@ impl Block {
 
         let cb = self.coinbase().ok_or(Bip34Error::NotPresent)?;
         let input = cb.input.first().ok_or(Bip34Error::NotPresent)?;
-        let push = input.script_sig.instructions_minimal()
+        let push = input
+            .script_sig
+            .instructions_minimal()
             .next()
             .ok_or(Bip34Error::NotPresent)?
             .map_err(to_bip34_error)?;
         match (push.script_num(), push.push_bytes().map(|b| b.read_scriptint())) {
-            (Some(num), Some(Ok(_)) | None) => Ok(num.try_into().map_err(|_| Bip34Error::NegativeHeight)?),
+            (Some(num), Some(Ok(_)) | None) =>
+                Ok(num.try_into().map_err(|_| Bip34Error::NegativeHeight)?),
             (_, Some(Err(err))) => Err(to_bip34_error(err)),
             (None, _) => Err(Bip34Error::NotPresent),
         }

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -64,9 +64,7 @@ mod primitive {
         }
 
         /// Constructs an empty `&PushBytes`.
-        pub fn empty() -> &'static Self {
-            Self::from_slice_unchecked(&[])
-        }
+        pub fn empty() -> &'static Self { Self::from_slice_unchecked(&[]) }
 
         /// Returns the underlying bytes.
         pub fn as_bytes(&self) -> &[u8] { &self.0 }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -118,7 +118,7 @@ pub mod taproot;
 // that it is available in the event that we add some functionality there.
 #[doc(inline)]
 pub use primitives::{
-    block::{BlockHash, WitnessCommitment, Header as BlockHeader},
+    block::{BlockHash, Header as BlockHeader, WitnessCommitment},
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
     opcodes::Opcode,
     pow::CompactTarget, // No `pow` module outside of `primitives`.
@@ -141,11 +141,13 @@ pub use crate::{
     bip158::{FilterHash, FilterHeader},
     bip32::XKeyIdentifier,
     crypto::ecdsa,
-    crypto::key::{self, PrivateKey, PubkeyHash, PublicKey, CompressedPublicKey, WPubkeyHash, XOnlyPublicKey},
+    crypto::key::{
+        self, CompressedPublicKey, PrivateKey, PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey,
+    },
     crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},
     merkle_tree::MerkleBlock,
-    network::{Network, NetworkKind, TestnetVersion},
     network::params::{self, Params},
+    network::{Network, NetworkKind, TestnetVersion},
     pow::{Target, Work},
     psbt::Psbt,
     sighash::{EcdsaSighashType, TapSighashType},

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -114,7 +114,27 @@ pub mod psbt;
 pub mod sign_message;
 pub mod taproot;
 
-#[rustfmt::skip]                // Keep public re-exports separate.
+// Re-export the type from where it is defined but the module from the highest place up the stack
+// that it is available in the event that we add some functionality there.
+#[doc(inline)]
+pub use primitives::{
+    block::{BlockHash, WitnessCommitment, Header as BlockHeader},
+    merkle_tree::{TxMerkleNode, WitnessMerkleNode},
+    opcodes::Opcode,
+    pow::CompactTarget, // No `pow` module outside of `primitives`.
+    script::{Script, ScriptBuf},
+    sequence::{self, Sequence}, // No `sequence` module outside of `primitives`.
+    transaction::{OutPoint, Transaction, TxIn, TxOut, Txid, Wtxid},
+    witness::Witness,
+};
+#[doc(inline)]
+pub use units::{
+    amount::{Amount, Denomination, SignedAmount},
+    block::{BlockHeight, BlockInterval},
+    fee_rate::FeeRate,
+    weight::Weight,
+};
+
 #[doc(inline)]
 pub use crate::{
     address::{Address, AddressType, KnownHrp},
@@ -134,32 +154,16 @@ pub use crate::{
 // Re-export all modules from `blockdata`, users should never need to use `blockdata` directly.
 #[doc(inline)]
 pub use crate::{
-    // These modules also re-export all the respective `primitives` types.
-    blockdata::{block, constants, fee_rate, locktime, opcodes, script, transaction, weight, witness},
-    // And re-export types and modules from `blockdata` that don't come from `primitives`.
-    blockdata::block::Block, // TODO: Move this down below after it is in primitives.
+    // Also, re-export types and modules from `blockdata` that don't come from `primitives`.
+    blockdata::block::Block, // TODO: Move this after `Block` is in primitives.
     blockdata::locktime::{absolute, relative},
     blockdata::script::witness_program::{self, WitnessProgram},
     blockdata::script::witness_version::{self, WitnessVersion},
     blockdata::script::{ScriptHash, WScriptHash}, // TODO: Move these down below after they are in primitives.
-};
-#[doc(inline)]
-pub use primitives::{
-    block::{BlockHash, WitnessCommitment, Header as BlockHeader},
-    merkle_tree::{TxMerkleNode, WitnessMerkleNode},
-    opcodes::Opcode,
-    pow::CompactTarget,
-    script::{Script, ScriptBuf},
-    transaction::{OutPoint, Transaction, TxIn, TxOut, Txid, Wtxid},
-    witness::Witness,
-    sequence::Sequence,
-};
-#[doc(inline)]
-pub use units::{
-    amount::{Amount, Denomination, SignedAmount},
-    block::{BlockHeight, BlockInterval},
-    fee_rate::FeeRate,
-    weight::Weight
+    // These modules also re-export all the respective `primitives` types.
+    blockdata::{
+        block, constants, fee_rate, locktime, opcodes, script, transaction, weight, witness,
+    },
 };
 
 #[rustfmt::skip]

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -3,7 +3,6 @@
 //! Combine the ChaCha20 stream cipher with the Poly1305 message authentication code
 //! to form an authenticated encryption with additional data (AEAD) algorithm.
 #![no_std]
-
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -44,7 +44,7 @@ pub mod transaction;
 pub mod witness;
 
 #[doc(inline)]
-pub use units::amount::{Amount, SignedAmount};
+pub use units::amount::{self, Amount, SignedAmount};
 #[cfg(feature = "alloc")]
 #[doc(inline)]
 pub use units::{

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -67,10 +67,7 @@ impl SignedAmount {
     pub fn from_int_btc(btc: i64) -> Result<SignedAmount, OutOfRangeError> {
         match btc.checked_mul(100_000_000) {
             Some(amount) => Ok(SignedAmount::from_sat(amount)),
-            None => Err(OutOfRangeError {
-                is_signed: true,
-                is_greater_than_max: true,
-            })
+            None => Err(OutOfRangeError { is_signed: true, is_greater_than_max: true }),
         }
     }
 

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -77,10 +77,7 @@ impl Amount {
     pub fn from_int_btc(btc: u64) -> Result<Amount, OutOfRangeError> {
         match btc.checked_mul(100_000_000) {
             Some(amount) => Ok(Amount::from_sat(amount)),
-            None => Err(OutOfRangeError {
-                is_signed: false,
-                is_greater_than_max: true,
-            })
+            None => Err(OutOfRangeError { is_signed: false, is_greater_than_max: true }),
         }
     }
 


### PR DESCRIPTION
When we messed with the re-exports recently we failed to notice that the formatter would move the `pub use` blocks around because I only put `rustfmt::skip` on one block, I thought that had the effect of stopping all exports below that block being changed, turns out I was wrong.

Run the formatter then make some minor changes to the re-exports in `bitcoin`, including changing comments that do not make sense with the new layout.