### PR TITLE
backport: Deprecate Amount::fmt_value_in

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -987,6 +987,7 @@ impl Amount {
     ///
     /// Does not include the denomination.
     #[rustfmt::skip]
+    #[deprecated(since = "0.1.3", note = "use `display_in()` instead")]
     pub fn fmt_value_in(self, f: &mut dyn fmt::Write, denom: Denomination) -> fmt::Result {
         fmt_satoshi_in(self.to_sat(), false, f, denom, false, FormatOptions::default())
     }
@@ -995,20 +996,13 @@ impl Amount {
     ///
     /// Does not include the denomination.
     #[cfg(feature = "alloc")]
-    pub fn to_string_in(self, denom: Denomination) -> String {
-        let mut buf = String::new();
-        self.fmt_value_in(&mut buf, denom).unwrap();
-        buf
-    }
+    pub fn to_string_in(self, denom: Denomination) -> String { self.display_in(denom).to_string() }
 
     /// Get a formatted string of this [Amount] in the given denomination,
     /// suffixed with the abbreviation for the denomination.
     #[cfg(feature = "alloc")]
     pub fn to_string_with_denomination(self, denom: Denomination) -> String {
-        let mut buf = String::new();
-        self.fmt_value_in(&mut buf, denom).unwrap();
-        write!(buf, " {}", denom).unwrap();
-        buf
+        self.display_in(denom).show_denomination().to_string()
     }
 
     // Some arithmetic that doesn't fit in `core::ops` traits.


### PR DESCRIPTION
We an use `Amount::display_in` now, this was done on master in PR #2951.