### PR TITLE
Fix typo in hash tag type

### DIFF
--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -68,7 +68,7 @@ crate::internal_macros::define_extension_trait! {
             let mut eng = sha256t::Hash::<TapLeafTag>::engine();
             ver.to_consensus().consensus_encode(&mut eng).expect("engines don't error");
             script.consensus_encode(&mut eng).expect("engines don't error");
-            let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
+            let inner = sha256t::Hash::<TapLeafTag>::from_engine(eng);
             TapLeafHash::from_byte_array(inner.to_byte_array())
         }
     }


### PR DESCRIPTION
In commit: `39f7dcb Reduce API surface of tagged wrapped hash types` I introduced a typo in the tagged hash tag type. Fortunately it has no effect because the tag type controls how an engine  is created (when the tag is input into the engine) and has no effect on the call to `from_engine`. However the typo makes the code confusing.

This bug is currently unreleased.

Fix: #3649