### PR TITLE
hashes: Documents C-QUESTION-MARK

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -5,7 +5,7 @@
 //! This library implements the hash functions needed by Bitcoin. As an ancillary thing, it exposes
 //! hexadecimal serialization and deserialization, since these are needed to display hashes.
 //!
-//! ## Commonly used operations
+//! # Examples
 //!
 //! Hashing a single byte slice or a string:
 //!
@@ -26,7 +26,7 @@
 //!
 //! let mut reader: &[u8] = b"hello"; // In real code, this could be a `File` or `TcpStream`.
 //! let mut engine = Sha256::engine();
-//! std::io::copy(&mut reader, &mut engine).unwrap();
+//! std::io::copy(&mut reader, &mut engine).expect("engine writes don't error");
 //! let _hash = Sha256::from_engine(engine);
 //! # }
 //! ```


### PR DESCRIPTION
To conform to Rust API guidelines in Issue #3633 examples should use ?, not try!, not unwrap (C-QUESTION-MARK).

The examples were originally labelled `## Commonly used operations`, change the label to `# Examples`.
Replace `unwrap()` with `expect()` since these cases cannot error.  

Two uses of `unwrap()` have been left since they are in a set of three writes with an engine that can not error and the first case uses `expect()` with the relevant error message.