### PR TITLE
Re-design and move `Block` to `primitives`

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -9,13 +9,12 @@
 
 use core::fmt;
 
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 use hashes::{sha256d, HashEngine};
 use internals::compact_size;
 use io::{BufRead, Write};
 
 use super::Weight;
+use crate::consensus::encode::WriteExt as _;
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::merkle_tree::{MerkleNode as _, TxMerkleNode, WitnessMerkleNode};
@@ -27,7 +26,7 @@ use crate::transaction::{Transaction, TransactionExt as _, Wtxid};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use primitives::block::{Version, BlockHash, Header, WitnessCommitment};
+pub use primitives::block::{Block, Checked, Unchecked, Validation, Version, BlockHash, Header, WitnessCommitment};
 #[doc(inline)]
 pub use units::block::{BlockHeight, BlockInterval, TooBigForRelativeBlockHeightError};
 
@@ -85,135 +84,202 @@ impl Decodable for Version {
     }
 }
 
-/// Bitcoin block.
-///
-/// A collection of transactions with an attached proof of work.
-///
-/// See [Bitcoin Wiki: Block][wiki-block] for more information.
-///
-/// [wiki-block]: https://en.bitcoin.it/wiki/Block
-///
-/// ### Bitcoin Core References
-///
-/// * [CBlock definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/block.h#L62)
-#[derive(PartialEq, Eq, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Block {
-    /// The block header
-    pub header: Header,
-    /// List of transactions contained in the block
-    pub txdata: Vec<Transaction>,
+/// Extension functionality for the [`Block<Unchecked>`] type.
+pub trait BlockUncheckedExt: sealed::Sealed {
+    /// Validates (or checks) a block.
+    ///
+    /// We define valid as:
+    ///
+    /// * The Merkle root of the header matches Merkle root of the transaction list.
+    /// * The witness commitment in coinbase matches the transaction list.
+    fn validate(self) -> Result<Block<Checked>, InvalidBlockError>;
 }
 
