### PR TITLE
units: Comment alloc feature

### DIFF
--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -24,7 +24,7 @@ use core::fmt;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "alloc")] // This is because `to_float_in` uses `to_string`.
 use super::Denomination;
 use super::{Amount, ParseAmountError, SignedAmount};
 


### PR DESCRIPTION
Add a comment to the `serde` module about why we have all the `alloc` feature gating.

Done as part of #3556 - auditing the whole crate for use of `alloc` feature.