### PR TITLE
Pull `serde` stuff out of `impl_bytelike_traits` macro

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -62,6 +62,9 @@ hashes::hash_newtype! {
     pub struct FilterHeader(sha256d::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(FilterHash, FilterHeader);
+
 impl_hashencode!(FilterHash);
 impl_hashencode!(FilterHeader);
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -58,6 +58,9 @@ hash_newtype! {
     pub struct XKeyIdentifier(hash160::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(XKeyIdentifier);
+
 /// Extended private key
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -92,6 +92,10 @@ hashes::hash_newtype! {
     /// SegWit version of a Bitcoin Script bytecode hash.
     pub struct WScriptHash(sha256::Hash);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(ScriptHash, WScriptHash);
+
 impl_asref_push_bytes!(ScriptHash, WScriptHash);
 
 impl ScriptHash {

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -264,6 +264,10 @@ hashes::hash_newtype! {
     /// SegWit version of a public key hash.
     pub struct WPubkeyHash(hash160::Hash);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(PubkeyHash, WPubkeyHash);
+
 impl_asref_push_bytes!(PubkeyHash, WPubkeyHash);
 
 impl From<PublicKey> for PubkeyHash {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -56,6 +56,9 @@ hash_newtype! {
     pub struct SegwitV0Sighash(sha256d::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(LegacySighash, SegwitV0Sighash);
+
 impl_message_from_hash!(LegacySighash);
 impl_message_from_hash!(SegwitV0Sighash);
 
@@ -81,6 +84,9 @@ hash_newtype! {
     /// This hash type is used for computing Taproot signature hash."
     pub struct TapSighash(sha256t::Hash<TapSighashTag>);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapSighash);
 
 impl_message_from_hash!(TapSighash);
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -28,6 +28,9 @@ macro_rules! hash_trait_impls {
             fn from_engine(e: HashEngine) -> Hash<$($gen),*> { Self::from_engine(e) }
         }
 
+        #[cfg(feature = "serde")]
+        $crate::serde_impl!(Hash, { $bits / 8} $(, $gen: $gent)*);
+
         impl<$($gen: $gent),*> $crate::Hash for Hash<$($gen),*> {
             type Bytes = [u8; $bits / 8];
 

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -162,6 +162,9 @@ hashes::hash_newtype! {
     pub struct WitnessCommitment(sha256d::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(BlockHash, WitnessCommitment);
+
 impl BlockHash {
     /// Dummy hash used as the previous blockhash of the genesis block.
     pub const GENESIS_PREVIOUS_BLOCK_HASH: Self = Self::from_byte_array([0; 32]);

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -10,3 +10,6 @@ hashes::hash_newtype! {
     /// A hash corresponding to the Merkle tree root for witness data.
     pub struct WitnessMerkleNode(sha256d::Hash);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TxMerkleNode, WitnessMerkleNode);

--- a/primitives/src/taproot.rs
+++ b/primitives/src/taproot.rs
@@ -18,6 +18,9 @@ hash_newtype! {
     pub struct TapLeafHash(sha256t::Hash<TapLeafTag>);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapLeafHash);
+
 sha256t_tag! {
     pub struct TapBranchTag = hash_str("TapBranch");
 }
@@ -29,6 +32,9 @@ hash_newtype! {
     pub struct TapNodeHash(sha256t::Hash<TapBranchTag>);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapNodeHash);
+
 sha256t_tag! {
     pub struct TapTweakTag = hash_str("TapTweak");
 }
@@ -39,6 +45,9 @@ hash_newtype! {
     /// This hash type is used while computing the tweaked public key.
     pub struct TapTweakHash(sha256t::Hash<TapTweakTag>);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapTweakHash);
 
 impl From<TapLeafHash> for TapNodeHash {
     fn from(leaf: TapLeafHash) -> TapNodeHash { TapNodeHash::from_byte_array(leaf.to_byte_array()) }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -476,6 +476,9 @@ hashes::hash_newtype! {
     pub struct Wtxid(sha256d::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(Txid, Wtxid);
+
 impl Txid {
     /// The `Txid` used in a coinbase prevout.
     ///


### PR DESCRIPTION
The `impl_bytelike_traits` macro is public and it is used in the `hash_newtype` macro, also public.

Currently if a user calls the `hash_newtype` macro in a crate that depends on `hashes` without the `serde` feature enabled and with no `serde` dependency everything works. However if the user then adds a dependency that happens to enable the `serde` feature in `hashes` their build will blow up because `serde` code will start getting called from the original crate's call to `hash_newtype`.

Pull the serde stuff out of `hash_newtype` and provide a macro to implement it `impl_serde_for_newtype`.