### PR TITLE
Fix internal weight calculation

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1965,6 +1965,21 @@ mod tests {
     }
 
     #[test]
+    fn weight_prediction_const_from_slices() {
+        let predict = [
+            InputWeightPrediction::P2WPKH_MAX,
+            InputWeightPrediction::NESTED_P2WPKH_MAX,
+            InputWeightPrediction::P2PKH_COMPRESSED_MAX,
+            InputWeightPrediction::P2PKH_UNCOMPRESSED_MAX,
+            InputWeightPrediction::P2TR_KEY_DEFAULT_SIGHASH,
+            InputWeightPrediction::P2TR_KEY_NON_DEFAULT_SIGHASH
+        ];
+
+        let weight = predict_weight_from_slices(&predict, &[1]);
+        assert_eq!(weight, Weight::from_wu(2493));
+    }
+
+    #[test]
     fn sequence_debug_output() {
         let seq = Sequence::from_seconds_floor(1000);
         println!("{:?}", seq)

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -920,14 +920,14 @@ pub const fn predict_weight_from_slices(
     inputs: &[InputWeightPrediction],
     output_script_lens: &[usize],
 ) -> Weight {
-    let mut partial_input_weight = 0;
+    let mut input_weight = 0;
     let mut inputs_with_witnesses = 0;
 
     // for loops not supported in const fn
     let mut i = 0;
     while i < inputs.len() {
         let prediction = inputs[i];
-        partial_input_weight += prediction.witness_weight().to_wu() as usize;
+        input_weight += prediction.total_weight().to_wu() as usize;
         inputs_with_witnesses += (prediction.witness_size > 0) as usize;
         i += 1;
     }
@@ -943,7 +943,7 @@ pub const fn predict_weight_from_slices(
 
     predict_weight_internal(
         inputs.len(),
-        partial_input_weight,
+        input_weight,
         inputs_with_witnesses,
         output_script_lens.len(),
         output_scripts_size,


### PR DESCRIPTION
A fix for https://github.com/rust-bitcoin/rust-bitcoin/pull/3653/commits/261c8d8ae659d98fd3f63228f16d8f2eb4010b7e.  Maybe it's better to roll back that commit instead.  Clearly there needs to be a test or two added here as well since this change causes not test failures.