### PR TITLE
Add constructor to `FeeRate`

### DIFF
--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -62,6 +62,9 @@ impl FeeRate {
     /// Constructs a new [`FeeRate`] from satoshis per virtual bytes without overflow check.
     pub const fn from_sat_per_vb_unchecked(sat_vb: u64) -> Self { FeeRate(sat_vb * (1000 / 4)) }
 
+    /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes).
+    pub const fn from_sat_per_kvb(sat_kvb: u64) -> Self { FeeRate(sat_kvb / 4) }
+
     /// Returns raw fee rate.
     ///
     /// Can be used instead of `into()` to avoid inference issues.


### PR DESCRIPTION
This is partially to check my understanding. I did poorly in physics class as part of my misunderstanding of unit conversions. 

The `feefilter` message expresses the fee as satoshis per 1,000 vbyte, see the [p2p handling](https://github.com/bitcoin/bitcoin/blob/1dda1892b6bcc3d4f9678960cc9e9920f491e87e/src/net_processing.cpp#L5331) which calls [this function](https://github.com/bitcoin/bitcoin/blob/master/src/policy/feerate.h#L63) on the mempool. I presume all that needs to happen to express this in `kwu` is to divide by 4, but ideally a `FeeRate` may be constructed directly from a `feefilter` message using a constructor. 

My conversion is (sat / kvb * kvb / 4 kwu)