-impl Block {
-    /// Returns the block hash.
-    pub fn block_hash(&self) -> BlockHash { self.header.block_hash() }
+impl BlockUncheckedExt for Block<Unchecked> {
+    fn validate(self) -> Result<Block<Checked>, InvalidBlockError> {
+        let (header, transactions) = self.into_parts();
 
-    /// Checks if Merkle root of header matches Merkle root of the transaction list.
-    pub fn check_merkle_root(&self) -> bool {
-        match self.compute_merkle_root() {
-            Some(merkle_root) => self.header.merkle_root == merkle_root,
-            None => false,
-        }
-    }
-
-    /// Checks if witness commitment in coinbase matches the transaction list.
-    pub fn check_witness_commitment(&self) -> bool {
-        // Consists of OP_RETURN, OP_PUSHBYTES_36, and four "witness header" bytes.
-        const MAGIC: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
-        // Witness commitment is optional if there are no transactions using SegWit in the block.
-        if self.txdata.iter().all(|t| t.input.iter().all(|i| i.witness.is_empty())) {
-            return true;
+        if !check_merkle_root(&header, &transactions) {
+            return Err(InvalidBlockError::InvalidMerkleRoot);
         }
 
-        if self.txdata.is_empty() {
-            return false;
-        }
-
-        let coinbase = &self.txdata[0];
-        if !coinbase.is_coinbase() {
-            return false;
-        }
-
-        // Commitment is in the last output that starts with magic bytes.
-        if let Some(pos) = coinbase
-            .output
-            .iter()
-            .rposition(|o| o.script_pubkey.len() >= 38 && o.script_pubkey.as_bytes()[0..6] == MAGIC)
-        {
-            let bytes = <[u8; 32]>::try_from(&coinbase.output[pos].script_pubkey.as_bytes()[6..38])
-                .unwrap();
-            let commitment = WitnessCommitment::from_byte_array(bytes);
-            // Witness reserved value is in coinbase input witness.
-            let witness_vec: Vec<_> = coinbase.input[0].witness.iter().collect();
-            if witness_vec.len() == 1 && witness_vec[0].len() == 32 {
-                if let Some(witness_root) = self.witness_root() {
-                    return commitment
-                        == Self::compute_witness_commitment(witness_root, witness_vec[0]);
-                }
+        match check_witness_commitment(&transactions) {
+            (false, _) => Err(InvalidBlockError::InvalidWitnessCommitment),
+            (true, witness_root) => {
+                let block = Block::new_unchecked(header, transactions);
+                Ok(block.assume_checked(witness_root))
             }
         }
-
-        false
     }
+}
 
-    /// Computes the transaction Merkle root.
-    pub fn compute_merkle_root(&self) -> Option<TxMerkleNode> {
-        let hashes = self.txdata.iter().map(|obj| obj.compute_txid());
-        TxMerkleNode::calculate_root(hashes)
-    }
+/// Computes the Merkle root for a list of transactions.
+pub fn compute_merkle_root(transactions: &[Transaction]) -> Option<TxMerkleNode> {
+    let hashes = transactions.iter().map(|obj| obj.compute_txid());
+    TxMerkleNode::calculate_root(hashes)
+}
 
-    /// Computes the witness commitment for the block's transaction list.
-    pub fn compute_witness_commitment(
-        witness_root: WitnessMerkleNode,
-        witness_reserved_value: &[u8],
-    ) -> WitnessCommitment {
+/// Computes the witness commitment for a list of transactions.
+pub fn compute_witness_commitment(
+    transactions: &[Transaction],
+    witness_reserved_value: &[u8],
+) -> Option<(WitnessMerkleNode, WitnessCommitment)> {
+    compute_witness_root(transactions).map(|witness_root| {
         let mut encoder = sha256d::Hash::engine();
         witness_root.consensus_encode(&mut encoder).expect("engines don't error");
         encoder.input(witness_reserved_value);
-        WitnessCommitment::from_byte_array(sha256d::Hash::from_engine(encoder).to_byte_array())
+        let witness_commitment =
+            WitnessCommitment::from_byte_array(sha256d::Hash::from_engine(encoder).to_byte_array());
+        (witness_root, witness_commitment)
+    })
+}
+
+/// Computes the Merkle root of transactions hashed for witness.
+pub fn compute_witness_root(transactions: &[Transaction]) -> Option<WitnessMerkleNode> {
+    let hashes = transactions.iter().enumerate().map(|(i, t)| {
+        if i == 0 {
+            // Replace the first hash with zeroes.
+            Wtxid::COINBASE
+        } else {
+            t.compute_wtxid()
+        }
+    });
+    WitnessMerkleNode::calculate_root(hashes)
+}
+
+/// Checks if Merkle root of header matches Merkle root of the transaction list.
+fn check_merkle_root(header: &Header, transactions: &[Transaction]) -> bool {
+    match compute_merkle_root(transactions) {
+        Some(merkle_root) => header.merkle_root == merkle_root,
+        None => false,
+    }
+}
+
+/// Checks if witness commitment in coinbase matches the transaction list.
+// Returns the Merkle root if it was computed (so it can be cached in `assume_checked`).
+fn check_witness_commitment(transactions: &[Transaction]) -> (bool, Option<WitnessMerkleNode>) {
+    // Witness commitment is optional if there are no transactions using SegWit in the block.
+    if transactions.iter().all(|t| t.input.iter().all(|i| i.witness.is_empty())) {
+        return (true, None);
     }
 
-    /// Computes the Merkle root of transactions hashed for witness.
-    pub fn witness_root(&self) -> Option<WitnessMerkleNode> {
-        let hashes = self.txdata.iter().enumerate().map(|(i, t)| {
-            if i == 0 {
-                // Replace the first hash with zeroes.
-                Wtxid::COINBASE
-            } else {
-                t.compute_wtxid()
-            }
-        });
-        WitnessMerkleNode::calculate_root(hashes)
+    if transactions.is_empty() {
+        return (false, None);
     }
+
+    if transactions[0].is_coinbase() {
+        let coinbase = transactions[0].clone();
+        if let Some(commitment) = witness_commitment_from_coinbase(&coinbase) {
+            // Witness reserved value is in coinbase input witness.
+            let witness_vec: Vec<_> = coinbase.input[0].witness.iter().collect();
+            if witness_vec.len() == 1 && witness_vec[0].len() == 32 {
+                if let Some((witness_root, witness_commitment)) =
+                    compute_witness_commitment(transactions, witness_vec[0])
+                {
+                    if commitment == witness_commitment {
+                        return (true, Some(witness_root));
+                    }
+                }
+            }
+        }
+    }
+
+    (false, None)
+}
+
+fn witness_commitment_from_coinbase(coinbase: &Transaction) -> Option<WitnessCommitment> {
+    // Consists of OP_RETURN, OP_PUSHBYTES_36, and four "witness header" bytes.
+    const MAGIC: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+
+    if !coinbase.is_coinbase() {
+        return None;
+    }
+
+    // Commitment is in the last output that starts with magic bytes.
+    if let Some(pos) = coinbase
+        .output
+        .iter()
+        .rposition(|o| o.script_pubkey.len() >= 38 && o.script_pubkey.as_bytes()[0..6] == MAGIC)
+    {
+        let bytes =
+            <[u8; 32]>::try_from(&coinbase.output[pos].script_pubkey.as_bytes()[6..38]).unwrap();
+        Some(WitnessCommitment::from_byte_array(bytes))
+    } else {
+        None
+    }
+}
+
+/// Extension functionality for the [`Block<Checked>`] type.
+pub trait BlockCheckedExt: sealed::Sealed {
+    /// Constructs a new [`Block`].
+    ///
+    /// # Returns
+    ///
+    /// Return the block if it is valid, `None` if not. See [`Block::validate`].
+    fn new_checked(
+        header: Header,
+        transactions: Vec<Transaction>,
+    ) -> Result<Block<Checked>, InvalidBlockError>;
+
+    /// Returns the transaction Merkle root.
+    fn merkle_root(&self) -> TxMerkleNode;
+
+    /// Returns the Merkle root of transactions hashed for witness.
+    ///
+    /// This value was computed during block validation and was cached at that time.
+    fn witness_root(&mut self) -> Option<WitnessMerkleNode>;
 
     /// Returns the weight of the block.
     ///
     /// > Block weight is defined as Base size * 3 + Total size.
-    pub fn weight(&self) -> Weight {
-        // This is the exact definition of a weight unit, as defined by BIP-141 (quote above).
-        let wu = block_base_size(&self.txdata) * 3 + self.total_size();
-        Weight::from_wu_usize(wu)
-    }
+    fn weight(&self) -> Weight;
 
     /// Returns the total block size.
     ///
     /// > Total size is the block size in bytes with transactions serialized as described in BIP144,
     /// > including base data and witness data.
-    pub fn total_size(&self) -> usize {
+    fn total_size(&self) -> usize;
+
+    /// Returns the coinbase transaction, if one is present.
+    fn coinbase(&self) -> Option<&Transaction>;
+
+    /// Returns the block height, as encoded in the coinbase transaction according to BIP34.
+    fn bip34_block_height(&self) -> Result<u64, Bip34Error>;
+}
+
+impl BlockCheckedExt for Block<Checked> {
+    fn new_checked(
+        header: Header,
+        transactions: Vec<Transaction>,
+    ) -> Result<Block<Checked>, InvalidBlockError> {
+        let block = Block::new_unchecked(header, transactions);
+        block.validate()
+    }
+
+    fn merkle_root(&self) -> TxMerkleNode { self.header().merkle_root }
+
+    fn witness_root(&mut self) -> Option<WitnessMerkleNode> { self.cached_witness_root() }
+
+    fn weight(&self) -> Weight {
+        // This is the exact definition of a weight unit, as defined by BIP-141 (quote above).
+        let wu = block_base_size(self.transactions()) * 3 + self.total_size();
+        Weight::from_wu_usize(wu)
+    }
+
+    fn total_size(&self) -> usize {
         let mut size = Header::SIZE;
 
-        size += compact_size::encoded_size(self.txdata.len());
-        size += self.txdata.iter().map(|tx| tx.total_size()).sum::<usize>();
+        size += compact_size::encoded_size(self.transactions().len());
+        size += self.transactions().iter().map(|tx| tx.total_size()).sum::<usize>();
 
         size
     }
 
     /// Returns the coinbase transaction, if one is present.
-    pub fn coinbase(&self) -> Option<&Transaction> { self.txdata.first() }
+    fn coinbase(&self) -> Option<&Transaction> { self.transactions().first() }
 
     /// Returns the block height, as encoded in the coinbase transaction according to BIP34.
-    pub fn bip34_block_height(&self) -> Result<u64, Bip34Error> {
+    fn bip34_block_height(&self) -> Result<u64, Bip34Error> {
         // Citing the spec:
         // Add height as the first item in the coinbase transaction's scriptSig,
         // and increase block version to 2. The format of the height is
@@ -223,7 +289,7 @@ impl Block {
         // number (including a sign bit). Height is the height of the mined
         // block in the block chain, where the genesis block is height zero (0).
 
-        if self.header.version < Version::TWO {
+        if self.header().version < Version::TWO {
             return Err(Bip34Error::Unsupported);
         }
 
@@ -244,10 +310,6 @@ impl Block {
     }
 }
 
-/// Returns the base block size.
-///
-/// > Base size is the block size in bytes with the original transaction serialization without
-/// > any witness-related data, as seen by a non-upgraded node.
 fn block_base_size(transactions: &[Transaction]) -> usize {
     let mut size = Header::SIZE;
 
@@ -257,49 +319,85 @@ fn block_base_size(transactions: &[Transaction]) -> usize {
     size
 }
 
-impl From<Block> for BlockHash {
-    fn from(block: Block) -> BlockHash { block.block_hash() }
-}
-
-impl From<&Block> for BlockHash {
-    fn from(block: &Block) -> BlockHash { block.block_hash() }
-}
-
-impl Encodable for Block {
+impl Encodable for Block<Unchecked> {
     #[inline]
-    fn consensus_encode<R: io::Write + ?Sized>(&self, r: &mut R) -> Result<usize, io::Error> {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        // TODO: Should we be able to encode without cloning?
+        // This is ok, we decode as unchecked anyway.
+        let block = self.clone().assume_checked(None);
+        block.consensus_encode(w)
+    }
+}
+
+impl Encodable for Block<Checked> {
+    #[inline]
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
-        len += self.header.consensus_encode(r)?;
-        len += self.txdata.consensus_encode(r)?;
+        len += self.header().consensus_encode(w)?;
+
+        let transactions = self.transactions();
+        len += w.emit_compact_size(transactions.len())?;
+        for c in transactions.iter() {
+            len += c.consensus_encode(w)?;
+        }
+
         Ok(len)
     }
 }
 
-impl Decodable for Block {
+impl Decodable for Block<Unchecked> {
     #[inline]
     fn consensus_decode_from_finite_reader<R: io::BufRead + ?Sized>(
         r: &mut R,
     ) -> Result<Block, encode::Error> {
-        Ok(Block {
-            header: Decodable::consensus_decode_from_finite_reader(r)?,
-            txdata: Decodable::consensus_decode_from_finite_reader(r)?,
-        })
+        let header = Decodable::consensus_decode_from_finite_reader(r)?;
+        let transactions = Decodable::consensus_decode_from_finite_reader(r)?;
+
+        Ok(Block::new_unchecked(header, transactions))
     }
 
     #[inline]
     fn consensus_decode<R: io::BufRead + ?Sized>(r: &mut R) -> Result<Block, encode::Error> {
         let mut r = r.take(internals::ToU64::to_u64(encode::MAX_VEC_SIZE));
-        Ok(Block {
-            header: Decodable::consensus_decode(&mut r)?,
-            txdata: Decodable::consensus_decode(&mut r)?,
-        })
+        let header = Decodable::consensus_decode(&mut r)?;
+        let transactions = Decodable::consensus_decode(&mut r)?;
+
+        Ok(Block::new_unchecked(header, transactions))
     }
 }
 
 mod sealed {
+    /// Seals the extension traits.
     pub trait Sealed {}
     impl Sealed for super::Header {}
+    impl<V: super::Validation> Sealed for super::Block<V> {}
 }
+
+/// Invalid block error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidBlockError {
+    /// Header Merkle root does not match the calculated Merkle root.
+    InvalidMerkleRoot,
+    /// The witness commitment in coinbase transaction does not match the calculated witness_root.
+    InvalidWitnessCommitment,
+}
+
+internals::impl_from_infallible!(InvalidBlockError);
+
+impl fmt::Display for InvalidBlockError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use InvalidBlockError::*;
+
+        match *self {
+            InvalidMerkleRoot => write!(f, "header Merkle root does not match the calculated Merkle root"),
+            InvalidWitnessCommitment => write!(f, "the witness commitment in coinbase transaction does not match the calculated witness_root"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidBlockError {}
 
 /// An error when looking up a BIP34 block height.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -383,13 +481,6 @@ impl std::error::Error for ValidationError {
     }
 }
 
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for Block {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Block { header: Header::arbitrary(u)?, txdata: Vec::<Transaction>::arbitrary(u)? })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use hex::test_hex_unwrap as hex;
@@ -397,14 +488,31 @@ mod tests {
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::{CompactTarget, Network, TestnetVersion};
     use crate::pow::test_utils::{u128_to_work, u64_to_work};
+    use crate::{block, CompactTarget, Network, TestnetVersion};
+
+    #[test]
+    fn static_vector() {
+        // testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
+        let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw");
+        let block: Block = deserialize(&segwit_block[..]).expect("failed to deserialize block");
+        let (header, transactions) = block.into_parts();
+
+        assert!(block::check_merkle_root(&header, &transactions));
+        let block = Block::new_unchecked(header, transactions).assume_checked(None);
+
+        // Same as `block.check_merkle_root` but do it explicitly.
+        let hashes_iter = block.transactions().iter().map(|obj| obj.compute_txid());
+        let from_iter = TxMerkleNode::calculate_root(hashes_iter.clone());
+        assert_eq!(from_iter, Some(block.header().merkle_root));
+    }
 
     #[test]
     fn test_coinbase_and_bip34() {
         // testnet block 100,000
         const BLOCK_HEX: &str = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
         let block: Block = deserialize(&hex!(BLOCK_HEX)).unwrap();
+        let block = block.assume_checked(None);
 
         let cb_txid = "d574f343976d8e70d91cb278d21044dd8a396019e6db70755a0a50e4783dba38";
         assert_eq!(block.coinbase().unwrap().compute_txid().to_string(), cb_txid);
@@ -414,24 +522,28 @@ mod tests {
         // block with 3-byte bip34 push for height 0x03010000 (non-minimal 1)
         const BAD_HEX: &str = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703010000000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
         let bad: Block = deserialize(&hex!(BAD_HEX)).unwrap();
+        let bad = bad.assume_checked(None);
 
         assert_eq!(bad.bip34_block_height(), Err(super::Bip34Error::NonMinimalPush));
 
         // Block 15 on Testnet4 has height of 0x5f (15 PUSHNUM)
         const BLOCK_HEX_SMALL_HEIGHT_15: &str = "000000200fd8c4c1e88f313b561b2724542ff9be1bc54a7dab8db8ef6359d48a00000000705bf9145e6d3c413702cc61f32e4e7bfe3117b1eb928071a59adcf75694a3fb07d83866ffff001dcf4c5e8401010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff095f00062f4077697a2fffffffff0200f2052a010000001976a9140a59837ccd4df25adc31cdad39be6a8d97557ed688ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000";
         let block: Block = deserialize(&hex!(BLOCK_HEX_SMALL_HEIGHT_15)).unwrap();
+        let block = block.assume_checked(None);
 
         assert_eq!(block.bip34_block_height(), Ok(15));
 
         // Block 42 on Testnet4 has height of 0x012a (42)
         const BLOCK_HEX_SMALL_HEIGHT_42: &str = "000000202803addb5a3f42f3e8d6c8536598b2d872b04f3b4f0698c26afdb17300000000463dd9a37a5d3d5c05f9c80a1485b41f1f513dee00338bbc33f5a6e836fce0345dda3866ffff001d872b9def01010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff09012a062f4077697a2fffffffff0200f2052a010000001976a9140a59837ccd4df25adc31cdad39be6a8d97557ed688ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000";
         let block: Block = deserialize(&hex!(BLOCK_HEX_SMALL_HEIGHT_42)).unwrap();
+        let block = block.assume_checked(None);
 
         assert_eq!(block.bip34_block_height(), Ok(42));
 
         // Block 42 on Testnet4 using OP_PUSHDATA1 0x4c012a (42) instead of 0x012a (42)
         const BLOCK_HEX_SMALL_HEIGHT_42_WRONG: &str = "000000202803addb5a3f42f3e8d6c8536598b2d872b04f3b4f0698c26afdb17300000000463dd9a37a5d3d5c05f9c80a1485b41f1f513dee00338bbc33f5a6e836fce0345dda3866ffff001d872b9def01010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0a4c012a062f4077697a2fffffffff0200f2052a010000001976a9140a59837ccd4df25adc31cdad39be6a8d97557ed688ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000";
         let block: Block = deserialize(&hex!(BLOCK_HEX_SMALL_HEIGHT_42_WRONG)).unwrap();
+        let block = block.assume_checked(None);
 
         assert_eq!(block.bip34_block_height(), Err(super::Bip34Error::NonMinimalPush));
 
@@ -439,6 +551,7 @@ mod tests {
         // this is an overflow for ScriptNum (i32) parsing
         const BLOCK_HEX_5_BYTE_HEIGHT: &str = "000000202803addb5a3f42f3e8d6c8536598b2d872b04f3b4f0698c26afdb17300000000463dd9a37a5d3d5c05f9c80a1485b41f1f513dee00338bbc33f5a6e836fce0345dda3866ffff001d872b9def01010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0d052a2a2a2a2a062f4077697a2fffffffff0200f2052a010000001976a9140a59837ccd4df25adc31cdad39be6a8d97557ed688ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000";
         let block: Block = deserialize(&hex!(BLOCK_HEX_5_BYTE_HEIGHT)).unwrap();
+        let block = block.assume_checked(None);
 
         assert_eq!(block.bip34_block_height(), Err(super::Bip34Error::NotPresent));
     }
@@ -459,31 +572,41 @@ mod tests {
 
         assert!(decode.is_ok());
         assert!(bad_decode.is_err());
-        let real_decode = decode.unwrap();
-        assert_eq!(real_decode.header.version, Version::from_consensus(1));
-        assert_eq!(serialize(&real_decode.header.prev_blockhash), prevhash);
-        assert_eq!(real_decode.header.merkle_root, real_decode.compute_merkle_root().unwrap());
-        assert_eq!(serialize(&real_decode.header.merkle_root), merkle);
-        assert_eq!(real_decode.header.time, 1231965655);
-        assert_eq!(real_decode.header.bits, CompactTarget::from_consensus(486604799));
-        assert_eq!(real_decode.header.nonce, 2067413810);
-        assert_eq!(real_decode.header.work(), work);
+
+        let (header, transactions) = decode.unwrap().into_parts();
+        // should be also ok for a non-witness block as commitment is optional in that case
+        let (witness_commitment_matches, witness_root) =
+            block::check_witness_commitment(&transactions);
+        assert!(witness_commitment_matches);
+
+        let real_decode =
+            Block::new_unchecked(header, transactions.clone()).assume_checked(witness_root);
+
+        assert_eq!(real_decode.header().version, Version::from_consensus(1));
+        assert_eq!(serialize(&real_decode.header().prev_blockhash), prevhash);
         assert_eq!(
-            real_decode.header.validate_pow(real_decode.header.target()).unwrap(),
+            real_decode.header().merkle_root,
+            block::compute_merkle_root(&transactions).unwrap()
+        );
+        assert_eq!(serialize(&real_decode.header().merkle_root), merkle);
+        assert_eq!(real_decode.header().time, 1231965655);
+        assert_eq!(real_decode.header().bits, CompactTarget::from_consensus(486604799));
+        assert_eq!(real_decode.header().nonce, 2067413810);
+        assert_eq!(real_decode.header().work(), work);
+
+        assert_eq!(real_decode.header().difficulty(&params), 1);
+        assert_eq!(real_decode.header().difficulty_float(&params), 1.0);
+
+        assert_eq!(
+            real_decode.header().validate_pow(real_decode.header().target()).unwrap(),
             real_decode.block_hash()
         );
-        assert_eq!(real_decode.header.difficulty(&params), 1);
-        assert_eq!(real_decode.header.difficulty_float(&params), 1.0);
-
         assert_eq!(real_decode.total_size(), some_block.len());
-        assert_eq!(block_base_size(&real_decode.txdata), some_block.len());
+        assert_eq!(block_base_size(real_decode.transactions()), some_block.len());
         assert_eq!(
             real_decode.weight(),
             Weight::from_non_witness_data_size(some_block.len().to_u64())
         );
-
-        // should be also ok for a non-witness block as commitment is optional in that case
-        assert!(real_decode.check_witness_commitment());
 
         assert_eq!(serialize(&real_decode), some_block);
     }
@@ -501,27 +624,36 @@ mod tests {
         let work = u64_to_work(0x257c3becdacc64_u64);
 
         assert!(decode.is_ok());
-        let real_decode = decode.unwrap();
-        assert_eq!(real_decode.header.version, Version::from_consensus(0x2000_0000)); // VERSIONBITS but no bits set
-        assert_eq!(serialize(&real_decode.header.prev_blockhash), prevhash);
-        assert_eq!(serialize(&real_decode.header.merkle_root), merkle);
-        assert_eq!(real_decode.header.merkle_root, real_decode.compute_merkle_root().unwrap());
-        assert_eq!(real_decode.header.time, 1472004949);
-        assert_eq!(real_decode.header.bits, CompactTarget::from_consensus(0x1a06d450));
-        assert_eq!(real_decode.header.nonce, 1879759182);
-        assert_eq!(real_decode.header.work(), work);
+
+        let (header, transactions) = decode.unwrap().into_parts();
+        let (witness_commitment_matches, witness_root) =
+            block::check_witness_commitment(&transactions);
+        assert!(witness_commitment_matches);
+
+        let real_decode =
+            Block::new_unchecked(header, transactions.clone()).assume_checked(witness_root);
+
+        assert_eq!(real_decode.header().version, Version::from_consensus(0x2000_0000)); // VERSIONBITS but no bits set
+        assert_eq!(serialize(&real_decode.header().prev_blockhash), prevhash);
+        assert_eq!(serialize(&real_decode.header().merkle_root), merkle);
         assert_eq!(
-            real_decode.header.validate_pow(real_decode.header.target()).unwrap(),
+            real_decode.header().merkle_root,
+            block::compute_merkle_root(&transactions).unwrap()
+        );
+        assert_eq!(real_decode.header().time, 1472004949);
+        assert_eq!(real_decode.header().bits, CompactTarget::from_consensus(0x1a06d450));
+        assert_eq!(real_decode.header().nonce, 1879759182);
+        assert_eq!(real_decode.header().work(), work);
+        assert_eq!(real_decode.header().difficulty(&params), 2456598);
+        assert_eq!(real_decode.header().difficulty_float(&params), 2456598.4399242126);
+
+        assert_eq!(
+            real_decode.header().validate_pow(real_decode.header().target()).unwrap(),
             real_decode.block_hash()
         );
-        assert_eq!(real_decode.header.difficulty(&params), 2456598);
-        assert_eq!(real_decode.header.difficulty_float(&params), 2456598.4399242126);
-
         assert_eq!(real_decode.total_size(), segwit_block.len());
-        assert_eq!(block_base_size(&real_decode.txdata), 4283);
+        assert_eq!(block_base_size(real_decode.transactions()), 4283);
         assert_eq!(real_decode.weight(), Weight::from_wu(17168));
-
-        assert!(real_decode.check_witness_commitment());
 
         assert_eq!(serialize(&real_decode), segwit_block);
     }
@@ -531,14 +663,15 @@ mod tests {
         let block = hex!("ffffff7f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         let decode: Result<Block, _> = deserialize(&block);
         assert!(decode.is_ok());
-        let real_decode = decode.unwrap();
-        assert_eq!(real_decode.header.version, Version::from_consensus(2147483647));
+
+        let real_decode = decode.unwrap().assume_checked(None);
+        assert_eq!(real_decode.header().version, Version::from_consensus(2147483647));
 
         let block2 = hex!("000000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         let decode2: Result<Block, _> = deserialize(&block2);
         assert!(decode2.is_ok());
-        let real_decode2 = decode2.unwrap();
-        assert_eq!(real_decode2.header.version, Version::from_consensus(-2147483648));
+        let real_decode2 = decode2.unwrap().assume_checked(None);
+        assert_eq!(real_decode2.header().version, Version::from_consensus(-2147483648));
     }
 
     #[test]

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -73,11 +73,6 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl Sealed for super::Header {}
-}
-
 impl Encodable for Version {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         self.to_consensus().consensus_encode(w)
@@ -299,6 +294,11 @@ impl Decodable for Block {
             txdata: Decodable::consensus_decode(&mut r)?,
         })
     }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Header {}
 }
 
 /// An error when looking up a BIP34 block height.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1263,7 +1263,7 @@ mod tests {
         use crate::network::Network;
 
         let genesis = constants::genesis_block(Network::Bitcoin);
-        assert!(genesis.txdata[0].is_coinbase());
+        assert!(genesis.transactions()[0].is_coinbase());
         let tx_bytes = hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000");
         let tx: Transaction = deserialize(&tx_bytes).unwrap();
         assert!(!tx.is_coinbase());

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -118,7 +118,10 @@ pub mod taproot;
 // that it is available in the event that we add some functionality there.
 #[doc(inline)]
 pub use primitives::{
-    block::{BlockHash, Header as BlockHeader, WitnessCommitment},
+    block::{
+        Block, BlockHash, Checked as BlockChecked, Header as BlockHeader,
+        Unchecked as BockUnchecked, Validation as BlockValidation, WitnessCommitment,
+    },
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
     opcodes::Opcode,
     pow::CompactTarget, // No `pow` module outside of `primitives`.
@@ -157,7 +160,6 @@ pub use crate::{
 #[doc(inline)]
 pub use crate::{
     // Also, re-export types and modules from `blockdata` that don't come from `primitives`.
-    blockdata::block::Block, // TODO: Move this after `Block` is in primitives.
     blockdata::locktime::{absolute, relative},
     blockdata::script::witness_program::{self, WitnessProgram},
     blockdata::script::witness_version::{self, WitnessVersion},

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -113,24 +113,3 @@ impl MerkleNode for WitnessMerkleNode {
         Self::from_byte_array(sha256d::Hash::from_engine(encoder).to_byte_array())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::block::Block;
-    use crate::consensus::encode::deserialize;
-
-    #[test]
-    fn static_vector() {
-        // testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
-        let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw");
-        let block: Block = deserialize(&segwit_block[..]).expect("failed to deserialize block");
-
-        assert!(block.check_merkle_root());
-
-        // Same as `block.check_merkle_root` but do it explicitly.
-        let hashes_iter = block.txdata.iter().map(|obj| obj.compute_txid());
-        let from_iter = TxMerkleNode::calculate_root(hashes_iter.clone());
-        assert_eq!(from_iter, Some(block.header.merkle_root));
-    }
-}

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1784,7 +1784,7 @@ mod tests {
         use crate::constants::genesis_block;
         use crate::TxMerkleNode;
         let params = Params::new(crate::Network::Signet);
-        let epoch_start = genesis_block(&params).header;
+        let epoch_start = *genesis_block(&params).header();
 
         // Block 2015, the only information used are `bits` and `time`
         let current = Header {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -54,6 +54,16 @@ pub use units::{
 };
 
 #[doc(inline)]
+#[cfg(feature = "alloc")]
+pub use self::{
+    block::{
+        Block, Checked as BlockChecked, Unchecked as BlockUnchecked, Validation as BlockValidation,
+    },
+    locktime::{absolute, relative},
+    transaction::{Transaction, TxIn, TxOut},
+    witness::Witness,
+};
+#[doc(inline)]
 pub use self::{
     block::{BlockHash, Header as BlockHeader, WitnessCommitment},
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
@@ -61,13 +71,6 @@ pub use self::{
     sequence::Sequence,
     taproot::{TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash, TapTweakHash, TapTweakTag},
     transaction::{Txid, Wtxid},
-};
-#[doc(inline)]
-#[cfg(feature = "alloc")]
-pub use self::{
-    locktime::{absolute, relative},
-    transaction::{Transaction, TxIn, TxOut},
-    witness::Witness,
 };
 
 #[rustfmt::skip]


### PR DESCRIPTION
Re-design the `Block` API and move the type to `primitives`.