### PR TITLE
Add unchecked suffix to function name

### DIFF
--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -63,7 +63,7 @@ impl FeeRate {
     pub const fn from_sat_per_vb_unchecked(sat_vb: u64) -> Self { FeeRate(sat_vb * (1000 / 4)) }
 
     /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes).
-    pub const fn from_sat_per_kvb(sat_kvb: u64) -> Self { FeeRate(sat_kvb / 4) }
+    pub const fn from_sat_per_kvb_unchecked(sat_kvb: u64) -> Self { FeeRate(sat_kvb / 4) }
 
     /// Returns raw fee rate.
     ///
@@ -340,6 +340,9 @@ mod tests {
     fn from_sat_per_vb_unchecked_test() {
         let fee_rate = FeeRate::from_sat_per_vb_unchecked(10);
         assert_eq!(FeeRate(2500), fee_rate);
+
+        let fee_rate = FeeRate::from_sat_per_kvb_unchecked(10);
+        assert_eq!(FeeRate(2), fee_rate);
     }
 
     #[test]


### PR DESCRIPTION
I just noticed that the naming convention in this module is to name these unchecked if it's not returning an Option (see `from_sat_per_vb_unchecked`). Follow up from https://github.com/rust-bitcoin/rust-bitcoin/pull/3604