### PR TITLE
Close `amounts` error types

### DIFF
--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -15,10 +15,8 @@ use super::INPUT_STRING_LEN_LIMIT;
 pub enum ParseError {
     /// Invalid amount.
     Amount(ParseAmountError),
-
     /// Invalid denomination.
     Denomination(ParseDenominationError),
-
     /// The denomination was not identified.
     MissingDenomination(MissingDenominationError),
 }

--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -56,8 +56,7 @@ impl fmt::Display for ParseError {
         match self {
             ParseError::Amount(error) => write_err!(f, "invalid amount"; error),
             ParseError::Denomination(error) => write_err!(f, "invalid denomination"; error),
-            // We consider this to not be a source because it currently doesn't contain useful
-            // information
+            // We consider this to not be a source because it currently doesn't contain useful info.
             ParseError::MissingDenomination(_) =>
                 f.write_str("the input doesn't contain a denomination"),
         }
@@ -70,8 +69,7 @@ impl std::error::Error for ParseError {
         match self {
             ParseError::Amount(error) => Some(error),
             ParseError::Denomination(error) => Some(error),
-            // We consider this to not be a source because it currently doesn't contain useful
-            // information
+            // We consider this to not be a source because it currently doesn't contain useful info.
             ParseError::MissingDenomination(_) => None,
         }
     }

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -33,7 +33,9 @@ fn from_str_zero() {
         match s.parse::<Amount>() {
             Err(e) => assert_eq!(
                 e,
-                ParseError::Amount(ParseAmountError::OutOfRange(OutOfRangeError::negative()))
+                ParseError(ParseErrorInner::Amount(ParseAmountError(
+                    ParseAmountErrorInner::OutOfRange(OutOfRangeError::negative())
+                )))
             ),
             Ok(_) => panic!("unsigned amount from {}", s),
         }
@@ -321,7 +323,7 @@ fn parsing() {
     // more than 50 chars.
     assert_eq!(
         p("100000000000000.00000000000000000000000000000000000", Denomination::Bitcoin),
-        Err(E::InputTooLarge(InputTooLargeError { len: 51 }))
+        Err(E(ParseAmountErrorInner::InputTooLarge(InputTooLargeError { len: 51 })))
     );
 }
 
@@ -731,10 +733,10 @@ fn serde_as_btc() {
     // errors
     let t: Result<T, serde_json::Error> =
         serde_json::from_str("{\"amt\": 1000000.000000001, \"samt\": 1}");
-    assert!(t
-        .unwrap_err()
-        .to_string()
-        .contains(&ParseAmountError::TooPrecise(TooPreciseError { position: 16 }).to_string()));
+    assert!(t.unwrap_err().to_string().contains(
+        &ParseAmountError(ParseAmountErrorInner::TooPrecise(TooPreciseError { position: 16 }))
+            .to_string()
+    ));
     let t: Result<T, serde_json::Error> = serde_json::from_str("{\"amt\": -1, \"samt\": 1}");
     assert!(t.unwrap_err().to_string().contains(&OutOfRangeError::negative().to_string()));
 }

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -12,6 +12,7 @@ use ::serde::{Deserialize, Serialize};
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 
+use super::error::{ParseAmountErrorInner, ParseErrorInner};
 use super::{
     parse_signed_to_satoshi, split_amount_and_denomination, Denomination, Display, DisplayStyle,
     OutOfRangeError, ParseAmountError, ParseError, SignedAmount,
@@ -103,7 +104,9 @@ impl Amount {
         let (negative, satoshi) =
             parse_signed_to_satoshi(s, denom).map_err(|error| error.convert(false))?;
         if negative {
-            return Err(ParseAmountError::OutOfRange(OutOfRangeError::negative()));
+            return Err(ParseAmountError(ParseAmountErrorInner::OutOfRange(
+                OutOfRangeError::negative(),
+            )));
         }
         Ok(Amount::from_sat(satoshi))
     }
@@ -405,7 +408,7 @@ impl FromStr for Amount {
         let result = Amount::from_str_with_denomination(s);
 
         match result {
-            Err(ParseError::MissingDenomination(_)) => {
+            Err(ParseError(ParseErrorInner::MissingDenomination(_))) => {
                 let d = Amount::from_str_in(s, Denomination::Satoshi);
 
                 if d == Ok(Amount::ZERO) {


### PR DESCRIPTION
Close the two pubic enum error types in `units::amounts`. All the other structs are closed already because they either have private fields or marked `non_exhaustive`.
