### PR TITLE
Add callouts to the chacha20-poly1305 public docs

### DIFF
--- a/chacha20_poly1305/README.md
+++ b/chacha20_poly1305/README.md
@@ -2,6 +2,8 @@
 
 An authenticated encryption with associated data (AEAD) algorithm implemented with the ChaCha20 stream cipher and the Poly1305 message authentication code (MAC).
 
+This implementation is maintained by the rust-bitcoin community and has a focus on a bare-bones API suitable for the bitcoin ecosystem.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This library should always compile with any combination of features on **Rust 1.63.0**.


### PR DESCRIPTION
Making it clear in the chacha20-poly1305 documentation that this implementation is maintained by bitcoin developers and targeted specifically for bitcoin ecosystem use cases.