### PR TITLE
Accept underscores inserted into numeric literals to improve readability

### DIFF
--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -21,7 +21,7 @@ use crate::{FeeRate, Weight};
 fn from_str_zero() {
     let denoms = ["BTC", "mBTC", "uBTC", "bits", "sats"];
     for denom in denoms {
-        for v in &["0", "000"] {
+        for v in &["0", "000", "0_0"] {
             let s = format!("{} {}", v, denom);
             match s.parse::<Amount>() {
                 Err(e) => panic!("failed to crate amount from {}: {:?}", s, e),

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -117,7 +117,8 @@ impl Amount {
     /// If you want to parse only the amount without the denomination, use [`Self::from_str_in`].
     pub fn from_str_with_denomination(s: &str) -> Result<Amount, ParseError> {
         let (amt, denom) = split_amount_and_denomination(s)?;
-        Amount::from_str_in(amt, denom).map_err(Into::into)
+        let sanitized = &amt.replace("_", "");
+        Amount::from_str_in(sanitized, denom).map_err(Into::into)
     }
 
     /// Expresses this [`Amount`] as a floating-point value in the given denomination.


### PR DESCRIPTION
Accept underscores inserted into numeric literals to improve readability

ref: https://doc.rust-lang.org/rust-by-example/primitives/literals.html