### PR TITLE
backport: Re-export bech32 crate

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -64,6 +64,9 @@ pub extern crate base64;
 /// Bitcoin base58 encoding and decoding.
 pub extern crate base58;
 
+/// Re-export the `bech32` crate.
+pub extern crate bech32;
+
 /// Rust implementation of cryptographic hash function algorithms.
 pub extern crate hashes;
 


### PR DESCRIPTION
Backport #3657

---

`rust-bitcoin` is a lot further from 1.0 than `bech32` is. We previously removed the re-export of `bech32` because we thought it might hold us up releasing `rust-bitcoin 1.0` but in hindsite this was incorrect.

Having a public re-export of dependencies helps users keep their deps in sync with those in `rust-bitcoin` and is thus useful.

