### PR TITLE
address: Add `Address::into_unchecked`

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -383,6 +383,9 @@ impl<V: NetworkValidation> Address<V> {
     pub fn as_unchecked(&self) -> &Address<NetworkUnchecked> {
         unsafe { &*(self as *const Address<V> as *const Address<NetworkUnchecked>) }
     }
+
+    /// Marks the network of this address as unchecked.
+    pub fn into_unchecked(self) -> Address<NetworkUnchecked> { Address(self.0, PhantomData) }
 }
 
 /// Methods and functions that can be called only on `Address<NetworkChecked>`.

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -795,16 +795,7 @@ impl Address<NetworkUnchecked> {
     /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
     /// on [`Address`].
     #[inline]
-    pub fn assume_checked(self) -> Address {
-        use AddressInner::*;
-
-        let inner = match self.0 {
-            P2pkh { hash, network } => P2pkh { hash, network },
-            P2sh { hash, network } => P2sh { hash, network },
-            Segwit { program, hrp } => Segwit { program, hrp },
-        };
-        Address(inner, PhantomData)
-    }
+    pub fn assume_checked(self) -> Address { Address(self.0, PhantomData) }
 
     /// Parse a bech32 Address string
     pub fn from_bech32_str(s: &str) -> Result<Address<NetworkUnchecked>, Bech32Error> {


### PR DESCRIPTION
## Commits

### address: Add `Address::into_unchecked`

Adds an ergonomic way to convert any `Address` (network can be checked
or unchecked) into an `Address<NetworkUnchecked>` without cloning, which
I've found useful in several contexts.

### address: Simplify `Address::assume_checked` impl

Removes an unnecessary `match` which I noticed while implementing `Address::into_unchecked`.

## Small note on use of `Self`

The style guide in `CONTRIBUTING.md` notes to return `Self` when possible, but that doesn't apply here as the `Address` being returned is different from the `Address` type referred to by `Self`, due to the changed `NetworkValidation` type.