### PR TITLE
Rename tests that have _test suffix

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -543,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn compact_roundrtip() {
+    fn compact_roundtrip() {
         let header = header();
         assert_eq!(header.bits, header.target().to_compact_lossy());
     }

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -415,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn block_test() {
+    fn block() {
         let params = Params::new(Network::Bitcoin);
         // Mainnet block 00000000b0c5a240b2a61d2e75692224efd4cbecdf6eaf4cc2cf477ca7c270e7
         let some_block = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac00000000");
@@ -461,7 +461,7 @@ mod tests {
 
     // Check testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
     #[test]
-    fn segwit_block_test() {
+    fn segwit_block() {
         let params = Params::new(Network::Testnet(TestnetVersion::V3));
         let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw").to_vec();
 
@@ -498,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn block_version_test() {
+    fn block_version() {
         let block = hex!("ffffff7f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         let decode: Result<Block, _> = deserialize(&block);
         assert!(decode.is_ok());
@@ -513,7 +513,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_pow_test() {
+    fn validate_pow() {
         let some_header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
         let some_header: Header =
             deserialize(&some_header).expect("can't deserialize correct block header");
@@ -543,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn compact_roundrtip_test() {
+    fn compact_roundrtip() {
         let header = header();
         assert_eq!(header.bits, header.target().to_compact_lossy());
     }

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -384,7 +384,7 @@ fn script_hashes() {
 }
 
 #[test]
-fn provably_unspendable_test() {
+fn provably_unspendable() {
     // p2pk
     assert!(!ScriptBuf::from_hex("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").unwrap().is_op_return());
     assert!(!ScriptBuf::from_hex("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").unwrap().is_op_return());
@@ -398,7 +398,7 @@ fn provably_unspendable_test() {
 }
 
 #[test]
-fn op_return_test() {
+fn op_return() {
     assert!(ScriptBuf::from_hex("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
         .unwrap()
         .is_op_return());
@@ -409,7 +409,7 @@ fn op_return_test() {
 }
 
 #[test]
-fn standard_op_return_test() {
+fn standard_op_return() {
     assert!(ScriptBuf::from_hex("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
         .unwrap()
         .is_standard_op_return());
@@ -682,7 +682,7 @@ fn test_bitcoinconsensus() {
 }
 
 #[test]
-fn defult_dust_value_tests() {
+fn defult_dust_value() {
     // Check that our dust_value() calculator correctly calculates the dust limit on common
     // well-known scriptPubKey types.
     let script_p2wpkh = Builder::new().push_int_unchecked(0).push_slice([42; 20]).into_script();

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -682,7 +682,7 @@ fn test_bitcoinconsensus() {
 }
 
 #[test]
-fn defult_dust_value() {
+fn default_dust_value() {
     // Check that our dust_value() calculator correctly calculates the dust limit on common
     // well-known scriptPubKey types.
     let script_p2wpkh = Builder::new().push_int_unchecked(0).push_slice([42; 20]).into_script();

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -769,7 +769,7 @@ mod tests {
     use crate::p2p::{message_blockdata::Inventory, Address};
 
     #[test]
-    fn serialize_int_test() {
+    fn serialize_int() {
         // bool
         assert_eq!(serialize(&false), [0u8]);
         assert_eq!(serialize(&true), [1u8]);
@@ -825,7 +825,7 @@ mod tests {
     }
 
     #[test]
-    fn serialize_varint_test() {
+    fn serialize_varint() {
         fn encode(v: u64) -> Vec<u8> {
             let mut buf = Vec::new();
             buf.emit_compact_size(v).unwrap();
@@ -925,23 +925,23 @@ mod tests {
     }
 
     #[test]
-    fn serialize_checkeddata_test() {
+    fn serialize_checkeddata() {
         let cd = CheckedData::new(vec![1u8, 2, 3, 4, 5]);
         assert_eq!(serialize(&cd), [5, 0, 0, 0, 162, 107, 175, 90, 1, 2, 3, 4, 5]);
     }
 
     #[test]
-    fn serialize_vector_test() {
+    fn serialize_vector() {
         assert_eq!(serialize(&vec![1u8, 2, 3]), [3u8, 1, 2, 3]);
     }
 
     #[test]
-    fn serialize_strbuf_test() {
+    fn serialize_strbuf() {
         assert_eq!(serialize(&"Andrew".to_string()), [6u8, 0x41, 0x6e, 0x64, 0x72, 0x65, 0x77]);
     }
 
     #[test]
-    fn deserialize_int_test() {
+    fn deserialize_int() {
         // bool
         assert!((deserialize(&[58u8, 0]) as Result<bool, _>).is_err());
         assert_eq!(deserialize(&[58u8]).ok(), Some(true));
@@ -1024,7 +1024,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_vec_test() {
+    fn deserialize_vec() {
         assert_eq!(deserialize(&[3u8, 2, 3, 4]).ok(), Some(vec![2u8, 3, 4]));
         assert!((deserialize(&[4u8, 2, 3, 4, 5, 6]) as Result<Vec<u8>, _>).is_err());
         // found by cargo fuzz
@@ -1067,7 +1067,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_strbuf_test() {
+    fn deserialize_strbuf() {
         assert_eq!(
             deserialize(&[6u8, 0x41, 0x6e, 0x64, 0x72, 0x65, 0x77]).ok(),
             Some("Andrew".to_string())
@@ -1079,14 +1079,14 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_checkeddata_test() {
+    fn deserialize_checkeddata() {
         let cd: Result<CheckedData, _> =
             deserialize(&[5u8, 0, 0, 0, 162, 107, 175, 90, 1, 2, 3, 4, 5]);
         assert_eq!(cd.ok(), Some(CheckedData::new(vec![1u8, 2, 3, 4, 5])));
     }
 
     #[test]
-    fn limit_read_test() {
+    fn limit_read() {
         let witness = vec![vec![0u8; 3_999_999]; 2];
         let ser = serialize(&witness);
         let mut reader = io::Cursor::new(ser);

--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -367,7 +367,7 @@ mod tests {
     use crate::p2p::ServiceFlags;
 
     #[test]
-    fn serialize_test() {
+    fn serialize_deserialize() {
         assert_eq!(serialize(&Network::Bitcoin.magic()), &[0xf9, 0xbe, 0xb4, 0xd9]);
         assert_eq!(
             serialize(&Network::Testnet(TestnetVersion::V3).magic()),
@@ -394,7 +394,7 @@ mod tests {
     }
 
     #[test]
-    fn string_test() {
+    fn string() {
         assert_eq!(Network::Bitcoin.to_string(), "bitcoin");
         assert_eq!(Network::Testnet(TestnetVersion::V3).to_string(), "testnet");
         assert_eq!(Network::Testnet(TestnetVersion::V4).to_string(), "testnet4");
@@ -410,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn service_flags_test() {
+    fn service_flags() {
         let all = [
             ServiceFlags::NETWORK,
             ServiceFlags::GETUTXO,

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -307,7 +307,7 @@ mod test {
     use crate::consensus::encode::{deserialize, serialize};
 
     #[test]
-    fn serialize_address_test() {
+    fn serialize_address() {
         assert_eq!(
             serialize(&Address {
                 services: ServiceFlags::NETWORK,
@@ -322,7 +322,7 @@ mod test {
     }
 
     #[test]
-    fn debug_format_test() {
+    fn debug_format() {
         let mut flags = ServiceFlags::NETWORK;
         assert_eq!(
             format!("The address is: {:?}", Address {
@@ -344,7 +344,7 @@ mod test {
     }
 
     #[test]
-    fn deserialize_address_test() {
+    fn deserialize_address() {
         let mut addr: Result<Address, _> = deserialize(&[
             1u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x0a, 0, 0, 1,
             0x20, 0x8d,
@@ -378,7 +378,7 @@ mod test {
     }
 
     #[test]
-    fn onion_test() {
+    fn onion() {
         let onionaddr = SocketAddr::new(
             IpAddr::V6("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca".parse::<Ipv6Addr>().unwrap()),
             1111,
@@ -388,7 +388,7 @@ mod test {
     }
 
     #[test]
-    fn serialize_addrv2_test() {
+    fn serialize_addrv2() {
         // Taken from https://github.com/bitcoin/bitcoin/blob/12a1c3ad1a43634d2a98717e49e3f02c4acea2fe/src/test/net_tests.cpp#L348
 
         let ip = AddrV2::Ipv4(Ipv4Addr::new(1, 2, 3, 4));
@@ -427,7 +427,7 @@ mod test {
     }
 
     #[test]
-    fn deserialize_addrv2_test() {
+    fn deserialize_addrv2() {
         // Taken from https://github.com/bitcoin/bitcoin/blob/12a1c3ad1a43634d2a98717e49e3f02c4acea2fe/src/test/net_tests.cpp#L386
 
         // Valid IPv4.
@@ -525,7 +525,7 @@ mod test {
     }
 
     #[test]
-    fn addrv2message_test() {
+    fn addrv2message() {
         let raw = hex!("0261bc6649019902abab208d79627683fd4804010409090909208d");
         let addresses: Vec<AddrV2Message> = deserialize(&raw).unwrap();
 

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -563,7 +563,7 @@ mod test {
     fn hash(slice: [u8; 32]) -> sha256d::Hash { sha256d::Hash::from_slice(&slice).unwrap() }
 
     #[test]
-    fn full_round_ser_der_raw_network_message_test() {
+    fn full_round_ser_der_raw_network_message() {
         let version_msg: VersionMessage = deserialize(&hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff0000000000000100000000000000fd87d87eeb4364f22cf54dca59412db7208d47d920cffce83ee8102f5361746f7368693a302e392e39392f2c9f040001")).unwrap();
         let tx: Transaction = deserialize(&hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000")).unwrap();
         let block: Block = deserialize(&include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw")[..]).unwrap();
@@ -676,7 +676,7 @@ mod test {
     }
 
     #[test]
-    fn commandstring_test() {
+    fn commandstring() {
         // Test converting.
         assert_eq!(
             CommandString::try_from_static("AndrewAndrew").unwrap().as_ref(),
@@ -702,7 +702,7 @@ mod test {
 
     #[test]
     #[rustfmt::skip]
-    fn serialize_verack_test() {
+    fn serialize_verack() {
         assert_eq!(serialize(&RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::Verack)),
                        [0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x61,
                         0x63, 0x6B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -711,7 +711,7 @@ mod test {
 
     #[test]
     #[rustfmt::skip]
-    fn serialize_ping_test() {
+    fn serialize_ping() {
         assert_eq!(serialize(&RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::Ping(100))),
                        [0xf9, 0xbe, 0xb4, 0xd9, 0x70, 0x69, 0x6e, 0x67,
                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -721,7 +721,7 @@ mod test {
 
     #[test]
     #[rustfmt::skip]
-    fn serialize_mempool_test() {
+    fn serialize_mempool() {
         assert_eq!(serialize(&RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::MemPool)),
                        [0xf9, 0xbe, 0xb4, 0xd9, 0x6d, 0x65, 0x6d, 0x70,
                         0x6f, 0x6f, 0x6c, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -730,7 +730,7 @@ mod test {
 
     #[test]
     #[rustfmt::skip]
-    fn serialize_getaddr_test() {
+    fn serialize_getaddr() {
         assert_eq!(serialize(&RawNetworkMessage::new(Magic::BITCOIN, NetworkMessage::GetAddr)),
                        [0xf9, 0xbe, 0xb4, 0xd9, 0x67, 0x65, 0x74, 0x61,
                         0x64, 0x64, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -738,7 +738,7 @@ mod test {
     }
 
     #[test]
-    fn deserialize_getaddr_test() {
+    fn deserialize_getaddr() {
         #[rustfmt::skip]
         let msg = deserialize(&[
             0xf9, 0xbe, 0xb4, 0xd9, 0x67, 0x65, 0x74, 0x61,
@@ -753,7 +753,7 @@ mod test {
     }
 
     #[test]
-    fn deserialize_version_test() {
+    fn deserialize_version() {
         #[rustfmt::skip]
         let msg = deserialize::<RawNetworkMessage>(&[
             0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x73,
@@ -797,7 +797,7 @@ mod test {
     }
 
     #[test]
-    fn deserialize_partial_message_test() {
+    fn deserialize_partial_message() {
         #[rustfmt::skip]
         let data = [
             0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x73,

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -149,7 +149,7 @@ mod tests {
     use crate::consensus::encode::{deserialize, serialize};
 
     #[test]
-    fn getblocks_message_test() {
+    fn getblocks_message() {
         let from_sat = hex!("72110100014a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b0000000000000000000000000000000000000000000000000000000000000000");
         let genhash = hex!("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn getheaders_message_test() {
+    fn getheaders_message() {
         let from_sat = hex!("72110100014a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b0000000000000000000000000000000000000000000000000000000000000000");
         let genhash = hex!("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 


### PR DESCRIPTION
Convention is to not include test as a suffix

Used `git grep -n _test` and renamed all the tests that made sense to rename.  There are a number of fn `do_test(data: &[u8]) {` that I felt it would be better not to touch.  Everything else that was a testname I renamed if it had a _test suffix.