### PR TITLE
Hashes: Make `hex` dependency optional

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -253,8 +253,10 @@ jobs:
         run: cd bitcoin/embedded && cargo run --target thumbv7m-none-eabi
       - name: "Run hashes/embedded no alloc"
         run: cd hashes/embedded && cargo run --target thumbv7m-none-eabi
-      - name: "Run hashes/embedded with alloc"
+      - name: "Run hashes/embedded with alloc and no hex"
         run: cd hashes/embedded && cargo run --target thumbv7m-none-eabi --features=alloc
+      - name: "Run hashes/embedded with alloc and hex"
+        run: cd hashes/embedded && cargo run --target thumbv7m-none-eabi --features=alloc,hex
 
   ASAN:                         # hashes crate only.
     name: ASAN - nightly toolchain

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -27,7 +27,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 [dependencies]
 base58 = { package = "base58ck", version = "0.1.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = false, features = ["alloc", "bitcoin-io"] }
+hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = false, features = ["alloc", "bitcoin-io", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -62,6 +62,7 @@ hashes::hash_newtype! {
     pub struct FilterHeader(sha256d::Hash);
 }
 
+hashes::impl_hex_for_newtype!(FilterHash, FilterHeader);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(FilterHash, FilterHeader);
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -62,6 +62,9 @@ hashes::hash_newtype! {
     pub struct FilterHeader(sha256d::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(FilterHash, FilterHeader);
+
 impl_hashencode!(FilterHash);
 impl_hashencode!(FilterHeader);
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -58,6 +58,7 @@ hash_newtype! {
     pub struct XKeyIdentifier(hash160::Hash);
 }
 
+hashes::impl_hex_for_newtype!(XKeyIdentifier);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(XKeyIdentifier);
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -58,6 +58,9 @@ hash_newtype! {
     pub struct XKeyIdentifier(hash160::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(XKeyIdentifier);
+
 /// Extended private key
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -93,6 +93,7 @@ hashes::hash_newtype! {
     pub struct WScriptHash(sha256::Hash);
 }
 
+hashes::impl_hex_for_newtype!(ScriptHash, WScriptHash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(ScriptHash, WScriptHash);
 

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -92,6 +92,10 @@ hashes::hash_newtype! {
     /// SegWit version of a Bitcoin Script bytecode hash.
     pub struct WScriptHash(sha256::Hash);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(ScriptHash, WScriptHash);
+
 impl_asref_push_bytes!(ScriptHash, WScriptHash);
 
 impl ScriptHash {

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -265,6 +265,7 @@ hashes::hash_newtype! {
     pub struct WPubkeyHash(hash160::Hash);
 }
 
+hashes::impl_hex_for_newtype!(PubkeyHash, WPubkeyHash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(PubkeyHash, WPubkeyHash);
 

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -264,6 +264,10 @@ hashes::hash_newtype! {
     /// SegWit version of a public key hash.
     pub struct WPubkeyHash(hash160::Hash);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(PubkeyHash, WPubkeyHash);
+
 impl_asref_push_bytes!(PubkeyHash, WPubkeyHash);
 
 impl From<PublicKey> for PubkeyHash {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -56,6 +56,9 @@ hash_newtype! {
     pub struct SegwitV0Sighash(sha256d::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(LegacySighash, SegwitV0Sighash);
+
 impl_message_from_hash!(LegacySighash);
 impl_message_from_hash!(SegwitV0Sighash);
 
@@ -81,6 +84,9 @@ hash_newtype! {
     /// This hash type is used for computing Taproot signature hash."
     pub struct TapSighash(sha256t::Hash<TapSighashTag>);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapSighash);
 
 impl_message_from_hash!(TapSighash);
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -56,6 +56,7 @@ hash_newtype! {
     pub struct SegwitV0Sighash(sha256d::Hash);
 }
 
+hashes::impl_hex_for_newtype!(LegacySighash, SegwitV0Sighash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(LegacySighash, SegwitV0Sighash);
 
@@ -85,6 +86,7 @@ hash_newtype! {
     pub struct TapSighash(sha256t::Hash<TapSighashTag>);
 }
 
+hashes::impl_hex_for_newtype!(TapSighash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TapSighash);
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -17,12 +17,13 @@ exclude = ["tests", "contrib"]
 default = ["std"]
 std = ["alloc", "bitcoin-io?/std", "hex/std"]
 alloc = ["bitcoin-io?/alloc", "hex/alloc"]
+serde = ["dep:serde", "hex"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
 
 [dependencies]
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
 
+hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 bitcoin-io = { version = "0.2.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 

--- a/hashes/embedded/Cargo.toml
+++ b/hashes/embedded/Cargo.toml
@@ -11,6 +11,7 @@ members = ["."]
 
 [features]
 alloc = ["alloc-cortex-m", "bitcoin_hashes/alloc"]
+hex = ["bitcoin_hashes/hex"]
 
 [dependencies]
 cortex-m = "0.6.0"

--- a/hashes/embedded/src/main.rs
+++ b/hashes/embedded/src/main.rs
@@ -12,12 +12,19 @@ extern crate bitcoin_hashes;
 use bitcoin_hashes::{sha256, HashEngine};
 use bitcoin_io::Write;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::{debug, hprintln};
+use cortex_m_semihosting::debug;
+#[cfg(feature = "hex")]
+use cortex_m_semihosting::hprintln;
 use panic_halt as _;
 
 hash_newtype! {
     struct TestType(sha256::Hash);
 }
+
+#[cfg(feature = "hex")]
+bitcoin_hashes::impl_hex_for_newtype!(TestType);
+#[cfg(not(feature = "hex"))]
+bitcoin_hashes::impl_debug_only_for_newtype!(TestType);
 
 // this is the allocator the application will use
 #[cfg(feature = "alloc")]
@@ -34,16 +41,19 @@ fn main() -> ! {
 
     let mut engine = sha256::Hash::engine();
     engine.write_all(b"abc").unwrap();
+    #[cfg(feature = "hex")]
     check_result(engine);
 
     let mut engine = sha256::Hash::engine();
     engine.input(b"abc");
+    #[cfg(feature = "hex")]
     check_result(engine);
 
     debug::exit(debug::EXIT_SUCCESS);
     loop {}
 }
 
+#[cfg(feature = "hex")]
 fn check_result(engine: sha256::HashEngine) {
     let hash = TestType(sha256::Hash::from_engine(engine));
 

--- a/hashes/src/hmac.rs
+++ b/hashes/src/hmac.rs
@@ -96,15 +96,15 @@ impl<T: GeneralHash> HashEngine for HmacEngine<T> {
     fn input(&mut self, buf: &[u8]) { self.iengine.input(buf) }
 }
 
-impl<T: GeneralHash> fmt::Debug for Hmac<T> {
+impl<T: GeneralHash + fmt::Debug> fmt::Debug for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Debug::fmt(&self.0, f) }
 }
 
-impl<T: GeneralHash> fmt::Display for Hmac<T> {
+impl<T: GeneralHash + fmt::Display> fmt::Display for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
-impl<T: GeneralHash> fmt::LowerHex for Hmac<T> {
+impl<T: GeneralHash + fmt::LowerHex> fmt::LowerHex for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -21,7 +21,10 @@
 macro_rules! hash_trait_impls {
     ($bits:expr, $reverse:expr $(, $gen:ident: $gent:ident)*) => {
         $crate::impl_bytelike_traits!(Hash, { $bits / 8 } $(, $gen: $gent)*);
+        #[cfg(feature = "hex")]
         $crate::impl_hex_string_traits!(Hash, { $bits / 8 }, $reverse $(, $gen: $gent)*);
+        #[cfg(not(feature = "hex"))]
+        $crate::impl_debug_only!(Hash, { $bits / 8 }, $reverse $(, $gen: $gent)*);
 
         impl<$($gen: $gent),*> $crate::GeneralHash for Hash<$($gen),*> {
             type Engine = HashEngine;

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -20,7 +20,8 @@
 /// `from_engine` obviously implements the finalization algorithm.
 macro_rules! hash_trait_impls {
     ($bits:expr, $reverse:expr $(, $gen:ident: $gent:ident)*) => {
-        $crate::impl_bytelike_traits!(Hash, { $bits / 8 }, $reverse $(, $gen: $gent)*);
+        $crate::impl_bytelike_traits!(Hash, { $bits / 8 } $(, $gen: $gent)*);
+        $crate::impl_hex_string_traits!(Hash, { $bits / 8 }, $reverse $(, $gen: $gent)*);
 
         impl<$($gen: $gent),*> $crate::GeneralHash for Hash<$($gen),*> {
             type Engine = HashEngine;

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -28,6 +28,9 @@ macro_rules! hash_trait_impls {
             fn from_engine(e: HashEngine) -> Hash<$($gen),*> { Self::from_engine(e) }
         }
 
+        #[cfg(feature = "serde")]
+        $crate::serde_impl!(Hash, { $bits / 8} $(, $gen: $gent)*);
+
         impl<$($gen: $gent),*> $crate::Hash for Hash<$($gen),*> {
             type Bytes = [u8; $bits / 8];
 

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -126,7 +126,7 @@ pub mod serde_macros {
     }
 }
 
-use core::{convert, fmt, hash};
+use core::{convert, hash};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -261,20 +261,10 @@ pub trait GeneralHash: Hash {
 
 /// Trait which applies to hashes of all types.
 pub trait Hash:
-    Copy
-    + Clone
-    + PartialEq
-    + Eq
-    + PartialOrd
-    + Ord
-    + hash::Hash
-    + fmt::Debug
-    + fmt::Display
-    + fmt::LowerHex
-    + convert::AsRef<[u8]>
+    Copy + Clone + PartialEq + Eq + PartialOrd + Ord + hash::Hash + convert::AsRef<[u8]>
 {
     /// The byte array that represents the hash internally.
-    type Bytes: hex::FromHex + Copy + IsByteArray;
+    type Bytes: Copy + IsByteArray;
 
     /// Length of the hash, in bytes.
     const LEN: usize = Self::Bytes::LEN;
@@ -334,6 +324,8 @@ mod tests {
         /// A test newtype
         struct TestNewtype2(sha256d::Hash);
     }
+
+    crate::impl_hex_for_newtype!(TestNewtype, TestNewtype2);
 
     #[test]
     #[cfg(feature = "alloc")]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -86,6 +86,7 @@ extern crate serde_test;
 extern crate test;
 
 /// Re-export the `hex-conservative` crate.
+#[cfg(feature = "hex")]
 pub extern crate hex;
 
 #[doc(hidden)]
@@ -126,6 +127,7 @@ pub mod serde_macros {
     }
 }
 
+use core::fmt::{self, Write as _};
 use core::{convert, hash};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -312,6 +314,22 @@ fn incomplete_block_len<H: HashEngine>(eng: &H) -> usize {
     (eng.n_bytes_hashed() % block_size) as usize
 }
 
+/// Writes `bytes` as a `hex` string to the formatter.
+///
+/// For when we cannot rely on having the `hex` feature enabled. Ignores formatter options and just
+/// writes with plain old `f.write_char()`.
+pub fn debug_hex(bytes: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
+    const HEX_TABLE: [u8; 16] = *b"0123456789abcdef";
+
+    for &b in bytes {
+        let lower = HEX_TABLE[usize::from(b >> 4)];
+        let upper = HEX_TABLE[usize::from(b & 0b00001111)];
+        f.write_char(char::from(lower))?;
+        f.write_char(char::from(upper))?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,7 +343,10 @@ mod tests {
         struct TestNewtype2(sha256d::Hash);
     }
 
+    #[cfg(feature = "hex")]
     crate::impl_hex_for_newtype!(TestNewtype, TestNewtype2);
+    #[cfg(not(feature = "hex"))]
+    crate::impl_debug_only_for_newtype!(TestNewtype, TestNewtype2);
 
     #[test]
     #[cfg(feature = "alloc")]

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -8,8 +8,6 @@ use core::arch::x86::*;
 use core::arch::x86_64::*;
 use core::{cmp, convert, fmt};
 
-use hex::DisplayHex;
-
 use crate::{incomplete_block_len, sha256d, HashEngine as _};
 #[cfg(doc)]
 use crate::{sha256t, sha256t_tag};
@@ -218,8 +216,15 @@ impl Midstate {
 
 impl fmt::Debug for Midstate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        struct Encoder<'a> {
+            bytes: &'a [u8; 32],
+        }
+        impl fmt::Debug for Encoder<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { crate::debug_hex(self.bytes, f) }
+        }
+
         f.debug_struct("Midstate")
-            .field("bytes", &self.bytes.as_hex())
+            .field("bytes", &Encoder { bytes: &self.bytes })
             .field("length", &self.bytes_hashed)
             .finish()
     }

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -321,10 +321,14 @@ mod tests {
         #[hash_newtype(backward)]
         struct NewTypeHashBackward(sha256t::Hash<NewTypeTagBackward>);
     }
+    #[cfg(feature = "hex")]
     crate::impl_hex_for_newtype!(NewTypeHashBackward);
+    #[cfg(not(feature = "hex"))]
+    crate::impl_debug_only_for_newtype!(NewTypeHashBackward);
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn macro_created_sha256t_hash_type_backward() {
         use alloc::string::ToString;
 
@@ -345,10 +349,14 @@ mod tests {
         #[hash_newtype(forward)]
         struct NewTypeHashForward(sha256t::Hash<NewTypeTagForward>);
     }
+    #[cfg(feature = "hex")]
     crate::impl_hex_for_newtype!(NewTypeHashForward);
+    #[cfg(not(feature = "hex"))]
+    crate::impl_debug_only_for_newtype!(NewTypeHashForward);
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn macro_created_sha256t_hash_type_prints_forward() {
         use alloc::string::ToString;
 

--- a/hashes/src/sha256t.rs
+++ b/hashes/src/sha256t.rs
@@ -321,6 +321,7 @@ mod tests {
         #[hash_newtype(backward)]
         struct NewTypeHashBackward(sha256t::Hash<NewTypeTagBackward>);
     }
+    crate::impl_hex_for_newtype!(NewTypeHashBackward);
 
     #[test]
     #[cfg(feature = "alloc")]
@@ -344,6 +345,7 @@ mod tests {
         #[hash_newtype(forward)]
         struct NewTypeHashForward(sha256t::Hash<NewTypeTagForward>);
     }
+    crate::impl_hex_for_newtype!(NewTypeHashForward);
 
     #[test]
     #[cfg(feature = "alloc")]

--- a/hashes/tests/io.rs
+++ b/hashes/tests/io.rs
@@ -3,6 +3,7 @@
 //! Test the `bitcoin-io` implementations.
 
 #![cfg(feature = "bitcoin-io")]
+#![cfg(feature = "hex")]
 
 use bitcoin_hashes::{
     hash160, hmac, ripemd160, sha1, sha256, sha256d, sha384, sha512, sha512_256, siphash24,

--- a/hashes/tests/regression.rs
+++ b/hashes/tests/regression.rs
@@ -2,6 +2,8 @@
 //!
 //! Note that if `bitcoin-io` is enabled then we get more regression-like testing from `./io.rs`.
 
+#![cfg(feature = "hex")]
+
 use bitcoin_hashes::{
     hash160, ripemd160, sha1, sha256, sha256d, sha256t, sha384, sha512, sha512_256, siphash24,
     GeneralHash as _, HashEngine as _, Hmac, HmacEngine,

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = false, features = ["bitcoin-io"] }
+hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = false, features = ["bitcoin-io", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false }

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -162,6 +162,9 @@ hashes::hash_newtype! {
     pub struct WitnessCommitment(sha256d::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(BlockHash, WitnessCommitment);
+
 impl BlockHash {
     /// Dummy hash used as the previous blockhash of the genesis block.
     pub const GENESIS_PREVIOUS_BLOCK_HASH: Self = Self::from_byte_array([0; 32]);

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -162,6 +162,7 @@ hashes::hash_newtype! {
     pub struct WitnessCommitment(sha256d::Hash);
 }
 
+hashes::impl_hex_for_newtype!(BlockHash, WitnessCommitment);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(BlockHash, WitnessCommitment);
 

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -10,3 +10,6 @@ hashes::hash_newtype! {
     /// A hash corresponding to the Merkle tree root for witness data.
     pub struct WitnessMerkleNode(sha256d::Hash);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TxMerkleNode, WitnessMerkleNode);

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -11,5 +11,6 @@ hashes::hash_newtype! {
     pub struct WitnessMerkleNode(sha256d::Hash);
 }
 
+hashes::impl_hex_for_newtype!(TxMerkleNode, WitnessMerkleNode);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TxMerkleNode, WitnessMerkleNode);

--- a/primitives/src/taproot.rs
+++ b/primitives/src/taproot.rs
@@ -18,6 +18,7 @@ hash_newtype! {
     pub struct TapLeafHash(sha256t::Hash<TapLeafTag>);
 }
 
+hashes::impl_hex_for_newtype!(TapLeafHash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TapLeafHash);
 
@@ -32,6 +33,7 @@ hash_newtype! {
     pub struct TapNodeHash(sha256t::Hash<TapBranchTag>);
 }
 
+hashes::impl_hex_for_newtype!(TapNodeHash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TapNodeHash);
 
@@ -46,6 +48,7 @@ hash_newtype! {
     pub struct TapTweakHash(sha256t::Hash<TapTweakTag>);
 }
 
+hashes::impl_hex_for_newtype!(TapTweakHash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TapTweakHash);
 

--- a/primitives/src/taproot.rs
+++ b/primitives/src/taproot.rs
@@ -18,6 +18,9 @@ hash_newtype! {
     pub struct TapLeafHash(sha256t::Hash<TapLeafTag>);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapLeafHash);
+
 sha256t_tag! {
     pub struct TapBranchTag = hash_str("TapBranch");
 }
@@ -29,6 +32,9 @@ hash_newtype! {
     pub struct TapNodeHash(sha256t::Hash<TapBranchTag>);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapNodeHash);
+
 sha256t_tag! {
     pub struct TapTweakTag = hash_str("TapTweak");
 }
@@ -39,6 +45,9 @@ hash_newtype! {
     /// This hash type is used while computing the tweaked public key.
     pub struct TapTweakHash(sha256t::Hash<TapTweakTag>);
 }
+
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapTweakHash);
 
 impl From<TapLeafHash> for TapNodeHash {
     fn from(leaf: TapLeafHash) -> TapNodeHash { TapNodeHash::from_byte_array(leaf.to_byte_array()) }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -476,6 +476,9 @@ hashes::hash_newtype! {
     pub struct Wtxid(sha256d::Hash);
 }
 
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(Txid, Wtxid);
+
 impl Txid {
     /// The `Txid` used in a coinbase prevout.
     ///

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -476,6 +476,7 @@ hashes::hash_newtype! {
     pub struct Wtxid(sha256d::Hash);
 }
 
+hashes::impl_hex_for_newtype!(Txid, Wtxid);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(Txid, Wtxid);
 


### PR DESCRIPTION
This is done in 3 parts:

1. Pull the `serde` stuff out of `impl_bytelike_traits` to fix the bug described here: https://github.com/rust-bitcoin/rust-bitcoin/issues/2654#issuecomment-2470716693
2. Prepare the `hashes` trait by removing string/hex trait bounds from `GeneralHash` and also pull the hex/string stuff out of `impl_bytelike_traits`
3. Make hex optional, including adding custom debug logic when `hex` feature is not enabled

Patch 3 is tested in `hashes/embedded`, by the new `debug` unit test, and there is a `Midstate` unit test as well that covers the `Debug` impl.

Close: #2654 - BOOM!