### PR TITLE
units: Implement `iter::Sum` for all types that implement `ops::Add`

### DIFF
--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -442,6 +442,16 @@ impl core::iter::Sum for SignedAmount {
     }
 }
 
+impl<'a> core::iter::Sum<&'a SignedAmount> for SignedAmount {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a SignedAmount>,
+    {
+        let sats: i64 = iter.map(|amt| amt.0).sum();
+        SignedAmount::from_sat(sats)
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for SignedAmount {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -825,8 +825,8 @@ fn serde_as_sat_opt() {
 
 #[test]
 fn sum_amounts() {
-    assert_eq!(Amount::from_sat(0), [].into_iter().sum::<Amount>());
-    assert_eq!(SignedAmount::from_sat(0), [].into_iter().sum::<SignedAmount>());
+    assert_eq!(Amount::from_sat(0), [].iter().sum::<Amount>());
+    assert_eq!(SignedAmount::from_sat(0), [].iter().sum::<SignedAmount>());
 
     let amounts = [Amount::from_sat(42), Amount::from_sat(1337), Amount::from_sat(21)];
     let sum = amounts.into_iter().sum::<Amount>();

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -432,6 +432,16 @@ impl core::iter::Sum for Amount {
     }
 }
 
+impl<'a> core::iter::Sum<&'a Amount> for Amount {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Amount>,
+    {
+        let sats: u64 = iter.map(|amt| amt.0).sum();
+        Amount::from_sat(sats)
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Amount {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -231,6 +231,23 @@ impl ops::SubAssign<BlockInterval> for BlockInterval {
     fn sub_assign(&mut self, rhs: BlockInterval) { self.0 = self.to_u32() - rhs.to_u32(); }
 }
 
+impl core::iter::Sum for BlockInterval {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        let sum = iter.map(|interval| interval.0).sum();
+        BlockInterval::from_u32(sum)
+    }
+}
+
+impl<'a> core::iter::Sum<&'a BlockInterval> for BlockInterval {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a BlockInterval>,
+    {
+        let sum = iter.map(|interval| interval.0).sum();
+        BlockInterval::from_u32(sum)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -267,6 +267,24 @@ impl SubAssign<&FeeRate> for FeeRate {
     fn sub_assign(&mut self, rhs: &FeeRate) { self.0 -= rhs.0 }
 }
 
+impl core::iter::Sum for FeeRate {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = Self>,
+    {
+        FeeRate::from_sat_per_kwu(iter.map(FeeRate::to_sat_per_kwu).sum())
+    }
+}
+
+impl<'a> core::iter::Sum<&'a FeeRate> for FeeRate {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a FeeRate>,
+    {
+        FeeRate::from_sat_per_kwu(iter.map(|f| FeeRate::to_sat_per_kwu(*f)).sum())
+    }
+}
+
 crate::impl_parse_str_from_int_infallible!(FeeRate, u64, from_sat_per_kwu);
 
 #[cfg(test)]


### PR DESCRIPTION
Enables summing an iterator of values. Note that this does not include either `LockTime`s. `absolute::LockTime` should not be added and for `relative::LockTime` we have https://github.com/rust-bitcoin/rust-bitcoin/issues/3676

Close: #1638