### PR TITLE
Update `from_next_work_required` to take an i64 for timespan

### DIFF
--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -113,7 +113,7 @@ pub struct Params {
     /// Expected amount of time to mine one block.
     pub pow_target_spacing: u64,
     /// Difficulty recalculation interval.
-    pub pow_target_timespan: u64,
+    pub pow_target_timespan: u32,
     /// Determines whether minimal difficulty may be used for blocks or not.
     pub allow_min_difficulty_blocks: bool,
     /// Determines whether retargeting is disabled for this network or not.
@@ -261,7 +261,7 @@ impl Params {
 
     /// Calculates the number of blocks between difficulty adjustments.
     pub fn difficulty_adjustment_interval(&self) -> u64 {
-        self.pow_target_timespan / self.pow_target_spacing
+        u64::from(self.pow_target_timespan) / self.pow_target_spacing
     }
 }
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -357,7 +357,7 @@ define_extension_trait! {
         /// ref: <https://github.com/bitcoin/bitcoin/blob/0503cbea9aab47ec0a87d34611e5453158727169/src/pow.cpp>
         ///
         /// Given the previous Target, represented as a [`CompactTarget`], the difficulty is adjusted
-        /// by taking the timespan between them, and multipling the current [`CompactTarget`] by a factor
+        /// by taking the timespan between them, and multiplying the current [`CompactTarget`] by a factor
         /// of the net timespan and expected timespan. The [`CompactTarget`] may not adjust by more than
         /// a factor of 4, or adjust beyond the maximum threshold for the network.
         ///


### PR DESCRIPTION
[In Core](https://github.com/bitcoin/bitcoin/blob/f7144b24be09e7db2173a0b15d73f99a08b98118/src/pow.cpp#L56), the timespan is defined as a signed int64. This PR will update `from_next_work_required` to take in an `i64` instead of a `u64`

Fixes #3652 