### PR TITLE
Mark `checked_` functions as `const`

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -627,8 +627,11 @@ impl Psbt {
 
     /// Gets the input at `input_index` after checking that it is a valid index.
     fn checked_input(&self, input_index: usize) -> Result<&Input, IndexOutOfBoundsError> {
-        self.check_index_is_within_bounds(input_index)?;
-        Ok(&self.inputs[input_index])
+        // No `?` operator in const context.
+        match self.check_index_is_within_bounds(input_index) {
+            Ok(_) => Ok(&self.inputs[input_index]),
+            Err(e) => Err(e),
+        }
     }
 
     /// Checks `input_index` is within bounds for the PSBT `inputs` array and

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -217,27 +217,45 @@ impl SignedAmount {
     /// Consider using `unsigned_abs` which is often more practical.
     ///
     /// Returns [`None`] if overflow occurred. (`self == MIN`)
-    pub fn checked_abs(self) -> Option<SignedAmount> { self.0.checked_abs().map(SignedAmount) }
+    pub const fn checked_abs(self) -> Option<SignedAmount> {
+        // No `map()` in const context.
+        match self.0.checked_abs() {
+            Some(res) => Some(SignedAmount(res)),
+            None => None,
+        }
+    }
 
     /// Checked addition.
     ///
     /// Returns [`None`] if overflow occurred.
-    pub fn checked_add(self, rhs: SignedAmount) -> Option<SignedAmount> {
-        self.0.checked_add(rhs.0).map(SignedAmount)
+    pub const fn checked_add(self, rhs: SignedAmount) -> Option<SignedAmount> {
+        // No `map()` in const context.
+        match self.0.checked_add(rhs.0) {
+            Some(res) => Some(SignedAmount(res)),
+            None => None,
+        }
     }
 
     /// Checked subtraction.
     ///
     /// Returns [`None`] if overflow occurred.
-    pub fn checked_sub(self, rhs: SignedAmount) -> Option<SignedAmount> {
-        self.0.checked_sub(rhs.0).map(SignedAmount)
+    pub const fn checked_sub(self, rhs: SignedAmount) -> Option<SignedAmount> {
+        // No `map()` in const context.
+        match self.0.checked_sub(rhs.0) {
+            Some(res) => Some(SignedAmount(res)),
+            None => None,
+        }
     }
 
     /// Checked multiplication.
     ///
     /// Returns [`None`] if overflow occurred.
-    pub fn checked_mul(self, rhs: i64) -> Option<SignedAmount> {
-        self.0.checked_mul(rhs).map(SignedAmount)
+    pub const fn checked_mul(self, rhs: i64) -> Option<SignedAmount> {
+        // No `map()` in const context.
+        match self.0.checked_mul(rhs) {
+            Some(res) => Some(SignedAmount(res)),
+            None => None,
+        }
     }
 
     /// Checked integer division.
@@ -245,15 +263,23 @@ impl SignedAmount {
     /// Be aware that integer division loses the remainder if no exact division can be made.
     ///
     /// Returns [`None`] if overflow occurred.
-    pub fn checked_div(self, rhs: i64) -> Option<SignedAmount> {
-        self.0.checked_div(rhs).map(SignedAmount)
+    pub const fn checked_div(self, rhs: i64) -> Option<SignedAmount> {
+        // No `map()` in const context.
+        match self.0.checked_div(rhs) {
+            Some(res) => Some(SignedAmount(res)),
+            None => None,
+        }
     }
 
     /// Checked remainder.
     ///
     /// Returns [`None`] if overflow occurred.
-    pub fn checked_rem(self, rhs: i64) -> Option<SignedAmount> {
-        self.0.checked_rem(rhs).map(SignedAmount)
+    pub const fn checked_rem(self, rhs: i64) -> Option<SignedAmount> {
+        // No `map()` in const context.
+        match self.0.checked_rem(rhs) {
+            Some(res) => Some(SignedAmount(res)),
+            None => None,
+        }
     }
 
     /// Unchecked addition.


### PR DESCRIPTION
Following on #3608, #3627 and #1174 the rest of the `checked_` functions in all `rust-bitcoin` have been marked as const.  Except for tests and traits.

