### PR TITLE
Remove unused extern statement

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -1,5 +1,3 @@
-extern crate bitcoin;
-
 use std::{env, process};
 
 use bitcoin::address::{Address, KnownHrp};

--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -1,5 +1,3 @@
-extern crate bitcoin;
-
 use std::io::{BufReader, Write};
 use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpStream};
 use std::time::{SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
`extern crate` keywords are no longer needed to import a crate as of Rust 2018