### PR TITLE
Mark function as const

### DIFF
--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -55,8 +55,12 @@ impl Weight {
     pub fn from_kwu(wu: u64) -> Option<Self> { wu.checked_mul(1000).map(Weight) }
 
     /// Constructs a new [`Weight`] from virtual bytes, returning [`None`] if an overflow occurred.
-    pub fn from_vb(vb: u64) -> Option<Self> {
-        vb.checked_mul(Self::WITNESS_SCALE_FACTOR).map(Weight::from_wu)
+    pub const fn from_vb(vb: u64) -> Option<Self> {
+        // No `map()` in const context.
+        match vb.checked_mul(Self::WITNESS_SCALE_FACTOR) {
+            Some(wu) => Some(Weight::from_wu(wu)),
+            None => None,
+        }
     }
 
     /// Constructs a new [`Weight`] from virtual bytes panicking if an overflow occurred.


### PR DESCRIPTION
We discussed marking from_vb as const here: https://github.com/rust-bitcoin/rust-bitcoin/issues/3602

However, from what I can tell, map() isn't const and I don't see a tracking issue for changing it.  Also, the question mark operator isn't available in const context either, although there is a tracking issue for that: https://github.com/rust-lang/rust/issues/74935.  It will be a long while before that makes it into this projects MSRV if/when it lands.

There are some other functions in this module that could use the same re-write to make them const as well it looks like.