### PR TITLE
Add API scripts and output files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -305,3 +305,23 @@ jobs:
         with:
           args: "--only-codegen"
 
+  API:
+    name: API - nightly toolchain
+    needs: Prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dep: [recent]
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v4
+      - name: "Select toolchain"
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ needs.Prepare.outputs.nightly_version }}
+      - name: "Install cargo-public-api"
+        # Pin version so that updates don't introduce changes to the text files.
+        run: cargo +stable install --locked cargo-public-api@0.42.0
+      - name: "Run API checker script"
+        run: ./contrib/check-for-api-changes.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,18 @@ test out the patch set and opine on the technical merits of the patch. Please,
 first review PR on the conceptual level before focusing on code style or
 grammar fixes.
 
+### API changes
+
+The API of the following crates is almost stable. Changing it is supposed to be non-trivial. To
+assist in this effort ll PRs that change the public API of any these crates must include a patch to
+the `api/` text files. This should be a separate final patch to the PR that is the diff created by
+running `just check-api`.
+
+- `hashes`
+- `io`
+- `primitives`
+- `units`
+
 ### Repository maintainers
 
 Pull request merge requirements:

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,12 @@
+# API text files
+
+Each file here lists the public API when built with some set of features
+enabled. To create these files run `../contrib/check-for-api-changes.sh`:
+
+Requires `cargo-public-api`, install with:
+
+```
+cargo +stable install cargo-public-api --locked
+```
+
+ref: https://github.com/enselic/cargo-public-api

--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -1,0 +1,1094 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha384::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::error::FromSliceError
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::hash160::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::sha384::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_io::Write for bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::error::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256::MidstateError
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256d::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha384::Hash
+impl core::clone::Clone for bitcoin_hashes::sha384::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::error::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha384::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha384::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::error::FromSliceError
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::error::FromSliceError
+impl core::default::Default for bitcoin_hashes::hash160::HashEngine
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha256d::HashEngine
+impl core::default::Default for bitcoin_hashes::sha384::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::error::Error for bitcoin_hashes::error::FromSliceError
+impl core::error::Error for bitcoin_hashes::hkdf::MaxLengthError
+impl core::error::Error for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Debug for bitcoin_hashes::error::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha384::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::error::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha384::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha384::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha384::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha384::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha384::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::error::FromSliceError
+impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Midstate
+impl core::marker::Freeze for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Freeze for bitcoin_hashes::sha256d::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha384::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::State
+impl core::marker::Send for bitcoin_hashes::error::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha384::Hash
+impl core::marker::Send for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::error::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha384::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::error::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha384::Hash
+impl core::marker::Sync for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::error::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha384::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::error::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::error::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha384::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl serde::ser::Serialize for bitcoin_hashes::hash160::Hash
+impl serde::ser::Serialize for bitcoin_hashes::ripemd160::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha1::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256d::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha384::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha512::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha512_256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::siphash24::Hash
+impl std::io::Write for bitcoin_hashes::hash160::HashEngine
+impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine
+impl std::io::Write for bitcoin_hashes::sha1::HashEngine
+impl std::io::Write for bitcoin_hashes::sha256::HashEngine
+impl std::io::Write for bitcoin_hashes::sha256d::HashEngine
+impl std::io::Write for bitcoin_hashes::sha384::HashEngine
+impl std::io::Write for bitcoin_hashes::sha512::HashEngine
+impl std::io::Write for bitcoin_hashes::sha512_256::HashEngine
+impl std::io::Write for bitcoin_hashes::siphash24::HashEngine
+impl<'de, T: bitcoin_hashes::GeneralHash + serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
+impl<'de, T: bitcoin_hashes::sha256t::Tag> serde::de::Deserialize<'de> for bitcoin_hashes::sha256t::Hash<T>
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::hash160::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::ripemd160::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha1::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256d::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha384::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512_256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::siphash24::Hash
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::Display> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::LowerHex> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + serde::ser::Serialize> serde::ser::Serialize for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::GeneralHash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_io::Write for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::GeneralHash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+impl<T: bitcoin_hashes::GeneralHash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> serde::ser::Serialize for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::GeneralHash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::GeneralHash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::clone::Clone
+impl<T: core::cmp::Eq + bitcoin_hashes::GeneralHash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::GeneralHash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::GeneralHash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::GeneralHash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::GeneralHash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::GeneralHash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<ValueT, const N: usize> core::default::Default for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>
+impl<ValueT, const N: usize> core::marker::Freeze for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>
+impl<ValueT, const N: usize> core::marker::Send for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::marker::Send
+impl<ValueT, const N: usize> core::marker::Sync for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::marker::Sync
+impl<ValueT, const N: usize> core::marker::Unpin for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::marker::Unpin
+impl<ValueT, const N: usize> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::panic::unwind_safe::RefUnwindSafe
+impl<ValueT, const N: usize> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::panic::unwind_safe::UnwindSafe
+impl<ValueT, const N: usize> serde::de::Visitor<'_> for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: bitcoin_hashes::Hash + bitcoin_hashes::Hash<Bytes = [u8; N]>
+impl<ValueT> core::default::Default for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>
+impl<ValueT> core::marker::Freeze for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>
+impl<ValueT> core::marker::Send for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::marker::Send
+impl<ValueT> core::marker::Sync for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::marker::Sync
+impl<ValueT> core::marker::Unpin for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::marker::Unpin
+impl<ValueT> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::panic::unwind_safe::RefUnwindSafe
+impl<ValueT> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::panic::unwind_safe::UnwindSafe
+impl<ValueT> serde::de::Visitor<'_> for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::str::traits::FromStr, <ValueT as core::str::traits::FromStr>::Err: core::fmt::Display
+impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
+pub const [u8; N]::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::IsByteArray::LEN: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::hash_unoptimized(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256::HashEngine::can_extract_midstate(&self) -> bool
+pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::as_parts(&self) -> (&[u8; 32], u64)
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::new(state: [u8; 32], bytes_hashed: u64) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_parts(self) -> ([u8; 32], u64)
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
+pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub extern crate bitcoin_hashes::hex
+pub extern crate bitcoin_hashes::serde
+pub fn bitcoin_hashes::GeneralHash::engine() -> Self::Engine where Self::Engine: core::default::Default
+pub fn bitcoin_hashes::GeneralHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::GeneralHash::hash(data: &[u8]) -> Self where Self::Engine: core::default::Default
+pub fn bitcoin_hashes::GeneralHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>, Self::Engine: core::default::Default
+pub fn bitcoin_hashes::GeneralHash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error> where Self::Engine: core::default::Default
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::debug_hex(bytes: &[u8], f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::error::FromSliceError::clone(&self) -> bitcoin_hashes::error::FromSliceError
+pub fn bitcoin_hashes::error::FromSliceError::eq(&self, other: &bitcoin_hashes::error::FromSliceError) -> bool
+pub fn bitcoin_hashes::error::FromSliceError::expected_length(&self) -> usize
+pub fn bitcoin_hashes::error::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::error::FromSliceError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_hashes::error::FromSliceError::invalid_length(&self) -> usize
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hash160::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::hash160::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hash160::Hash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hash160::HashEngine::clone(&self) -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::hash160::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::hash160::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hash160::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::hash160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand_to_len(&self, info: &[u8], len: usize) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::GeneralHash>::Engine, oengine: <T as bitcoin_hashes::GeneralHash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>::default() -> Self
+pub fn bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>::expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>::visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E> where E: serde::de::Error
+pub fn bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::default() -> Self
+pub fn bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E> where E: serde::de::Error
+pub fn bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::visit_str<E>(self, v: &str) -> core::result::Result<Self::Value, E> where E: serde::de::Error
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::ripemd160::Hash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha1::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::MidstateError>
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::MidstateError::clone(&self) -> bitcoin_hashes::sha256::MidstateError
+pub fn bitcoin_hashes::sha256::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::MidstateError) -> bool
+pub fn bitcoin_hashes::sha256::MidstateError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256d::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256d::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::HashEngine::clone(&self) -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256d::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::sha256d::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256d::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::sha256d::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha384::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha384::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
+pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
+pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha384::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha384::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha384::Hash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha384::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha384::HashEngine::clone(&self) -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha384::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::sha384::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha384::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::sha384::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::hash_reader<R: bitcoin_io::BufRead>(reader: &mut R) -> core::result::Result<Self, bitcoin_io::error::Error>
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::sha512_256::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512_256::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::sha512_256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::siphash24::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::to_u64(self) -> u64
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::impl_debug_only_for_newtype!
+pub macro bitcoin_hashes::impl_hex_for_newtype!
+pub macro bitcoin_hashes::impl_serde_for_newtype!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub macro bitcoin_hashes::sha256t_tag!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::error
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::macros
+pub mod bitcoin_hashes::macros::serde_details
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::serde_macros::serde_details
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha384
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::FromSliceError(_)
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::error::FromSliceError(_)
+pub struct bitcoin_hashes::hash160::HashEngine(_)
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, const N: usize>(_)
+pub struct bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>(_)
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::serde_macros::serde_details::BytesVisitor<ValueT, const N: usize>(_)
+pub struct bitcoin_hashes::serde_macros::serde_details::HexVisitor<ValueT>(_)
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate
+pub struct bitcoin_hashes::sha256::MidstateError
+pub struct bitcoin_hashes::sha256d::HashEngine(_)
+pub struct bitcoin_hashes::sha384::HashEngine(_)
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::GeneralHash: bitcoin_hashes::Hash
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::convert::AsRef<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone
+pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + sealed::IsByteArray
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::GeneralHash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::Hash::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::hash160::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>::Value = ValueT
+pub type bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::Value = ValueT
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256d::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha384::Hash::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::Hash::Engine = bitcoin_hashes::sha384::HashEngine
+pub type bitcoin_hashes::sha384::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::error::HexToArrayError

--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -1,0 +1,945 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha384::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::error::FromSliceError
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::error::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256::MidstateError
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256d::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha384::Hash
+impl core::clone::Clone for bitcoin_hashes::sha384::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::error::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha384::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha384::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::error::FromSliceError
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::error::FromSliceError
+impl core::default::Default for bitcoin_hashes::hash160::HashEngine
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha256d::HashEngine
+impl core::default::Default for bitcoin_hashes::sha384::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::error::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha384::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::error::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha384::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha384::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha384::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha384::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha384::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::error::FromSliceError
+impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Midstate
+impl core::marker::Freeze for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Freeze for bitcoin_hashes::sha256d::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha384::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::State
+impl core::marker::Send for bitcoin_hashes::error::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha384::Hash
+impl core::marker::Send for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::error::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha384::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::error::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha384::Hash
+impl core::marker::Sync for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::error::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha384::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::error::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::error::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha384::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::Display> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::LowerHex> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::GeneralHash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::GeneralHash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+impl<T: bitcoin_hashes::GeneralHash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::GeneralHash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::GeneralHash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::clone::Clone
+impl<T: core::cmp::Eq + bitcoin_hashes::GeneralHash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::GeneralHash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::GeneralHash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::GeneralHash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::GeneralHash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::GeneralHash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
+pub const [u8; N]::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::IsByteArray::LEN: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::hash_unoptimized(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256::HashEngine::can_extract_midstate(&self) -> bool
+pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::as_parts(&self) -> (&[u8; 32], u64)
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::new(state: [u8; 32], bytes_hashed: u64) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_parts(self) -> ([u8; 32], u64)
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
+pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub extern crate bitcoin_hashes::hex
+pub fn bitcoin_hashes::GeneralHash::engine() -> Self::Engine where Self::Engine: core::default::Default
+pub fn bitcoin_hashes::GeneralHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::GeneralHash::hash(data: &[u8]) -> Self where Self::Engine: core::default::Default
+pub fn bitcoin_hashes::GeneralHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>, Self::Engine: core::default::Default
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::debug_hex(bytes: &[u8], f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::error::FromSliceError::clone(&self) -> bitcoin_hashes::error::FromSliceError
+pub fn bitcoin_hashes::error::FromSliceError::eq(&self, other: &bitcoin_hashes::error::FromSliceError) -> bool
+pub fn bitcoin_hashes::error::FromSliceError::expected_length(&self) -> usize
+pub fn bitcoin_hashes::error::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::error::FromSliceError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_hashes::error::FromSliceError::invalid_length(&self) -> usize
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::hash160::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hash160::HashEngine::clone(&self) -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand_to_len(&self, info: &[u8], len: usize) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::GeneralHash>::Engine, oengine: <T as bitcoin_hashes::GeneralHash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::MidstateError>
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::MidstateError::clone(&self) -> bitcoin_hashes::sha256::MidstateError
+pub fn bitcoin_hashes::sha256::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::MidstateError) -> bool
+pub fn bitcoin_hashes::sha256::MidstateError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256d::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::HashEngine::clone(&self) -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
+pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
+pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha384::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha384::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha384::HashEngine::clone(&self) -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::to_u64(self) -> u64
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::impl_debug_only_for_newtype!
+pub macro bitcoin_hashes::impl_hex_for_newtype!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub macro bitcoin_hashes::sha256t_tag!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::error
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::macros
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha384
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::FromSliceError(_)
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::error::FromSliceError(_)
+pub struct bitcoin_hashes::hash160::HashEngine(_)
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate
+pub struct bitcoin_hashes::sha256::MidstateError
+pub struct bitcoin_hashes::sha256d::HashEngine(_)
+pub struct bitcoin_hashes::sha384::HashEngine(_)
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::GeneralHash: bitcoin_hashes::Hash
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::convert::AsRef<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone
+pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + sealed::IsByteArray
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::GeneralHash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::Hash::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::hash160::HashEngine
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256d::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha384::Hash::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::Hash::Engine = bitcoin_hashes::sha384::HashEngine
+pub type bitcoin_hashes::sha384::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::error::HexToArrayError

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -1,0 +1,882 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::GeneralHash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha384::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::GeneralHash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::error::FromSliceError
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::error::FromSliceError
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256::MidstateError
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256d::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha384::Hash
+impl core::clone::Clone for bitcoin_hashes::sha384::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::error::FromSliceError
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha384::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha384::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::error::FromSliceError
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::error::FromSliceError
+impl core::default::Default for bitcoin_hashes::hash160::HashEngine
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha256d::HashEngine
+impl core::default::Default for bitcoin_hashes::sha384::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::error::FromSliceError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha384::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::error::FromSliceError
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Display for bitcoin_hashes::sha256::MidstateError
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha384::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha384::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::error::FromSliceError
+impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Midstate
+impl core::marker::Freeze for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Freeze for bitcoin_hashes::sha256d::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha384::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::State
+impl core::marker::Send for bitcoin_hashes::error::FromSliceError
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha384::Hash
+impl core::marker::Send for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::error::FromSliceError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha384::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::error::FromSliceError
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha384::Hash
+impl core::marker::Sync for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::error::FromSliceError
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha384::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::error::FromSliceError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::error::FromSliceError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::Display> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::fmt::LowerHex> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::GeneralHash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+impl<T: bitcoin_hashes::GeneralHash> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::GeneralHash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::GeneralHash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+impl<T: bitcoin_hashes::GeneralHash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::GeneralHash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::GeneralHash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::GeneralHash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::clone::Clone
+impl<T: core::cmp::Eq + bitcoin_hashes::GeneralHash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::GeneralHash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialEq + bitcoin_hashes::GeneralHash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::GeneralHash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::hash::Hash + bitcoin_hashes::GeneralHash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::GeneralHash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
+pub const [u8; N]::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::IsByteArray::LEN: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::hash_unoptimized(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256::HashEngine::can_extract_midstate(&self) -> bool
+pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::as_parts(&self) -> (&[u8; 32], u64)
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::new(state: [u8; 32], bytes_hashed: u64) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_parts(self) -> ([u8; 32], u64)
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
+pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::GeneralHash::engine() -> Self::Engine where Self::Engine: core::default::Default
+pub fn bitcoin_hashes::GeneralHash::from_engine(e: Self::Engine) -> Self
+pub fn bitcoin_hashes::GeneralHash::hash(data: &[u8]) -> Self where Self::Engine: core::default::Default
+pub fn bitcoin_hashes::GeneralHash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>, Self::Engine: core::default::Default
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::from_slice(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::debug_hex(bytes: &[u8], f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::error::FromSliceError::clone(&self) -> bitcoin_hashes::error::FromSliceError
+pub fn bitcoin_hashes::error::FromSliceError::eq(&self, other: &bitcoin_hashes::error::FromSliceError) -> bool
+pub fn bitcoin_hashes::error::FromSliceError::expected_length(&self) -> usize
+pub fn bitcoin_hashes::error::FromSliceError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::error::FromSliceError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_hashes::error::FromSliceError::invalid_length(&self) -> usize
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::hash160::HashEngine) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hash160::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hash160::HashEngine::clone(&self) -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_engine(e: bitcoin_hashes::hmac::HmacEngine<T>) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::GeneralHash>::Engine, oengine: <T as bitcoin_hashes::GeneralHash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::GeneralHash>::Engine: core::default::Default
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha1::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::MidstateError>
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::MidstateError::clone(&self) -> bitcoin_hashes::sha256::MidstateError
+pub fn bitcoin_hashes::sha256::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::MidstateError) -> bool
+pub fn bitcoin_hashes::sha256::MidstateError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256d::HashEngine) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256d::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::HashEngine::clone(&self) -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &bitcoin_hashes::sha256t::Hash<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
+pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
+pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha384::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha384::HashEngine::clone(&self) -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::as_u64(&self) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::siphash24::Hash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::to_u64(self) -> u64
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::impl_debug_only_for_newtype!
+pub macro bitcoin_hashes::serde_impl!
+pub macro bitcoin_hashes::sha256t_hash_newtype!
+pub macro bitcoin_hashes::sha256t_tag!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::error
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::macros
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::serde_macros
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha384
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::FromSliceError(_)
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::error::FromSliceError(_)
+pub struct bitcoin_hashes::hash160::HashEngine(_)
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::GeneralHash>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate
+pub struct bitcoin_hashes::sha256::MidstateError
+pub struct bitcoin_hashes::sha256d::HashEngine(_)
+pub struct bitcoin_hashes::sha384::HashEngine(_)
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::GeneralHash: bitcoin_hashes::Hash
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::convert::AsRef<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone
+pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + sealed::IsByteArray
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::GeneralHash::Engine: bitcoin_hashes::HashEngine
+pub type bitcoin_hashes::Hash::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::hash160::HashEngine
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256d::HashEngine
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Engine = bitcoin_hashes::sha256::HashEngine
+pub type bitcoin_hashes::sha384::Hash::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::Hash::Engine = bitcoin_hashes::sha384::HashEngine
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine

--- a/api/io/all-features.txt
+++ b/api/io/all-features.txt
@@ -1,0 +1,377 @@
+#[repr(transparent)] pub struct bitcoin_io::FromStd<T>(_)
+#[repr(transparent)] pub struct bitcoin_io::ToStd<T>(_)
+impl !core::marker::Sync for bitcoin_io::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
+impl bitcoin_io::BufRead for &[u8]
+impl bitcoin_io::BufRead for alloc::collections::vec_deque::VecDeque<u8>
+impl bitcoin_io::BufRead for std::io::stdio::StdinLock<'_>
+impl bitcoin_io::BufRead for std::io::util::Empty
+impl bitcoin_io::Error
+impl bitcoin_io::Read for &[u8]
+impl bitcoin_io::Read for &std::fs::File
+impl bitcoin_io::Read for &std::io::stdio::Stdin
+impl bitcoin_io::Read for &std::net::tcp::TcpStream
+impl bitcoin_io::Read for &std::os::unix::net::stream::UnixStream
+impl bitcoin_io::Read for alloc::collections::vec_deque::VecDeque<u8>
+impl bitcoin_io::Read for alloc::sync::Arc<std::fs::File>
+impl bitcoin_io::Read for std::fs::File
+impl bitcoin_io::Read for std::io::stdio::Stdin
+impl bitcoin_io::Read for std::io::stdio::StdinLock<'_>
+impl bitcoin_io::Read for std::io::util::Empty
+impl bitcoin_io::Read for std::io::util::Repeat
+impl bitcoin_io::Read for std::net::tcp::TcpStream
+impl bitcoin_io::Read for std::os::unix::net::stream::UnixStream
+impl bitcoin_io::Read for std::process::ChildStderr
+impl bitcoin_io::Read for std::process::ChildStdout
+impl bitcoin_io::Write for &mut [u8]
+impl bitcoin_io::Write for &std::fs::File
+impl bitcoin_io::Write for &std::io::stdio::Stderr
+impl bitcoin_io::Write for &std::io::stdio::Stdout
+impl bitcoin_io::Write for &std::io::util::Empty
+impl bitcoin_io::Write for &std::net::tcp::TcpStream
+impl bitcoin_io::Write for &std::os::unix::net::stream::UnixStream
+impl bitcoin_io::Write for &std::process::ChildStdin
+impl bitcoin_io::Write for alloc::collections::vec_deque::VecDeque<u8>
+impl bitcoin_io::Write for alloc::sync::Arc<std::fs::File>
+impl bitcoin_io::Write for alloc::vec::Vec<u8>
+impl bitcoin_io::Write for bitcoin_io::Sink
+impl bitcoin_io::Write for std::fs::File
+impl bitcoin_io::Write for std::io::cursor::Cursor<&mut alloc::vec::Vec<u8>>
+impl bitcoin_io::Write for std::io::cursor::Cursor<alloc::boxed::Box<[u8]>>
+impl bitcoin_io::Write for std::io::cursor::Cursor<alloc::vec::Vec<u8>>
+impl bitcoin_io::Write for std::io::stdio::Stderr
+impl bitcoin_io::Write for std::io::stdio::Stdout
+impl bitcoin_io::Write for std::io::util::Empty
+impl bitcoin_io::Write for std::net::tcp::TcpStream
+impl bitcoin_io::Write for std::os::unix::net::stream::UnixStream
+impl bitcoin_io::Write for std::process::ChildStdin
+impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::cmp::Eq for bitcoin_io::ErrorKind
+impl core::cmp::PartialEq for bitcoin_io::ErrorKind
+impl core::convert::From<bitcoin_io::Error> for std::io::error::Error
+impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
+impl core::convert::From<core::convert::Infallible> for bitcoin_io::ErrorKind
+impl core::convert::From<std::io::error::Error> for bitcoin_io::Error
+impl core::error::Error for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::ErrorKind
+impl core::fmt::Display for bitcoin_io::Error
+impl core::hash::Hash for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Freeze for bitcoin_io::Error
+impl core::marker::Freeze for bitcoin_io::ErrorKind
+impl core::marker::Freeze for bitcoin_io::Sink
+impl core::marker::Send for bitcoin_io::Error
+impl core::marker::Send for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Sink
+impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Sink
+impl core::marker::Unpin for bitcoin_io::Error
+impl core::marker::Unpin for bitcoin_io::ErrorKind
+impl core::marker::Unpin for bitcoin_io::Sink
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Sink
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Sink
+impl std::io::Write for bitcoin_io::Sink
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Take<'a, R>
+impl<'a, R> core::marker::Freeze for bitcoin_io::Take<'a, R> where R: ?core::marker::Sized
+impl<'a, R> core::marker::Send for bitcoin_io::Take<'a, R> where R: core::marker::Send + ?core::marker::Sized
+impl<'a, R> core::marker::Sync for bitcoin_io::Take<'a, R> where R: core::marker::Sync + ?core::marker::Sized
+impl<'a, R> core::marker::Unpin for bitcoin_io::Take<'a, R> where R: ?core::marker::Sized
+impl<'a, R> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Take<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<R1: std::io::BufRead, R2: std::io::BufRead> bitcoin_io::BufRead for std::io::Chain<R1, R2>
+impl<R1: std::io::Read, R2: std::io::Read> bitcoin_io::Read for std::io::Chain<R1, R2>
+impl<R: bitcoin_io::BufRead + ?core::marker::Sized> bitcoin_io::BufRead for bitcoin_io::Take<'_, R>
+impl<R: bitcoin_io::Read + ?core::marker::Sized> bitcoin_io::Read for bitcoin_io::Take<'_, R>
+impl<R: bitcoin_io::Read + ?core::marker::Sized> bitcoin_io::Take<'_, R>
+impl<R: std::io::BufRead> bitcoin_io::BufRead for std::io::Take<R>
+impl<R: std::io::Read> bitcoin_io::Read for std::io::Take<R>
+impl<R> bitcoin_io::BufRead for std::io::buffered::bufreader::BufReader<R> where R: ?core::marker::Sized + std::io::Read
+impl<R> bitcoin_io::Read for std::io::buffered::bufreader::BufReader<R> where R: ?core::marker::Sized + std::io::Read
+impl<T: bitcoin_io::BufRead> bitcoin_io::BufRead for &mut T
+impl<T: bitcoin_io::BufRead> bitcoin_io::BufRead for bitcoin_io::ToStd<T>
+impl<T: bitcoin_io::BufRead> std::io::BufRead for bitcoin_io::ToStd<T>
+impl<T: bitcoin_io::Read> bitcoin_io::Read for &mut T
+impl<T: bitcoin_io::Read> bitcoin_io::Read for bitcoin_io::ToStd<T>
+impl<T: bitcoin_io::Read> std::io::Read for bitcoin_io::ToStd<T>
+impl<T: bitcoin_io::Write> bitcoin_io::Write for &mut T
+impl<T: bitcoin_io::Write> bitcoin_io::Write for bitcoin_io::ToStd<T>
+impl<T: bitcoin_io::Write> std::io::Write for bitcoin_io::ToStd<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for std::io::cursor::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for std::io::cursor::Cursor<T>
+impl<T: std::io::BufRead> bitcoin_io::BufRead for bitcoin_io::FromStd<T>
+impl<T: std::io::BufRead> std::io::BufRead for bitcoin_io::FromStd<T>
+impl<T: std::io::Read> bitcoin_io::Read for bitcoin_io::FromStd<T>
+impl<T: std::io::Read> std::io::Read for bitcoin_io::FromStd<T>
+impl<T: std::io::Write> bitcoin_io::Write for bitcoin_io::FromStd<T>
+impl<T: std::io::Write> std::io::Write for bitcoin_io::FromStd<T>
+impl<T> bitcoin_io::FromStd<T>
+impl<T> bitcoin_io::ToStd<T>
+impl<T> core::marker::Freeze for bitcoin_io::Cursor<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_io::FromStd<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_io::ToStd<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_io::FromStd<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_io::ToStd<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_io::FromStd<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_io::ToStd<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_io::Cursor<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_io::FromStd<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_io::ToStd<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::FromStd<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::ToStd<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_io::FromStd<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_io::ToStd<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<W> bitcoin_io::Write for std::io::buffered::bufwriter::BufWriter<W> where W: ?core::marker::Sized + std::io::Write
+impl<W> bitcoin_io::Write for std::io::buffered::linewriter::LineWriter<W> where W: ?core::marker::Sized + std::io::Write
+pub bitcoin_io::ErrorKind::AddrInUse
+pub bitcoin_io::ErrorKind::AddrNotAvailable
+pub bitcoin_io::ErrorKind::AlreadyExists
+pub bitcoin_io::ErrorKind::BrokenPipe
+pub bitcoin_io::ErrorKind::ConnectionAborted
+pub bitcoin_io::ErrorKind::ConnectionRefused
+pub bitcoin_io::ErrorKind::ConnectionReset
+pub bitcoin_io::ErrorKind::Interrupted
+pub bitcoin_io::ErrorKind::InvalidData
+pub bitcoin_io::ErrorKind::InvalidInput
+pub bitcoin_io::ErrorKind::NotConnected
+pub bitcoin_io::ErrorKind::NotFound
+pub bitcoin_io::ErrorKind::Other
+pub bitcoin_io::ErrorKind::PermissionDenied
+pub bitcoin_io::ErrorKind::TimedOut
+pub bitcoin_io::ErrorKind::UnexpectedEof
+pub bitcoin_io::ErrorKind::WouldBlock
+pub bitcoin_io::ErrorKind::WriteZero
+pub const fn bitcoin_io::FromStd<T>::new(inner: T) -> Self
+pub const fn bitcoin_io::ToStd<T>::new(inner: T) -> Self
+pub const fn bitcoin_io::from_std<T>(std_io: T) -> bitcoin_io::FromStd<T>
+pub enum bitcoin_io::ErrorKind
+pub fn &[u8]::consume(&mut self, amount: usize)
+pub fn &[u8]::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn &[u8]::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::consume(&mut self, amount: usize)
+pub fn &mut T::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn &mut T::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &mut T::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn &mut T::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &mut [u8]::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &mut [u8]::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &std::fs::File::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &std::fs::File::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &std::fs::File::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn &std::fs::File::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &std::fs::File::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &std::io::stdio::Stderr::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &std::io::stdio::Stderr::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &std::io::stdio::Stderr::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &std::io::stdio::Stdin::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &std::io::stdio::Stdin::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn &std::io::stdio::Stdout::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &std::io::stdio::Stdout::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &std::io::stdio::Stdout::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &std::io::util::Empty::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &std::io::util::Empty::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &std::io::util::Empty::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &std::net::tcp::TcpStream::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &std::net::tcp::TcpStream::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &std::net::tcp::TcpStream::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn &std::net::tcp::TcpStream::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &std::net::tcp::TcpStream::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &std::os::unix::net::stream::UnixStream::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &std::os::unix::net::stream::UnixStream::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &std::os::unix::net::stream::UnixStream::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn &std::os::unix::net::stream::UnixStream::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &std::os::unix::net::stream::UnixStream::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &std::process::ChildStdin::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &std::process::ChildStdin::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &std::process::ChildStdin::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn alloc::collections::vec_deque::VecDeque<u8>::consume(&mut self, amount: usize)
+pub fn alloc::collections::vec_deque::VecDeque<u8>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn alloc::collections::vec_deque::VecDeque<u8>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn alloc::collections::vec_deque::VecDeque<u8>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn alloc::collections::vec_deque::VecDeque<u8>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn alloc::collections::vec_deque::VecDeque<u8>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn alloc::collections::vec_deque::VecDeque<u8>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn alloc::sync::Arc<std::fs::File>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn alloc::sync::Arc<std::fs::File>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn alloc::sync::Arc<std::fs::File>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn alloc::sync::Arc<std::fs::File>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn alloc::sync::Arc<std::fs::File>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn alloc::vec::Vec<u8>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn alloc::vec::Vec<u8>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
+pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::inner(&self) -> &T
+pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
+pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
+pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Cursor<T>::set_position(&mut self, position: u64)
+pub fn bitcoin_io::Error::cause(&self) -> core::option::Option<&dyn core::error::Error>
+pub fn bitcoin_io::Error::description(&self) -> &str
+pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::Error::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_io::Error::from(kind: bitcoin_io::ErrorKind) -> bitcoin_io::Error
+pub fn bitcoin_io::Error::from(o: std::io::error::Error) -> bitcoin_io::Error
+pub fn bitcoin_io::Error::get_ref(&self) -> core::option::Option<&(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>
+pub fn bitcoin_io::Error::kind(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::Error::new<E>(kind: bitcoin_io::ErrorKind, error: E) -> bitcoin_io::Error where E: core::convert::Into<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>>
+pub fn bitcoin_io::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_io::ErrorKind::clone(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::ErrorKind::eq(&self, other: &bitcoin_io::ErrorKind) -> bool
+pub fn bitcoin_io::ErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::ErrorKind::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_io::ErrorKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_io::FromStd<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::FromStd<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::FromStd<T>::fill_buf(&mut self) -> std::io::error::Result<&[u8]>
+pub fn bitcoin_io::FromStd<T>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::FromStd<T>::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_io::FromStd<T>::inner(&self) -> &T
+pub fn bitcoin_io::FromStd<T>::inner_mut(&mut self) -> &mut T
+pub fn bitcoin_io::FromStd<T>::into_inner(self) -> T
+pub fn bitcoin_io::FromStd<T>::new_boxed(inner: alloc::boxed::Box<T>) -> alloc::boxed::Box<Self>
+pub fn bitcoin_io::FromStd<T>::new_mut(inner: &mut T) -> &mut Self
+pub fn bitcoin_io::FromStd<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::FromStd<T>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_io::FromStd<T>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::FromStd<T>::read_exact(&mut self, buf: &mut [u8]) -> std::io::error::Result<()>
+pub fn bitcoin_io::FromStd<T>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::FromStd<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_io::FromStd<T>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::FromStd<T>::write_all(&mut self, buf: &[u8]) -> std::io::error::Result<()>
+pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Read::read_to_limit(&mut self, buf: &mut alloc::vec::Vec<u8>, limit: u64) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Sink::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_io::Sink::write_all(&mut self, _: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Sink::write_all(&mut self, _: &[u8]) -> std::io::error::Result<()>
+pub fn bitcoin_io::Take<'_, R>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Take<'_, R>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Take<'_, R>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Take<'_, R>::read_to_end(&mut self, buf: &mut alloc::vec::Vec<u8>) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::ToStd<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::ToStd<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::ToStd<T>::fill_buf(&mut self) -> std::io::error::Result<&[u8]>
+pub fn bitcoin_io::ToStd<T>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::ToStd<T>::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_io::ToStd<T>::inner(&self) -> &T
+pub fn bitcoin_io::ToStd<T>::inner_mut(&mut self) -> &mut T
+pub fn bitcoin_io::ToStd<T>::into_inner(self) -> T
+pub fn bitcoin_io::ToStd<T>::new_boxed(inner: alloc::boxed::Box<T>) -> alloc::boxed::Box<Self>
+pub fn bitcoin_io::ToStd<T>::new_mut(inner: &mut T) -> &mut Self
+pub fn bitcoin_io::ToStd<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::ToStd<T>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_io::ToStd<T>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::ToStd<T>::read_exact(&mut self, buf: &mut [u8]) -> std::io::error::Result<()>
+pub fn bitcoin_io::ToStd<T>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::ToStd<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_io::ToStd<T>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::ToStd<T>::write_all(&mut self, buf: &[u8]) -> std::io::error::Result<()>
+pub fn bitcoin_io::Write::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Write::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::from_std_mut<T>(std_io: &mut T) -> &mut bitcoin_io::FromStd<T>
+pub fn bitcoin_io::sink() -> bitcoin_io::Sink
+pub fn std::fs::File::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::fs::File::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::fs::File::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::fs::File::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::fs::File::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::Chain<R1, R2>::consume(&mut self, amount: usize)
+pub fn std::io::Chain<R1, R2>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn std::io::Chain<R1, R2>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::Chain<R1, R2>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::io::Take<R>::consume(&mut self, amount: usize)
+pub fn std::io::Take<R>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn std::io::Take<R>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::Take<R>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::io::buffered::bufreader::BufReader<R>::consume(&mut self, amount: usize)
+pub fn std::io::buffered::bufreader::BufReader<R>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn std::io::buffered::bufreader::BufReader<R>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::buffered::bufreader::BufReader<R>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::io::buffered::bufwriter::BufWriter<W>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::io::buffered::bufwriter::BufWriter<W>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::buffered::bufwriter::BufWriter<W>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::buffered::linewriter::LineWriter<W>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::io::buffered::linewriter::LineWriter<W>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::buffered::linewriter::LineWriter<W>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::cursor::Cursor<&mut alloc::vec::Vec<u8>>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::io::cursor::Cursor<&mut alloc::vec::Vec<u8>>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::cursor::Cursor<&mut alloc::vec::Vec<u8>>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::cursor::Cursor<T>::consume(&mut self, amount: usize)
+pub fn std::io::cursor::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn std::io::cursor::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::cursor::Cursor<T>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::io::cursor::Cursor<alloc::boxed::Box<[u8]>>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::io::cursor::Cursor<alloc::boxed::Box<[u8]>>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::cursor::Cursor<alloc::boxed::Box<[u8]>>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::cursor::Cursor<alloc::vec::Vec<u8>>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::io::cursor::Cursor<alloc::vec::Vec<u8>>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::cursor::Cursor<alloc::vec::Vec<u8>>::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::error::Error::from(o: bitcoin_io::Error) -> std::io::error::Error
+pub fn std::io::stdio::Stderr::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::io::stdio::Stderr::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::stdio::Stderr::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::stdio::Stdin::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::stdio::Stdin::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::io::stdio::StdinLock<'_>::consume(&mut self, amount: usize)
+pub fn std::io::stdio::StdinLock<'_>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn std::io::stdio::StdinLock<'_>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::stdio::StdinLock<'_>::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::io::stdio::Stdout::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::io::stdio::Stdout::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::stdio::Stdout::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::util::Empty::consume(&mut self, amount: usize)
+pub fn std::io::util::Empty::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn std::io::util::Empty::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::io::util::Empty::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::util::Empty::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::io::util::Empty::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::util::Empty::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::io::util::Repeat::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::io::util::Repeat::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::net::tcp::TcpStream::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::net::tcp::TcpStream::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::net::tcp::TcpStream::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::net::tcp::TcpStream::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::net::tcp::TcpStream::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::os::unix::net::stream::UnixStream::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::os::unix::net::stream::UnixStream::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::os::unix::net::stream::UnixStream::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::os::unix::net::stream::UnixStream::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::os::unix::net::stream::UnixStream::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::process::ChildStderr::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::process::ChildStderr::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn std::process::ChildStdin::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn std::process::ChildStdin::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn std::process::ChildStdin::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn std::process::ChildStdout::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn std::process::ChildStdout::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub macro bitcoin_io::impl_write!
+pub mod bitcoin_io
+pub struct bitcoin_io::Cursor<T>
+pub struct bitcoin_io::Error
+pub struct bitcoin_io::Sink
+pub struct bitcoin_io::Take<'a, R: bitcoin_io::Read + ?core::marker::Sized>
+pub trait bitcoin_io::BufRead: bitcoin_io::Read
+pub trait bitcoin_io::Read
+pub trait bitcoin_io::Write
+pub type bitcoin_io::Result<T> = core::result::Result<T, bitcoin_io::Error>

--- a/api/io/alloc-only.txt
+++ b/api/io/alloc-only.txt
@@ -1,0 +1,135 @@
+impl !core::marker::Sync for bitcoin_io::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
+impl bitcoin_io::BufRead for &[u8]
+impl bitcoin_io::Error
+impl bitcoin_io::Read for &[u8]
+impl bitcoin_io::Write for &mut [u8]
+impl bitcoin_io::Write for alloc::vec::Vec<u8>
+impl bitcoin_io::Write for bitcoin_io::Sink
+impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::cmp::Eq for bitcoin_io::ErrorKind
+impl core::cmp::PartialEq for bitcoin_io::ErrorKind
+impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
+impl core::convert::From<core::convert::Infallible> for bitcoin_io::ErrorKind
+impl core::fmt::Debug for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::ErrorKind
+impl core::fmt::Display for bitcoin_io::Error
+impl core::hash::Hash for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Freeze for bitcoin_io::Error
+impl core::marker::Freeze for bitcoin_io::ErrorKind
+impl core::marker::Freeze for bitcoin_io::Sink
+impl core::marker::Send for bitcoin_io::Error
+impl core::marker::Send for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Sink
+impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Sink
+impl core::marker::Unpin for bitcoin_io::Error
+impl core::marker::Unpin for bitcoin_io::ErrorKind
+impl core::marker::Unpin for bitcoin_io::Sink
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Sink
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Sink
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Take<'a, R>
+impl<'a, R> core::marker::Freeze for bitcoin_io::Take<'a, R> where R: ?core::marker::Sized
+impl<'a, R> core::marker::Send for bitcoin_io::Take<'a, R> where R: core::marker::Send + ?core::marker::Sized
+impl<'a, R> core::marker::Sync for bitcoin_io::Take<'a, R> where R: core::marker::Sync + ?core::marker::Sized
+impl<'a, R> core::marker::Unpin for bitcoin_io::Take<'a, R> where R: ?core::marker::Sized
+impl<'a, R> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Take<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<R: bitcoin_io::BufRead + ?core::marker::Sized> bitcoin_io::BufRead for bitcoin_io::Take<'_, R>
+impl<R: bitcoin_io::Read + ?core::marker::Sized> bitcoin_io::Read for bitcoin_io::Take<'_, R>
+impl<R: bitcoin_io::Read + ?core::marker::Sized> bitcoin_io::Take<'_, R>
+impl<T: bitcoin_io::BufRead> bitcoin_io::BufRead for &mut T
+impl<T: bitcoin_io::Read> bitcoin_io::Read for &mut T
+impl<T: bitcoin_io::Write> bitcoin_io::Write for &mut T
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
+impl<T> core::marker::Freeze for bitcoin_io::Cursor<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_io::Cursor<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_io::ErrorKind::AddrInUse
+pub bitcoin_io::ErrorKind::AddrNotAvailable
+pub bitcoin_io::ErrorKind::AlreadyExists
+pub bitcoin_io::ErrorKind::BrokenPipe
+pub bitcoin_io::ErrorKind::ConnectionAborted
+pub bitcoin_io::ErrorKind::ConnectionRefused
+pub bitcoin_io::ErrorKind::ConnectionReset
+pub bitcoin_io::ErrorKind::Interrupted
+pub bitcoin_io::ErrorKind::InvalidData
+pub bitcoin_io::ErrorKind::InvalidInput
+pub bitcoin_io::ErrorKind::NotConnected
+pub bitcoin_io::ErrorKind::NotFound
+pub bitcoin_io::ErrorKind::Other
+pub bitcoin_io::ErrorKind::PermissionDenied
+pub bitcoin_io::ErrorKind::TimedOut
+pub bitcoin_io::ErrorKind::UnexpectedEof
+pub bitcoin_io::ErrorKind::WouldBlock
+pub bitcoin_io::ErrorKind::WriteZero
+pub enum bitcoin_io::ErrorKind
+pub fn &[u8]::consume(&mut self, amount: usize)
+pub fn &[u8]::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn &[u8]::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::consume(&mut self, amount: usize)
+pub fn &mut T::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn &mut T::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &mut T::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn &mut T::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &mut [u8]::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &mut [u8]::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn alloc::vec::Vec<u8>::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn alloc::vec::Vec<u8>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
+pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::inner(&self) -> &T
+pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
+pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
+pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Cursor<T>::set_position(&mut self, position: u64)
+pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::Error::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_io::Error::from(kind: bitcoin_io::ErrorKind) -> bitcoin_io::Error
+pub fn bitcoin_io::Error::get_ref(&self) -> core::option::Option<&(dyn core::fmt::Debug + core::marker::Send + core::marker::Sync + 'static)>
+pub fn bitcoin_io::Error::kind(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::Error::new<E: sealed::IntoBoxDynDebug>(kind: bitcoin_io::ErrorKind, error: E) -> bitcoin_io::Error
+pub fn bitcoin_io::ErrorKind::clone(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::ErrorKind::eq(&self, other: &bitcoin_io::ErrorKind) -> bool
+pub fn bitcoin_io::ErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::ErrorKind::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_io::ErrorKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Read::read_to_limit(&mut self, buf: &mut alloc::vec::Vec<u8>, limit: u64) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Sink::write_all(&mut self, _: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Take<'_, R>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Take<'_, R>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Take<'_, R>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Take<'_, R>::read_to_end(&mut self, buf: &mut alloc::vec::Vec<u8>) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Write::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::sink() -> bitcoin_io::Sink
+pub macro bitcoin_io::impl_write!
+pub mod bitcoin_io
+pub struct bitcoin_io::Cursor<T>
+pub struct bitcoin_io::Error
+pub struct bitcoin_io::Sink
+pub struct bitcoin_io::Take<'a, R: bitcoin_io::Read + ?core::marker::Sized>
+pub trait bitcoin_io::BufRead: bitcoin_io::Read
+pub trait bitcoin_io::Read
+pub trait bitcoin_io::Write
+pub type bitcoin_io::Result<T> = core::result::Result<T, bitcoin_io::Error>

--- a/api/io/no-features.txt
+++ b/api/io/no-features.txt
@@ -1,0 +1,127 @@
+impl !core::marker::Sync for bitcoin_io::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
+impl !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
+impl bitcoin_io::BufRead for &[u8]
+impl bitcoin_io::Error
+impl bitcoin_io::Read for &[u8]
+impl bitcoin_io::Write for &mut [u8]
+impl bitcoin_io::Write for bitcoin_io::Sink
+impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::cmp::Eq for bitcoin_io::ErrorKind
+impl core::cmp::PartialEq for bitcoin_io::ErrorKind
+impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
+impl core::convert::From<core::convert::Infallible> for bitcoin_io::ErrorKind
+impl core::fmt::Debug for bitcoin_io::Error
+impl core::fmt::Debug for bitcoin_io::ErrorKind
+impl core::fmt::Display for bitcoin_io::Error
+impl core::hash::Hash for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Freeze for bitcoin_io::Error
+impl core::marker::Freeze for bitcoin_io::ErrorKind
+impl core::marker::Freeze for bitcoin_io::Sink
+impl core::marker::Send for bitcoin_io::Error
+impl core::marker::Send for bitcoin_io::ErrorKind
+impl core::marker::Send for bitcoin_io::Sink
+impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Sink
+impl core::marker::Unpin for bitcoin_io::Error
+impl core::marker::Unpin for bitcoin_io::ErrorKind
+impl core::marker::Unpin for bitcoin_io::Sink
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Sink
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::ErrorKind
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Sink
+impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Take<'a, R>
+impl<'a, R> core::marker::Freeze for bitcoin_io::Take<'a, R> where R: ?core::marker::Sized
+impl<'a, R> core::marker::Send for bitcoin_io::Take<'a, R> where R: core::marker::Send + ?core::marker::Sized
+impl<'a, R> core::marker::Sync for bitcoin_io::Take<'a, R> where R: core::marker::Sync + ?core::marker::Sized
+impl<'a, R> core::marker::Unpin for bitcoin_io::Take<'a, R> where R: ?core::marker::Sized
+impl<'a, R> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Take<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<R: bitcoin_io::BufRead + ?core::marker::Sized> bitcoin_io::BufRead for bitcoin_io::Take<'_, R>
+impl<R: bitcoin_io::Read + ?core::marker::Sized> bitcoin_io::Read for bitcoin_io::Take<'_, R>
+impl<T: bitcoin_io::BufRead> bitcoin_io::BufRead for &mut T
+impl<T: bitcoin_io::Read> bitcoin_io::Read for &mut T
+impl<T: bitcoin_io::Write> bitcoin_io::Write for &mut T
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
+impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
+impl<T> core::marker::Freeze for bitcoin_io::Cursor<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_io::Cursor<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_io::ErrorKind::AddrInUse
+pub bitcoin_io::ErrorKind::AddrNotAvailable
+pub bitcoin_io::ErrorKind::AlreadyExists
+pub bitcoin_io::ErrorKind::BrokenPipe
+pub bitcoin_io::ErrorKind::ConnectionAborted
+pub bitcoin_io::ErrorKind::ConnectionRefused
+pub bitcoin_io::ErrorKind::ConnectionReset
+pub bitcoin_io::ErrorKind::Interrupted
+pub bitcoin_io::ErrorKind::InvalidData
+pub bitcoin_io::ErrorKind::InvalidInput
+pub bitcoin_io::ErrorKind::NotConnected
+pub bitcoin_io::ErrorKind::NotFound
+pub bitcoin_io::ErrorKind::Other
+pub bitcoin_io::ErrorKind::PermissionDenied
+pub bitcoin_io::ErrorKind::TimedOut
+pub bitcoin_io::ErrorKind::UnexpectedEof
+pub bitcoin_io::ErrorKind::WouldBlock
+pub bitcoin_io::ErrorKind::WriteZero
+pub enum bitcoin_io::ErrorKind
+pub fn &[u8]::consume(&mut self, amount: usize)
+pub fn &[u8]::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn &[u8]::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::consume(&mut self, amount: usize)
+pub fn &mut T::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn &mut T::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &mut T::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn &mut T::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn &mut T::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn &mut [u8]::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn &mut [u8]::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
+pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::inner(&self) -> &T
+pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
+pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
+pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Cursor<T>::set_position(&mut self, position: u64)
+pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::Error::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_io::Error::from(kind: bitcoin_io::ErrorKind) -> bitcoin_io::Error
+pub fn bitcoin_io::Error::kind(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::ErrorKind::clone(&self) -> bitcoin_io::ErrorKind
+pub fn bitcoin_io::ErrorKind::eq(&self, other: &bitcoin_io::ErrorKind) -> bool
+pub fn bitcoin_io::ErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_io::ErrorKind::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_io::ErrorKind::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Sink::write_all(&mut self, _: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Take<'_, R>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Take<'_, R>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Take<'_, R>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::flush(&mut self) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::Write::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
+pub fn bitcoin_io::Write::write_all(&mut self, buf: &[u8]) -> bitcoin_io::Result<()>
+pub fn bitcoin_io::sink() -> bitcoin_io::Sink
+pub macro bitcoin_io::impl_write!
+pub mod bitcoin_io
+pub struct bitcoin_io::Cursor<T>
+pub struct bitcoin_io::Error
+pub struct bitcoin_io::Sink
+pub struct bitcoin_io::Take<'a, R: bitcoin_io::Read + ?core::marker::Sized>
+pub trait bitcoin_io::BufRead: bitcoin_io::Read
+pub trait bitcoin_io::Read
+pub trait bitcoin_io::Write
+pub type bitcoin_io::Result<T> = core::result::Result<T, bitcoin_io::Error>

--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -1,0 +1,1873 @@
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::ParseOutPointError
+#[non_exhaustive] pub struct bitcoin_primitives::locktime::relative::IncompatibleHeightError
+#[non_exhaustive] pub struct bitcoin_primitives::locktime::relative::IncompatibleTimeError
+#[non_exhaustive] pub struct bitcoin_primitives::relative::IncompatibleHeightError
+#[non_exhaustive] pub struct bitcoin_primitives::relative::IncompatibleTimeError
+#[repr(transparent)] pub struct bitcoin_primitives::script::Script(_)
+impl !core::marker::Sized for bitcoin_primitives::script::Script
+impl alloc::borrow::ToOwned for bitcoin_primitives::script::Script
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapLeafHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapNodeHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapTweakHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Wtxid
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapBranchTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapLeafTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapTweakTag
+impl bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
+impl bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+impl bitcoin_primitives::block::BlockHash
+impl bitcoin_primitives::block::Header
+impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked
+impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchecked
+impl bitcoin_primitives::block::Version
+impl bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_primitives::locktime::absolute::LockTime
+impl bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl bitcoin_primitives::locktime::relative::LockTime
+impl bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_primitives::opcodes::Opcode
+impl bitcoin_primitives::pow::CompactTarget
+impl bitcoin_primitives::script::Script
+impl bitcoin_primitives::script::ScriptBuf
+impl bitcoin_primitives::sequence::Sequence
+impl bitcoin_primitives::taproot::TapLeafHash
+impl bitcoin_primitives::taproot::TapNodeHash
+impl bitcoin_primitives::taproot::TapTweakHash
+impl bitcoin_primitives::transaction::OutPoint
+impl bitcoin_primitives::transaction::Transaction
+impl bitcoin_primitives::transaction::TxIn
+impl bitcoin_primitives::transaction::TxOut
+impl bitcoin_primitives::transaction::Txid
+impl bitcoin_primitives::transaction::Version
+impl bitcoin_primitives::transaction::Wtxid
+impl bitcoin_primitives::witness::Witness
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::borrow::BorrowMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::block::BlockHash
+impl core::clone::Clone for bitcoin_primitives::block::Checked
+impl core::clone::Clone for bitcoin_primitives::block::Header
+impl core::clone::Clone for bitcoin_primitives::block::Unchecked
+impl core::clone::Clone for bitcoin_primitives::block::Version
+impl core::clone::Clone for bitcoin_primitives::block::WitnessCommitment
+impl core::clone::Clone for bitcoin_primitives::locktime::absolute::LockTime
+impl core::clone::Clone for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::clone::Clone for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::clone::Clone for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::clone::Clone for bitcoin_primitives::locktime::relative::LockTime
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::clone::Clone for bitcoin_primitives::opcodes::Class
+impl core::clone::Clone for bitcoin_primitives::opcodes::ClassifyContext
+impl core::clone::Clone for bitcoin_primitives::opcodes::Opcode
+impl core::clone::Clone for bitcoin_primitives::pow::CompactTarget
+impl core::clone::Clone for bitcoin_primitives::script::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::sequence::Sequence
+impl core::clone::Clone for bitcoin_primitives::taproot::TapBranchTag
+impl core::clone::Clone for bitcoin_primitives::taproot::TapLeafHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapLeafTag
+impl core::clone::Clone for bitcoin_primitives::taproot::TapNodeHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapTweakHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapTweakTag
+impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
+impl core::clone::Clone for bitcoin_primitives::transaction::ParseOutPointError
+impl core::clone::Clone for bitcoin_primitives::transaction::Transaction
+impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
+impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
+impl core::clone::Clone for bitcoin_primitives::transaction::Txid
+impl core::clone::Clone for bitcoin_primitives::transaction::Version
+impl core::clone::Clone for bitcoin_primitives::transaction::Wtxid
+impl core::clone::Clone for bitcoin_primitives::witness::Witness
+impl core::cmp::Eq for bitcoin_primitives::block::BlockHash
+impl core::cmp::Eq for bitcoin_primitives::block::Checked
+impl core::cmp::Eq for bitcoin_primitives::block::Header
+impl core::cmp::Eq for bitcoin_primitives::block::Unchecked
+impl core::cmp::Eq for bitcoin_primitives::block::Version
+impl core::cmp::Eq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin_primitives::locktime::absolute::LockTime
+impl core::cmp::Eq for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::cmp::Eq for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_primitives::locktime::relative::LockTime
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::opcodes::Class
+impl core::cmp::Eq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::Eq for bitcoin_primitives::opcodes::Opcode
+impl core::cmp::Eq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Eq for bitcoin_primitives::script::Script
+impl core::cmp::Eq for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::Eq for bitcoin_primitives::sequence::Sequence
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::Eq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Eq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::cmp::Eq for bitcoin_primitives::transaction::Transaction
+impl core::cmp::Eq for bitcoin_primitives::transaction::TxIn
+impl core::cmp::Eq for bitcoin_primitives::transaction::TxOut
+impl core::cmp::Eq for bitcoin_primitives::transaction::Txid
+impl core::cmp::Eq for bitcoin_primitives::transaction::Version
+impl core::cmp::Eq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Eq for bitcoin_primitives::witness::Witness
+impl core::cmp::Ord for bitcoin_primitives::block::BlockHash
+impl core::cmp::Ord for bitcoin_primitives::block::Checked
+impl core::cmp::Ord for bitcoin_primitives::block::Header
+impl core::cmp::Ord for bitcoin_primitives::block::Unchecked
+impl core::cmp::Ord for bitcoin_primitives::block::Version
+impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::Ord for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Ord for bitcoin_primitives::script::Script
+impl core::cmp::Ord for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::Ord for bitcoin_primitives::sequence::Sequence
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::Ord for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Ord for bitcoin_primitives::transaction::Transaction
+impl core::cmp::Ord for bitcoin_primitives::transaction::TxIn
+impl core::cmp::Ord for bitcoin_primitives::transaction::TxOut
+impl core::cmp::Ord for bitcoin_primitives::transaction::Txid
+impl core::cmp::Ord for bitcoin_primitives::transaction::Version
+impl core::cmp::Ord for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Ord for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialEq for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialEq for bitcoin_primitives::block::Checked
+impl core::cmp::PartialEq for bitcoin_primitives::block::Header
+impl core::cmp::PartialEq for bitcoin_primitives::block::Unchecked
+impl core::cmp::PartialEq for bitcoin_primitives::block::Version
+impl core::cmp::PartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::absolute::LockTime
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::relative::LockTime
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Class
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Opcode
+impl core::cmp::PartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin_primitives::script::Script
+impl core::cmp::PartialEq for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialEq for bitcoin_primitives::sequence::Sequence
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Transaction
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::TxIn
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::TxOut
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialEq<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialEq<bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::Script
+impl core::cmp::PartialOrd for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Checked
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Header
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Unchecked
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin_primitives::locktime::absolute::LockTime
+impl core::cmp::PartialOrd for bitcoin_primitives::locktime::relative::LockTime
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::PartialOrd for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin_primitives::script::Script
+impl core::cmp::PartialOrd for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin_primitives::sequence::Sequence
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Transaction
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::TxIn
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::TxOut
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialOrd<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialOrd<bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::Script
+impl core::convert::AsMut<[u8]> for bitcoin_primitives::script::Script
+impl core::convert::AsMut<[u8]> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::Script
+impl core::convert::AsMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::Script
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<bitcoin_primitives::script::Script> for bitcoin_primitives::script::Script
+impl core::convert::AsRef<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::From<&[&[u8]]> for bitcoin_primitives::witness::Witness
+impl core::convert::From<&[alloc::vec::Vec<u8>]> for bitcoin_primitives::witness::Witness
+impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<&bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin_primitives::witness::Witness
+impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin_primitives::witness::Witness
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::block::BlockHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::block::WitnessCommitment> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::locktime::relative::LockTime> for bitcoin_primitives::sequence::Sequence
+impl core::convert::From<bitcoin_primitives::merkle_tree::TxMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::merkle_tree::WitnessMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin_primitives::script::Script>
+impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::boxed::Box<bitcoin_primitives::script::Script>
+impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin_primitives::sequence::Sequence> for u32
+impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>
+impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::From<bitcoin_primitives::taproot::TapNodeHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>
+impl core::convert::From<bitcoin_primitives::taproot::TapTweakHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>
+impl core::convert::From<bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<bitcoin_primitives::transaction::Txid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::transaction::Wtxid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::From<bitcoin_units::locktime::absolute::Time> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_primitives::locktime::relative::LockTime
+impl core::convert::From<bitcoin_units::locktime::relative::Time> for bitcoin_primitives::locktime::relative::LockTime
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::ParseOutPointError
+impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
+impl core::convert::TryFrom<&str> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::TryFrom<&str> for bitcoin_primitives::sequence::Sequence
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_primitives::sequence::Sequence
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_primitives::sequence::Sequence
+impl core::convert::TryFrom<bitcoin_primitives::sequence::Sequence> for bitcoin_primitives::locktime::relative::LockTime
+impl core::default::Default for bitcoin_primitives::block::Version
+impl core::default::Default for bitcoin_primitives::pow::CompactTarget
+impl core::default::Default for bitcoin_primitives::script::ScriptBuf
+impl core::default::Default for bitcoin_primitives::sequence::Sequence
+impl core::default::Default for bitcoin_primitives::taproot::TapBranchTag
+impl core::default::Default for bitcoin_primitives::taproot::TapLeafTag
+impl core::default::Default for bitcoin_primitives::taproot::TapTweakTag
+impl core::default::Default for bitcoin_primitives::witness::Witness
+impl core::error::Error for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::error::Error for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::error::Error for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::error::Error for bitcoin_primitives::transaction::ParseOutPointError
+impl core::fmt::Debug for bitcoin_primitives::block::BlockHash
+impl core::fmt::Debug for bitcoin_primitives::block::Checked
+impl core::fmt::Debug for bitcoin_primitives::block::Header
+impl core::fmt::Debug for bitcoin_primitives::block::Unchecked
+impl core::fmt::Debug for bitcoin_primitives::block::Version
+impl core::fmt::Debug for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin_primitives::locktime::absolute::LockTime
+impl core::fmt::Debug for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::fmt::Debug for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::fmt::Debug for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::fmt::Debug for bitcoin_primitives::locktime::relative::LockTime
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::opcodes::Class
+impl core::fmt::Debug for bitcoin_primitives::opcodes::ClassifyContext
+impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
+impl core::fmt::Debug for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_primitives::script::Script
+impl core::fmt::Debug for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::Debug for bitcoin_primitives::sequence::Sequence
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::Debug for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Debug for bitcoin_primitives::transaction::ParseOutPointError
+impl core::fmt::Debug for bitcoin_primitives::transaction::Transaction
+impl core::fmt::Debug for bitcoin_primitives::transaction::TxIn
+impl core::fmt::Debug for bitcoin_primitives::transaction::TxOut
+impl core::fmt::Debug for bitcoin_primitives::transaction::Txid
+impl core::fmt::Debug for bitcoin_primitives::transaction::Version
+impl core::fmt::Debug for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::Debug for bitcoin_primitives::witness::Witness
+impl core::fmt::Display for bitcoin_primitives::block::BlockHash
+impl core::fmt::Display for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Display for bitcoin_primitives::locktime::absolute::LockTime
+impl core::fmt::Display for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::fmt::Display for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::fmt::Display for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::fmt::Display for bitcoin_primitives::locktime::relative::LockTime
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Display for bitcoin_primitives::opcodes::Opcode
+impl core::fmt::Display for bitcoin_primitives::script::Script
+impl core::fmt::Display for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::Display for bitcoin_primitives::sequence::Sequence
+impl core::fmt::Display for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::Display for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::Display for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::Display for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Display for bitcoin_primitives::transaction::ParseOutPointError
+impl core::fmt::Display for bitcoin_primitives::transaction::Txid
+impl core::fmt::Display for bitcoin_primitives::transaction::Version
+impl core::fmt::Display for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::LowerHex for bitcoin_primitives::block::BlockHash
+impl core::fmt::LowerHex for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::LowerHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::LowerHex for bitcoin_primitives::script::Script
+impl core::fmt::LowerHex for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::LowerHex for bitcoin_primitives::sequence::Sequence
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::LowerHex for bitcoin_primitives::transaction::Txid
+impl core::fmt::LowerHex for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::UpperHex for bitcoin_primitives::block::BlockHash
+impl core::fmt::UpperHex for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::UpperHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin_primitives::script::Script
+impl core::fmt::UpperHex for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::UpperHex for bitcoin_primitives::sequence::Sequence
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::UpperHex for bitcoin_primitives::transaction::Txid
+impl core::fmt::UpperHex for bitcoin_primitives::transaction::Wtxid
+impl core::hash::Hash for bitcoin_primitives::block::BlockHash
+impl core::hash::Hash for bitcoin_primitives::block::Checked
+impl core::hash::Hash for bitcoin_primitives::block::Header
+impl core::hash::Hash for bitcoin_primitives::block::Unchecked
+impl core::hash::Hash for bitcoin_primitives::block::Version
+impl core::hash::Hash for bitcoin_primitives::block::WitnessCommitment
+impl core::hash::Hash for bitcoin_primitives::locktime::absolute::LockTime
+impl core::hash::Hash for bitcoin_primitives::locktime::relative::LockTime
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::hash::Hash for bitcoin_primitives::opcodes::ClassifyContext
+impl core::hash::Hash for bitcoin_primitives::pow::CompactTarget
+impl core::hash::Hash for bitcoin_primitives::script::Script
+impl core::hash::Hash for bitcoin_primitives::script::ScriptBuf
+impl core::hash::Hash for bitcoin_primitives::sequence::Sequence
+impl core::hash::Hash for bitcoin_primitives::taproot::TapBranchTag
+impl core::hash::Hash for bitcoin_primitives::taproot::TapLeafHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapLeafTag
+impl core::hash::Hash for bitcoin_primitives::taproot::TapNodeHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapTweakTag
+impl core::hash::Hash for bitcoin_primitives::transaction::OutPoint
+impl core::hash::Hash for bitcoin_primitives::transaction::Transaction
+impl core::hash::Hash for bitcoin_primitives::transaction::TxIn
+impl core::hash::Hash for bitcoin_primitives::transaction::TxOut
+impl core::hash::Hash for bitcoin_primitives::transaction::Txid
+impl core::hash::Hash for bitcoin_primitives::transaction::Version
+impl core::hash::Hash for bitcoin_primitives::transaction::Wtxid
+impl core::hash::Hash for bitcoin_primitives::witness::Witness
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin_primitives::witness::Iter<'_>
+impl core::marker::Copy for bitcoin_primitives::block::BlockHash
+impl core::marker::Copy for bitcoin_primitives::block::Header
+impl core::marker::Copy for bitcoin_primitives::block::Version
+impl core::marker::Copy for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Copy for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Copy for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Copy for bitcoin_primitives::opcodes::Class
+impl core::marker::Copy for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Copy for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Copy for bitcoin_primitives::sequence::Sequence
+impl core::marker::Copy for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Copy for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Copy for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Copy for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Copy for bitcoin_primitives::transaction::Txid
+impl core::marker::Copy for bitcoin_primitives::transaction::Version
+impl core::marker::Copy for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::block::BlockHash
+impl core::marker::Freeze for bitcoin_primitives::block::Checked
+impl core::marker::Freeze for bitcoin_primitives::block::Header
+impl core::marker::Freeze for bitcoin_primitives::block::Unchecked
+impl core::marker::Freeze for bitcoin_primitives::block::Version
+impl core::marker::Freeze for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Freeze for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Freeze for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::Freeze for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::opcodes::Class
+impl core::marker::Freeze for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Freeze for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Freeze for bitcoin_primitives::script::Script
+impl core::marker::Freeze for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Freeze for bitcoin_primitives::sequence::Sequence
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Freeze for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Freeze for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Freeze for bitcoin_primitives::transaction::Transaction
+impl core::marker::Freeze for bitcoin_primitives::transaction::TxIn
+impl core::marker::Freeze for bitcoin_primitives::transaction::TxOut
+impl core::marker::Freeze for bitcoin_primitives::transaction::Txid
+impl core::marker::Freeze for bitcoin_primitives::transaction::Version
+impl core::marker::Freeze for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::witness::Witness
+impl core::marker::Send for bitcoin_primitives::block::BlockHash
+impl core::marker::Send for bitcoin_primitives::block::Checked
+impl core::marker::Send for bitcoin_primitives::block::Header
+impl core::marker::Send for bitcoin_primitives::block::Unchecked
+impl core::marker::Send for bitcoin_primitives::block::Version
+impl core::marker::Send for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Send for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Send for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::Send for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::Send for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::Send for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Send for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Send for bitcoin_primitives::opcodes::Class
+impl core::marker::Send for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Send for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Send for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Send for bitcoin_primitives::script::Script
+impl core::marker::Send for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Send for bitcoin_primitives::sequence::Sequence
+impl core::marker::Send for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Send for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Send for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Send for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Send for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Send for bitcoin_primitives::transaction::Transaction
+impl core::marker::Send for bitcoin_primitives::transaction::TxIn
+impl core::marker::Send for bitcoin_primitives::transaction::TxOut
+impl core::marker::Send for bitcoin_primitives::transaction::Txid
+impl core::marker::Send for bitcoin_primitives::transaction::Version
+impl core::marker::Send for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Send for bitcoin_primitives::witness::Witness
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Checked
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Header
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Unchecked
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Class
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::Script
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin_primitives::sequence::Sequence
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Transaction
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::TxIn
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::TxOut
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness::Witness
+impl core::marker::Sync for bitcoin_primitives::block::BlockHash
+impl core::marker::Sync for bitcoin_primitives::block::Checked
+impl core::marker::Sync for bitcoin_primitives::block::Header
+impl core::marker::Sync for bitcoin_primitives::block::Unchecked
+impl core::marker::Sync for bitcoin_primitives::block::Version
+impl core::marker::Sync for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Sync for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Sync for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::Sync for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Sync for bitcoin_primitives::opcodes::Class
+impl core::marker::Sync for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Sync for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Sync for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Sync for bitcoin_primitives::script::Script
+impl core::marker::Sync for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Sync for bitcoin_primitives::sequence::Sequence
+impl core::marker::Sync for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Sync for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Sync for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Sync for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Sync for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Sync for bitcoin_primitives::transaction::Transaction
+impl core::marker::Sync for bitcoin_primitives::transaction::TxIn
+impl core::marker::Sync for bitcoin_primitives::transaction::TxOut
+impl core::marker::Sync for bitcoin_primitives::transaction::Txid
+impl core::marker::Sync for bitcoin_primitives::transaction::Version
+impl core::marker::Sync for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Sync for bitcoin_primitives::witness::Witness
+impl core::marker::Unpin for bitcoin_primitives::block::BlockHash
+impl core::marker::Unpin for bitcoin_primitives::block::Checked
+impl core::marker::Unpin for bitcoin_primitives::block::Header
+impl core::marker::Unpin for bitcoin_primitives::block::Unchecked
+impl core::marker::Unpin for bitcoin_primitives::block::Version
+impl core::marker::Unpin for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Unpin for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::Unpin for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::opcodes::Class
+impl core::marker::Unpin for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Unpin for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Unpin for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Unpin for bitcoin_primitives::script::Script
+impl core::marker::Unpin for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Unpin for bitcoin_primitives::sequence::Sequence
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Unpin for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Unpin for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Unpin for bitcoin_primitives::transaction::Transaction
+impl core::marker::Unpin for bitcoin_primitives::transaction::TxIn
+impl core::marker::Unpin for bitcoin_primitives::transaction::TxOut
+impl core::marker::Unpin for bitcoin_primitives::transaction::Txid
+impl core::marker::Unpin for bitcoin_primitives::transaction::Version
+impl core::marker::Unpin for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Unpin for bitcoin_primitives::witness::Witness
+impl core::ops::deref::Deref for bitcoin_primitives::script::ScriptBuf
+impl core::ops::deref::DerefMut for bitcoin_primitives::script::ScriptBuf
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<usize> for bitcoin_primitives::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Checked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Unchecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::absolute::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::relative::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Class
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Opcode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::Script
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::sequence::Sequence
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapBranchTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapLeafHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapLeafTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapNodeHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapTweakHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapTweakTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::ParseOutPointError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Transaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::TxIn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::TxOut
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness::Witness
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Checked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Unchecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::absolute::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::relative::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Class
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Opcode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::Script
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::sequence::Sequence
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapBranchTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapLeafHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapLeafTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapNodeHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapTweakHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapTweakTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::ParseOutPointError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Transaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::TxIn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::TxOut
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness::Witness
+impl core::str::traits::FromStr for bitcoin_primitives::block::BlockHash
+impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
+impl core::str::traits::FromStr for bitcoin_primitives::locktime::absolute::LockTime
+impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::sequence::Sequence
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapLeafHash
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapNodeHash
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapTweakHash
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::OutPoint
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::Txid
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::Wtxid
+impl ordered::ArbitraryOrd for bitcoin_primitives::locktime::absolute::LockTime
+impl ordered::ArbitraryOrd for bitcoin_primitives::locktime::relative::LockTime
+impl serde::ser::Serialize for bitcoin_primitives::block::BlockHash
+impl serde::ser::Serialize for bitcoin_primitives::block::Header
+impl serde::ser::Serialize for bitcoin_primitives::block::Version
+impl serde::ser::Serialize for bitcoin_primitives::block::WitnessCommitment
+impl serde::ser::Serialize for bitcoin_primitives::locktime::absolute::LockTime
+impl serde::ser::Serialize for bitcoin_primitives::locktime::relative::LockTime
+impl serde::ser::Serialize for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl serde::ser::Serialize for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl serde::ser::Serialize for bitcoin_primitives::opcodes::Opcode
+impl serde::ser::Serialize for bitcoin_primitives::pow::CompactTarget
+impl serde::ser::Serialize for bitcoin_primitives::script::Script
+impl serde::ser::Serialize for bitcoin_primitives::script::ScriptBuf
+impl serde::ser::Serialize for bitcoin_primitives::sequence::Sequence
+impl serde::ser::Serialize for bitcoin_primitives::taproot::TapLeafHash
+impl serde::ser::Serialize for bitcoin_primitives::taproot::TapNodeHash
+impl serde::ser::Serialize for bitcoin_primitives::taproot::TapTweakHash
+impl serde::ser::Serialize for bitcoin_primitives::transaction::OutPoint
+impl serde::ser::Serialize for bitcoin_primitives::transaction::Transaction
+impl serde::ser::Serialize for bitcoin_primitives::transaction::TxIn
+impl serde::ser::Serialize for bitcoin_primitives::transaction::TxOut
+impl serde::ser::Serialize for bitcoin_primitives::transaction::Txid
+impl serde::ser::Serialize for bitcoin_primitives::transaction::Version
+impl serde::ser::Serialize for bitcoin_primitives::transaction::Wtxid
+impl serde::ser::Serialize for bitcoin_primitives::witness::Witness
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Block
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Header
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Version
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::locktime::absolute::LockTime
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::script::ScriptBuf
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::sequence::Sequence
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::OutPoint
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::Transaction
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::TxIn
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::TxOut
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::Txid
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::Version
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::witness::Witness
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for alloc::boxed::Box<bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for alloc::rc::Rc<bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for alloc::sync::Arc<bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>> for alloc::boxed::Box<bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>> for bitcoin_primitives::script::ScriptBuf
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin_primitives::witness::Witness
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Freeze for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Send for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Sync for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Unpin for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness::Iter<'a>
+impl<'de, V> serde::de::Deserialize<'de> for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<'de> serde::de::Deserialize<'de> for &'de bitcoin_primitives::script::Script
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::block::BlockHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::block::Header
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::block::Version
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::block::WitnessCommitment
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::locktime::absolute::LockTime
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::locktime::relative::LockTime
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::pow::CompactTarget
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::script::ScriptBuf
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::sequence::Sequence
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::taproot::TapLeafHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::taproot::TapNodeHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::taproot::TapTweakHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::OutPoint
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::Transaction
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::TxIn
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::TxOut
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::Txid
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::Version
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::Wtxid
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::witness::Witness
+impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
+impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
+impl<V> core::cmp::Eq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::Eq
+impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
+impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug
+impl<V> core::marker::Freeze for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::Send for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::StructuralPartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<V> core::marker::Sync for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::Unpin for bitcoin_primitives::block::Block<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Block<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Block<V> where V: core::panic::unwind_safe::UnwindSafe
+impl<V> serde::ser::Serialize for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+pub bitcoin_primitives::BlockHeader::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::BlockHeader::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::BlockHeader::nonce: u32
+pub bitcoin_primitives::BlockHeader::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::BlockHeader::time: u32
+pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::Transaction::input: alloc::vec::Vec<bitcoin_primitives::transaction::TxIn>
+pub bitcoin_primitives::Transaction::lock_time: bitcoin_primitives::locktime::absolute::LockTime
+pub bitcoin_primitives::Transaction::output: alloc::vec::Vec<bitcoin_primitives::transaction::TxOut>
+pub bitcoin_primitives::Transaction::version: bitcoin_primitives::transaction::Version
+pub bitcoin_primitives::TxIn::previous_output: bitcoin_primitives::transaction::OutPoint
+pub bitcoin_primitives::TxIn::script_sig: bitcoin_primitives::script::ScriptBuf
+pub bitcoin_primitives::TxIn::sequence: bitcoin_primitives::sequence::Sequence
+pub bitcoin_primitives::TxIn::witness: bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::TxOut::script_pubkey: bitcoin_primitives::script::ScriptBuf
+pub bitcoin_primitives::TxOut::value: bitcoin_units::amount::unsigned::Amount
+pub bitcoin_primitives::absolute::LockTime::Blocks(bitcoin_units::locktime::absolute::Height)
+pub bitcoin_primitives::absolute::LockTime::Seconds(bitcoin_units::locktime::absolute::Time)
+pub bitcoin_primitives::block::Header::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::block::Header::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::block::Header::nonce: u32
+pub bitcoin_primitives::block::Header::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::block::Header::time: u32
+pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::locktime::absolute::LockTime::Blocks(bitcoin_units::locktime::absolute::Height)
+pub bitcoin_primitives::locktime::absolute::LockTime::Seconds(bitcoin_units::locktime::absolute::Time)
+pub bitcoin_primitives::locktime::relative::IncompatibleHeightError::height: bitcoin_units::locktime::relative::Height
+pub bitcoin_primitives::locktime::relative::IncompatibleHeightError::time: bitcoin_units::locktime::relative::Time
+pub bitcoin_primitives::locktime::relative::IncompatibleTimeError::height: bitcoin_units::locktime::relative::Height
+pub bitcoin_primitives::locktime::relative::IncompatibleTimeError::time: bitcoin_units::locktime::relative::Time
+pub bitcoin_primitives::locktime::relative::LockTime::Blocks(bitcoin_units::locktime::relative::Height)
+pub bitcoin_primitives::locktime::relative::LockTime::Time(bitcoin_units::locktime::relative::Time)
+pub bitcoin_primitives::opcodes::Class::IllegalOp
+pub bitcoin_primitives::opcodes::Class::NoOp
+pub bitcoin_primitives::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin_primitives::opcodes::Class::PushBytes(u32)
+pub bitcoin_primitives::opcodes::Class::PushNum(i32)
+pub bitcoin_primitives::opcodes::Class::ReturnOp
+pub bitcoin_primitives::opcodes::Class::SuccessOp
+pub bitcoin_primitives::opcodes::ClassifyContext::Legacy
+pub bitcoin_primitives::opcodes::ClassifyContext::TapScript
+pub bitcoin_primitives::relative::IncompatibleHeightError::height: bitcoin_units::locktime::relative::Height
+pub bitcoin_primitives::relative::IncompatibleHeightError::time: bitcoin_units::locktime::relative::Time
+pub bitcoin_primitives::relative::IncompatibleTimeError::height: bitcoin_units::locktime::relative::Height
+pub bitcoin_primitives::relative::IncompatibleTimeError::time: bitcoin_units::locktime::relative::Time
+pub bitcoin_primitives::relative::LockTime::Blocks(bitcoin_units::locktime::relative::Height)
+pub bitcoin_primitives::relative::LockTime::Time(bitcoin_units::locktime::relative::Time)
+pub bitcoin_primitives::transaction::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::transaction::OutPoint::vout: u32
+pub bitcoin_primitives::transaction::ParseOutPointError::Format
+pub bitcoin_primitives::transaction::ParseOutPointError::TooLong
+pub bitcoin_primitives::transaction::ParseOutPointError::Txid(hex_conservative::error::HexToArrayError)
+pub bitcoin_primitives::transaction::ParseOutPointError::Vout(bitcoin_units::parse::ParseIntError)
+pub bitcoin_primitives::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin_primitives::transaction::Transaction::input: alloc::vec::Vec<bitcoin_primitives::transaction::TxIn>
+pub bitcoin_primitives::transaction::Transaction::lock_time: bitcoin_primitives::locktime::absolute::LockTime
+pub bitcoin_primitives::transaction::Transaction::output: alloc::vec::Vec<bitcoin_primitives::transaction::TxOut>
+pub bitcoin_primitives::transaction::Transaction::version: bitcoin_primitives::transaction::Version
+pub bitcoin_primitives::transaction::TxIn::previous_output: bitcoin_primitives::transaction::OutPoint
+pub bitcoin_primitives::transaction::TxIn::script_sig: bitcoin_primitives::script::ScriptBuf
+pub bitcoin_primitives::transaction::TxIn::sequence: bitcoin_primitives::sequence::Sequence
+pub bitcoin_primitives::transaction::TxIn::witness: bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::transaction::TxOut::script_pubkey: bitcoin_primitives::script::ScriptBuf
+pub bitcoin_primitives::transaction::TxOut::value: bitcoin_units::amount::unsigned::Amount
+pub const bitcoin_primitives::BlockValidation::IS_CHECKED: bool
+pub const bitcoin_primitives::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::block::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH: Self
+pub const bitcoin_primitives::block::Checked::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Header::SIZE: usize
+pub const bitcoin_primitives::block::Unchecked::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Validation::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin_primitives::block::Version::ONE: Self
+pub const bitcoin_primitives::block::Version::TWO: Self
+pub const bitcoin_primitives::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::locktime::absolute::LockTime::SIZE: usize
+pub const bitcoin_primitives::locktime::absolute::LockTime::ZERO: bitcoin_primitives::locktime::absolute::LockTime
+pub const bitcoin_primitives::locktime::relative::LockTime::SIZE: usize
+pub const bitcoin_primitives::locktime::relative::LockTime::ZERO: bitcoin_primitives::locktime::relative::LockTime
+pub const bitcoin_primitives::merkle_tree::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::opcodes::all::OP_0NOTEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_1ADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_1SUB: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DIV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DROP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2MUL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2OVER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2ROT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2SWAP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_3DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ABS: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_AND: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_BOOLAND: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_BOOLOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CAT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKMULTISIG: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKMULTISIGVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIG: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIGADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIGVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CLTV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CODESEPARATOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CSV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DEPTH: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DIV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DROP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ELSE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ENDIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_EQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_EQUALVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_FROMALTSTACK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_GREATERTHAN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_GREATERTHANOREQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_HASH160: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_HASH256: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_IF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_IFDUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_INVALIDOPCODE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_INVERT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LEFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LESSTHAN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LESSTHANOREQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LSHIFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MAX: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MIN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MOD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MUL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NEGATE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NIP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOTIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMEQUALVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMNOTEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_OR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_OVER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PICK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_0: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_11: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_12: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_13: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_14: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_15: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_16: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_17: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_18: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_19: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_20: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_21: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_22: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_23: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_24: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_25: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_26: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_27: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_28: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_29: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_30: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_31: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_32: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_33: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_34: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_35: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_36: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_37: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_38: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_39: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_3: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_40: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_41: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_42: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_43: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_44: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_45: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_46: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_47: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_48: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_49: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_50: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_51: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_52: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_53: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_54: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_55: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_56: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_57: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_58: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_59: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_60: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_61: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_62: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_63: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_64: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_65: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_66: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_67: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_68: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_69: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_70: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_71: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_72: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_73: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_74: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_75: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_11: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_12: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_13: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_14: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_15: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_16: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_3: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_NEG1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_187: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_188: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_189: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_190: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_191: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_192: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_193: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_194: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_195: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_196: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_197: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_198: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_199: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_200: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_201: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_202: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_203: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_204: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_205: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_206: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_207: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_208: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_209: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_210: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_211: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_212: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_213: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_214: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_215: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_216: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_217: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_218: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_219: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_220: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_221: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_222: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_223: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_224: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_225: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_226: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_227: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_228: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_229: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_230: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_231: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_232: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_233: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_234: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_235: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_236: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_237: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_238: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_239: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_240: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_241: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_242: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_243: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_244: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_245: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_246: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_247: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_248: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_249: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_250: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_251: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_252: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_253: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_254: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RIGHT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RIPEMD160: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ROLL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ROT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RSHIFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SHA1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SHA256: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SIZE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SUB: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SUBSTR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SWAP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_TOALTSTACK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_TUCK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERNOTIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_WITHIN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_XOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
+pub const bitcoin_primitives::sequence::Sequence::FINAL: Self
+pub const bitcoin_primitives::sequence::Sequence::MAX: Self
+pub const bitcoin_primitives::sequence::Sequence::SIZE: usize
+pub const bitcoin_primitives::sequence::Sequence::ZERO: Self
+pub const bitcoin_primitives::taproot::TapLeafHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::taproot::TapNodeHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::taproot::TapTweakHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
+pub const bitcoin_primitives::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin_units::weight::Weight
+pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: bitcoin_primitives::transaction::TxIn
+pub const bitcoin_primitives::transaction::TxOut::NULL: Self
+pub const bitcoin_primitives::transaction::Txid::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::Version::ONE: Self
+pub const bitcoin_primitives::transaction::Version::THREE: Self
+pub const bitcoin_primitives::transaction::Version::TWO: Self
+pub const bitcoin_primitives::transaction::Wtxid::COINBASE: Self
+pub const bitcoin_primitives::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::locktime::absolute::LockTime::is_block_height(&self) -> bool
+pub const fn bitcoin_primitives::locktime::absolute::LockTime::is_block_time(&self) -> bool
+pub const fn bitcoin_primitives::locktime::absolute::LockTime::is_same_unit(&self, other: bitcoin_primitives::locktime::absolute::LockTime) -> bool
+pub const fn bitcoin_primitives::locktime::relative::LockTime::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_primitives::locktime::relative::LockTime::from_height(n: u16) -> Self
+pub const fn bitcoin_primitives::locktime::relative::LockTime::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_primitives::locktime::relative::LockTime::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_primitives::locktime::relative::LockTime::is_block_height(&self) -> bool
+pub const fn bitcoin_primitives::locktime::relative::LockTime::is_block_time(&self) -> bool
+pub const fn bitcoin_primitives::locktime::relative::LockTime::is_same_unit(&self, other: bitcoin_primitives::locktime::relative::LockTime) -> bool
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::opcodes::Opcode::decode_pushnum(self) -> core::option::Option<u8>
+pub const fn bitcoin_primitives::opcodes::Opcode::to_u8(self) -> u8
+pub const fn bitcoin_primitives::script::ScriptBuf::new() -> Self
+pub const fn bitcoin_primitives::taproot::TapLeafHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapLeafHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapLeafHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapNodeHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapNodeHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapNodeHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapTweakHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapTweakHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapTweakHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::witness::Witness::new() -> Self
+pub enum bitcoin_primitives::BlockChecked
+pub enum bitcoin_primitives::BlockUnchecked
+pub enum bitcoin_primitives::absolute::LockTime
+pub enum bitcoin_primitives::block::Checked
+pub enum bitcoin_primitives::block::Unchecked
+pub enum bitcoin_primitives::locktime::absolute::LockTime
+pub enum bitcoin_primitives::locktime::relative::LockTime
+pub enum bitcoin_primitives::opcodes::Class
+pub enum bitcoin_primitives::opcodes::ClassifyContext
+pub enum bitcoin_primitives::relative::LockTime
+pub fn &'a bitcoin_primitives::witness::Witness::into_iter(self) -> Self::IntoIter
+pub fn &'de bitcoin_primitives::script::Script::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn alloc::borrow::Cow<'_, bitcoin_primitives::script::Script>::from(value: bitcoin_primitives::script::ScriptBuf) -> Self
+pub fn alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::script::Script>::from(v: bitcoin_primitives::script::ScriptBuf) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::script::Script>::from(value: alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>) -> Self
+pub fn alloc::rc::Rc<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn alloc::sync::Arc<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn alloc::vec::Vec<u8>::from(v: bitcoin_primitives::script::ScriptBuf) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::BlockHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::WitnessCommitment) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::merkle_tree::TxMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::transaction::Txid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::transaction::Wtxid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>::from(hashtype: bitcoin_primitives::taproot::TapNodeHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>::from(hashtype: bitcoin_primitives::taproot::TapLeafHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>::from(hashtype: bitcoin_primitives::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>
+pub fn bitcoin_primitives::block::Block::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V>
+pub fn bitcoin_primitives::block::Block<V>::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &bitcoin_primitives::block::Block<V>) -> bool
+pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Block<V>::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::cached_witness_root(&self) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::header(&self) -> &bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::transactions(&self) -> &[bitcoin_primitives::transaction::Transaction]
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::assume_checked(self, witness_root: core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+pub fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::clone(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::BlockHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::block::BlockHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::block::BlockHash::eq(&self, other: &bitcoin_primitives::block::BlockHash) -> bool
+pub fn bitcoin_primitives::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::BlockHash::from(block: &bitcoin_primitives::block::Block) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(block: bitcoin_primitives::block::Block) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: &bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::BlockHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::block::BlockHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::BlockHash::partial_cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::BlockHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::block::Checked::clone(&self) -> bitcoin_primitives::block::Checked
+pub fn bitcoin_primitives::block::Checked::cmp(&self, other: &bitcoin_primitives::block::Checked) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Checked::eq(&self, other: &bitcoin_primitives::block::Checked) -> bool
+pub fn bitcoin_primitives::block::Checked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Checked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Checked::partial_cmp(&self, other: &bitcoin_primitives::block::Checked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Header::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Header::clone(&self) -> bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Header::cmp(&self, other: &bitcoin_primitives::block::Header) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Header::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::block::Header::eq(&self, other: &bitcoin_primitives::block::Header) -> bool
+pub fn bitcoin_primitives::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Header::partial_cmp(&self, other: &bitcoin_primitives::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Header::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::block::Unchecked::clone(&self) -> bitcoin_primitives::block::Unchecked
+pub fn bitcoin_primitives::block::Unchecked::cmp(&self, other: &bitcoin_primitives::block::Unchecked) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Unchecked::eq(&self, other: &bitcoin_primitives::block::Unchecked) -> bool
+pub fn bitcoin_primitives::block::Unchecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Unchecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Unchecked::partial_cmp(&self, other: &bitcoin_primitives::block::Unchecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::block::Version::clone(&self) -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::cmp(&self, other: &bitcoin_primitives::block::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Version::default() -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::block::Version::eq(&self, other: &bitcoin_primitives::block::Version) -> bool
+pub fn bitcoin_primitives::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(&self, bit: u8) -> bool
+pub fn bitcoin_primitives::block::Version::partial_cmp(&self, other: &bitcoin_primitives::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
+pub fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::clone(&self) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::WitnessCommitment::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::block::WitnessCommitment, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::block::WitnessCommitment::eq(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> bool
+pub fn bitcoin_primitives::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::WitnessCommitment, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::WitnessCommitment::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::locktime::absolute::LockTime::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::arbitrary_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_primitives::locktime::absolute::LockTime::clone(&self) -> bitcoin_primitives::locktime::absolute::LockTime
+pub fn bitcoin_primitives::locktime::absolute::LockTime::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::eq(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> bool
+pub fn bitcoin_primitives::locktime::absolute::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from(t: bitcoin_units::locktime::absolute::Time) -> Self
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_consensus(n: u32) -> Self
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_height(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_time(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::locktime::absolute::LockTime::is_implied_by(&self, other: bitcoin_primitives::locktime::absolute::LockTime) -> bool
+pub fn bitcoin_primitives::locktime::absolute::LockTime::is_satisfied_by(&self, height: bitcoin_units::locktime::absolute::Height, time: bitcoin_units::locktime::absolute::Time) -> bool
+pub fn bitcoin_primitives::locktime::absolute::LockTime::partial_cmp(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::locktime::absolute::LockTime::to_consensus_u32(self) -> u32
+pub fn bitcoin_primitives::locktime::absolute::LockTime::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::locktime::relative::DisabledLockTimeError::clone(&self) -> bitcoin_primitives::locktime::relative::DisabledLockTimeError
+pub fn bitcoin_primitives::locktime::relative::DisabledLockTimeError::disabled_locktime_value(&self) -> u32
+pub fn bitcoin_primitives::locktime::relative::DisabledLockTimeError::eq(&self, other: &bitcoin_primitives::locktime::relative::DisabledLockTimeError) -> bool
+pub fn bitcoin_primitives::locktime::relative::DisabledLockTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::relative::IncompatibleHeightError::clone(&self) -> bitcoin_primitives::locktime::relative::IncompatibleHeightError
+pub fn bitcoin_primitives::locktime::relative::IncompatibleHeightError::eq(&self, other: &bitcoin_primitives::locktime::relative::IncompatibleHeightError) -> bool
+pub fn bitcoin_primitives::locktime::relative::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::relative::IncompatibleTimeError::clone(&self) -> bitcoin_primitives::locktime::relative::IncompatibleTimeError
+pub fn bitcoin_primitives::locktime::relative::IncompatibleTimeError::eq(&self, other: &bitcoin_primitives::locktime::relative::IncompatibleTimeError) -> bool
+pub fn bitcoin_primitives::locktime::relative::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::relative::LockTime::arbitrary_cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_primitives::locktime::relative::LockTime::clone(&self) -> bitcoin_primitives::locktime::relative::LockTime
+pub fn bitcoin_primitives::locktime::relative::LockTime::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::locktime::relative::LockTime::eq(&self, other: &bitcoin_primitives::locktime::relative::LockTime) -> bool
+pub fn bitcoin_primitives::locktime::relative::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::relative::LockTime::from(h: bitcoin_units::locktime::relative::Height) -> Self
+pub fn bitcoin_primitives::locktime::relative::LockTime::from(t: bitcoin_units::locktime::relative::Time) -> Self
+pub fn bitcoin_primitives::locktime::relative::LockTime::from_consensus(n: u32) -> core::result::Result<Self, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
+pub fn bitcoin_primitives::locktime::relative::LockTime::from_sequence(n: bitcoin_primitives::sequence::Sequence) -> core::result::Result<Self, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
+pub fn bitcoin_primitives::locktime::relative::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_implied_by(&self, other: bitcoin_primitives::locktime::relative::LockTime) -> bool
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_implied_by_sequence(&self, other: bitcoin_primitives::sequence::Sequence) -> bool
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by(&self, h: bitcoin_units::locktime::relative::Height, t: bitcoin_units::locktime::relative::Time) -> bool
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_height(&self, height: bitcoin_units::locktime::relative::Height) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleHeightError>
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_time(&self, time: bitcoin_units::locktime::relative::Time) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleTimeError>
+pub fn bitcoin_primitives::locktime::relative::LockTime::partial_cmp(&self, other: &bitcoin_primitives::locktime::relative::LockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::locktime::relative::LockTime::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_consensus_u32(&self) -> u32
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_sequence(&self) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::locktime::relative::LockTime::try_from(seq: bitcoin_primitives::sequence::Sequence) -> core::result::Result<bitcoin_primitives::locktime::relative::LockTime, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::merkle_tree::TxMerkleNode, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::TxMerkleNode, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::merkle_tree::WitnessMerkleNode, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::opcodes::Class::clone(&self) -> bitcoin_primitives::opcodes::Class
+pub fn bitcoin_primitives::opcodes::Class::eq(&self, other: &bitcoin_primitives::opcodes::Class) -> bool
+pub fn bitcoin_primitives::opcodes::Class::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::ClassifyContext::clone(&self) -> bitcoin_primitives::opcodes::ClassifyContext
+pub fn bitcoin_primitives::opcodes::ClassifyContext::cmp(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> core::cmp::Ordering
+pub fn bitcoin_primitives::opcodes::ClassifyContext::eq(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> bool
+pub fn bitcoin_primitives::opcodes::ClassifyContext::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::ClassifyContext::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::opcodes::ClassifyContext::partial_cmp(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::opcodes::Opcode::classify(self, ctx: bitcoin_primitives::opcodes::ClassifyContext) -> bitcoin_primitives::opcodes::Class
+pub fn bitcoin_primitives::opcodes::Opcode::clone(&self) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives::opcodes::Opcode) -> bool
+pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin_primitives::pow::CompactTarget::default() -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::pow::CompactTarget::eq(&self, other: &bitcoin_primitives::pow::CompactTarget) -> bool
+pub fn bitcoin_primitives::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin_primitives::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::pow::CompactTarget::partial_cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::pow::CompactTarget::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_primitives::pow::CompactTarget::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::script::Script::as_bytes(&self) -> &[u8]
+pub fn bitcoin_primitives::script::Script::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::script::Script::as_mut(&mut self) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::script::Script::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::Script::as_ref(&self) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::cmp(&self, other: &bitcoin_primitives::script::Script) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::Script::eq(&self, other: &bitcoin_primitives::script::Script) -> bool
+pub fn bitcoin_primitives::script::Script::eq(&self, other: &bitcoin_primitives::script::ScriptBuf) -> bool
+pub fn bitcoin_primitives::script::Script::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::Script::from_bytes(bytes: &[u8]) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::from_bytes_mut(bytes: &mut [u8]) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::Script::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin_primitives::script::ScriptBuf
+pub fn bitcoin_primitives::script::Script::is_empty(&self) -> bool
+pub fn bitcoin_primitives::script::Script::len(&self) -> usize
+pub fn bitcoin_primitives::script::Script::new() -> &'static bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::partial_cmp(&self, other: &bitcoin_primitives::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::Script::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::Script::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::script::Script::to_bytes(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::script::Script::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::script::Script::to_owned(&self) -> Self::Owned
+pub fn bitcoin_primitives::script::Script::to_vec(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::script::ScriptBuf::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::script::ScriptBuf::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::script::ScriptBuf::as_mut(&mut self) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptBuf::as_ref(&self) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::as_script(&self) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::borrow(&self) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::borrow_mut(&mut self) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::clone(&self) -> bitcoin_primitives::script::ScriptBuf
+pub fn bitcoin_primitives::script::ScriptBuf::cmp(&self, other: &bitcoin_primitives::script::ScriptBuf) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::ScriptBuf::default() -> bitcoin_primitives::script::ScriptBuf
+pub fn bitcoin_primitives::script::ScriptBuf::deref(&self) -> &Self::Target
+pub fn bitcoin_primitives::script::ScriptBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin_primitives::script::ScriptBuf::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::script::ScriptBuf::eq(&self, other: &bitcoin_primitives::script::Script) -> bool
+pub fn bitcoin_primitives::script::ScriptBuf::eq(&self, other: &bitcoin_primitives::script::ScriptBuf) -> bool
+pub fn bitcoin_primitives::script::ScriptBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::ScriptBuf::from(v: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf::from(value: alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::script::Script>
+pub fn bitcoin_primitives::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::script::ScriptBuf::partial_cmp(&self, other: &bitcoin_primitives::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::ScriptBuf::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::ScriptBuf::reserve(&mut self, additional_len: usize)
+pub fn bitcoin_primitives::script::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
+pub fn bitcoin_primitives::script::ScriptBuf::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::script::ScriptBuf::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::script::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::sequence::Sequence::clone(&self) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::sequence::Sequence::cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::cmp::Ordering
+pub fn bitcoin_primitives::sequence::Sequence::default() -> Self
+pub fn bitcoin_primitives::sequence::Sequence::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::sequence::Sequence::enables_absolute_lock_time(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::eq(&self, other: &bitcoin_primitives::sequence::Sequence) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::sequence::Sequence::from(lt: bitcoin_primitives::locktime::relative::LockTime) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::sequence::Sequence::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::from_consensus(n: u32) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::from_height(height: u16) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_primitives::sequence::Sequence::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub fn bitcoin_primitives::sequence::Sequence::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub fn bitcoin_primitives::sequence::Sequence::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::sequence::Sequence::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_primitives::sequence::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::sequence::Sequence::is_final(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_height_locked(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_rbf(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_relative_lock_time(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_time_locked(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::partial_cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::sequence::Sequence::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::sequence::Sequence::to_consensus_u32(self) -> u32
+pub fn bitcoin_primitives::sequence::Sequence::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::sequence::Sequence::to_relative_lock_time(&self) -> core::option::Option<bitcoin_primitives::locktime::relative::LockTime>
+pub fn bitcoin_primitives::sequence::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::sequence::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::sequence::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::taproot::TapBranchTag::clone(&self) -> bitcoin_primitives::taproot::TapBranchTag
+pub fn bitcoin_primitives::taproot::TapBranchTag::cmp(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapBranchTag::default() -> bitcoin_primitives::taproot::TapBranchTag
+pub fn bitcoin_primitives::taproot::TapBranchTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapBranchTag::eq(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> bool
+pub fn bitcoin_primitives::taproot::TapBranchTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapBranchTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapLeafHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapLeafHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapLeafHash::clone(&self) -> bitcoin_primitives::taproot::TapLeafHash
+pub fn bitcoin_primitives::taproot::TapLeafHash::cmp(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapLeafHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::taproot::TapLeafHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::taproot::TapLeafHash::eq(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> bool
+pub fn bitcoin_primitives::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>) -> bitcoin_primitives::taproot::TapLeafHash
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapLeafHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapLeafHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapLeafTag::clone(&self) -> bitcoin_primitives::taproot::TapLeafTag
+pub fn bitcoin_primitives::taproot::TapLeafTag::cmp(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapLeafTag::default() -> bitcoin_primitives::taproot::TapLeafTag
+pub fn bitcoin_primitives::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapLeafTag::eq(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> bool
+pub fn bitcoin_primitives::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapNodeHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapNodeHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapNodeHash::clone(&self) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::cmp(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapNodeHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::taproot::TapNodeHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::taproot::TapNodeHash::eq(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> bool
+pub fn bitcoin_primitives::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::from(leaf: bitcoin_primitives::taproot::TapLeafHash) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapNodeHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapNodeHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapTweakHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapTweakHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapTweakHash::clone(&self) -> bitcoin_primitives::taproot::TapTweakHash
+pub fn bitcoin_primitives::taproot::TapTweakHash::cmp(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapTweakHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::taproot::TapTweakHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::taproot::TapTweakHash::eq(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> bool
+pub fn bitcoin_primitives::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>) -> bitcoin_primitives::taproot::TapTweakHash
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapTweakHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapTweakHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakTag::clone(&self) -> bitcoin_primitives::taproot::TapTweakTag
+pub fn bitcoin_primitives::taproot::TapTweakTag::cmp(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapTweakTag::default() -> bitcoin_primitives::taproot::TapTweakTag
+pub fn bitcoin_primitives::taproot::TapTweakTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapTweakTag::eq(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> bool
+pub fn bitcoin_primitives::taproot::TapTweakTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapTweakTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::OutPoint::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::OutPoint::clone(&self) -> bitcoin_primitives::transaction::OutPoint
+pub fn bitcoin_primitives::transaction::OutPoint::cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::OutPoint::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin_primitives::transaction::OutPoint, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::OutPoint::eq(&self, other: &bitcoin_primitives::transaction::OutPoint) -> bool
+pub fn bitcoin_primitives::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::OutPoint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::OutPoint::partial_cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::OutPoint::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::ParseOutPointError::clone(&self) -> bitcoin_primitives::transaction::ParseOutPointError
+pub fn bitcoin_primitives::transaction::ParseOutPointError::eq(&self, other: &bitcoin_primitives::transaction::ParseOutPointError) -> bool
+pub fn bitcoin_primitives::transaction::ParseOutPointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::ParseOutPointError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_primitives::transaction::ParseOutPointError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_primitives::transaction::Transaction::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::Transaction::clone(&self) -> bitcoin_primitives::transaction::Transaction
+pub fn bitcoin_primitives::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Transaction::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::Transaction::eq(&self, other: &bitcoin_primitives::transaction::Transaction) -> bool
+pub fn bitcoin_primitives::transaction::Transaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Transaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Transaction::inputs(&self) -> &[bitcoin_primitives::transaction::TxIn]
+pub fn bitcoin_primitives::transaction::Transaction::inputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxIn]
+pub fn bitcoin_primitives::transaction::Transaction::outputs(&self) -> &[bitcoin_primitives::transaction::TxOut]
+pub fn bitcoin_primitives::transaction::Transaction::outputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxOut]
+pub fn bitcoin_primitives::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Transaction::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::TxIn::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::TxIn::clone(&self) -> bitcoin_primitives::transaction::TxIn
+pub fn bitcoin_primitives::transaction::TxIn::cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::TxIn::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::TxIn::eq(&self, other: &bitcoin_primitives::transaction::TxIn) -> bool
+pub fn bitcoin_primitives::transaction::TxIn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::TxIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::TxIn::partial_cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::TxIn::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::TxOut::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::TxOut::clone(&self) -> bitcoin_primitives::transaction::TxOut
+pub fn bitcoin_primitives::transaction::TxOut::cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::TxOut::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::TxOut::eq(&self, other: &bitcoin_primitives::transaction::TxOut) -> bool
+pub fn bitcoin_primitives::transaction::TxOut::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::TxOut::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::TxOut::partial_cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::TxOut::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::Txid::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::clone(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Txid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::transaction::Txid, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::transaction::Txid::eq(&self, other: &bitcoin_primitives::transaction::Txid) -> bool
+pub fn bitcoin_primitives::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from(tx: &bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from(tx: bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Txid, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::transaction::Txid::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Txid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::transaction::Version::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::Version::clone(&self) -> bitcoin_primitives::transaction::Version
+pub fn bitcoin_primitives::transaction::Version::cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::Version::eq(&self, other: &bitcoin_primitives::transaction::Version) -> bool
+pub fn bitcoin_primitives::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Version::partial_cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::clone(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Wtxid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::transaction::Wtxid, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::transaction::Wtxid::eq(&self, other: &bitcoin_primitives::transaction::Wtxid) -> bool
+pub fn bitcoin_primitives::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from(tx: &bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from(tx: bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Wtxid, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::transaction::Wtxid::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Wtxid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin_primitives::witness::Iter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin_primitives::witness::Witness::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::witness::Witness::clear(&mut self)
+pub fn bitcoin_primitives::witness::Witness::clone(&self) -> bitcoin_primitives::witness::Witness
+pub fn bitcoin_primitives::witness::Witness::cmp(&self, other: &bitcoin_primitives::witness::Witness) -> core::cmp::Ordering
+pub fn bitcoin_primitives::witness::Witness::default() -> Self
+pub fn bitcoin_primitives::witness::Witness::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::witness::Witness::eq(&self, other: &bitcoin_primitives::witness::Witness) -> bool
+pub fn bitcoin_primitives::witness::Witness::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[&[u8]]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[alloc::vec::Vec<u8>]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(vec: alloc::vec::Vec<&[u8]>) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(vec: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
+pub fn bitcoin_primitives::witness::Witness::from_slice<T: core::convert::AsRef<[u8]>>(slice: &[T]) -> Self
+pub fn bitcoin_primitives::witness::Witness::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::witness::Witness::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin_primitives::witness::Witness::is_empty(&self) -> bool
+pub fn bitcoin_primitives::witness::Witness::iter(&self) -> bitcoin_primitives::witness::Iter<'_>
+pub fn bitcoin_primitives::witness::Witness::last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::len(&self) -> usize
+pub fn bitcoin_primitives::witness::Witness::nth(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::partial_cmp(&self, other: &bitcoin_primitives::witness::Witness) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
+pub fn bitcoin_primitives::witness::Witness::second_to_last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::witness::Witness::size(&self) -> usize
+pub fn bitcoin_primitives::witness::Witness::third_to_last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
+pub fn u32::from(sequence: bitcoin_primitives::sequence::Sequence) -> u32
+pub mod bitcoin_primitives
+pub mod bitcoin_primitives::absolute
+pub mod bitcoin_primitives::block
+pub mod bitcoin_primitives::locktime
+pub mod bitcoin_primitives::locktime::absolute
+pub mod bitcoin_primitives::locktime::relative
+pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::opcodes
+pub mod bitcoin_primitives::opcodes::all
+pub mod bitcoin_primitives::pow
+pub mod bitcoin_primitives::relative
+pub mod bitcoin_primitives::script
+pub mod bitcoin_primitives::sequence
+pub mod bitcoin_primitives::taproot
+pub mod bitcoin_primitives::transaction
+pub mod bitcoin_primitives::witness
+pub static bitcoin_primitives::opcodes::OP_0: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_FALSE: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_NOP2: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_NOP3: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_TRUE: bitcoin_primitives::opcodes::Opcode
+pub struct bitcoin_primitives::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::BlockHash(_)
+pub struct bitcoin_primitives::BlockHeader
+pub struct bitcoin_primitives::CompactTarget(_)
+pub struct bitcoin_primitives::Sequence(pub u32)
+pub struct bitcoin_primitives::TapBranchTag
+pub struct bitcoin_primitives::TapLeafHash(_)
+pub struct bitcoin_primitives::TapLeafTag
+pub struct bitcoin_primitives::TapNodeHash(_)
+pub struct bitcoin_primitives::TapTweakHash(_)
+pub struct bitcoin_primitives::TapTweakTag
+pub struct bitcoin_primitives::Transaction
+pub struct bitcoin_primitives::TxIn
+pub struct bitcoin_primitives::TxMerkleNode(_)
+pub struct bitcoin_primitives::TxOut
+pub struct bitcoin_primitives::Txid(_)
+pub struct bitcoin_primitives::Witness
+pub struct bitcoin_primitives::WitnessCommitment(_)
+pub struct bitcoin_primitives::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::Wtxid(_)
+pub struct bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::block::BlockHash(_)
+pub struct bitcoin_primitives::block::Header
+pub struct bitcoin_primitives::block::Version(_)
+pub struct bitcoin_primitives::block::WitnessCommitment(_)
+pub struct bitcoin_primitives::locktime::relative::DisabledLockTimeError(_)
+pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
+pub struct bitcoin_primitives::merkle_tree::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::opcodes::Opcode
+pub struct bitcoin_primitives::pow::CompactTarget(_)
+pub struct bitcoin_primitives::relative::DisabledLockTimeError(_)
+pub struct bitcoin_primitives::script::ScriptBuf(_)
+pub struct bitcoin_primitives::sequence::Sequence(pub u32)
+pub struct bitcoin_primitives::taproot::TapBranchTag
+pub struct bitcoin_primitives::taproot::TapLeafHash(_)
+pub struct bitcoin_primitives::taproot::TapLeafTag
+pub struct bitcoin_primitives::taproot::TapNodeHash(_)
+pub struct bitcoin_primitives::taproot::TapTweakHash(_)
+pub struct bitcoin_primitives::taproot::TapTweakTag
+pub struct bitcoin_primitives::transaction::OutPoint
+pub struct bitcoin_primitives::transaction::Transaction
+pub struct bitcoin_primitives::transaction::TxIn
+pub struct bitcoin_primitives::transaction::TxOut
+pub struct bitcoin_primitives::transaction::Txid(_)
+pub struct bitcoin_primitives::transaction::Version(pub i32)
+pub struct bitcoin_primitives::transaction::Wtxid(_)
+pub struct bitcoin_primitives::witness::Iter<'a>
+pub struct bitcoin_primitives::witness::Witness
+pub trait bitcoin_primitives::BlockValidation: sealed::Validation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub trait bitcoin_primitives::block::Validation: sealed::Validation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub type &'a bitcoin_primitives::witness::Witness::IntoIter = bitcoin_primitives::witness::Iter<'a>
+pub type &'a bitcoin_primitives::witness::Witness::Item = &'a [u8]
+pub type bitcoin_primitives::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::BlockHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::WitnessCommitment::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::locktime::absolute::LockTime::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_primitives::locktime::absolute::LockTime::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_primitives::locktime::relative::LockTime::Error = bitcoin_primitives::locktime::relative::DisabledLockTimeError
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::Script::Output = bitcoin_primitives::script::Script
+pub type bitcoin_primitives::script::Script::Owned = bitcoin_primitives::script::ScriptBuf
+pub type bitcoin_primitives::script::ScriptBuf::Target = bitcoin_primitives::script::Script
+pub type bitcoin_primitives::sequence::Sequence::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_primitives::sequence::Sequence::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_primitives::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapLeafHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::taproot::TapNodeHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapNodeHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::taproot::TapTweakHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapTweakHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::transaction::OutPoint::Err = bitcoin_primitives::transaction::ParseOutPointError
+pub type bitcoin_primitives::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Txid::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Wtxid::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::witness::Iter<'a>::Item = &'a [u8]
+pub type bitcoin_primitives::witness::Witness::Output = [u8]
+pub use bitcoin_primitives::Amount
+pub use bitcoin_primitives::BlockHeight
+pub use bitcoin_primitives::BlockInterval
+pub use bitcoin_primitives::FeeRate
+pub use bitcoin_primitives::SignedAmount
+pub use bitcoin_primitives::Weight
+pub use bitcoin_primitives::absolute::ConversionError
+pub use bitcoin_primitives::absolute::Height
+pub use bitcoin_primitives::absolute::LOCK_TIME_THRESHOLD
+pub use bitcoin_primitives::absolute::ParseHeightError
+pub use bitcoin_primitives::absolute::ParseTimeError
+pub use bitcoin_primitives::absolute::Time
+pub use bitcoin_primitives::amount
+pub use bitcoin_primitives::fee_rate
+pub use bitcoin_primitives::locktime::absolute::ConversionError
+pub use bitcoin_primitives::locktime::absolute::Height
+pub use bitcoin_primitives::locktime::absolute::LOCK_TIME_THRESHOLD
+pub use bitcoin_primitives::locktime::absolute::ParseHeightError
+pub use bitcoin_primitives::locktime::absolute::ParseTimeError
+pub use bitcoin_primitives::locktime::absolute::Time
+pub use bitcoin_primitives::locktime::relative::Height
+pub use bitcoin_primitives::locktime::relative::Time
+pub use bitcoin_primitives::locktime::relative::TimeOverflowError
+pub use bitcoin_primitives::relative::Height
+pub use bitcoin_primitives::relative::Time
+pub use bitcoin_primitives::relative::TimeOverflowError
+pub use bitcoin_primitives::weight

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -1,0 +1,1740 @@
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::ParseOutPointError
+#[non_exhaustive] pub struct bitcoin_primitives::locktime::relative::IncompatibleHeightError
+#[non_exhaustive] pub struct bitcoin_primitives::locktime::relative::IncompatibleTimeError
+#[non_exhaustive] pub struct bitcoin_primitives::relative::IncompatibleHeightError
+#[non_exhaustive] pub struct bitcoin_primitives::relative::IncompatibleTimeError
+#[repr(transparent)] pub struct bitcoin_primitives::script::Script(_)
+impl !core::marker::Sized for bitcoin_primitives::script::Script
+impl alloc::borrow::ToOwned for bitcoin_primitives::script::Script
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapLeafHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapNodeHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapTweakHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Wtxid
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapBranchTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapLeafTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapTweakTag
+impl bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
+impl bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+impl bitcoin_primitives::block::BlockHash
+impl bitcoin_primitives::block::Header
+impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked
+impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchecked
+impl bitcoin_primitives::block::Version
+impl bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_primitives::locktime::absolute::LockTime
+impl bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl bitcoin_primitives::locktime::relative::LockTime
+impl bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_primitives::opcodes::Opcode
+impl bitcoin_primitives::pow::CompactTarget
+impl bitcoin_primitives::script::Script
+impl bitcoin_primitives::script::ScriptBuf
+impl bitcoin_primitives::sequence::Sequence
+impl bitcoin_primitives::taproot::TapLeafHash
+impl bitcoin_primitives::taproot::TapNodeHash
+impl bitcoin_primitives::taproot::TapTweakHash
+impl bitcoin_primitives::transaction::OutPoint
+impl bitcoin_primitives::transaction::Transaction
+impl bitcoin_primitives::transaction::TxIn
+impl bitcoin_primitives::transaction::TxOut
+impl bitcoin_primitives::transaction::Txid
+impl bitcoin_primitives::transaction::Version
+impl bitcoin_primitives::transaction::Wtxid
+impl bitcoin_primitives::witness::Witness
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::borrow::BorrowMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::block::BlockHash
+impl core::clone::Clone for bitcoin_primitives::block::Checked
+impl core::clone::Clone for bitcoin_primitives::block::Header
+impl core::clone::Clone for bitcoin_primitives::block::Unchecked
+impl core::clone::Clone for bitcoin_primitives::block::Version
+impl core::clone::Clone for bitcoin_primitives::block::WitnessCommitment
+impl core::clone::Clone for bitcoin_primitives::locktime::absolute::LockTime
+impl core::clone::Clone for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::clone::Clone for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::clone::Clone for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::clone::Clone for bitcoin_primitives::locktime::relative::LockTime
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::clone::Clone for bitcoin_primitives::opcodes::Class
+impl core::clone::Clone for bitcoin_primitives::opcodes::ClassifyContext
+impl core::clone::Clone for bitcoin_primitives::opcodes::Opcode
+impl core::clone::Clone for bitcoin_primitives::pow::CompactTarget
+impl core::clone::Clone for bitcoin_primitives::script::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::sequence::Sequence
+impl core::clone::Clone for bitcoin_primitives::taproot::TapBranchTag
+impl core::clone::Clone for bitcoin_primitives::taproot::TapLeafHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapLeafTag
+impl core::clone::Clone for bitcoin_primitives::taproot::TapNodeHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapTweakHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapTweakTag
+impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
+impl core::clone::Clone for bitcoin_primitives::transaction::ParseOutPointError
+impl core::clone::Clone for bitcoin_primitives::transaction::Transaction
+impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
+impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
+impl core::clone::Clone for bitcoin_primitives::transaction::Txid
+impl core::clone::Clone for bitcoin_primitives::transaction::Version
+impl core::clone::Clone for bitcoin_primitives::transaction::Wtxid
+impl core::clone::Clone for bitcoin_primitives::witness::Witness
+impl core::cmp::Eq for bitcoin_primitives::block::BlockHash
+impl core::cmp::Eq for bitcoin_primitives::block::Checked
+impl core::cmp::Eq for bitcoin_primitives::block::Header
+impl core::cmp::Eq for bitcoin_primitives::block::Unchecked
+impl core::cmp::Eq for bitcoin_primitives::block::Version
+impl core::cmp::Eq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin_primitives::locktime::absolute::LockTime
+impl core::cmp::Eq for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::cmp::Eq for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_primitives::locktime::relative::LockTime
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::opcodes::Class
+impl core::cmp::Eq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::Eq for bitcoin_primitives::opcodes::Opcode
+impl core::cmp::Eq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Eq for bitcoin_primitives::script::Script
+impl core::cmp::Eq for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::Eq for bitcoin_primitives::sequence::Sequence
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::Eq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Eq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::cmp::Eq for bitcoin_primitives::transaction::Transaction
+impl core::cmp::Eq for bitcoin_primitives::transaction::TxIn
+impl core::cmp::Eq for bitcoin_primitives::transaction::TxOut
+impl core::cmp::Eq for bitcoin_primitives::transaction::Txid
+impl core::cmp::Eq for bitcoin_primitives::transaction::Version
+impl core::cmp::Eq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Eq for bitcoin_primitives::witness::Witness
+impl core::cmp::Ord for bitcoin_primitives::block::BlockHash
+impl core::cmp::Ord for bitcoin_primitives::block::Checked
+impl core::cmp::Ord for bitcoin_primitives::block::Header
+impl core::cmp::Ord for bitcoin_primitives::block::Unchecked
+impl core::cmp::Ord for bitcoin_primitives::block::Version
+impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::Ord for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Ord for bitcoin_primitives::script::Script
+impl core::cmp::Ord for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::Ord for bitcoin_primitives::sequence::Sequence
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::Ord for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Ord for bitcoin_primitives::transaction::Transaction
+impl core::cmp::Ord for bitcoin_primitives::transaction::TxIn
+impl core::cmp::Ord for bitcoin_primitives::transaction::TxOut
+impl core::cmp::Ord for bitcoin_primitives::transaction::Txid
+impl core::cmp::Ord for bitcoin_primitives::transaction::Version
+impl core::cmp::Ord for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Ord for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialEq for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialEq for bitcoin_primitives::block::Checked
+impl core::cmp::PartialEq for bitcoin_primitives::block::Header
+impl core::cmp::PartialEq for bitcoin_primitives::block::Unchecked
+impl core::cmp::PartialEq for bitcoin_primitives::block::Version
+impl core::cmp::PartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::absolute::LockTime
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_primitives::locktime::relative::LockTime
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Class
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Opcode
+impl core::cmp::PartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin_primitives::script::Script
+impl core::cmp::PartialEq for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialEq for bitcoin_primitives::sequence::Sequence
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Transaction
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::TxIn
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::TxOut
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialEq<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialEq<bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::Script
+impl core::cmp::PartialOrd for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Checked
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Header
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Unchecked
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin_primitives::locktime::absolute::LockTime
+impl core::cmp::PartialOrd for bitcoin_primitives::locktime::relative::LockTime
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::PartialOrd for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin_primitives::script::Script
+impl core::cmp::PartialOrd for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin_primitives::sequence::Sequence
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Transaction
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::TxIn
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::TxOut
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialOrd<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialOrd<bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::Script
+impl core::convert::AsMut<[u8]> for bitcoin_primitives::script::Script
+impl core::convert::AsMut<[u8]> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::Script
+impl core::convert::AsMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::Script
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<bitcoin_primitives::script::Script> for bitcoin_primitives::script::Script
+impl core::convert::AsRef<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::From<&[&[u8]]> for bitcoin_primitives::witness::Witness
+impl core::convert::From<&[alloc::vec::Vec<u8>]> for bitcoin_primitives::witness::Witness
+impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<&bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin_primitives::witness::Witness
+impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin_primitives::witness::Witness
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::block::BlockHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::block::WitnessCommitment> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::locktime::relative::LockTime> for bitcoin_primitives::sequence::Sequence
+impl core::convert::From<bitcoin_primitives::merkle_tree::TxMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::merkle_tree::WitnessMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin_primitives::script::Script>
+impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::boxed::Box<bitcoin_primitives::script::Script>
+impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin_primitives::sequence::Sequence> for u32
+impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>
+impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::From<bitcoin_primitives::taproot::TapNodeHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>
+impl core::convert::From<bitcoin_primitives::taproot::TapTweakHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>
+impl core::convert::From<bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<bitcoin_primitives::transaction::Txid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::transaction::Wtxid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::From<bitcoin_units::locktime::absolute::Time> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_primitives::locktime::relative::LockTime
+impl core::convert::From<bitcoin_units::locktime::relative::Time> for bitcoin_primitives::locktime::relative::LockTime
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::ParseOutPointError
+impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
+impl core::convert::TryFrom<&str> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::TryFrom<&str> for bitcoin_primitives::sequence::Sequence
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_primitives::sequence::Sequence
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_primitives::locktime::absolute::LockTime
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_primitives::sequence::Sequence
+impl core::convert::TryFrom<bitcoin_primitives::sequence::Sequence> for bitcoin_primitives::locktime::relative::LockTime
+impl core::default::Default for bitcoin_primitives::block::Version
+impl core::default::Default for bitcoin_primitives::pow::CompactTarget
+impl core::default::Default for bitcoin_primitives::script::ScriptBuf
+impl core::default::Default for bitcoin_primitives::sequence::Sequence
+impl core::default::Default for bitcoin_primitives::taproot::TapBranchTag
+impl core::default::Default for bitcoin_primitives::taproot::TapLeafTag
+impl core::default::Default for bitcoin_primitives::taproot::TapTweakTag
+impl core::default::Default for bitcoin_primitives::witness::Witness
+impl core::fmt::Debug for bitcoin_primitives::block::BlockHash
+impl core::fmt::Debug for bitcoin_primitives::block::Checked
+impl core::fmt::Debug for bitcoin_primitives::block::Header
+impl core::fmt::Debug for bitcoin_primitives::block::Unchecked
+impl core::fmt::Debug for bitcoin_primitives::block::Version
+impl core::fmt::Debug for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin_primitives::locktime::absolute::LockTime
+impl core::fmt::Debug for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::fmt::Debug for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::fmt::Debug for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::fmt::Debug for bitcoin_primitives::locktime::relative::LockTime
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::opcodes::Class
+impl core::fmt::Debug for bitcoin_primitives::opcodes::ClassifyContext
+impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
+impl core::fmt::Debug for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_primitives::script::Script
+impl core::fmt::Debug for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::Debug for bitcoin_primitives::sequence::Sequence
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::Debug for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Debug for bitcoin_primitives::transaction::ParseOutPointError
+impl core::fmt::Debug for bitcoin_primitives::transaction::Transaction
+impl core::fmt::Debug for bitcoin_primitives::transaction::TxIn
+impl core::fmt::Debug for bitcoin_primitives::transaction::TxOut
+impl core::fmt::Debug for bitcoin_primitives::transaction::Txid
+impl core::fmt::Debug for bitcoin_primitives::transaction::Version
+impl core::fmt::Debug for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::Debug for bitcoin_primitives::witness::Witness
+impl core::fmt::Display for bitcoin_primitives::block::BlockHash
+impl core::fmt::Display for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Display for bitcoin_primitives::locktime::absolute::LockTime
+impl core::fmt::Display for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::fmt::Display for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::fmt::Display for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::fmt::Display for bitcoin_primitives::locktime::relative::LockTime
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Display for bitcoin_primitives::opcodes::Opcode
+impl core::fmt::Display for bitcoin_primitives::script::Script
+impl core::fmt::Display for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::Display for bitcoin_primitives::sequence::Sequence
+impl core::fmt::Display for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::Display for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::Display for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::Display for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Display for bitcoin_primitives::transaction::ParseOutPointError
+impl core::fmt::Display for bitcoin_primitives::transaction::Txid
+impl core::fmt::Display for bitcoin_primitives::transaction::Version
+impl core::fmt::Display for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::LowerHex for bitcoin_primitives::block::BlockHash
+impl core::fmt::LowerHex for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::LowerHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::LowerHex for bitcoin_primitives::script::Script
+impl core::fmt::LowerHex for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::LowerHex for bitcoin_primitives::sequence::Sequence
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::LowerHex for bitcoin_primitives::transaction::Txid
+impl core::fmt::LowerHex for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::UpperHex for bitcoin_primitives::block::BlockHash
+impl core::fmt::UpperHex for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::UpperHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin_primitives::script::Script
+impl core::fmt::UpperHex for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::UpperHex for bitcoin_primitives::sequence::Sequence
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::UpperHex for bitcoin_primitives::transaction::Txid
+impl core::fmt::UpperHex for bitcoin_primitives::transaction::Wtxid
+impl core::hash::Hash for bitcoin_primitives::block::BlockHash
+impl core::hash::Hash for bitcoin_primitives::block::Checked
+impl core::hash::Hash for bitcoin_primitives::block::Header
+impl core::hash::Hash for bitcoin_primitives::block::Unchecked
+impl core::hash::Hash for bitcoin_primitives::block::Version
+impl core::hash::Hash for bitcoin_primitives::block::WitnessCommitment
+impl core::hash::Hash for bitcoin_primitives::locktime::absolute::LockTime
+impl core::hash::Hash for bitcoin_primitives::locktime::relative::LockTime
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::hash::Hash for bitcoin_primitives::opcodes::ClassifyContext
+impl core::hash::Hash for bitcoin_primitives::pow::CompactTarget
+impl core::hash::Hash for bitcoin_primitives::script::Script
+impl core::hash::Hash for bitcoin_primitives::script::ScriptBuf
+impl core::hash::Hash for bitcoin_primitives::sequence::Sequence
+impl core::hash::Hash for bitcoin_primitives::taproot::TapBranchTag
+impl core::hash::Hash for bitcoin_primitives::taproot::TapLeafHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapLeafTag
+impl core::hash::Hash for bitcoin_primitives::taproot::TapNodeHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapTweakTag
+impl core::hash::Hash for bitcoin_primitives::transaction::OutPoint
+impl core::hash::Hash for bitcoin_primitives::transaction::Transaction
+impl core::hash::Hash for bitcoin_primitives::transaction::TxIn
+impl core::hash::Hash for bitcoin_primitives::transaction::TxOut
+impl core::hash::Hash for bitcoin_primitives::transaction::Txid
+impl core::hash::Hash for bitcoin_primitives::transaction::Version
+impl core::hash::Hash for bitcoin_primitives::transaction::Wtxid
+impl core::hash::Hash for bitcoin_primitives::witness::Witness
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin_primitives::witness::Iter<'_>
+impl core::marker::Copy for bitcoin_primitives::block::BlockHash
+impl core::marker::Copy for bitcoin_primitives::block::Header
+impl core::marker::Copy for bitcoin_primitives::block::Version
+impl core::marker::Copy for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Copy for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Copy for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Copy for bitcoin_primitives::opcodes::Class
+impl core::marker::Copy for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Copy for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Copy for bitcoin_primitives::sequence::Sequence
+impl core::marker::Copy for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Copy for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Copy for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Copy for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Copy for bitcoin_primitives::transaction::Txid
+impl core::marker::Copy for bitcoin_primitives::transaction::Version
+impl core::marker::Copy for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::block::BlockHash
+impl core::marker::Freeze for bitcoin_primitives::block::Checked
+impl core::marker::Freeze for bitcoin_primitives::block::Header
+impl core::marker::Freeze for bitcoin_primitives::block::Unchecked
+impl core::marker::Freeze for bitcoin_primitives::block::Version
+impl core::marker::Freeze for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Freeze for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Freeze for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::Freeze for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::opcodes::Class
+impl core::marker::Freeze for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Freeze for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Freeze for bitcoin_primitives::script::Script
+impl core::marker::Freeze for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Freeze for bitcoin_primitives::sequence::Sequence
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Freeze for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Freeze for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Freeze for bitcoin_primitives::transaction::Transaction
+impl core::marker::Freeze for bitcoin_primitives::transaction::TxIn
+impl core::marker::Freeze for bitcoin_primitives::transaction::TxOut
+impl core::marker::Freeze for bitcoin_primitives::transaction::Txid
+impl core::marker::Freeze for bitcoin_primitives::transaction::Version
+impl core::marker::Freeze for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::witness::Witness
+impl core::marker::Send for bitcoin_primitives::block::BlockHash
+impl core::marker::Send for bitcoin_primitives::block::Checked
+impl core::marker::Send for bitcoin_primitives::block::Header
+impl core::marker::Send for bitcoin_primitives::block::Unchecked
+impl core::marker::Send for bitcoin_primitives::block::Version
+impl core::marker::Send for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Send for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Send for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::Send for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::Send for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::Send for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Send for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Send for bitcoin_primitives::opcodes::Class
+impl core::marker::Send for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Send for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Send for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Send for bitcoin_primitives::script::Script
+impl core::marker::Send for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Send for bitcoin_primitives::sequence::Sequence
+impl core::marker::Send for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Send for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Send for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Send for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Send for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Send for bitcoin_primitives::transaction::Transaction
+impl core::marker::Send for bitcoin_primitives::transaction::TxIn
+impl core::marker::Send for bitcoin_primitives::transaction::TxOut
+impl core::marker::Send for bitcoin_primitives::transaction::Txid
+impl core::marker::Send for bitcoin_primitives::transaction::Version
+impl core::marker::Send for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Send for bitcoin_primitives::witness::Witness
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Checked
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Header
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Unchecked
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Class
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::Script
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin_primitives::sequence::Sequence
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Transaction
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::TxIn
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::TxOut
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness::Witness
+impl core::marker::Sync for bitcoin_primitives::block::BlockHash
+impl core::marker::Sync for bitcoin_primitives::block::Checked
+impl core::marker::Sync for bitcoin_primitives::block::Header
+impl core::marker::Sync for bitcoin_primitives::block::Unchecked
+impl core::marker::Sync for bitcoin_primitives::block::Version
+impl core::marker::Sync for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Sync for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Sync for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::Sync for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Sync for bitcoin_primitives::opcodes::Class
+impl core::marker::Sync for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Sync for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Sync for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Sync for bitcoin_primitives::script::Script
+impl core::marker::Sync for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Sync for bitcoin_primitives::sequence::Sequence
+impl core::marker::Sync for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Sync for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Sync for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Sync for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Sync for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Sync for bitcoin_primitives::transaction::Transaction
+impl core::marker::Sync for bitcoin_primitives::transaction::TxIn
+impl core::marker::Sync for bitcoin_primitives::transaction::TxOut
+impl core::marker::Sync for bitcoin_primitives::transaction::Txid
+impl core::marker::Sync for bitcoin_primitives::transaction::Version
+impl core::marker::Sync for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Sync for bitcoin_primitives::witness::Witness
+impl core::marker::Unpin for bitcoin_primitives::block::BlockHash
+impl core::marker::Unpin for bitcoin_primitives::block::Checked
+impl core::marker::Unpin for bitcoin_primitives::block::Header
+impl core::marker::Unpin for bitcoin_primitives::block::Unchecked
+impl core::marker::Unpin for bitcoin_primitives::block::Version
+impl core::marker::Unpin for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin_primitives::locktime::absolute::LockTime
+impl core::marker::Unpin for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::marker::Unpin for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_primitives::locktime::relative::LockTime
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::opcodes::Class
+impl core::marker::Unpin for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Unpin for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Unpin for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Unpin for bitcoin_primitives::script::Script
+impl core::marker::Unpin for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Unpin for bitcoin_primitives::sequence::Sequence
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Unpin for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Unpin for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Unpin for bitcoin_primitives::transaction::Transaction
+impl core::marker::Unpin for bitcoin_primitives::transaction::TxIn
+impl core::marker::Unpin for bitcoin_primitives::transaction::TxOut
+impl core::marker::Unpin for bitcoin_primitives::transaction::Txid
+impl core::marker::Unpin for bitcoin_primitives::transaction::Version
+impl core::marker::Unpin for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Unpin for bitcoin_primitives::witness::Witness
+impl core::ops::deref::Deref for bitcoin_primitives::script::ScriptBuf
+impl core::ops::deref::DerefMut for bitcoin_primitives::script::ScriptBuf
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin_primitives::script::Script
+impl core::ops::index::Index<usize> for bitcoin_primitives::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Checked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Unchecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::absolute::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::locktime::relative::LockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Class
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Opcode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::Script
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::sequence::Sequence
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapBranchTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapLeafHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapLeafTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapNodeHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapTweakHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapTweakTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::ParseOutPointError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Transaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::TxIn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::TxOut
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness::Witness
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Checked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Unchecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::absolute::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::relative::DisabledLockTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::relative::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::locktime::relative::LockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Class
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Opcode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::Script
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::sequence::Sequence
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapBranchTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapLeafHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapLeafTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapNodeHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapTweakHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapTweakTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::ParseOutPointError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Transaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::TxIn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::TxOut
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness::Witness
+impl core::str::traits::FromStr for bitcoin_primitives::block::BlockHash
+impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
+impl core::str::traits::FromStr for bitcoin_primitives::locktime::absolute::LockTime
+impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::sequence::Sequence
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapLeafHash
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapNodeHash
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapTweakHash
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::OutPoint
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::Txid
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::Wtxid
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for alloc::boxed::Box<bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for alloc::rc::Rc<bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for alloc::sync::Arc<bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>> for alloc::boxed::Box<bitcoin_primitives::script::Script>
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>> for bitcoin_primitives::script::ScriptBuf
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin_primitives::witness::Witness
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Freeze for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Send for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Sync for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Unpin for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness::Iter<'a>
+impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
+impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
+impl<V> core::cmp::Eq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::Eq
+impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
+impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug
+impl<V> core::marker::Freeze for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::Send for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::StructuralPartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<V> core::marker::Sync for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::Unpin for bitcoin_primitives::block::Block<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Block<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Block<V> where V: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_primitives::BlockHeader::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::BlockHeader::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::BlockHeader::nonce: u32
+pub bitcoin_primitives::BlockHeader::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::BlockHeader::time: u32
+pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::Transaction::input: alloc::vec::Vec<bitcoin_primitives::transaction::TxIn>
+pub bitcoin_primitives::Transaction::lock_time: bitcoin_primitives::locktime::absolute::LockTime
+pub bitcoin_primitives::Transaction::output: alloc::vec::Vec<bitcoin_primitives::transaction::TxOut>
+pub bitcoin_primitives::Transaction::version: bitcoin_primitives::transaction::Version
+pub bitcoin_primitives::TxIn::previous_output: bitcoin_primitives::transaction::OutPoint
+pub bitcoin_primitives::TxIn::script_sig: bitcoin_primitives::script::ScriptBuf
+pub bitcoin_primitives::TxIn::sequence: bitcoin_primitives::sequence::Sequence
+pub bitcoin_primitives::TxIn::witness: bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::TxOut::script_pubkey: bitcoin_primitives::script::ScriptBuf
+pub bitcoin_primitives::TxOut::value: bitcoin_units::amount::unsigned::Amount
+pub bitcoin_primitives::absolute::LockTime::Blocks(bitcoin_units::locktime::absolute::Height)
+pub bitcoin_primitives::absolute::LockTime::Seconds(bitcoin_units::locktime::absolute::Time)
+pub bitcoin_primitives::block::Header::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::block::Header::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::block::Header::nonce: u32
+pub bitcoin_primitives::block::Header::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::block::Header::time: u32
+pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::locktime::absolute::LockTime::Blocks(bitcoin_units::locktime::absolute::Height)
+pub bitcoin_primitives::locktime::absolute::LockTime::Seconds(bitcoin_units::locktime::absolute::Time)
+pub bitcoin_primitives::locktime::relative::IncompatibleHeightError::height: bitcoin_units::locktime::relative::Height
+pub bitcoin_primitives::locktime::relative::IncompatibleHeightError::time: bitcoin_units::locktime::relative::Time
+pub bitcoin_primitives::locktime::relative::IncompatibleTimeError::height: bitcoin_units::locktime::relative::Height
+pub bitcoin_primitives::locktime::relative::IncompatibleTimeError::time: bitcoin_units::locktime::relative::Time
+pub bitcoin_primitives::locktime::relative::LockTime::Blocks(bitcoin_units::locktime::relative::Height)
+pub bitcoin_primitives::locktime::relative::LockTime::Time(bitcoin_units::locktime::relative::Time)
+pub bitcoin_primitives::opcodes::Class::IllegalOp
+pub bitcoin_primitives::opcodes::Class::NoOp
+pub bitcoin_primitives::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin_primitives::opcodes::Class::PushBytes(u32)
+pub bitcoin_primitives::opcodes::Class::PushNum(i32)
+pub bitcoin_primitives::opcodes::Class::ReturnOp
+pub bitcoin_primitives::opcodes::Class::SuccessOp
+pub bitcoin_primitives::opcodes::ClassifyContext::Legacy
+pub bitcoin_primitives::opcodes::ClassifyContext::TapScript
+pub bitcoin_primitives::relative::IncompatibleHeightError::height: bitcoin_units::locktime::relative::Height
+pub bitcoin_primitives::relative::IncompatibleHeightError::time: bitcoin_units::locktime::relative::Time
+pub bitcoin_primitives::relative::IncompatibleTimeError::height: bitcoin_units::locktime::relative::Height
+pub bitcoin_primitives::relative::IncompatibleTimeError::time: bitcoin_units::locktime::relative::Time
+pub bitcoin_primitives::relative::LockTime::Blocks(bitcoin_units::locktime::relative::Height)
+pub bitcoin_primitives::relative::LockTime::Time(bitcoin_units::locktime::relative::Time)
+pub bitcoin_primitives::transaction::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::transaction::OutPoint::vout: u32
+pub bitcoin_primitives::transaction::ParseOutPointError::Format
+pub bitcoin_primitives::transaction::ParseOutPointError::TooLong
+pub bitcoin_primitives::transaction::ParseOutPointError::Txid(hex_conservative::error::HexToArrayError)
+pub bitcoin_primitives::transaction::ParseOutPointError::Vout(bitcoin_units::parse::ParseIntError)
+pub bitcoin_primitives::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin_primitives::transaction::Transaction::input: alloc::vec::Vec<bitcoin_primitives::transaction::TxIn>
+pub bitcoin_primitives::transaction::Transaction::lock_time: bitcoin_primitives::locktime::absolute::LockTime
+pub bitcoin_primitives::transaction::Transaction::output: alloc::vec::Vec<bitcoin_primitives::transaction::TxOut>
+pub bitcoin_primitives::transaction::Transaction::version: bitcoin_primitives::transaction::Version
+pub bitcoin_primitives::transaction::TxIn::previous_output: bitcoin_primitives::transaction::OutPoint
+pub bitcoin_primitives::transaction::TxIn::script_sig: bitcoin_primitives::script::ScriptBuf
+pub bitcoin_primitives::transaction::TxIn::sequence: bitcoin_primitives::sequence::Sequence
+pub bitcoin_primitives::transaction::TxIn::witness: bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::transaction::TxOut::script_pubkey: bitcoin_primitives::script::ScriptBuf
+pub bitcoin_primitives::transaction::TxOut::value: bitcoin_units::amount::unsigned::Amount
+pub const bitcoin_primitives::BlockValidation::IS_CHECKED: bool
+pub const bitcoin_primitives::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::block::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH: Self
+pub const bitcoin_primitives::block::Checked::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Header::SIZE: usize
+pub const bitcoin_primitives::block::Unchecked::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Validation::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin_primitives::block::Version::ONE: Self
+pub const bitcoin_primitives::block::Version::TWO: Self
+pub const bitcoin_primitives::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::locktime::absolute::LockTime::SIZE: usize
+pub const bitcoin_primitives::locktime::absolute::LockTime::ZERO: bitcoin_primitives::locktime::absolute::LockTime
+pub const bitcoin_primitives::locktime::relative::LockTime::SIZE: usize
+pub const bitcoin_primitives::locktime::relative::LockTime::ZERO: bitcoin_primitives::locktime::relative::LockTime
+pub const bitcoin_primitives::merkle_tree::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::opcodes::all::OP_0NOTEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_1ADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_1SUB: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DIV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DROP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2MUL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2OVER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2ROT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2SWAP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_3DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ABS: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_AND: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_BOOLAND: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_BOOLOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CAT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKMULTISIG: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKMULTISIGVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIG: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIGADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIGVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CLTV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CODESEPARATOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CSV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DEPTH: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DIV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DROP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ELSE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ENDIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_EQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_EQUALVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_FROMALTSTACK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_GREATERTHAN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_GREATERTHANOREQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_HASH160: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_HASH256: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_IF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_IFDUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_INVALIDOPCODE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_INVERT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LEFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LESSTHAN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LESSTHANOREQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LSHIFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MAX: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MIN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MOD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MUL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NEGATE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NIP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOTIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMEQUALVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMNOTEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_OR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_OVER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PICK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_0: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_11: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_12: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_13: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_14: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_15: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_16: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_17: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_18: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_19: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_20: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_21: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_22: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_23: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_24: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_25: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_26: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_27: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_28: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_29: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_30: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_31: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_32: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_33: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_34: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_35: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_36: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_37: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_38: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_39: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_3: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_40: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_41: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_42: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_43: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_44: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_45: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_46: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_47: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_48: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_49: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_50: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_51: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_52: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_53: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_54: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_55: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_56: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_57: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_58: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_59: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_60: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_61: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_62: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_63: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_64: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_65: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_66: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_67: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_68: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_69: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_70: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_71: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_72: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_73: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_74: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_75: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_11: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_12: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_13: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_14: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_15: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_16: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_3: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_NEG1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_187: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_188: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_189: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_190: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_191: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_192: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_193: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_194: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_195: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_196: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_197: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_198: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_199: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_200: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_201: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_202: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_203: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_204: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_205: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_206: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_207: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_208: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_209: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_210: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_211: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_212: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_213: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_214: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_215: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_216: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_217: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_218: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_219: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_220: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_221: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_222: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_223: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_224: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_225: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_226: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_227: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_228: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_229: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_230: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_231: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_232: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_233: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_234: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_235: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_236: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_237: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_238: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_239: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_240: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_241: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_242: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_243: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_244: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_245: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_246: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_247: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_248: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_249: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_250: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_251: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_252: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_253: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_254: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RIGHT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RIPEMD160: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ROLL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ROT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RSHIFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SHA1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SHA256: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SIZE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SUB: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SUBSTR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SWAP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_TOALTSTACK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_TUCK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERNOTIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_WITHIN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_XOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
+pub const bitcoin_primitives::sequence::Sequence::FINAL: Self
+pub const bitcoin_primitives::sequence::Sequence::MAX: Self
+pub const bitcoin_primitives::sequence::Sequence::SIZE: usize
+pub const bitcoin_primitives::sequence::Sequence::ZERO: Self
+pub const bitcoin_primitives::taproot::TapLeafHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::taproot::TapNodeHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::taproot::TapTweakHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
+pub const bitcoin_primitives::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin_units::weight::Weight
+pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: bitcoin_primitives::transaction::TxIn
+pub const bitcoin_primitives::transaction::TxOut::NULL: Self
+pub const bitcoin_primitives::transaction::Txid::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::Version::ONE: Self
+pub const bitcoin_primitives::transaction::Version::THREE: Self
+pub const bitcoin_primitives::transaction::Version::TWO: Self
+pub const bitcoin_primitives::transaction::Wtxid::COINBASE: Self
+pub const bitcoin_primitives::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::locktime::absolute::LockTime::is_block_height(&self) -> bool
+pub const fn bitcoin_primitives::locktime::absolute::LockTime::is_block_time(&self) -> bool
+pub const fn bitcoin_primitives::locktime::absolute::LockTime::is_same_unit(&self, other: bitcoin_primitives::locktime::absolute::LockTime) -> bool
+pub const fn bitcoin_primitives::locktime::relative::LockTime::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_primitives::locktime::relative::LockTime::from_height(n: u16) -> Self
+pub const fn bitcoin_primitives::locktime::relative::LockTime::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_primitives::locktime::relative::LockTime::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_primitives::locktime::relative::LockTime::is_block_height(&self) -> bool
+pub const fn bitcoin_primitives::locktime::relative::LockTime::is_block_time(&self) -> bool
+pub const fn bitcoin_primitives::locktime::relative::LockTime::is_same_unit(&self, other: bitcoin_primitives::locktime::relative::LockTime) -> bool
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::opcodes::Opcode::decode_pushnum(self) -> core::option::Option<u8>
+pub const fn bitcoin_primitives::opcodes::Opcode::to_u8(self) -> u8
+pub const fn bitcoin_primitives::script::ScriptBuf::new() -> Self
+pub const fn bitcoin_primitives::taproot::TapLeafHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapLeafHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapLeafHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapNodeHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapNodeHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapNodeHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapTweakHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapTweakHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapTweakHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::witness::Witness::new() -> Self
+pub enum bitcoin_primitives::BlockChecked
+pub enum bitcoin_primitives::BlockUnchecked
+pub enum bitcoin_primitives::absolute::LockTime
+pub enum bitcoin_primitives::block::Checked
+pub enum bitcoin_primitives::block::Unchecked
+pub enum bitcoin_primitives::locktime::absolute::LockTime
+pub enum bitcoin_primitives::locktime::relative::LockTime
+pub enum bitcoin_primitives::opcodes::Class
+pub enum bitcoin_primitives::opcodes::ClassifyContext
+pub enum bitcoin_primitives::relative::LockTime
+pub fn &'a bitcoin_primitives::witness::Witness::into_iter(self) -> Self::IntoIter
+pub fn alloc::borrow::Cow<'_, bitcoin_primitives::script::Script>::from(value: bitcoin_primitives::script::ScriptBuf) -> Self
+pub fn alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::script::Script>::from(v: bitcoin_primitives::script::ScriptBuf) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::script::Script>::from(value: alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>) -> Self
+pub fn alloc::rc::Rc<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn alloc::sync::Arc<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn alloc::vec::Vec<u8>::from(v: bitcoin_primitives::script::ScriptBuf) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::BlockHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::WitnessCommitment) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::merkle_tree::TxMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::transaction::Txid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::transaction::Wtxid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>::from(hashtype: bitcoin_primitives::taproot::TapNodeHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>::from(hashtype: bitcoin_primitives::taproot::TapLeafHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>::from(hashtype: bitcoin_primitives::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>
+pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V>
+pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &bitcoin_primitives::block::Block<V>) -> bool
+pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::cached_witness_root(&self) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::header(&self) -> &bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::transactions(&self) -> &[bitcoin_primitives::transaction::Transaction]
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::assume_checked(self, witness_root: core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+pub fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::clone(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::BlockHash::eq(&self, other: &bitcoin_primitives::block::BlockHash) -> bool
+pub fn bitcoin_primitives::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::BlockHash::from(block: &bitcoin_primitives::block::Block) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(block: bitcoin_primitives::block::Block) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: &bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::BlockHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::block::BlockHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::BlockHash::partial_cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::block::Checked::clone(&self) -> bitcoin_primitives::block::Checked
+pub fn bitcoin_primitives::block::Checked::cmp(&self, other: &bitcoin_primitives::block::Checked) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Checked::eq(&self, other: &bitcoin_primitives::block::Checked) -> bool
+pub fn bitcoin_primitives::block::Checked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Checked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Checked::partial_cmp(&self, other: &bitcoin_primitives::block::Checked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Header::clone(&self) -> bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Header::cmp(&self, other: &bitcoin_primitives::block::Header) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Header::eq(&self, other: &bitcoin_primitives::block::Header) -> bool
+pub fn bitcoin_primitives::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Header::partial_cmp(&self, other: &bitcoin_primitives::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Unchecked::clone(&self) -> bitcoin_primitives::block::Unchecked
+pub fn bitcoin_primitives::block::Unchecked::cmp(&self, other: &bitcoin_primitives::block::Unchecked) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Unchecked::eq(&self, other: &bitcoin_primitives::block::Unchecked) -> bool
+pub fn bitcoin_primitives::block::Unchecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Unchecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Unchecked::partial_cmp(&self, other: &bitcoin_primitives::block::Unchecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::clone(&self) -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::cmp(&self, other: &bitcoin_primitives::block::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Version::default() -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::eq(&self, other: &bitcoin_primitives::block::Version) -> bool
+pub fn bitcoin_primitives::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(&self, bit: u8) -> bool
+pub fn bitcoin_primitives::block::Version::partial_cmp(&self, other: &bitcoin_primitives::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
+pub fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::clone(&self) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::WitnessCommitment::eq(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> bool
+pub fn bitcoin_primitives::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::WitnessCommitment, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::locktime::absolute::LockTime::clone(&self) -> bitcoin_primitives::locktime::absolute::LockTime
+pub fn bitcoin_primitives::locktime::absolute::LockTime::eq(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> bool
+pub fn bitcoin_primitives::locktime::absolute::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from(t: bitcoin_units::locktime::absolute::Time) -> Self
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_consensus(n: u32) -> Self
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_height(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_time(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::locktime::absolute::LockTime::is_implied_by(&self, other: bitcoin_primitives::locktime::absolute::LockTime) -> bool
+pub fn bitcoin_primitives::locktime::absolute::LockTime::is_satisfied_by(&self, height: bitcoin_units::locktime::absolute::Height, time: bitcoin_units::locktime::absolute::Time) -> bool
+pub fn bitcoin_primitives::locktime::absolute::LockTime::partial_cmp(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::to_consensus_u32(self) -> u32
+pub fn bitcoin_primitives::locktime::absolute::LockTime::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::locktime::absolute::LockTime::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::locktime::relative::DisabledLockTimeError::clone(&self) -> bitcoin_primitives::locktime::relative::DisabledLockTimeError
+pub fn bitcoin_primitives::locktime::relative::DisabledLockTimeError::disabled_locktime_value(&self) -> u32
+pub fn bitcoin_primitives::locktime::relative::DisabledLockTimeError::eq(&self, other: &bitcoin_primitives::locktime::relative::DisabledLockTimeError) -> bool
+pub fn bitcoin_primitives::locktime::relative::DisabledLockTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::relative::IncompatibleHeightError::clone(&self) -> bitcoin_primitives::locktime::relative::IncompatibleHeightError
+pub fn bitcoin_primitives::locktime::relative::IncompatibleHeightError::eq(&self, other: &bitcoin_primitives::locktime::relative::IncompatibleHeightError) -> bool
+pub fn bitcoin_primitives::locktime::relative::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::relative::IncompatibleTimeError::clone(&self) -> bitcoin_primitives::locktime::relative::IncompatibleTimeError
+pub fn bitcoin_primitives::locktime::relative::IncompatibleTimeError::eq(&self, other: &bitcoin_primitives::locktime::relative::IncompatibleTimeError) -> bool
+pub fn bitcoin_primitives::locktime::relative::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::relative::LockTime::clone(&self) -> bitcoin_primitives::locktime::relative::LockTime
+pub fn bitcoin_primitives::locktime::relative::LockTime::eq(&self, other: &bitcoin_primitives::locktime::relative::LockTime) -> bool
+pub fn bitcoin_primitives::locktime::relative::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::locktime::relative::LockTime::from(h: bitcoin_units::locktime::relative::Height) -> Self
+pub fn bitcoin_primitives::locktime::relative::LockTime::from(t: bitcoin_units::locktime::relative::Time) -> Self
+pub fn bitcoin_primitives::locktime::relative::LockTime::from_consensus(n: u32) -> core::result::Result<Self, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
+pub fn bitcoin_primitives::locktime::relative::LockTime::from_sequence(n: bitcoin_primitives::sequence::Sequence) -> core::result::Result<Self, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
+pub fn bitcoin_primitives::locktime::relative::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_implied_by(&self, other: bitcoin_primitives::locktime::relative::LockTime) -> bool
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_implied_by_sequence(&self, other: bitcoin_primitives::sequence::Sequence) -> bool
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by(&self, h: bitcoin_units::locktime::relative::Height, t: bitcoin_units::locktime::relative::Time) -> bool
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_height(&self, height: bitcoin_units::locktime::relative::Height) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleHeightError>
+pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_time(&self, time: bitcoin_units::locktime::relative::Time) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleTimeError>
+pub fn bitcoin_primitives::locktime::relative::LockTime::partial_cmp(&self, other: &bitcoin_primitives::locktime::relative::LockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_consensus_u32(&self) -> u32
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_sequence(&self) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::locktime::relative::LockTime::try_from(seq: bitcoin_primitives::sequence::Sequence) -> core::result::Result<bitcoin_primitives::locktime::relative::LockTime, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::TxMerkleNode, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::opcodes::Class::clone(&self) -> bitcoin_primitives::opcodes::Class
+pub fn bitcoin_primitives::opcodes::Class::eq(&self, other: &bitcoin_primitives::opcodes::Class) -> bool
+pub fn bitcoin_primitives::opcodes::Class::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::ClassifyContext::clone(&self) -> bitcoin_primitives::opcodes::ClassifyContext
+pub fn bitcoin_primitives::opcodes::ClassifyContext::cmp(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> core::cmp::Ordering
+pub fn bitcoin_primitives::opcodes::ClassifyContext::eq(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> bool
+pub fn bitcoin_primitives::opcodes::ClassifyContext::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::ClassifyContext::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::opcodes::ClassifyContext::partial_cmp(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::opcodes::Opcode::classify(self, ctx: bitcoin_primitives::opcodes::ClassifyContext) -> bitcoin_primitives::opcodes::Class
+pub fn bitcoin_primitives::opcodes::Opcode::clone(&self) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives::opcodes::Opcode) -> bool
+pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin_primitives::pow::CompactTarget::default() -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::eq(&self, other: &bitcoin_primitives::pow::CompactTarget) -> bool
+pub fn bitcoin_primitives::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin_primitives::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::pow::CompactTarget::partial_cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_primitives::pow::CompactTarget::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::script::Script::as_bytes(&self) -> &[u8]
+pub fn bitcoin_primitives::script::Script::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::script::Script::as_mut(&mut self) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::script::Script::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::Script::as_ref(&self) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::cmp(&self, other: &bitcoin_primitives::script::Script) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::Script::eq(&self, other: &bitcoin_primitives::script::Script) -> bool
+pub fn bitcoin_primitives::script::Script::eq(&self, other: &bitcoin_primitives::script::ScriptBuf) -> bool
+pub fn bitcoin_primitives::script::Script::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::Script::from_bytes(bytes: &[u8]) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::from_bytes_mut(bytes: &mut [u8]) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::Script::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin_primitives::script::Script::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin_primitives::script::ScriptBuf
+pub fn bitcoin_primitives::script::Script::is_empty(&self) -> bool
+pub fn bitcoin_primitives::script::Script::len(&self) -> usize
+pub fn bitcoin_primitives::script::Script::new() -> &'static bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::Script::partial_cmp(&self, other: &bitcoin_primitives::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::Script::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::Script::to_bytes(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::script::Script::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::script::Script::to_owned(&self) -> Self::Owned
+pub fn bitcoin_primitives::script::Script::to_vec(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::script::ScriptBuf::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::script::ScriptBuf::as_mut(&mut self) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptBuf::as_ref(&self) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::as_script(&self) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::borrow(&self) -> &bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::borrow_mut(&mut self) -> &mut bitcoin_primitives::script::Script
+pub fn bitcoin_primitives::script::ScriptBuf::clone(&self) -> bitcoin_primitives::script::ScriptBuf
+pub fn bitcoin_primitives::script::ScriptBuf::cmp(&self, other: &bitcoin_primitives::script::ScriptBuf) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::ScriptBuf::default() -> bitcoin_primitives::script::ScriptBuf
+pub fn bitcoin_primitives::script::ScriptBuf::deref(&self) -> &Self::Target
+pub fn bitcoin_primitives::script::ScriptBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin_primitives::script::ScriptBuf::eq(&self, other: &bitcoin_primitives::script::Script) -> bool
+pub fn bitcoin_primitives::script::ScriptBuf::eq(&self, other: &bitcoin_primitives::script::ScriptBuf) -> bool
+pub fn bitcoin_primitives::script::ScriptBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::ScriptBuf::from(v: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf::from(value: &'a bitcoin_primitives::script::Script) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf::from(value: alloc::borrow::Cow<'a, bitcoin_primitives::script::Script>) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::script::Script>
+pub fn bitcoin_primitives::script::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::script::ScriptBuf::partial_cmp(&self, other: &bitcoin_primitives::script::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::ScriptBuf::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::ScriptBuf::reserve(&mut self, additional_len: usize)
+pub fn bitcoin_primitives::script::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
+pub fn bitcoin_primitives::script::ScriptBuf::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::script::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::clone(&self) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::sequence::Sequence::cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::cmp::Ordering
+pub fn bitcoin_primitives::sequence::Sequence::default() -> Self
+pub fn bitcoin_primitives::sequence::Sequence::enables_absolute_lock_time(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::eq(&self, other: &bitcoin_primitives::sequence::Sequence) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::sequence::Sequence::from(lt: bitcoin_primitives::locktime::relative::LockTime) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::sequence::Sequence::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::from_consensus(n: u32) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::from_height(height: u16) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_primitives::sequence::Sequence::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub fn bitcoin_primitives::sequence::Sequence::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub fn bitcoin_primitives::sequence::Sequence::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::sequence::Sequence::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_primitives::sequence::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::sequence::Sequence::is_final(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_height_locked(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_rbf(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_relative_lock_time(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_time_locked(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::partial_cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::sequence::Sequence::to_consensus_u32(self) -> u32
+pub fn bitcoin_primitives::sequence::Sequence::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::sequence::Sequence::to_relative_lock_time(&self) -> core::option::Option<bitcoin_primitives::locktime::relative::LockTime>
+pub fn bitcoin_primitives::sequence::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::sequence::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::sequence::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::taproot::TapBranchTag::clone(&self) -> bitcoin_primitives::taproot::TapBranchTag
+pub fn bitcoin_primitives::taproot::TapBranchTag::cmp(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapBranchTag::default() -> bitcoin_primitives::taproot::TapBranchTag
+pub fn bitcoin_primitives::taproot::TapBranchTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapBranchTag::eq(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> bool
+pub fn bitcoin_primitives::taproot::TapBranchTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapBranchTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapLeafHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapLeafHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapLeafHash::clone(&self) -> bitcoin_primitives::taproot::TapLeafHash
+pub fn bitcoin_primitives::taproot::TapLeafHash::cmp(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapLeafHash::eq(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> bool
+pub fn bitcoin_primitives::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>) -> bitcoin_primitives::taproot::TapLeafHash
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapLeafHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapLeafTag::clone(&self) -> bitcoin_primitives::taproot::TapLeafTag
+pub fn bitcoin_primitives::taproot::TapLeafTag::cmp(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapLeafTag::default() -> bitcoin_primitives::taproot::TapLeafTag
+pub fn bitcoin_primitives::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapLeafTag::eq(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> bool
+pub fn bitcoin_primitives::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapNodeHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapNodeHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapNodeHash::clone(&self) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::cmp(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapNodeHash::eq(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> bool
+pub fn bitcoin_primitives::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::from(leaf: bitcoin_primitives::taproot::TapLeafHash) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapNodeHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapTweakHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapTweakHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapTweakHash::clone(&self) -> bitcoin_primitives::taproot::TapTweakHash
+pub fn bitcoin_primitives::taproot::TapTweakHash::cmp(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapTweakHash::eq(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> bool
+pub fn bitcoin_primitives::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>) -> bitcoin_primitives::taproot::TapTweakHash
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapTweakHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakTag::clone(&self) -> bitcoin_primitives::taproot::TapTweakTag
+pub fn bitcoin_primitives::taproot::TapTweakTag::cmp(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapTweakTag::default() -> bitcoin_primitives::taproot::TapTweakTag
+pub fn bitcoin_primitives::taproot::TapTweakTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapTweakTag::eq(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> bool
+pub fn bitcoin_primitives::taproot::TapTweakTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapTweakTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::OutPoint::clone(&self) -> bitcoin_primitives::transaction::OutPoint
+pub fn bitcoin_primitives::transaction::OutPoint::cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::OutPoint::eq(&self, other: &bitcoin_primitives::transaction::OutPoint) -> bool
+pub fn bitcoin_primitives::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::OutPoint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::OutPoint::partial_cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::ParseOutPointError::clone(&self) -> bitcoin_primitives::transaction::ParseOutPointError
+pub fn bitcoin_primitives::transaction::ParseOutPointError::eq(&self, other: &bitcoin_primitives::transaction::ParseOutPointError) -> bool
+pub fn bitcoin_primitives::transaction::ParseOutPointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::ParseOutPointError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_primitives::transaction::Transaction::clone(&self) -> bitcoin_primitives::transaction::Transaction
+pub fn bitcoin_primitives::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Transaction::eq(&self, other: &bitcoin_primitives::transaction::Transaction) -> bool
+pub fn bitcoin_primitives::transaction::Transaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Transaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Transaction::inputs(&self) -> &[bitcoin_primitives::transaction::TxIn]
+pub fn bitcoin_primitives::transaction::Transaction::inputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxIn]
+pub fn bitcoin_primitives::transaction::Transaction::outputs(&self) -> &[bitcoin_primitives::transaction::TxOut]
+pub fn bitcoin_primitives::transaction::Transaction::outputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxOut]
+pub fn bitcoin_primitives::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::TxIn::clone(&self) -> bitcoin_primitives::transaction::TxIn
+pub fn bitcoin_primitives::transaction::TxIn::cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::TxIn::eq(&self, other: &bitcoin_primitives::transaction::TxIn) -> bool
+pub fn bitcoin_primitives::transaction::TxIn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::TxIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::TxIn::partial_cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::TxOut::clone(&self) -> bitcoin_primitives::transaction::TxOut
+pub fn bitcoin_primitives::transaction::TxOut::cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::TxOut::eq(&self, other: &bitcoin_primitives::transaction::TxOut) -> bool
+pub fn bitcoin_primitives::transaction::TxOut::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::TxOut::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::TxOut::partial_cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::clone(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Txid::eq(&self, other: &bitcoin_primitives::transaction::Txid) -> bool
+pub fn bitcoin_primitives::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from(tx: &bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from(tx: bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Txid, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::transaction::Txid::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Txid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::transaction::Version::clone(&self) -> bitcoin_primitives::transaction::Version
+pub fn bitcoin_primitives::transaction::Version::cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Version::eq(&self, other: &bitcoin_primitives::transaction::Version) -> bool
+pub fn bitcoin_primitives::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Version::partial_cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::clone(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Wtxid::eq(&self, other: &bitcoin_primitives::transaction::Wtxid) -> bool
+pub fn bitcoin_primitives::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from(tx: &bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from(tx: bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Wtxid, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::transaction::Wtxid::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Wtxid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin_primitives::witness::Iter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin_primitives::witness::Witness::clear(&mut self)
+pub fn bitcoin_primitives::witness::Witness::clone(&self) -> bitcoin_primitives::witness::Witness
+pub fn bitcoin_primitives::witness::Witness::cmp(&self, other: &bitcoin_primitives::witness::Witness) -> core::cmp::Ordering
+pub fn bitcoin_primitives::witness::Witness::default() -> Self
+pub fn bitcoin_primitives::witness::Witness::eq(&self, other: &bitcoin_primitives::witness::Witness) -> bool
+pub fn bitcoin_primitives::witness::Witness::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[&[u8]]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[alloc::vec::Vec<u8>]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(vec: alloc::vec::Vec<&[u8]>) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(vec: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
+pub fn bitcoin_primitives::witness::Witness::from_slice<T: core::convert::AsRef<[u8]>>(slice: &[T]) -> Self
+pub fn bitcoin_primitives::witness::Witness::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::witness::Witness::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin_primitives::witness::Witness::is_empty(&self) -> bool
+pub fn bitcoin_primitives::witness::Witness::iter(&self) -> bitcoin_primitives::witness::Iter<'_>
+pub fn bitcoin_primitives::witness::Witness::last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::len(&self) -> usize
+pub fn bitcoin_primitives::witness::Witness::nth(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::partial_cmp(&self, other: &bitcoin_primitives::witness::Witness) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
+pub fn bitcoin_primitives::witness::Witness::second_to_last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::size(&self) -> usize
+pub fn bitcoin_primitives::witness::Witness::third_to_last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
+pub fn u32::from(sequence: bitcoin_primitives::sequence::Sequence) -> u32
+pub mod bitcoin_primitives
+pub mod bitcoin_primitives::absolute
+pub mod bitcoin_primitives::block
+pub mod bitcoin_primitives::locktime
+pub mod bitcoin_primitives::locktime::absolute
+pub mod bitcoin_primitives::locktime::relative
+pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::opcodes
+pub mod bitcoin_primitives::opcodes::all
+pub mod bitcoin_primitives::pow
+pub mod bitcoin_primitives::relative
+pub mod bitcoin_primitives::script
+pub mod bitcoin_primitives::sequence
+pub mod bitcoin_primitives::taproot
+pub mod bitcoin_primitives::transaction
+pub mod bitcoin_primitives::witness
+pub static bitcoin_primitives::opcodes::OP_0: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_FALSE: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_NOP2: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_NOP3: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_TRUE: bitcoin_primitives::opcodes::Opcode
+pub struct bitcoin_primitives::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::BlockHash(_)
+pub struct bitcoin_primitives::BlockHeader
+pub struct bitcoin_primitives::CompactTarget(_)
+pub struct bitcoin_primitives::Sequence(pub u32)
+pub struct bitcoin_primitives::TapBranchTag
+pub struct bitcoin_primitives::TapLeafHash(_)
+pub struct bitcoin_primitives::TapLeafTag
+pub struct bitcoin_primitives::TapNodeHash(_)
+pub struct bitcoin_primitives::TapTweakHash(_)
+pub struct bitcoin_primitives::TapTweakTag
+pub struct bitcoin_primitives::Transaction
+pub struct bitcoin_primitives::TxIn
+pub struct bitcoin_primitives::TxMerkleNode(_)
+pub struct bitcoin_primitives::TxOut
+pub struct bitcoin_primitives::Txid(_)
+pub struct bitcoin_primitives::Witness
+pub struct bitcoin_primitives::WitnessCommitment(_)
+pub struct bitcoin_primitives::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::Wtxid(_)
+pub struct bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::block::BlockHash(_)
+pub struct bitcoin_primitives::block::Header
+pub struct bitcoin_primitives::block::Version(_)
+pub struct bitcoin_primitives::block::WitnessCommitment(_)
+pub struct bitcoin_primitives::locktime::relative::DisabledLockTimeError(_)
+pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
+pub struct bitcoin_primitives::merkle_tree::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::opcodes::Opcode
+pub struct bitcoin_primitives::pow::CompactTarget(_)
+pub struct bitcoin_primitives::relative::DisabledLockTimeError(_)
+pub struct bitcoin_primitives::script::ScriptBuf(_)
+pub struct bitcoin_primitives::sequence::Sequence(pub u32)
+pub struct bitcoin_primitives::taproot::TapBranchTag
+pub struct bitcoin_primitives::taproot::TapLeafHash(_)
+pub struct bitcoin_primitives::taproot::TapLeafTag
+pub struct bitcoin_primitives::taproot::TapNodeHash(_)
+pub struct bitcoin_primitives::taproot::TapTweakHash(_)
+pub struct bitcoin_primitives::taproot::TapTweakTag
+pub struct bitcoin_primitives::transaction::OutPoint
+pub struct bitcoin_primitives::transaction::Transaction
+pub struct bitcoin_primitives::transaction::TxIn
+pub struct bitcoin_primitives::transaction::TxOut
+pub struct bitcoin_primitives::transaction::Txid(_)
+pub struct bitcoin_primitives::transaction::Version(pub i32)
+pub struct bitcoin_primitives::transaction::Wtxid(_)
+pub struct bitcoin_primitives::witness::Iter<'a>
+pub struct bitcoin_primitives::witness::Witness
+pub trait bitcoin_primitives::BlockValidation: sealed::Validation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub trait bitcoin_primitives::block::Validation: sealed::Validation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub type &'a bitcoin_primitives::witness::Witness::IntoIter = bitcoin_primitives::witness::Iter<'a>
+pub type &'a bitcoin_primitives::witness::Witness::Item = &'a [u8]
+pub type bitcoin_primitives::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::BlockHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::WitnessCommitment::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::locktime::absolute::LockTime::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_primitives::locktime::absolute::LockTime::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_primitives::locktime::relative::LockTime::Error = bitcoin_primitives::locktime::relative::DisabledLockTimeError
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::Script::Output = bitcoin_primitives::script::Script
+pub type bitcoin_primitives::script::Script::Owned = bitcoin_primitives::script::ScriptBuf
+pub type bitcoin_primitives::script::ScriptBuf::Target = bitcoin_primitives::script::Script
+pub type bitcoin_primitives::sequence::Sequence::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_primitives::sequence::Sequence::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_primitives::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapLeafHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::taproot::TapNodeHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapNodeHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::taproot::TapTweakHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapTweakHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::transaction::OutPoint::Err = bitcoin_primitives::transaction::ParseOutPointError
+pub type bitcoin_primitives::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Txid::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Wtxid::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::witness::Iter<'a>::Item = &'a [u8]
+pub type bitcoin_primitives::witness::Witness::Output = [u8]
+pub use bitcoin_primitives::Amount
+pub use bitcoin_primitives::BlockHeight
+pub use bitcoin_primitives::BlockInterval
+pub use bitcoin_primitives::FeeRate
+pub use bitcoin_primitives::SignedAmount
+pub use bitcoin_primitives::Weight
+pub use bitcoin_primitives::absolute::ConversionError
+pub use bitcoin_primitives::absolute::Height
+pub use bitcoin_primitives::absolute::LOCK_TIME_THRESHOLD
+pub use bitcoin_primitives::absolute::ParseHeightError
+pub use bitcoin_primitives::absolute::ParseTimeError
+pub use bitcoin_primitives::absolute::Time
+pub use bitcoin_primitives::amount
+pub use bitcoin_primitives::fee_rate
+pub use bitcoin_primitives::locktime::absolute::ConversionError
+pub use bitcoin_primitives::locktime::absolute::Height
+pub use bitcoin_primitives::locktime::absolute::LOCK_TIME_THRESHOLD
+pub use bitcoin_primitives::locktime::absolute::ParseHeightError
+pub use bitcoin_primitives::locktime::absolute::ParseTimeError
+pub use bitcoin_primitives::locktime::absolute::Time
+pub use bitcoin_primitives::locktime::relative::Height
+pub use bitcoin_primitives::locktime::relative::Time
+pub use bitcoin_primitives::locktime::relative::TimeOverflowError
+pub use bitcoin_primitives::relative::Height
+pub use bitcoin_primitives::relative::Time
+pub use bitcoin_primitives::relative::TimeOverflowError
+pub use bitcoin_primitives::weight

--- a/api/primitives/no-features.txt
+++ b/api/primitives/no-features.txt
@@ -1,0 +1,1098 @@
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapLeafHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapNodeHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapTweakHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Wtxid
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapBranchTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapLeafTag
+impl bitcoin_hashes::sha256t::Tag for bitcoin_primitives::taproot::TapTweakTag
+impl bitcoin_primitives::block::BlockHash
+impl bitcoin_primitives::block::Header
+impl bitcoin_primitives::block::Version
+impl bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_primitives::opcodes::Opcode
+impl bitcoin_primitives::pow::CompactTarget
+impl bitcoin_primitives::sequence::Sequence
+impl bitcoin_primitives::taproot::TapLeafHash
+impl bitcoin_primitives::taproot::TapNodeHash
+impl bitcoin_primitives::taproot::TapTweakHash
+impl bitcoin_primitives::transaction::OutPoint
+impl bitcoin_primitives::transaction::Txid
+impl bitcoin_primitives::transaction::Version
+impl bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::clone::Clone for bitcoin_primitives::block::BlockHash
+impl core::clone::Clone for bitcoin_primitives::block::Header
+impl core::clone::Clone for bitcoin_primitives::block::Version
+impl core::clone::Clone for bitcoin_primitives::block::WitnessCommitment
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::clone::Clone for bitcoin_primitives::opcodes::Class
+impl core::clone::Clone for bitcoin_primitives::opcodes::ClassifyContext
+impl core::clone::Clone for bitcoin_primitives::opcodes::Opcode
+impl core::clone::Clone for bitcoin_primitives::pow::CompactTarget
+impl core::clone::Clone for bitcoin_primitives::sequence::Sequence
+impl core::clone::Clone for bitcoin_primitives::taproot::TapBranchTag
+impl core::clone::Clone for bitcoin_primitives::taproot::TapLeafHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapLeafTag
+impl core::clone::Clone for bitcoin_primitives::taproot::TapNodeHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapTweakHash
+impl core::clone::Clone for bitcoin_primitives::taproot::TapTweakTag
+impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
+impl core::clone::Clone for bitcoin_primitives::transaction::Txid
+impl core::clone::Clone for bitcoin_primitives::transaction::Version
+impl core::clone::Clone for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Eq for bitcoin_primitives::block::BlockHash
+impl core::cmp::Eq for bitcoin_primitives::block::Header
+impl core::cmp::Eq for bitcoin_primitives::block::Version
+impl core::cmp::Eq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::opcodes::Class
+impl core::cmp::Eq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::Eq for bitcoin_primitives::opcodes::Opcode
+impl core::cmp::Eq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Eq for bitcoin_primitives::sequence::Sequence
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::Eq for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::Eq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Eq for bitcoin_primitives::transaction::Txid
+impl core::cmp::Eq for bitcoin_primitives::transaction::Version
+impl core::cmp::Eq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Ord for bitcoin_primitives::block::BlockHash
+impl core::cmp::Ord for bitcoin_primitives::block::Header
+impl core::cmp::Ord for bitcoin_primitives::block::Version
+impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::Ord for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Ord for bitcoin_primitives::sequence::Sequence
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::Ord for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::Ord for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Ord for bitcoin_primitives::transaction::Txid
+impl core::cmp::Ord for bitcoin_primitives::transaction::Version
+impl core::cmp::Ord for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialEq for bitcoin_primitives::block::Header
+impl core::cmp::PartialEq for bitcoin_primitives::block::Version
+impl core::cmp::PartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Class
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Opcode
+impl core::cmp::PartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin_primitives::sequence::Sequence
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Header
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::opcodes::ClassifyContext
+impl core::cmp::PartialOrd for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin_primitives::sequence::Sequence
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapBranchTag
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapLeafHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapLeafTag
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapNodeHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapTweakHash
+impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapTweakTag
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<&bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>> for bitcoin_primitives::taproot::TapLeafHash
+impl core::convert::From<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>> for bitcoin_primitives::taproot::TapTweakHash
+impl core::convert::From<bitcoin_primitives::block::BlockHash> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::block::WitnessCommitment> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::merkle_tree::TxMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::merkle_tree::WitnessMerkleNode> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::sequence::Sequence> for u32
+impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>
+impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_primitives::taproot::TapNodeHash
+impl core::convert::From<bitcoin_primitives::taproot::TapNodeHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>
+impl core::convert::From<bitcoin_primitives::taproot::TapTweakHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>
+impl core::convert::From<bitcoin_primitives::transaction::Txid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<bitcoin_primitives::transaction::Wtxid> for bitcoin_hashes::sha256d::Hash
+impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
+impl core::default::Default for bitcoin_primitives::block::Version
+impl core::default::Default for bitcoin_primitives::pow::CompactTarget
+impl core::default::Default for bitcoin_primitives::sequence::Sequence
+impl core::default::Default for bitcoin_primitives::taproot::TapBranchTag
+impl core::default::Default for bitcoin_primitives::taproot::TapLeafTag
+impl core::default::Default for bitcoin_primitives::taproot::TapTweakTag
+impl core::fmt::Debug for bitcoin_primitives::block::BlockHash
+impl core::fmt::Debug for bitcoin_primitives::block::Header
+impl core::fmt::Debug for bitcoin_primitives::block::Version
+impl core::fmt::Debug for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::opcodes::Class
+impl core::fmt::Debug for bitcoin_primitives::opcodes::ClassifyContext
+impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
+impl core::fmt::Debug for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_primitives::sequence::Sequence
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::Debug for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::Debug for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Debug for bitcoin_primitives::transaction::Txid
+impl core::fmt::Debug for bitcoin_primitives::transaction::Version
+impl core::fmt::Debug for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::Display for bitcoin_primitives::block::BlockHash
+impl core::fmt::Display for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Display for bitcoin_primitives::opcodes::Opcode
+impl core::fmt::Display for bitcoin_primitives::sequence::Sequence
+impl core::fmt::Display for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::Display for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::Display for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::Display for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Display for bitcoin_primitives::transaction::Txid
+impl core::fmt::Display for bitcoin_primitives::transaction::Version
+impl core::fmt::Display for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::LowerHex for bitcoin_primitives::block::BlockHash
+impl core::fmt::LowerHex for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::LowerHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::LowerHex for bitcoin_primitives::sequence::Sequence
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::LowerHex for bitcoin_primitives::transaction::Txid
+impl core::fmt::LowerHex for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::UpperHex for bitcoin_primitives::block::BlockHash
+impl core::fmt::UpperHex for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::UpperHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin_primitives::sequence::Sequence
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapLeafHash
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapNodeHash
+impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapTweakHash
+impl core::fmt::UpperHex for bitcoin_primitives::transaction::Txid
+impl core::fmt::UpperHex for bitcoin_primitives::transaction::Wtxid
+impl core::hash::Hash for bitcoin_primitives::block::BlockHash
+impl core::hash::Hash for bitcoin_primitives::block::Header
+impl core::hash::Hash for bitcoin_primitives::block::Version
+impl core::hash::Hash for bitcoin_primitives::block::WitnessCommitment
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::hash::Hash for bitcoin_primitives::opcodes::ClassifyContext
+impl core::hash::Hash for bitcoin_primitives::pow::CompactTarget
+impl core::hash::Hash for bitcoin_primitives::sequence::Sequence
+impl core::hash::Hash for bitcoin_primitives::taproot::TapBranchTag
+impl core::hash::Hash for bitcoin_primitives::taproot::TapLeafHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapLeafTag
+impl core::hash::Hash for bitcoin_primitives::taproot::TapNodeHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapTweakHash
+impl core::hash::Hash for bitcoin_primitives::taproot::TapTweakTag
+impl core::hash::Hash for bitcoin_primitives::transaction::OutPoint
+impl core::hash::Hash for bitcoin_primitives::transaction::Txid
+impl core::hash::Hash for bitcoin_primitives::transaction::Version
+impl core::hash::Hash for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Copy for bitcoin_primitives::block::BlockHash
+impl core::marker::Copy for bitcoin_primitives::block::Header
+impl core::marker::Copy for bitcoin_primitives::block::Version
+impl core::marker::Copy for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Copy for bitcoin_primitives::opcodes::Class
+impl core::marker::Copy for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Copy for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Copy for bitcoin_primitives::sequence::Sequence
+impl core::marker::Copy for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Copy for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Copy for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Copy for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Copy for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Copy for bitcoin_primitives::transaction::Txid
+impl core::marker::Copy for bitcoin_primitives::transaction::Version
+impl core::marker::Copy for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::block::BlockHash
+impl core::marker::Freeze for bitcoin_primitives::block::Header
+impl core::marker::Freeze for bitcoin_primitives::block::Version
+impl core::marker::Freeze for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::opcodes::Class
+impl core::marker::Freeze for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Freeze for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Freeze for bitcoin_primitives::sequence::Sequence
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Freeze for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Freeze for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Freeze for bitcoin_primitives::transaction::Txid
+impl core::marker::Freeze for bitcoin_primitives::transaction::Version
+impl core::marker::Freeze for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Send for bitcoin_primitives::block::BlockHash
+impl core::marker::Send for bitcoin_primitives::block::Header
+impl core::marker::Send for bitcoin_primitives::block::Version
+impl core::marker::Send for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Send for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Send for bitcoin_primitives::opcodes::Class
+impl core::marker::Send for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Send for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Send for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Send for bitcoin_primitives::sequence::Sequence
+impl core::marker::Send for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Send for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Send for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Send for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Send for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Send for bitcoin_primitives::transaction::Txid
+impl core::marker::Send for bitcoin_primitives::transaction::Version
+impl core::marker::Send for bitcoin_primitives::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Header
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Class
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin_primitives::sequence::Sequence
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Sync for bitcoin_primitives::block::BlockHash
+impl core::marker::Sync for bitcoin_primitives::block::Header
+impl core::marker::Sync for bitcoin_primitives::block::Version
+impl core::marker::Sync for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Sync for bitcoin_primitives::opcodes::Class
+impl core::marker::Sync for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Sync for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Sync for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Sync for bitcoin_primitives::sequence::Sequence
+impl core::marker::Sync for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Sync for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Sync for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Sync for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Sync for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Sync for bitcoin_primitives::transaction::Txid
+impl core::marker::Sync for bitcoin_primitives::transaction::Version
+impl core::marker::Sync for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Unpin for bitcoin_primitives::block::BlockHash
+impl core::marker::Unpin for bitcoin_primitives::block::Header
+impl core::marker::Unpin for bitcoin_primitives::block::Version
+impl core::marker::Unpin for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::opcodes::Class
+impl core::marker::Unpin for bitcoin_primitives::opcodes::ClassifyContext
+impl core::marker::Unpin for bitcoin_primitives::opcodes::Opcode
+impl core::marker::Unpin for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Unpin for bitcoin_primitives::sequence::Sequence
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapBranchTag
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapLeafHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapLeafTag
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapNodeHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapTweakHash
+impl core::marker::Unpin for bitcoin_primitives::taproot::TapTweakTag
+impl core::marker::Unpin for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Unpin for bitcoin_primitives::transaction::Txid
+impl core::marker::Unpin for bitcoin_primitives::transaction::Version
+impl core::marker::Unpin for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Class
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Opcode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::sequence::Sequence
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapBranchTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapLeafHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapLeafTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapNodeHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapTweakHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapTweakTag
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Class
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Opcode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::sequence::Sequence
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapBranchTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapLeafHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapLeafTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapNodeHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapTweakHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapTweakTag
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::str::traits::FromStr for bitcoin_primitives::block::BlockHash
+impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
+impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapLeafHash
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapNodeHash
+impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapTweakHash
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::Txid
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::Wtxid
+pub bitcoin_primitives::BlockHeader::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::BlockHeader::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::BlockHeader::nonce: u32
+pub bitcoin_primitives::BlockHeader::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::BlockHeader::time: u32
+pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::block::Header::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::block::Header::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::block::Header::nonce: u32
+pub bitcoin_primitives::block::Header::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::block::Header::time: u32
+pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::opcodes::Class::IllegalOp
+pub bitcoin_primitives::opcodes::Class::NoOp
+pub bitcoin_primitives::opcodes::Class::Ordinary(Ordinary)
+pub bitcoin_primitives::opcodes::Class::PushBytes(u32)
+pub bitcoin_primitives::opcodes::Class::PushNum(i32)
+pub bitcoin_primitives::opcodes::Class::ReturnOp
+pub bitcoin_primitives::opcodes::Class::SuccessOp
+pub bitcoin_primitives::opcodes::ClassifyContext::Legacy
+pub bitcoin_primitives::opcodes::ClassifyContext::TapScript
+pub bitcoin_primitives::transaction::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::transaction::OutPoint::vout: u32
+pub const bitcoin_primitives::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::block::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH: Self
+pub const bitcoin_primitives::block::Header::SIZE: usize
+pub const bitcoin_primitives::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin_primitives::block::Version::ONE: Self
+pub const bitcoin_primitives::block::Version::TWO: Self
+pub const bitcoin_primitives::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::opcodes::all::OP_0NOTEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_1ADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_1SUB: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DIV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DROP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2MUL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2OVER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2ROT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_2SWAP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_3DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ABS: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_AND: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_BOOLAND: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_BOOLOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CAT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKMULTISIG: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKMULTISIGVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIG: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIGADD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CHECKSIGVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CLTV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CODESEPARATOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_CSV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DEPTH: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DIV: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DROP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_DUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ELSE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ENDIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_EQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_EQUALVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_FROMALTSTACK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_GREATERTHAN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_GREATERTHANOREQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_HASH160: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_HASH256: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_IF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_IFDUP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_INVALIDOPCODE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_INVERT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LEFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LESSTHAN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LESSTHANOREQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_LSHIFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MAX: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MIN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MOD: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_MUL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NEGATE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NIP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NOTIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMEQUALVERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_NUMNOTEQUAL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_OR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_OVER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PICK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_0: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_11: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_12: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_13: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_14: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_15: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_16: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_17: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_18: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_19: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_20: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_21: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_22: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_23: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_24: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_25: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_26: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_27: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_28: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_29: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_30: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_31: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_32: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_33: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_34: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_35: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_36: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_37: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_38: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_39: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_3: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_40: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_41: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_42: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_43: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_44: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_45: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_46: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_47: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_48: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_49: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_50: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_51: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_52: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_53: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_54: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_55: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_56: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_57: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_58: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_59: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_60: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_61: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_62: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_63: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_64: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_65: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_66: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_67: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_68: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_69: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_70: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_71: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_72: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_73: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_74: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_75: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHBYTES_9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHDATA4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_10: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_11: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_12: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_13: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_14: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_15: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_16: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_3: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_4: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_5: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_6: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_7: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_8: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_9: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_PUSHNUM_NEG1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED2: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RESERVED: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_187: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_188: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_189: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_190: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_191: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_192: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_193: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_194: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_195: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_196: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_197: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_198: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_199: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_200: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_201: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_202: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_203: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_204: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_205: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_206: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_207: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_208: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_209: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_210: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_211: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_212: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_213: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_214: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_215: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_216: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_217: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_218: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_219: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_220: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_221: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_222: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_223: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_224: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_225: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_226: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_227: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_228: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_229: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_230: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_231: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_232: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_233: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_234: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_235: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_236: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_237: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_238: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_239: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_240: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_241: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_242: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_243: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_244: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_245: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_246: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_247: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_248: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_249: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_250: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_251: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_252: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_253: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RETURN_254: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RIGHT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RIPEMD160: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ROLL: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_ROT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_RSHIFT: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SHA1: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SHA256: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SIZE: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SUB: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SUBSTR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_SWAP: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_TOALTSTACK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_TUCK: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VER: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERIFY: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_VERNOTIF: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_WITHIN: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::opcodes::all::OP_XOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
+pub const bitcoin_primitives::sequence::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
+pub const bitcoin_primitives::sequence::Sequence::FINAL: Self
+pub const bitcoin_primitives::sequence::Sequence::MAX: Self
+pub const bitcoin_primitives::sequence::Sequence::SIZE: usize
+pub const bitcoin_primitives::sequence::Sequence::ZERO: Self
+pub const bitcoin_primitives::taproot::TapLeafHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::taproot::TapNodeHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::taproot::TapTweakHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
+pub const bitcoin_primitives::transaction::Txid::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::Version::ONE: Self
+pub const bitcoin_primitives::transaction::Version::THREE: Self
+pub const bitcoin_primitives::transaction::Version::TWO: Self
+pub const bitcoin_primitives::transaction::Wtxid::COINBASE: Self
+pub const bitcoin_primitives::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::opcodes::Opcode::decode_pushnum(self) -> core::option::Option<u8>
+pub const fn bitcoin_primitives::opcodes::Opcode::to_u8(self) -> u8
+pub const fn bitcoin_primitives::taproot::TapLeafHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapLeafHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapLeafHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapNodeHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapNodeHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapNodeHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapTweakHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::taproot::TapTweakHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::taproot::TapTweakHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub enum bitcoin_primitives::opcodes::Class
+pub enum bitcoin_primitives::opcodes::ClassifyContext
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::BlockHash) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::WitnessCommitment) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::merkle_tree::TxMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::transaction::Txid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::transaction::Wtxid) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>::from(hashtype: bitcoin_primitives::taproot::TapNodeHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>::from(hashtype: bitcoin_primitives::taproot::TapLeafHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>
+pub fn bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>::from(hashtype: bitcoin_primitives::taproot::TapTweakHash) -> bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>
+pub fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::clone(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::BlockHash::eq(&self, other: &bitcoin_primitives::block::BlockHash) -> bool
+pub fn bitcoin_primitives::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::BlockHash::from(header: &bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::BlockHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::block::BlockHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::BlockHash::partial_cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Header::clone(&self) -> bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Header::cmp(&self, other: &bitcoin_primitives::block::Header) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Header::eq(&self, other: &bitcoin_primitives::block::Header) -> bool
+pub fn bitcoin_primitives::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Header::partial_cmp(&self, other: &bitcoin_primitives::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::clone(&self) -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::cmp(&self, other: &bitcoin_primitives::block::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Version::default() -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::eq(&self, other: &bitcoin_primitives::block::Version) -> bool
+pub fn bitcoin_primitives::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(&self, bit: u8) -> bool
+pub fn bitcoin_primitives::block::Version::partial_cmp(&self, other: &bitcoin_primitives::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
+pub fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::clone(&self) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::WitnessCommitment::eq(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> bool
+pub fn bitcoin_primitives::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::WitnessCommitment::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::WitnessCommitment, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::TxMerkleNode, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::opcodes::Class::clone(&self) -> bitcoin_primitives::opcodes::Class
+pub fn bitcoin_primitives::opcodes::Class::eq(&self, other: &bitcoin_primitives::opcodes::Class) -> bool
+pub fn bitcoin_primitives::opcodes::Class::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::ClassifyContext::clone(&self) -> bitcoin_primitives::opcodes::ClassifyContext
+pub fn bitcoin_primitives::opcodes::ClassifyContext::cmp(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> core::cmp::Ordering
+pub fn bitcoin_primitives::opcodes::ClassifyContext::eq(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> bool
+pub fn bitcoin_primitives::opcodes::ClassifyContext::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::ClassifyContext::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::opcodes::ClassifyContext::partial_cmp(&self, other: &bitcoin_primitives::opcodes::ClassifyContext) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::opcodes::Opcode::classify(self, ctx: bitcoin_primitives::opcodes::ClassifyContext) -> bitcoin_primitives::opcodes::Class
+pub fn bitcoin_primitives::opcodes::Opcode::clone(&self) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives::opcodes::Opcode) -> bool
+pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin_primitives::pow::CompactTarget::default() -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::eq(&self, other: &bitcoin_primitives::pow::CompactTarget) -> bool
+pub fn bitcoin_primitives::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin_primitives::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::pow::CompactTarget::partial_cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_primitives::sequence::Sequence::clone(&self) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::sequence::Sequence::cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::cmp::Ordering
+pub fn bitcoin_primitives::sequence::Sequence::default() -> Self
+pub fn bitcoin_primitives::sequence::Sequence::enables_absolute_lock_time(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::eq(&self, other: &bitcoin_primitives::sequence::Sequence) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::sequence::Sequence::from_512_second_intervals(intervals: u16) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::from_consensus(n: u32) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::from_height(height: u16) -> Self
+pub fn bitcoin_primitives::sequence::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::sequence::Sequence::is_final(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_height_locked(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_rbf(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_relative_lock_time(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::is_time_locked(&self) -> bool
+pub fn bitcoin_primitives::sequence::Sequence::partial_cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::sequence::Sequence::to_consensus_u32(self) -> u32
+pub fn bitcoin_primitives::taproot::TapBranchTag::clone(&self) -> bitcoin_primitives::taproot::TapBranchTag
+pub fn bitcoin_primitives::taproot::TapBranchTag::cmp(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapBranchTag::default() -> bitcoin_primitives::taproot::TapBranchTag
+pub fn bitcoin_primitives::taproot::TapBranchTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapBranchTag::eq(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> bool
+pub fn bitcoin_primitives::taproot::TapBranchTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapBranchTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapLeafHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapLeafHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapLeafHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapLeafHash::clone(&self) -> bitcoin_primitives::taproot::TapLeafHash
+pub fn bitcoin_primitives::taproot::TapLeafHash::cmp(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapLeafHash::eq(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> bool
+pub fn bitcoin_primitives::taproot::TapLeafHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapLeafHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>) -> bitcoin_primitives::taproot::TapLeafHash
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapLeafHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapLeafHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapLeafHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapLeafHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapLeafHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapLeafTag::clone(&self) -> bitcoin_primitives::taproot::TapLeafTag
+pub fn bitcoin_primitives::taproot::TapLeafTag::cmp(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapLeafTag::default() -> bitcoin_primitives::taproot::TapLeafTag
+pub fn bitcoin_primitives::taproot::TapLeafTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapLeafTag::eq(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> bool
+pub fn bitcoin_primitives::taproot::TapLeafTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapLeafTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapLeafTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapNodeHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapNodeHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapNodeHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapNodeHash::clone(&self) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::cmp(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapNodeHash::eq(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> bool
+pub fn bitcoin_primitives::taproot::TapNodeHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapNodeHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag>) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::from(leaf: bitcoin_primitives::taproot::TapLeafHash) -> bitcoin_primitives::taproot::TapNodeHash
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapNodeHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapNodeHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapNodeHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapNodeHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapNodeHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapTweakHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapTweakHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::taproot::TapTweakHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::taproot::TapTweakHash::clone(&self) -> bitcoin_primitives::taproot::TapTweakHash
+pub fn bitcoin_primitives::taproot::TapTweakHash::cmp(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapTweakHash::eq(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> bool
+pub fn bitcoin_primitives::taproot::TapTweakHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::taproot::TapTweakHash::from(inner: bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag>) -> bitcoin_primitives::taproot::TapTweakHash
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::taproot::TapTweakHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::taproot::TapTweakHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapTweakHash::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapTweakHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::taproot::TapTweakHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::taproot::TapTweakTag::clone(&self) -> bitcoin_primitives::taproot::TapTweakTag
+pub fn bitcoin_primitives::taproot::TapTweakTag::cmp(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> core::cmp::Ordering
+pub fn bitcoin_primitives::taproot::TapTweakTag::default() -> bitcoin_primitives::taproot::TapTweakTag
+pub fn bitcoin_primitives::taproot::TapTweakTag::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_primitives::taproot::TapTweakTag::eq(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> bool
+pub fn bitcoin_primitives::taproot::TapTweakTag::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::taproot::TapTweakTag::partial_cmp(&self, other: &bitcoin_primitives::taproot::TapTweakTag) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::OutPoint::clone(&self) -> bitcoin_primitives::transaction::OutPoint
+pub fn bitcoin_primitives::transaction::OutPoint::cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::OutPoint::eq(&self, other: &bitcoin_primitives::transaction::OutPoint) -> bool
+pub fn bitcoin_primitives::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::OutPoint::partial_cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::clone(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Txid::eq(&self, other: &bitcoin_primitives::transaction::Txid) -> bool
+pub fn bitcoin_primitives::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Txid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Txid, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::transaction::Txid::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Txid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::transaction::Version::clone(&self) -> bitcoin_primitives::transaction::Version
+pub fn bitcoin_primitives::transaction::Version::cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Version::eq(&self, other: &bitcoin_primitives::transaction::Version) -> bool
+pub fn bitcoin_primitives::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Version::partial_cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::clone(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Wtxid::eq(&self, other: &bitcoin_primitives::transaction::Wtxid) -> bool
+pub fn bitcoin_primitives::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Wtxid::from(inner: bitcoin_hashes::sha256d::Hash) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Wtxid, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::transaction::Wtxid::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Wtxid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn u32::from(sequence: bitcoin_primitives::sequence::Sequence) -> u32
+pub mod bitcoin_primitives
+pub mod bitcoin_primitives::block
+pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::opcodes
+pub mod bitcoin_primitives::opcodes::all
+pub mod bitcoin_primitives::pow
+pub mod bitcoin_primitives::sequence
+pub mod bitcoin_primitives::taproot
+pub mod bitcoin_primitives::transaction
+pub static bitcoin_primitives::opcodes::OP_0: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_FALSE: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_NOP2: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_NOP3: bitcoin_primitives::opcodes::Opcode
+pub static bitcoin_primitives::opcodes::OP_TRUE: bitcoin_primitives::opcodes::Opcode
+pub struct bitcoin_primitives::BlockHash(_)
+pub struct bitcoin_primitives::BlockHeader
+pub struct bitcoin_primitives::CompactTarget(_)
+pub struct bitcoin_primitives::Sequence(pub u32)
+pub struct bitcoin_primitives::TapBranchTag
+pub struct bitcoin_primitives::TapLeafHash(_)
+pub struct bitcoin_primitives::TapLeafTag
+pub struct bitcoin_primitives::TapNodeHash(_)
+pub struct bitcoin_primitives::TapTweakHash(_)
+pub struct bitcoin_primitives::TapTweakTag
+pub struct bitcoin_primitives::TxMerkleNode(_)
+pub struct bitcoin_primitives::Txid(_)
+pub struct bitcoin_primitives::WitnessCommitment(_)
+pub struct bitcoin_primitives::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::Wtxid(_)
+pub struct bitcoin_primitives::block::BlockHash(_)
+pub struct bitcoin_primitives::block::Header
+pub struct bitcoin_primitives::block::Version(_)
+pub struct bitcoin_primitives::block::WitnessCommitment(_)
+pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
+pub struct bitcoin_primitives::merkle_tree::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::opcodes::Opcode
+pub struct bitcoin_primitives::pow::CompactTarget(_)
+pub struct bitcoin_primitives::sequence::Sequence(pub u32)
+pub struct bitcoin_primitives::taproot::TapBranchTag
+pub struct bitcoin_primitives::taproot::TapLeafHash(_)
+pub struct bitcoin_primitives::taproot::TapLeafTag
+pub struct bitcoin_primitives::taproot::TapNodeHash(_)
+pub struct bitcoin_primitives::taproot::TapTweakHash(_)
+pub struct bitcoin_primitives::taproot::TapTweakTag
+pub struct bitcoin_primitives::transaction::OutPoint
+pub struct bitcoin_primitives::transaction::Txid(_)
+pub struct bitcoin_primitives::transaction::Version(pub i32)
+pub struct bitcoin_primitives::transaction::Wtxid(_)
+pub type bitcoin_primitives::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::BlockHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::WitnessCommitment::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapLeafHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::taproot::TapNodeHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapNodeHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::taproot::TapTweakHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapTweakTag> as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::taproot::TapTweakHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Txid::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Wtxid::Err = hex_conservative::error::HexToArrayError
+pub use bitcoin_primitives::Amount
+pub use bitcoin_primitives::SignedAmount
+pub use bitcoin_primitives::amount

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1,0 +1,1218 @@
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub enum bitcoin_units::amount::error::ParseDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::error::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::error::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::error::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+impl bitcoin_units::Amount
+impl bitcoin_units::SignedAmount
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::error::OutOfRangeError
+impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::Amount
+impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::SignedAmount
+impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::Amount
+impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::SignedAmount
+impl bitcoin_units::block::BlockHeight
+impl bitcoin_units::block::BlockInterval
+impl bitcoin_units::fee_rate::FeeRate
+impl bitcoin_units::locktime::absolute::Height
+impl bitcoin_units::locktime::absolute::Time
+impl bitcoin_units::locktime::relative::Height
+impl bitcoin_units::locktime::relative::Time
+impl bitcoin_units::locktime::relative::TimeOverflowError
+impl bitcoin_units::parse::Integer for i128
+impl bitcoin_units::parse::Integer for i16
+impl bitcoin_units::parse::Integer for i32
+impl bitcoin_units::parse::Integer for i64
+impl bitcoin_units::parse::Integer for i8
+impl bitcoin_units::parse::Integer for u128
+impl bitcoin_units::parse::Integer for u16
+impl bitcoin_units::parse::Integer for u32
+impl bitcoin_units::parse::Integer for u64
+impl bitcoin_units::parse::Integer for u8
+impl bitcoin_units::weight::Weight
+impl core::clone::Clone for bitcoin_units::Amount
+impl core::clone::Clone for bitcoin_units::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::error::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::error::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::error::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::error::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseError
+impl core::clone::Clone for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::error::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockInterval
+impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::clone::Clone for bitcoin_units::fee_rate::FeeRate
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Time
+impl core::clone::Clone for bitcoin_units::locktime::relative::Height
+impl core::clone::Clone for bitcoin_units::locktime::relative::Time
+impl core::clone::Clone for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::clone::Clone for bitcoin_units::parse::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::clone::Clone for bitcoin_units::weight::Weight
+impl core::cmp::Eq for bitcoin_units::Amount
+impl core::cmp::Eq for bitcoin_units::SignedAmount
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::error::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::error::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::error::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::block::BlockHeight
+impl core::cmp::Eq for bitcoin_units::block::BlockInterval
+impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::cmp::Eq for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Time
+impl core::cmp::Eq for bitcoin_units::locktime::relative::Height
+impl core::cmp::Eq for bitcoin_units::locktime::relative::Time
+impl core::cmp::Eq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::weight::Weight
+impl core::cmp::Ord for bitcoin_units::Amount
+impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::block::BlockHeight
+impl core::cmp::Ord for bitcoin_units::block::BlockInterval
+impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Time
+impl core::cmp::Ord for bitcoin_units::locktime::relative::Height
+impl core::cmp::Ord for bitcoin_units::locktime::relative::Time
+impl core::cmp::Ord for bitcoin_units::weight::Weight
+impl core::cmp::PartialEq for bitcoin_units::Amount
+impl core::cmp::PartialEq for bitcoin_units::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::error::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialEq for bitcoin_units::block::BlockInterval
+impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Time
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::Time
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::weight::Weight
+impl core::cmp::PartialOrd for bitcoin_units::Amount
+impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
+impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Time
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Time
+impl core::cmp::PartialOrd for bitcoin_units::weight::Weight
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::ParseAmountError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::ParseDenominationError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
+impl core::convert::From<bitcoin_units::block::BlockInterval> for u32
+impl core::convert::From<bitcoin_units::fee_rate::FeeRate> for u64
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_units::block::BlockHeight
+impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_units::block::BlockInterval
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin_units::weight::Weight> for u64
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<u16> for bitcoin_units::locktime::relative::Height
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
+impl core::convert::From<u32> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::fee_rate::FeeRate
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Time
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Time
+impl core::convert::TryFrom<&str> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::relative::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::relative::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<bitcoin_units::Amount> for bitcoin_units::SignedAmount
+impl core::convert::TryFrom<bitcoin_units::SignedAmount> for bitcoin_units::Amount
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeight> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<bitcoin_units::block::BlockInterval> for bitcoin_units::locktime::relative::Height
+impl core::default::Default for bitcoin_units::Amount
+impl core::default::Default for bitcoin_units::SignedAmount
+impl core::default::Default for bitcoin_units::locktime::relative::Height
+impl core::default::Default for bitcoin_units::locktime::relative::Time
+impl core::error::Error for bitcoin_units::amount::error::InputTooLargeError
+impl core::error::Error for bitcoin_units::amount::error::InvalidCharacterError
+impl core::error::Error for bitcoin_units::amount::error::MissingDigitsError
+impl core::error::Error for bitcoin_units::amount::error::OutOfRangeError
+impl core::error::Error for bitcoin_units::amount::error::ParseAmountError
+impl core::error::Error for bitcoin_units::amount::error::ParseDenominationError
+impl core::error::Error for bitcoin_units::amount::error::ParseError
+impl core::error::Error for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::error::Error for bitcoin_units::amount::error::TooPreciseError
+impl core::error::Error for bitcoin_units::amount::error::UnknownDenominationError
+impl core::error::Error for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::error::Error for bitcoin_units::locktime::absolute::ConversionError
+impl core::error::Error for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::error::Error for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::error::Error for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::error::Error for bitcoin_units::parse::ParseIntError
+impl core::error::Error for bitcoin_units::parse::PrefixedHexError
+impl core::error::Error for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Debug for bitcoin_units::Amount
+impl core::fmt::Debug for bitcoin_units::SignedAmount
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::error::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::error::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::error::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::error::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockInterval
+impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::fmt::Debug for bitcoin_units::fee_rate::FeeRate
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Time
+impl core::fmt::Debug for bitcoin_units::locktime::relative::Height
+impl core::fmt::Debug for bitcoin_units::locktime::relative::Time
+impl core::fmt::Debug for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Debug for bitcoin_units::weight::Weight
+impl core::fmt::Display for bitcoin_units::Amount
+impl core::fmt::Display for bitcoin_units::SignedAmount
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::error::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::error::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::error::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::error::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseError
+impl core::fmt::Display for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::error::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::block::BlockHeight
+impl core::fmt::Display for bitcoin_units::block::BlockInterval
+impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::fmt::Display for bitcoin_units::fee_rate::FeeRate
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Time
+impl core::fmt::Display for bitcoin_units::locktime::relative::Height
+impl core::fmt::Display for bitcoin_units::locktime::relative::Time
+impl core::fmt::Display for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Display for bitcoin_units::parse::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::weight::Weight
+impl core::hash::Hash for bitcoin_units::Amount
+impl core::hash::Hash for bitcoin_units::SignedAmount
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::block::BlockHeight
+impl core::hash::Hash for bitcoin_units::block::BlockInterval
+impl core::hash::Hash for bitcoin_units::fee_rate::FeeRate
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Height
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Time
+impl core::hash::Hash for bitcoin_units::locktime::relative::Height
+impl core::hash::Hash for bitcoin_units::locktime::relative::Time
+impl core::hash::Hash for bitcoin_units::weight::Weight
+impl core::iter::traits::accum::Sum for bitcoin_units::Amount
+impl core::iter::traits::accum::Sum for bitcoin_units::SignedAmount
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockInterval
+impl core::iter::traits::accum::Sum for bitcoin_units::fee_rate::FeeRate
+impl core::iter::traits::accum::Sum for bitcoin_units::weight::Weight
+impl core::marker::Copy for bitcoin_units::Amount
+impl core::marker::Copy for bitcoin_units::SignedAmount
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::block::BlockHeight
+impl core::marker::Copy for bitcoin_units::block::BlockInterval
+impl core::marker::Copy for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Height
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Time
+impl core::marker::Copy for bitcoin_units::locktime::relative::Height
+impl core::marker::Copy for bitcoin_units::locktime::relative::Time
+impl core::marker::Copy for bitcoin_units::weight::Weight
+impl core::marker::Freeze for bitcoin_units::Amount
+impl core::marker::Freeze for bitcoin_units::SignedAmount
+impl core::marker::Freeze for bitcoin_units::amount::Denomination
+impl core::marker::Freeze for bitcoin_units::amount::Display
+impl core::marker::Freeze for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::block::BlockHeight
+impl core::marker::Freeze for bitcoin_units::block::BlockInterval
+impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Freeze for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Time
+impl core::marker::Freeze for bitcoin_units::locktime::relative::Height
+impl core::marker::Freeze for bitcoin_units::locktime::relative::Time
+impl core::marker::Freeze for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Freeze for bitcoin_units::weight::Weight
+impl core::marker::Send for bitcoin_units::Amount
+impl core::marker::Send for bitcoin_units::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::ParseError
+impl core::marker::Send for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::block::BlockHeight
+impl core::marker::Send for bitcoin_units::block::BlockInterval
+impl core::marker::Send for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Send for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Send for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Height
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Time
+impl core::marker::Send for bitcoin_units::locktime::relative::Height
+impl core::marker::Send for bitcoin_units::locktime::relative::Time
+impl core::marker::Send for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Send for bitcoin_units::parse::ParseIntError
+impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::weight::Weight
+impl core::marker::StructuralPartialEq for bitcoin_units::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Time
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Time
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::weight::Weight
+impl core::marker::Sync for bitcoin_units::Amount
+impl core::marker::Sync for bitcoin_units::SignedAmount
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseError
+impl core::marker::Sync for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::block::BlockHeight
+impl core::marker::Sync for bitcoin_units::block::BlockInterval
+impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Sync for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Time
+impl core::marker::Sync for bitcoin_units::locktime::relative::Height
+impl core::marker::Sync for bitcoin_units::locktime::relative::Time
+impl core::marker::Sync for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Sync for bitcoin_units::parse::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::weight::Weight
+impl core::marker::Unpin for bitcoin_units::Amount
+impl core::marker::Unpin for bitcoin_units::SignedAmount
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::block::BlockHeight
+impl core::marker::Unpin for bitcoin_units::block::BlockInterval
+impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Unpin for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Time
+impl core::marker::Unpin for bitcoin_units::locktime::relative::Height
+impl core::marker::Unpin for bitcoin_units::locktime::relative::Time
+impl core::marker::Unpin for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::weight::Weight
+impl core::ops::arith::Add for bitcoin_units::Amount
+impl core::ops::arith::Add for bitcoin_units::SignedAmount
+impl core::ops::arith::Add for bitcoin_units::block::BlockInterval
+impl core::ops::arith::Add for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Add for bitcoin_units::weight::Weight
+impl core::ops::arith::Add<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Add<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::Amount
+impl core::ops::arith::AddAssign for bitcoin_units::SignedAmount
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockInterval
+impl core::ops::arith::AddAssign for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::weight::Weight
+impl core::ops::arith::AddAssign<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Div for bitcoin_units::weight::Weight
+impl core::ops::arith::Div<bitcoin_units::weight::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::Mul<bitcoin_units::fee_rate::FeeRate> for bitcoin_units::weight::Weight
+impl core::ops::arith::Mul<bitcoin_units::weight::Weight> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::weight::Weight> for u64
+impl core::ops::arith::Mul<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::Neg for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<u64> for bitcoin_units::Amount
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockInterval
+impl core::ops::arith::Sub for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Sub for bitcoin_units::weight::Weight
+impl core::ops::arith::Sub<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Sub<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::Amount
+impl core::ops::arith::SubAssign for bitcoin_units::SignedAmount
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockInterval
+impl core::ops::arith::SubAssign for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::weight::Weight
+impl core::ops::arith::SubAssign<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::weight::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::weight::Weight
+impl core::str::traits::FromStr for bitcoin_units::Amount
+impl core::str::traits::FromStr for bitcoin_units::SignedAmount
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeight
+impl core::str::traits::FromStr for bitcoin_units::block::BlockInterval
+impl core::str::traits::FromStr for bitcoin_units::fee_rate::FeeRate
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Time
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Time
+impl core::str::traits::FromStr for bitcoin_units::weight::Weight
+impl serde::ser::Serialize for bitcoin_units::block::BlockHeight
+impl serde::ser::Serialize for bitcoin_units::block::BlockInterval
+impl serde::ser::Serialize for bitcoin_units::fee_rate::FeeRate
+impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Height
+impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Time
+impl serde::ser::Serialize for bitcoin_units::locktime::relative::Height
+impl serde::ser::Serialize for bitcoin_units::locktime::relative::Time
+impl serde::ser::Serialize for bitcoin_units::weight::Weight
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::Amount
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::SignedAmount
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::fee_rate::FeeRate
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::weight::Weight
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::Amount> for bitcoin_units::Amount
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockInterval
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::weight::Weight> for bitcoin_units::weight::Weight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::block::BlockHeight
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::block::BlockInterval
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::fee_rate::FeeRate
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Height
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Time
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::Height
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::Time
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::weight::Weight
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Amount>
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::SignedAmount>
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub bitcoin_units::amount::error::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::error::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub const bitcoin_units::Amount::MAX: bitcoin_units::Amount
+pub const bitcoin_units::Amount::MAX_MONEY: bitcoin_units::Amount
+pub const bitcoin_units::Amount::MIN: bitcoin_units::Amount
+pub const bitcoin_units::Amount::ONE_BTC: bitcoin_units::Amount
+pub const bitcoin_units::Amount::ONE_SAT: bitcoin_units::Amount
+pub const bitcoin_units::Amount::SIZE: usize
+pub const bitcoin_units::Amount::ZERO: bitcoin_units::Amount
+pub const bitcoin_units::SignedAmount::MAX: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::MAX_MONEY: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::MIN: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ONE_BTC: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ONE_SAT: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ZERO: bitcoin_units::SignedAmount
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::block::BlockHeight::MAX: Self
+pub const bitcoin_units::block::BlockHeight::MIN: Self
+pub const bitcoin_units::block::BlockHeight::ZERO: Self
+pub const bitcoin_units::block::BlockInterval::MAX: Self
+pub const bitcoin_units::block::BlockInterval::MIN: Self
+pub const bitcoin_units::block::BlockInterval::ZERO: Self
+pub const bitcoin_units::fee_rate::FeeRate::BROADCAST_MIN: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::DUST: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::MAX: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::MIN: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::ZERO: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::locktime::absolute::Height::MAX: Self
+pub const bitcoin_units::locktime::absolute::Height::MIN: Self
+pub const bitcoin_units::locktime::absolute::Height::ZERO: Self
+pub const bitcoin_units::locktime::absolute::LOCK_TIME_THRESHOLD: u32
+pub const bitcoin_units::locktime::absolute::Time::MAX: Self
+pub const bitcoin_units::locktime::absolute::Time::MIN: Self
+pub const bitcoin_units::locktime::relative::Height::MAX: Self
+pub const bitcoin_units::locktime::relative::Height::MIN: Self
+pub const bitcoin_units::locktime::relative::Height::ZERO: Self
+pub const bitcoin_units::locktime::relative::Time::MAX: Self
+pub const bitcoin_units::locktime::relative::Time::MIN: Self
+pub const bitcoin_units::locktime::relative::Time::ZERO: Self
+pub const bitcoin_units::weight::WITNESS_SCALE_FACTOR: usize
+pub const bitcoin_units::weight::Weight::MAX: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MAX_BLOCK: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MIN: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MIN_TRANSACTION: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin_units::weight::Weight::ZERO: bitcoin_units::weight::Weight
+pub const fn bitcoin_units::Amount::checked_add(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_div_by_weight_ceil(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
+pub const fn bitcoin_units::Amount::checked_div_by_weight_floor(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
+pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_sub(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::from_int_btc_const(btc: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::to_sat(self) -> u64
+pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
+pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeight::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockInterval::to_u32(&self) -> u32
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_sub(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kvb(sat_kvb: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_vb_unchecked(sat_vb: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_kwu(self) -> u64
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin_units::locktime::absolute::Height::from_consensus(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Height, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Height::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::Time::from_consensus(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Time, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Time::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
+pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
+pub const fn bitcoin_units::locktime::relative::Height::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Height::value(self) -> u16
+pub const fn bitcoin_units::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::Time::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Time::value(self) -> u16
+pub const fn bitcoin_units::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::weight::Weight
+pub const fn bitcoin_units::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_wu_usize(wu: usize) -> Self
+pub const fn bitcoin_units::weight::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_wu(self) -> u64
+pub fn &bitcoin_units::fee_rate::FeeRate::add(self, other: &'a bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::add(self, other: bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::sub(self, other: &'a bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::sub(self, other: bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add_assign(&mut self, other: bitcoin_units::Amount)
+pub fn bitcoin_units::Amount::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::Amount::clone(&self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::cmp(&self, other: &bitcoin_units::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::Amount::default() -> Self
+pub fn bitcoin_units::Amount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::Amount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
+pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::Amount::from_int_btc(btc: u64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Amount::partial_cmp(&self, other: &bitcoin_units::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Amount::rem(self, modulus: u64) -> Self
+pub fn bitcoin_units::Amount::rem_assign(&mut self, modulus: u64)
+pub fn bitcoin_units::Amount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub_assign(&mut self, other: bitcoin_units::Amount)
+pub fn bitcoin_units::Amount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::Amount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Amount>
+pub fn bitcoin_units::Amount::to_btc(self) -> f64
+pub fn bitcoin_units::Amount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::Amount::type_prefix(_: private::Token) -> &'static str
+pub fn bitcoin_units::Amount::unchecked_add(self, rhs: bitcoin_units::Amount) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::unchecked_sub(self, rhs: bitcoin_units::Amount) -> bitcoin_units::Amount
+pub fn bitcoin_units::SignedAmount::abs(self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add_assign(&mut self, other: bitcoin_units::SignedAmount)
+pub fn bitcoin_units::SignedAmount::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::SignedAmount::clone(&self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::cmp(&self, other: &bitcoin_units::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::SignedAmount::default() -> Self
+pub fn bitcoin_units::SignedAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::SignedAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
+pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_int_btc(btc: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::SignedAmount::neg(self) -> Self::Output
+pub fn bitcoin_units::SignedAmount::partial_cmp(&self, other: &bitcoin_units::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::SignedAmount::positive_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn bitcoin_units::SignedAmount::rem(self, modulus: i64) -> Self
+pub fn bitcoin_units::SignedAmount::rem_assign(&mut self, modulus: i64)
+pub fn bitcoin_units::SignedAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub_assign(&mut self, other: bitcoin_units::SignedAmount)
+pub fn bitcoin_units::SignedAmount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::SignedAmount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::SignedAmount>
+pub fn bitcoin_units::SignedAmount::to_btc(self) -> f64
+pub fn bitcoin_units::SignedAmount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::SignedAmount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::SignedAmount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::try_from(value: bitcoin_units::Amount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::SignedAmount::type_prefix(_: private::Token) -> &'static str
+pub fn bitcoin_units::SignedAmount::unchecked_add(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
+pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::error::InputTooLargeError::clone(&self) -> bitcoin_units::amount::error::InputTooLargeError
+pub fn bitcoin_units::amount::error::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::error::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::error::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::error::InvalidCharacterError
+pub fn bitcoin_units::amount::error::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::error::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::error::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::MissingDenominationError::clone(&self) -> bitcoin_units::amount::error::MissingDenominationError
+pub fn bitcoin_units::amount::error::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::error::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::error::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::MissingDigitsError::clone(&self) -> bitcoin_units::amount::error::MissingDigitsError
+pub fn bitcoin_units::amount::error::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::error::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::error::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::OutOfRangeError::clone(&self) -> bitcoin_units::amount::error::OutOfRangeError
+pub fn bitcoin_units::amount::error::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::error::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::OutOfRangeError::is_above_max(&self) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::is_below_min(&self) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::valid_range(&self) -> (i64, u64)
+pub fn bitcoin_units::amount::error::ParseAmountError::clone(&self) -> bitcoin_units::amount::error::ParseAmountError
+pub fn bitcoin_units::amount::error::ParseAmountError::eq(&self, other: &bitcoin_units::amount::error::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::error::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::error::ParseDenominationError::clone(&self) -> bitcoin_units::amount::error::ParseDenominationError
+pub fn bitcoin_units::amount::error::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::error::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::error::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::ParseDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::error::ParseError::clone(&self) -> bitcoin_units::amount::error::ParseError
+pub fn bitcoin_units::amount::error::ParseError::eq(&self, other: &bitcoin_units::amount::error::ParseError) -> bool
+pub fn bitcoin_units::amount::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::ParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::error::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::error::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::error::TooPreciseError::clone(&self) -> bitcoin_units::amount::error::TooPreciseError
+pub fn bitcoin_units::amount::error::TooPreciseError::eq(&self, other: &bitcoin_units::amount::error::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::error::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::error::UnknownDenominationError
+pub fn bitcoin_units::amount::error::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::error::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::error::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::UnknownDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::type_prefix(_: private::Token) -> &'static str
+pub fn bitcoin_units::amount::serde::as_btc::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
+pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeight::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::block::BlockHeight::eq(&self, other: &bitcoin_units::block::BlockHeight) -> bool
+pub fn bitcoin_units::block::BlockHeight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_units::block::BlockHeight::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeight::partial_cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeight::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::clone(&self) -> bitcoin_units::block::BlockInterval
+pub fn bitcoin_units::block::BlockInterval::cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockInterval::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::block::BlockInterval::eq(&self, other: &bitcoin_units::block::BlockInterval) -> bool
+pub fn bitcoin_units::block::BlockInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockInterval::from(h: bitcoin_units::locktime::relative::Height) -> Self
+pub fn bitcoin_units::block::BlockInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockInterval::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::block::BlockInterval::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockInterval>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::clone(&self) -> bitcoin_units::block::TooBigForRelativeBlockHeightError
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::eq(&self, other: &bitcoin_units::block::TooBigForRelativeBlockHeightError) -> bool
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::fee_rate::FeeRate::add(self, other: &bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn bitcoin_units::fee_rate::FeeRate::add(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::add_assign(&mut self, rhs: &bitcoin_units::fee_rate::FeeRate)
+pub fn bitcoin_units::fee_rate::FeeRate::add_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::fee_rate::FeeRate::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::fee_rate::FeeRate::clone(&self) -> bitcoin_units::fee_rate::FeeRate
+pub fn bitcoin_units::fee_rate::FeeRate::cmp(&self, other: &bitcoin_units::fee_rate::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin_units::fee_rate::FeeRate::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::fee_rate::FeeRate::eq(&self, other: &bitcoin_units::fee_rate::FeeRate) -> bool
+pub fn bitcoin_units::fee_rate::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::fee_rate::FeeRate::fee_wu(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::fee_rate::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::fee_rate::FeeRate::from_sat_per_vb(sat_vb: u64) -> core::option::Option<Self>
+pub fn bitcoin_units::fee_rate::FeeRate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::fee_rate::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::fee_rate::FeeRate::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::partial_cmp(&self, other: &bitcoin_units::fee_rate::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::fee_rate::FeeRate::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::fee_rate::FeeRate::sub(self, other: &bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn bitcoin_units::fee_rate::FeeRate::sub(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::sub_assign(&mut self, rhs: &bitcoin_units::fee_rate::FeeRate)
+pub fn bitcoin_units::fee_rate::FeeRate::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::fee_rate::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::fee_rate::FeeRate>
+pub fn bitcoin_units::fee_rate::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::fee_rate::FeeRate::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::fee_rate::FeeRate::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::fee_rate::FeeRate::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ConversionError::clone(&self) -> bitcoin_units::locktime::absolute::ConversionError
+pub fn bitcoin_units::locktime::absolute::ConversionError::eq(&self, other: &bitcoin_units::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin_units::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ConversionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::locktime::absolute::Height::clone(&self) -> bitcoin_units::locktime::absolute::Height
+pub fn bitcoin_units::locktime::absolute::Height::cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Height::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::locktime::absolute::Height::eq(&self, other: &bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseHeightError>
+pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Height::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_units::locktime::absolute::Height::try_from(h: bitcoin_units::block::BlockHeight) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::ParseHeightError
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin_units::locktime::absolute::ParseTimeError
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::locktime::absolute::Time::clone(&self) -> bitcoin_units::locktime::absolute::Time
+pub fn bitcoin_units::locktime::absolute::Time::cmp(&self, other: &bitcoin_units::locktime::absolute::Time) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Time::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::locktime::absolute::Time::eq(&self, other: &bitcoin_units::locktime::absolute::Time) -> bool
+pub fn bitcoin_units::locktime::absolute::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Time::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseTimeError>
+pub fn bitcoin_units::locktime::absolute::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Time::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Time::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_units::locktime::absolute::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::clone(&self) -> bitcoin_units::locktime::relative::Height
+pub fn bitcoin_units::locktime::relative::Height::cmp(&self, other: &bitcoin_units::locktime::relative::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::Height::default() -> bitcoin_units::locktime::relative::Height
+pub fn bitcoin_units::locktime::relative::Height::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::locktime::relative::Height::eq(&self, other: &bitcoin_units::locktime::relative::Height) -> bool
+pub fn bitcoin_units::locktime::relative::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::Height::from(value: u16) -> Self
+pub fn bitcoin_units::locktime::relative::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::Height::partial_cmp(&self, other: &bitcoin_units::locktime::relative::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::Height::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::locktime::relative::Height::try_from(h: bitcoin_units::block::BlockInterval) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Time::clone(&self) -> bitcoin_units::locktime::relative::Time
+pub fn bitcoin_units::locktime::relative::Time::cmp(&self, other: &bitcoin_units::locktime::relative::Time) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::Time::default() -> bitcoin_units::locktime::relative::Time
+pub fn bitcoin_units::locktime::relative::Time::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::locktime::relative::Time::eq(&self, other: &bitcoin_units::locktime::relative::Time) -> bool
+pub fn bitcoin_units::locktime::relative::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::Time::partial_cmp(&self, other: &bitcoin_units::locktime::relative::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::Time::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::locktime::relative::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::TimeOverflowError
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::TimeOverflowError) -> bool
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::new(seconds: u32) -> Self
+pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
+pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::ParseIntError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
+pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::PrefixedHexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
+pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::int<T: bitcoin_units::parse::Integer, S: core::convert::AsRef<str> + core::convert::Into<bitcoin_internals::error::input_string::InputString>>(s: S) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::weight::Weight::add(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::add_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::weight::Weight::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::weight::Weight::clone(&self) -> bitcoin_units::weight::Weight
+pub fn bitcoin_units::weight::Weight::cmp(&self, other: &bitcoin_units::weight::Weight) -> core::cmp::Ordering
+pub fn bitcoin_units::weight::Weight::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::weight::Weight::div(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::weight::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::weight::Weight::eq(&self, other: &bitcoin_units::weight::Weight) -> bool
+pub fn bitcoin_units::weight::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::weight::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub fn bitcoin_units::weight::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::weight::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::weight::Weight::mul(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::weight::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::weight::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::weight::Weight::partial_cmp(&self, other: &bitcoin_units::weight::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::weight::Weight::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_units::weight::Weight::sub(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::weight::Weight>
+pub fn bitcoin_units::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::weight::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::weight::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::weight::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockHeight) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockInterval) -> Self
+pub fn u64::from(value: bitcoin_units::fee_rate::FeeRate) -> Self
+pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
+pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub macro bitcoin_units::impl_parse_str!
+pub macro bitcoin_units::impl_parse_str_from_int_infallible!
+pub macro bitcoin_units::impl_tryfrom_str!
+pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub mod bitcoin_units::amount::error
+pub mod bitcoin_units::amount::serde
+pub mod bitcoin_units::amount::serde::as_btc
+pub mod bitcoin_units::amount::serde::as_btc::opt
+pub mod bitcoin_units::amount::serde::as_sat
+pub mod bitcoin_units::amount::serde::as_sat::opt
+pub mod bitcoin_units::block
+pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::locktime
+pub mod bitcoin_units::locktime::absolute
+pub mod bitcoin_units::locktime::relative
+pub mod bitcoin_units::parse
+pub mod bitcoin_units::weight
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::BlockHeight(pub u32)
+pub struct bitcoin_units::BlockInterval(pub u32)
+pub struct bitcoin_units::FeeRate(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::Weight(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::InputTooLargeError
+pub struct bitcoin_units::amount::InvalidCharacterError
+pub struct bitcoin_units::amount::MissingDigitsError
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::ParseAmountError(_)
+pub struct bitcoin_units::amount::ParseError(_)
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub struct bitcoin_units::amount::TooPreciseError
+pub struct bitcoin_units::amount::error::InputTooLargeError
+pub struct bitcoin_units::amount::error::InvalidCharacterError
+pub struct bitcoin_units::amount::error::MissingDigitsError
+pub struct bitcoin_units::amount::error::OutOfRangeError
+pub struct bitcoin_units::amount::error::ParseAmountError(_)
+pub struct bitcoin_units::amount::error::ParseError(_)
+pub struct bitcoin_units::amount::error::TooPreciseError
+pub struct bitcoin_units::block::BlockHeight(pub u32)
+pub struct bitcoin_units::block::BlockInterval(pub u32)
+pub struct bitcoin_units::block::TooBigForRelativeBlockHeightError(_)
+pub struct bitcoin_units::fee_rate::FeeRate(_)
+pub struct bitcoin_units::locktime::absolute::Height(_)
+pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin_units::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin_units::locktime::absolute::Time(_)
+pub struct bitcoin_units::locktime::relative::Height(_)
+pub struct bitcoin_units::locktime::relative::Time(_)
+pub struct bitcoin_units::locktime::relative::TimeOverflowError
+pub struct bitcoin_units::parse::PrefixedHexError(_)
+pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::weight::Weight(_)
+pub trait bitcoin_units::amount::CheckedSum<R>: private::SumSeal<R>
+pub trait bitcoin_units::amount::serde::SerdeAmount: core::marker::Copy + core::marker::Sized
+pub trait bitcoin_units::amount::serde::SerdeAmountForOpt: core::marker::Copy + core::marker::Sized + bitcoin_units::amount::serde::SerdeAmount
+pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized
+pub type &bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::error::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
+pub type bitcoin_units::Amount::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::error::ParseError
+pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockInterval
+pub type bitcoin_units::block::BlockInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Output = bitcoin_units::block::BlockInterval
+pub type bitcoin_units::fee_rate::FeeRate::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::fee_rate::FeeRate::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::Amount
+pub type bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Time::Err = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::absolute::Time::Error = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::relative::Height::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::block::TooBigForRelativeBlockHeightError
+pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Time::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Time::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Output = bitcoin_units::Amount
+pub type bitcoin_units::weight::Weight::Output = bitcoin_units::weight::Weight
+pub type bitcoin_units::weight::Weight::Output = u64
+pub type u64::Output = bitcoin_units::weight::Weight

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1,0 +1,1109 @@
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub enum bitcoin_units::amount::error::ParseDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::error::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::error::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::error::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+impl bitcoin_units::Amount
+impl bitcoin_units::SignedAmount
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::error::OutOfRangeError
+impl bitcoin_units::block::BlockHeight
+impl bitcoin_units::block::BlockInterval
+impl bitcoin_units::fee_rate::FeeRate
+impl bitcoin_units::locktime::absolute::Height
+impl bitcoin_units::locktime::absolute::Time
+impl bitcoin_units::locktime::relative::Height
+impl bitcoin_units::locktime::relative::Time
+impl bitcoin_units::locktime::relative::TimeOverflowError
+impl bitcoin_units::parse::Integer for i128
+impl bitcoin_units::parse::Integer for i16
+impl bitcoin_units::parse::Integer for i32
+impl bitcoin_units::parse::Integer for i64
+impl bitcoin_units::parse::Integer for i8
+impl bitcoin_units::parse::Integer for u128
+impl bitcoin_units::parse::Integer for u16
+impl bitcoin_units::parse::Integer for u32
+impl bitcoin_units::parse::Integer for u64
+impl bitcoin_units::parse::Integer for u8
+impl bitcoin_units::weight::Weight
+impl core::clone::Clone for bitcoin_units::Amount
+impl core::clone::Clone for bitcoin_units::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::error::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::error::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::error::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::error::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseError
+impl core::clone::Clone for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::error::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockInterval
+impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::clone::Clone for bitcoin_units::fee_rate::FeeRate
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Time
+impl core::clone::Clone for bitcoin_units::locktime::relative::Height
+impl core::clone::Clone for bitcoin_units::locktime::relative::Time
+impl core::clone::Clone for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::clone::Clone for bitcoin_units::parse::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::clone::Clone for bitcoin_units::weight::Weight
+impl core::cmp::Eq for bitcoin_units::Amount
+impl core::cmp::Eq for bitcoin_units::SignedAmount
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::error::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::error::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::error::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::block::BlockHeight
+impl core::cmp::Eq for bitcoin_units::block::BlockInterval
+impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::cmp::Eq for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Time
+impl core::cmp::Eq for bitcoin_units::locktime::relative::Height
+impl core::cmp::Eq for bitcoin_units::locktime::relative::Time
+impl core::cmp::Eq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::weight::Weight
+impl core::cmp::Ord for bitcoin_units::Amount
+impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::block::BlockHeight
+impl core::cmp::Ord for bitcoin_units::block::BlockInterval
+impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Time
+impl core::cmp::Ord for bitcoin_units::locktime::relative::Height
+impl core::cmp::Ord for bitcoin_units::locktime::relative::Time
+impl core::cmp::Ord for bitcoin_units::weight::Weight
+impl core::cmp::PartialEq for bitcoin_units::Amount
+impl core::cmp::PartialEq for bitcoin_units::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::error::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialEq for bitcoin_units::block::BlockInterval
+impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Time
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::Time
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::weight::Weight
+impl core::cmp::PartialOrd for bitcoin_units::Amount
+impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
+impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Time
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Time
+impl core::cmp::PartialOrd for bitcoin_units::weight::Weight
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::ParseAmountError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::ParseDenominationError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
+impl core::convert::From<bitcoin_units::block::BlockInterval> for u32
+impl core::convert::From<bitcoin_units::fee_rate::FeeRate> for u64
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_units::block::BlockHeight
+impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_units::block::BlockInterval
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin_units::weight::Weight> for u64
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<u16> for bitcoin_units::locktime::relative::Height
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
+impl core::convert::From<u32> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::fee_rate::FeeRate
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Time
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Time
+impl core::convert::TryFrom<&str> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::Time
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::fee_rate::FeeRate
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::relative::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::relative::Time
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<bitcoin_units::Amount> for bitcoin_units::SignedAmount
+impl core::convert::TryFrom<bitcoin_units::SignedAmount> for bitcoin_units::Amount
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeight> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<bitcoin_units::block::BlockInterval> for bitcoin_units::locktime::relative::Height
+impl core::default::Default for bitcoin_units::Amount
+impl core::default::Default for bitcoin_units::SignedAmount
+impl core::default::Default for bitcoin_units::locktime::relative::Height
+impl core::default::Default for bitcoin_units::locktime::relative::Time
+impl core::fmt::Debug for bitcoin_units::Amount
+impl core::fmt::Debug for bitcoin_units::SignedAmount
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::error::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::error::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::error::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::error::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockInterval
+impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::fmt::Debug for bitcoin_units::fee_rate::FeeRate
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Time
+impl core::fmt::Debug for bitcoin_units::locktime::relative::Height
+impl core::fmt::Debug for bitcoin_units::locktime::relative::Time
+impl core::fmt::Debug for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Debug for bitcoin_units::weight::Weight
+impl core::fmt::Display for bitcoin_units::Amount
+impl core::fmt::Display for bitcoin_units::SignedAmount
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::error::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::error::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::error::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::error::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseError
+impl core::fmt::Display for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::error::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::block::BlockHeight
+impl core::fmt::Display for bitcoin_units::block::BlockInterval
+impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::fmt::Display for bitcoin_units::fee_rate::FeeRate
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Time
+impl core::fmt::Display for bitcoin_units::locktime::relative::Height
+impl core::fmt::Display for bitcoin_units::locktime::relative::Time
+impl core::fmt::Display for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Display for bitcoin_units::parse::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::weight::Weight
+impl core::hash::Hash for bitcoin_units::Amount
+impl core::hash::Hash for bitcoin_units::SignedAmount
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::block::BlockHeight
+impl core::hash::Hash for bitcoin_units::block::BlockInterval
+impl core::hash::Hash for bitcoin_units::fee_rate::FeeRate
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Height
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Time
+impl core::hash::Hash for bitcoin_units::locktime::relative::Height
+impl core::hash::Hash for bitcoin_units::locktime::relative::Time
+impl core::hash::Hash for bitcoin_units::weight::Weight
+impl core::iter::traits::accum::Sum for bitcoin_units::Amount
+impl core::iter::traits::accum::Sum for bitcoin_units::SignedAmount
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockInterval
+impl core::iter::traits::accum::Sum for bitcoin_units::fee_rate::FeeRate
+impl core::iter::traits::accum::Sum for bitcoin_units::weight::Weight
+impl core::marker::Copy for bitcoin_units::Amount
+impl core::marker::Copy for bitcoin_units::SignedAmount
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::block::BlockHeight
+impl core::marker::Copy for bitcoin_units::block::BlockInterval
+impl core::marker::Copy for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Height
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Time
+impl core::marker::Copy for bitcoin_units::locktime::relative::Height
+impl core::marker::Copy for bitcoin_units::locktime::relative::Time
+impl core::marker::Copy for bitcoin_units::weight::Weight
+impl core::marker::Freeze for bitcoin_units::Amount
+impl core::marker::Freeze for bitcoin_units::SignedAmount
+impl core::marker::Freeze for bitcoin_units::amount::Denomination
+impl core::marker::Freeze for bitcoin_units::amount::Display
+impl core::marker::Freeze for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::block::BlockHeight
+impl core::marker::Freeze for bitcoin_units::block::BlockInterval
+impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Freeze for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Time
+impl core::marker::Freeze for bitcoin_units::locktime::relative::Height
+impl core::marker::Freeze for bitcoin_units::locktime::relative::Time
+impl core::marker::Freeze for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Freeze for bitcoin_units::weight::Weight
+impl core::marker::Send for bitcoin_units::Amount
+impl core::marker::Send for bitcoin_units::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::ParseError
+impl core::marker::Send for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::block::BlockHeight
+impl core::marker::Send for bitcoin_units::block::BlockInterval
+impl core::marker::Send for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Send for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Send for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Height
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Time
+impl core::marker::Send for bitcoin_units::locktime::relative::Height
+impl core::marker::Send for bitcoin_units::locktime::relative::Time
+impl core::marker::Send for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Send for bitcoin_units::parse::ParseIntError
+impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::weight::Weight
+impl core::marker::StructuralPartialEq for bitcoin_units::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Time
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Time
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::weight::Weight
+impl core::marker::Sync for bitcoin_units::Amount
+impl core::marker::Sync for bitcoin_units::SignedAmount
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseError
+impl core::marker::Sync for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::block::BlockHeight
+impl core::marker::Sync for bitcoin_units::block::BlockInterval
+impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Sync for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Time
+impl core::marker::Sync for bitcoin_units::locktime::relative::Height
+impl core::marker::Sync for bitcoin_units::locktime::relative::Time
+impl core::marker::Sync for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Sync for bitcoin_units::parse::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::weight::Weight
+impl core::marker::Unpin for bitcoin_units::Amount
+impl core::marker::Unpin for bitcoin_units::SignedAmount
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::block::BlockHeight
+impl core::marker::Unpin for bitcoin_units::block::BlockInterval
+impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Unpin for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Time
+impl core::marker::Unpin for bitcoin_units::locktime::relative::Height
+impl core::marker::Unpin for bitcoin_units::locktime::relative::Time
+impl core::marker::Unpin for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::weight::Weight
+impl core::ops::arith::Add for bitcoin_units::Amount
+impl core::ops::arith::Add for bitcoin_units::SignedAmount
+impl core::ops::arith::Add for bitcoin_units::block::BlockInterval
+impl core::ops::arith::Add for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Add for bitcoin_units::weight::Weight
+impl core::ops::arith::Add<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Add<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::Amount
+impl core::ops::arith::AddAssign for bitcoin_units::SignedAmount
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockInterval
+impl core::ops::arith::AddAssign for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::weight::Weight
+impl core::ops::arith::AddAssign<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Div for bitcoin_units::weight::Weight
+impl core::ops::arith::Div<bitcoin_units::weight::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::Mul<bitcoin_units::fee_rate::FeeRate> for bitcoin_units::weight::Weight
+impl core::ops::arith::Mul<bitcoin_units::weight::Weight> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::weight::Weight> for u64
+impl core::ops::arith::Mul<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::Neg for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<u64> for bitcoin_units::Amount
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockInterval
+impl core::ops::arith::Sub for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Sub for bitcoin_units::weight::Weight
+impl core::ops::arith::Sub<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Sub<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::Amount
+impl core::ops::arith::SubAssign for bitcoin_units::SignedAmount
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockInterval
+impl core::ops::arith::SubAssign for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::weight::Weight
+impl core::ops::arith::SubAssign<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::weight::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::weight::Weight
+impl core::str::traits::FromStr for bitcoin_units::Amount
+impl core::str::traits::FromStr for bitcoin_units::SignedAmount
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeight
+impl core::str::traits::FromStr for bitcoin_units::block::BlockInterval
+impl core::str::traits::FromStr for bitcoin_units::fee_rate::FeeRate
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Time
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Time
+impl core::str::traits::FromStr for bitcoin_units::weight::Weight
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::Amount> for bitcoin_units::Amount
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockInterval
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::weight::Weight> for bitcoin_units::weight::Weight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Amount>
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::SignedAmount>
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub bitcoin_units::amount::error::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::error::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub const bitcoin_units::Amount::MAX: bitcoin_units::Amount
+pub const bitcoin_units::Amount::MAX_MONEY: bitcoin_units::Amount
+pub const bitcoin_units::Amount::MIN: bitcoin_units::Amount
+pub const bitcoin_units::Amount::ONE_BTC: bitcoin_units::Amount
+pub const bitcoin_units::Amount::ONE_SAT: bitcoin_units::Amount
+pub const bitcoin_units::Amount::SIZE: usize
+pub const bitcoin_units::Amount::ZERO: bitcoin_units::Amount
+pub const bitcoin_units::SignedAmount::MAX: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::MAX_MONEY: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::MIN: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ONE_BTC: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ONE_SAT: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ZERO: bitcoin_units::SignedAmount
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::block::BlockHeight::MAX: Self
+pub const bitcoin_units::block::BlockHeight::MIN: Self
+pub const bitcoin_units::block::BlockHeight::ZERO: Self
+pub const bitcoin_units::block::BlockInterval::MAX: Self
+pub const bitcoin_units::block::BlockInterval::MIN: Self
+pub const bitcoin_units::block::BlockInterval::ZERO: Self
+pub const bitcoin_units::fee_rate::FeeRate::BROADCAST_MIN: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::DUST: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::MAX: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::MIN: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::ZERO: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::locktime::absolute::Height::MAX: Self
+pub const bitcoin_units::locktime::absolute::Height::MIN: Self
+pub const bitcoin_units::locktime::absolute::Height::ZERO: Self
+pub const bitcoin_units::locktime::absolute::LOCK_TIME_THRESHOLD: u32
+pub const bitcoin_units::locktime::absolute::Time::MAX: Self
+pub const bitcoin_units::locktime::absolute::Time::MIN: Self
+pub const bitcoin_units::locktime::relative::Height::MAX: Self
+pub const bitcoin_units::locktime::relative::Height::MIN: Self
+pub const bitcoin_units::locktime::relative::Height::ZERO: Self
+pub const bitcoin_units::locktime::relative::Time::MAX: Self
+pub const bitcoin_units::locktime::relative::Time::MIN: Self
+pub const bitcoin_units::locktime::relative::Time::ZERO: Self
+pub const bitcoin_units::weight::WITNESS_SCALE_FACTOR: usize
+pub const bitcoin_units::weight::Weight::MAX: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MAX_BLOCK: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MIN: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MIN_TRANSACTION: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin_units::weight::Weight::ZERO: bitcoin_units::weight::Weight
+pub const fn bitcoin_units::Amount::checked_add(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_div_by_weight_ceil(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
+pub const fn bitcoin_units::Amount::checked_div_by_weight_floor(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
+pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_sub(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::from_int_btc_const(btc: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::to_sat(self) -> u64
+pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
+pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeight::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockInterval::to_u32(&self) -> u32
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_sub(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kvb(sat_kvb: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_vb_unchecked(sat_vb: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_kwu(self) -> u64
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin_units::locktime::absolute::Height::from_consensus(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Height, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Height::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::Time::from_consensus(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Time, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Time::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
+pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
+pub const fn bitcoin_units::locktime::relative::Height::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Height::value(self) -> u16
+pub const fn bitcoin_units::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::Time::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Time::value(self) -> u16
+pub const fn bitcoin_units::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::weight::Weight
+pub const fn bitcoin_units::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_wu_usize(wu: usize) -> Self
+pub const fn bitcoin_units::weight::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_wu(self) -> u64
+pub fn &bitcoin_units::fee_rate::FeeRate::add(self, other: &'a bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::add(self, other: bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::sub(self, other: &'a bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::sub(self, other: bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add_assign(&mut self, other: bitcoin_units::Amount)
+pub fn bitcoin_units::Amount::clone(&self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::cmp(&self, other: &bitcoin_units::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::Amount::default() -> Self
+pub fn bitcoin_units::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
+pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::Amount::from_int_btc(btc: u64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Amount::partial_cmp(&self, other: &bitcoin_units::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Amount::rem(self, modulus: u64) -> Self
+pub fn bitcoin_units::Amount::rem_assign(&mut self, modulus: u64)
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub_assign(&mut self, other: bitcoin_units::Amount)
+pub fn bitcoin_units::Amount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::Amount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Amount>
+pub fn bitcoin_units::Amount::to_btc(self) -> f64
+pub fn bitcoin_units::Amount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::Amount::unchecked_add(self, rhs: bitcoin_units::Amount) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::unchecked_sub(self, rhs: bitcoin_units::Amount) -> bitcoin_units::Amount
+pub fn bitcoin_units::SignedAmount::abs(self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add_assign(&mut self, other: bitcoin_units::SignedAmount)
+pub fn bitcoin_units::SignedAmount::clone(&self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::cmp(&self, other: &bitcoin_units::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::SignedAmount::default() -> Self
+pub fn bitcoin_units::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
+pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_int_btc(btc: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::SignedAmount::neg(self) -> Self::Output
+pub fn bitcoin_units::SignedAmount::partial_cmp(&self, other: &bitcoin_units::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::SignedAmount::positive_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn bitcoin_units::SignedAmount::rem(self, modulus: i64) -> Self
+pub fn bitcoin_units::SignedAmount::rem_assign(&mut self, modulus: i64)
+pub fn bitcoin_units::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub_assign(&mut self, other: bitcoin_units::SignedAmount)
+pub fn bitcoin_units::SignedAmount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::SignedAmount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::SignedAmount>
+pub fn bitcoin_units::SignedAmount::to_btc(self) -> f64
+pub fn bitcoin_units::SignedAmount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::SignedAmount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::SignedAmount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::try_from(value: bitcoin_units::Amount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::SignedAmount::unchecked_add(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
+pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::error::InputTooLargeError::clone(&self) -> bitcoin_units::amount::error::InputTooLargeError
+pub fn bitcoin_units::amount::error::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::error::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::error::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::error::InvalidCharacterError
+pub fn bitcoin_units::amount::error::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::error::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::error::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::MissingDenominationError::clone(&self) -> bitcoin_units::amount::error::MissingDenominationError
+pub fn bitcoin_units::amount::error::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::error::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::error::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::MissingDigitsError::clone(&self) -> bitcoin_units::amount::error::MissingDigitsError
+pub fn bitcoin_units::amount::error::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::error::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::error::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::OutOfRangeError::clone(&self) -> bitcoin_units::amount::error::OutOfRangeError
+pub fn bitcoin_units::amount::error::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::error::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::OutOfRangeError::is_above_max(&self) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::is_below_min(&self) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::valid_range(&self) -> (i64, u64)
+pub fn bitcoin_units::amount::error::ParseAmountError::clone(&self) -> bitcoin_units::amount::error::ParseAmountError
+pub fn bitcoin_units::amount::error::ParseAmountError::eq(&self, other: &bitcoin_units::amount::error::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::error::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::error::ParseDenominationError::clone(&self) -> bitcoin_units::amount::error::ParseDenominationError
+pub fn bitcoin_units::amount::error::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::error::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::error::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::ParseError::clone(&self) -> bitcoin_units::amount::error::ParseError
+pub fn bitcoin_units::amount::error::ParseError::eq(&self, other: &bitcoin_units::amount::error::ParseError) -> bool
+pub fn bitcoin_units::amount::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::error::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::error::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::TooPreciseError::clone(&self) -> bitcoin_units::amount::error::TooPreciseError
+pub fn bitcoin_units::amount::error::TooPreciseError::eq(&self, other: &bitcoin_units::amount::error::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::error::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::error::UnknownDenominationError
+pub fn bitcoin_units::amount::error::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::error::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::error::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
+pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeight::eq(&self, other: &bitcoin_units::block::BlockHeight) -> bool
+pub fn bitcoin_units::block::BlockHeight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_units::block::BlockHeight::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeight::partial_cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::clone(&self) -> bitcoin_units::block::BlockInterval
+pub fn bitcoin_units::block::BlockInterval::cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockInterval::eq(&self, other: &bitcoin_units::block::BlockInterval) -> bool
+pub fn bitcoin_units::block::BlockInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockInterval::from(h: bitcoin_units::locktime::relative::Height) -> Self
+pub fn bitcoin_units::block::BlockInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockInterval::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockInterval>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::clone(&self) -> bitcoin_units::block::TooBigForRelativeBlockHeightError
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::eq(&self, other: &bitcoin_units::block::TooBigForRelativeBlockHeightError) -> bool
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::fee_rate::FeeRate::add(self, other: &bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn bitcoin_units::fee_rate::FeeRate::add(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::add_assign(&mut self, rhs: &bitcoin_units::fee_rate::FeeRate)
+pub fn bitcoin_units::fee_rate::FeeRate::add_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::fee_rate::FeeRate::clone(&self) -> bitcoin_units::fee_rate::FeeRate
+pub fn bitcoin_units::fee_rate::FeeRate::cmp(&self, other: &bitcoin_units::fee_rate::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin_units::fee_rate::FeeRate::eq(&self, other: &bitcoin_units::fee_rate::FeeRate) -> bool
+pub fn bitcoin_units::fee_rate::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::fee_rate::FeeRate::fee_wu(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::fee_rate::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::fee_rate::FeeRate::from_sat_per_vb(sat_vb: u64) -> core::option::Option<Self>
+pub fn bitcoin_units::fee_rate::FeeRate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::fee_rate::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::fee_rate::FeeRate::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::partial_cmp(&self, other: &bitcoin_units::fee_rate::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::fee_rate::FeeRate::sub(self, other: &bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn bitcoin_units::fee_rate::FeeRate::sub(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::sub_assign(&mut self, rhs: &bitcoin_units::fee_rate::FeeRate)
+pub fn bitcoin_units::fee_rate::FeeRate::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::fee_rate::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::fee_rate::FeeRate>
+pub fn bitcoin_units::fee_rate::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::fee_rate::FeeRate::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::fee_rate::FeeRate::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::fee_rate::FeeRate::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ConversionError::clone(&self) -> bitcoin_units::locktime::absolute::ConversionError
+pub fn bitcoin_units::locktime::absolute::ConversionError::eq(&self, other: &bitcoin_units::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin_units::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::clone(&self) -> bitcoin_units::locktime::absolute::Height
+pub fn bitcoin_units::locktime::absolute::Height::cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Height::eq(&self, other: &bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseHeightError>
+pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(h: bitcoin_units::block::BlockHeight) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::ParseHeightError
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin_units::locktime::absolute::ParseTimeError
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Time::clone(&self) -> bitcoin_units::locktime::absolute::Time
+pub fn bitcoin_units::locktime::absolute::Time::cmp(&self, other: &bitcoin_units::locktime::absolute::Time) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Time::eq(&self, other: &bitcoin_units::locktime::absolute::Time) -> bool
+pub fn bitcoin_units::locktime::absolute::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Time::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseTimeError>
+pub fn bitcoin_units::locktime::absolute::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Time::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::clone(&self) -> bitcoin_units::locktime::relative::Height
+pub fn bitcoin_units::locktime::relative::Height::cmp(&self, other: &bitcoin_units::locktime::relative::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::Height::default() -> bitcoin_units::locktime::relative::Height
+pub fn bitcoin_units::locktime::relative::Height::eq(&self, other: &bitcoin_units::locktime::relative::Height) -> bool
+pub fn bitcoin_units::locktime::relative::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::Height::from(value: u16) -> Self
+pub fn bitcoin_units::locktime::relative::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::Height::partial_cmp(&self, other: &bitcoin_units::locktime::relative::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::Height::try_from(h: bitcoin_units::block::BlockInterval) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Time::clone(&self) -> bitcoin_units::locktime::relative::Time
+pub fn bitcoin_units::locktime::relative::Time::cmp(&self, other: &bitcoin_units::locktime::relative::Time) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::Time::default() -> bitcoin_units::locktime::relative::Time
+pub fn bitcoin_units::locktime::relative::Time::eq(&self, other: &bitcoin_units::locktime::relative::Time) -> bool
+pub fn bitcoin_units::locktime::relative::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::Time::partial_cmp(&self, other: &bitcoin_units::locktime::relative::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Time::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Time::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::TimeOverflowError
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::TimeOverflowError) -> bool
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::new(seconds: u32) -> Self
+pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
+pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
+pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
+pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::int<T: bitcoin_units::parse::Integer, S: core::convert::AsRef<str> + core::convert::Into<bitcoin_internals::error::input_string::InputString>>(s: S) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::weight::Weight::add(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::add_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::weight::Weight::clone(&self) -> bitcoin_units::weight::Weight
+pub fn bitcoin_units::weight::Weight::cmp(&self, other: &bitcoin_units::weight::Weight) -> core::cmp::Ordering
+pub fn bitcoin_units::weight::Weight::div(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::weight::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::weight::Weight::eq(&self, other: &bitcoin_units::weight::Weight) -> bool
+pub fn bitcoin_units::weight::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::weight::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub fn bitcoin_units::weight::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::weight::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::weight::Weight::mul(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::weight::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::weight::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::weight::Weight::partial_cmp(&self, other: &bitcoin_units::weight::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::weight::Weight::sub(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::weight::Weight>
+pub fn bitcoin_units::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::weight::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::weight::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::weight::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockHeight) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockInterval) -> Self
+pub fn u64::from(value: bitcoin_units::fee_rate::FeeRate) -> Self
+pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
+pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub macro bitcoin_units::impl_parse_str!
+pub macro bitcoin_units::impl_parse_str_from_int_infallible!
+pub macro bitcoin_units::impl_tryfrom_str!
+pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub mod bitcoin_units::amount::error
+pub mod bitcoin_units::block
+pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::locktime
+pub mod bitcoin_units::locktime::absolute
+pub mod bitcoin_units::locktime::relative
+pub mod bitcoin_units::parse
+pub mod bitcoin_units::weight
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::BlockHeight(pub u32)
+pub struct bitcoin_units::BlockInterval(pub u32)
+pub struct bitcoin_units::FeeRate(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::Weight(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::InputTooLargeError
+pub struct bitcoin_units::amount::InvalidCharacterError
+pub struct bitcoin_units::amount::MissingDigitsError
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::ParseAmountError(_)
+pub struct bitcoin_units::amount::ParseError(_)
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub struct bitcoin_units::amount::TooPreciseError
+pub struct bitcoin_units::amount::error::InputTooLargeError
+pub struct bitcoin_units::amount::error::InvalidCharacterError
+pub struct bitcoin_units::amount::error::MissingDigitsError
+pub struct bitcoin_units::amount::error::OutOfRangeError
+pub struct bitcoin_units::amount::error::ParseAmountError(_)
+pub struct bitcoin_units::amount::error::ParseError(_)
+pub struct bitcoin_units::amount::error::TooPreciseError
+pub struct bitcoin_units::block::BlockHeight(pub u32)
+pub struct bitcoin_units::block::BlockInterval(pub u32)
+pub struct bitcoin_units::block::TooBigForRelativeBlockHeightError(_)
+pub struct bitcoin_units::fee_rate::FeeRate(_)
+pub struct bitcoin_units::locktime::absolute::Height(_)
+pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin_units::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin_units::locktime::absolute::Time(_)
+pub struct bitcoin_units::locktime::relative::Height(_)
+pub struct bitcoin_units::locktime::relative::Time(_)
+pub struct bitcoin_units::locktime::relative::TimeOverflowError
+pub struct bitcoin_units::parse::PrefixedHexError(_)
+pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::weight::Weight(_)
+pub trait bitcoin_units::amount::CheckedSum<R>: private::SumSeal<R>
+pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized
+pub type &bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::error::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
+pub type bitcoin_units::Amount::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::error::ParseError
+pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockInterval
+pub type bitcoin_units::block::BlockInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Output = bitcoin_units::block::BlockInterval
+pub type bitcoin_units::fee_rate::FeeRate::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::fee_rate::FeeRate::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::Amount
+pub type bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Time::Err = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::absolute::Time::Error = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::relative::Height::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::block::TooBigForRelativeBlockHeightError
+pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Time::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Time::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Output = bitcoin_units::Amount
+pub type bitcoin_units::weight::Weight::Output = bitcoin_units::weight::Weight
+pub type bitcoin_units::weight::Weight::Output = u64
+pub type u64::Output = bitcoin_units::weight::Weight

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1,0 +1,1063 @@
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub enum bitcoin_units::amount::error::ParseDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::error::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::error::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::error::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+impl bitcoin_units::Amount
+impl bitcoin_units::SignedAmount
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::error::OutOfRangeError
+impl bitcoin_units::block::BlockHeight
+impl bitcoin_units::block::BlockInterval
+impl bitcoin_units::fee_rate::FeeRate
+impl bitcoin_units::locktime::absolute::Height
+impl bitcoin_units::locktime::absolute::Time
+impl bitcoin_units::locktime::relative::Height
+impl bitcoin_units::locktime::relative::Time
+impl bitcoin_units::locktime::relative::TimeOverflowError
+impl bitcoin_units::parse::Integer for i128
+impl bitcoin_units::parse::Integer for i16
+impl bitcoin_units::parse::Integer for i32
+impl bitcoin_units::parse::Integer for i64
+impl bitcoin_units::parse::Integer for i8
+impl bitcoin_units::parse::Integer for u128
+impl bitcoin_units::parse::Integer for u16
+impl bitcoin_units::parse::Integer for u32
+impl bitcoin_units::parse::Integer for u64
+impl bitcoin_units::parse::Integer for u8
+impl bitcoin_units::weight::Weight
+impl core::clone::Clone for bitcoin_units::Amount
+impl core::clone::Clone for bitcoin_units::SignedAmount
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::error::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::error::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::error::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::error::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::ParseError
+impl core::clone::Clone for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::error::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::error::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockInterval
+impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::clone::Clone for bitcoin_units::fee_rate::FeeRate
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Time
+impl core::clone::Clone for bitcoin_units::locktime::relative::Height
+impl core::clone::Clone for bitcoin_units::locktime::relative::Time
+impl core::clone::Clone for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::clone::Clone for bitcoin_units::parse::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::clone::Clone for bitcoin_units::weight::Weight
+impl core::cmp::Eq for bitcoin_units::Amount
+impl core::cmp::Eq for bitcoin_units::SignedAmount
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::error::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::error::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::error::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::error::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::block::BlockHeight
+impl core::cmp::Eq for bitcoin_units::block::BlockInterval
+impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::cmp::Eq for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Time
+impl core::cmp::Eq for bitcoin_units::locktime::relative::Height
+impl core::cmp::Eq for bitcoin_units::locktime::relative::Time
+impl core::cmp::Eq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::weight::Weight
+impl core::cmp::Ord for bitcoin_units::Amount
+impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::block::BlockHeight
+impl core::cmp::Ord for bitcoin_units::block::BlockInterval
+impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Time
+impl core::cmp::Ord for bitcoin_units::locktime::relative::Height
+impl core::cmp::Ord for bitcoin_units::locktime::relative::Time
+impl core::cmp::Ord for bitcoin_units::weight::Weight
+impl core::cmp::PartialEq for bitcoin_units::Amount
+impl core::cmp::PartialEq for bitcoin_units::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::error::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialEq for bitcoin_units::block::BlockInterval
+impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Time
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::Time
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::weight::Weight
+impl core::cmp::PartialOrd for bitcoin_units::Amount
+impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
+impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Time
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Time
+impl core::cmp::PartialOrd for bitcoin_units::weight::Weight
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::ParseAmountError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::ParseDenominationError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
+impl core::convert::From<bitcoin_units::block::BlockInterval> for u32
+impl core::convert::From<bitcoin_units::fee_rate::FeeRate> for u64
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_units::block::BlockHeight
+impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_units::block::BlockInterval
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin_units::weight::Weight> for u64
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<u16> for bitcoin_units::locktime::relative::Height
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
+impl core::convert::From<u32> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::fee_rate::FeeRate
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Time
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::Time
+impl core::convert::TryFrom<&str> for bitcoin_units::weight::Weight
+impl core::convert::TryFrom<bitcoin_units::Amount> for bitcoin_units::SignedAmount
+impl core::convert::TryFrom<bitcoin_units::SignedAmount> for bitcoin_units::Amount
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeight> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<bitcoin_units::block::BlockInterval> for bitcoin_units::locktime::relative::Height
+impl core::default::Default for bitcoin_units::Amount
+impl core::default::Default for bitcoin_units::SignedAmount
+impl core::default::Default for bitcoin_units::locktime::relative::Height
+impl core::default::Default for bitcoin_units::locktime::relative::Time
+impl core::fmt::Debug for bitcoin_units::Amount
+impl core::fmt::Debug for bitcoin_units::SignedAmount
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::error::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::error::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::error::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::error::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::error::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockInterval
+impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::fmt::Debug for bitcoin_units::fee_rate::FeeRate
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Time
+impl core::fmt::Debug for bitcoin_units::locktime::relative::Height
+impl core::fmt::Debug for bitcoin_units::locktime::relative::Time
+impl core::fmt::Debug for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Debug for bitcoin_units::weight::Weight
+impl core::fmt::Display for bitcoin_units::Amount
+impl core::fmt::Display for bitcoin_units::SignedAmount
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::error::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::error::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::error::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::error::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::error::ParseError
+impl core::fmt::Display for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::error::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::block::BlockHeight
+impl core::fmt::Display for bitcoin_units::block::BlockInterval
+impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::fmt::Display for bitcoin_units::fee_rate::FeeRate
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Time
+impl core::fmt::Display for bitcoin_units::locktime::relative::Height
+impl core::fmt::Display for bitcoin_units::locktime::relative::Time
+impl core::fmt::Display for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Display for bitcoin_units::parse::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::weight::Weight
+impl core::hash::Hash for bitcoin_units::Amount
+impl core::hash::Hash for bitcoin_units::SignedAmount
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::block::BlockHeight
+impl core::hash::Hash for bitcoin_units::block::BlockInterval
+impl core::hash::Hash for bitcoin_units::fee_rate::FeeRate
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Height
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Time
+impl core::hash::Hash for bitcoin_units::locktime::relative::Height
+impl core::hash::Hash for bitcoin_units::locktime::relative::Time
+impl core::hash::Hash for bitcoin_units::weight::Weight
+impl core::iter::traits::accum::Sum for bitcoin_units::Amount
+impl core::iter::traits::accum::Sum for bitcoin_units::SignedAmount
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockInterval
+impl core::iter::traits::accum::Sum for bitcoin_units::fee_rate::FeeRate
+impl core::iter::traits::accum::Sum for bitcoin_units::weight::Weight
+impl core::marker::Copy for bitcoin_units::Amount
+impl core::marker::Copy for bitcoin_units::SignedAmount
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::block::BlockHeight
+impl core::marker::Copy for bitcoin_units::block::BlockInterval
+impl core::marker::Copy for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Height
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Time
+impl core::marker::Copy for bitcoin_units::locktime::relative::Height
+impl core::marker::Copy for bitcoin_units::locktime::relative::Time
+impl core::marker::Copy for bitcoin_units::weight::Weight
+impl core::marker::Freeze for bitcoin_units::Amount
+impl core::marker::Freeze for bitcoin_units::SignedAmount
+impl core::marker::Freeze for bitcoin_units::amount::Denomination
+impl core::marker::Freeze for bitcoin_units::amount::Display
+impl core::marker::Freeze for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::block::BlockHeight
+impl core::marker::Freeze for bitcoin_units::block::BlockInterval
+impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Freeze for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Time
+impl core::marker::Freeze for bitcoin_units::locktime::relative::Height
+impl core::marker::Freeze for bitcoin_units::locktime::relative::Time
+impl core::marker::Freeze for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Freeze for bitcoin_units::weight::Weight
+impl core::marker::Send for bitcoin_units::Amount
+impl core::marker::Send for bitcoin_units::SignedAmount
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::ParseError
+impl core::marker::Send for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::block::BlockHeight
+impl core::marker::Send for bitcoin_units::block::BlockInterval
+impl core::marker::Send for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Send for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Send for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Height
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Time
+impl core::marker::Send for bitcoin_units::locktime::relative::Height
+impl core::marker::Send for bitcoin_units::locktime::relative::Time
+impl core::marker::Send for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Send for bitcoin_units::parse::ParseIntError
+impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::weight::Weight
+impl core::marker::StructuralPartialEq for bitcoin_units::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Time
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Time
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::weight::Weight
+impl core::marker::Sync for bitcoin_units::Amount
+impl core::marker::Sync for bitcoin_units::SignedAmount
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::ParseError
+impl core::marker::Sync for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::block::BlockHeight
+impl core::marker::Sync for bitcoin_units::block::BlockInterval
+impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Sync for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Time
+impl core::marker::Sync for bitcoin_units::locktime::relative::Height
+impl core::marker::Sync for bitcoin_units::locktime::relative::Time
+impl core::marker::Sync for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Sync for bitcoin_units::parse::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::weight::Weight
+impl core::marker::Unpin for bitcoin_units::Amount
+impl core::marker::Unpin for bitcoin_units::SignedAmount
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::error::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::error::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::error::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::error::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::block::BlockHeight
+impl core::marker::Unpin for bitcoin_units::block::BlockInterval
+impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::marker::Unpin for bitcoin_units::fee_rate::FeeRate
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Time
+impl core::marker::Unpin for bitcoin_units::locktime::relative::Height
+impl core::marker::Unpin for bitcoin_units::locktime::relative::Time
+impl core::marker::Unpin for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::weight::Weight
+impl core::ops::arith::Add for bitcoin_units::Amount
+impl core::ops::arith::Add for bitcoin_units::SignedAmount
+impl core::ops::arith::Add for bitcoin_units::block::BlockInterval
+impl core::ops::arith::Add for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Add for bitcoin_units::weight::Weight
+impl core::ops::arith::Add<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Add<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::Amount
+impl core::ops::arith::AddAssign for bitcoin_units::SignedAmount
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockInterval
+impl core::ops::arith::AddAssign for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::weight::Weight
+impl core::ops::arith::AddAssign<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Div for bitcoin_units::weight::Weight
+impl core::ops::arith::Div<bitcoin_units::weight::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::Mul<bitcoin_units::fee_rate::FeeRate> for bitcoin_units::weight::Weight
+impl core::ops::arith::Mul<bitcoin_units::weight::Weight> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::weight::Weight> for u64
+impl core::ops::arith::Mul<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::weight::Weight
+impl core::ops::arith::Neg for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<u64> for bitcoin_units::Amount
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockInterval
+impl core::ops::arith::Sub for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Sub for bitcoin_units::weight::Weight
+impl core::ops::arith::Sub<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::Sub<bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::Amount
+impl core::ops::arith::SubAssign for bitcoin_units::SignedAmount
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockInterval
+impl core::ops::arith::SubAssign for bitcoin_units::fee_rate::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::weight::Weight
+impl core::ops::arith::SubAssign<&bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::Time
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::weight::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::Time
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::weight::Weight
+impl core::str::traits::FromStr for bitcoin_units::Amount
+impl core::str::traits::FromStr for bitcoin_units::SignedAmount
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeight
+impl core::str::traits::FromStr for bitcoin_units::block::BlockInterval
+impl core::str::traits::FromStr for bitcoin_units::fee_rate::FeeRate
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Time
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Time
+impl core::str::traits::FromStr for bitcoin_units::weight::Weight
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::Amount> for bitcoin_units::Amount
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockInterval> for bitcoin_units::block::BlockInterval
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::fee_rate::FeeRate> for bitcoin_units::fee_rate::FeeRate
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::weight::Weight> for bitcoin_units::weight::Weight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::fee_rate::FeeRate> for &bitcoin_units::fee_rate::FeeRate
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Amount>
+impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::SignedAmount>
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub bitcoin_units::amount::error::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::error::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub const bitcoin_units::Amount::MAX: bitcoin_units::Amount
+pub const bitcoin_units::Amount::MAX_MONEY: bitcoin_units::Amount
+pub const bitcoin_units::Amount::MIN: bitcoin_units::Amount
+pub const bitcoin_units::Amount::ONE_BTC: bitcoin_units::Amount
+pub const bitcoin_units::Amount::ONE_SAT: bitcoin_units::Amount
+pub const bitcoin_units::Amount::SIZE: usize
+pub const bitcoin_units::Amount::ZERO: bitcoin_units::Amount
+pub const bitcoin_units::SignedAmount::MAX: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::MAX_MONEY: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::MIN: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ONE_BTC: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ONE_SAT: bitcoin_units::SignedAmount
+pub const bitcoin_units::SignedAmount::ZERO: bitcoin_units::SignedAmount
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::block::BlockHeight::MAX: Self
+pub const bitcoin_units::block::BlockHeight::MIN: Self
+pub const bitcoin_units::block::BlockHeight::ZERO: Self
+pub const bitcoin_units::block::BlockInterval::MAX: Self
+pub const bitcoin_units::block::BlockInterval::MIN: Self
+pub const bitcoin_units::block::BlockInterval::ZERO: Self
+pub const bitcoin_units::fee_rate::FeeRate::BROADCAST_MIN: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::DUST: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::MAX: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::MIN: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::fee_rate::FeeRate::ZERO: bitcoin_units::fee_rate::FeeRate
+pub const bitcoin_units::locktime::absolute::Height::MAX: Self
+pub const bitcoin_units::locktime::absolute::Height::MIN: Self
+pub const bitcoin_units::locktime::absolute::Height::ZERO: Self
+pub const bitcoin_units::locktime::absolute::LOCK_TIME_THRESHOLD: u32
+pub const bitcoin_units::locktime::absolute::Time::MAX: Self
+pub const bitcoin_units::locktime::absolute::Time::MIN: Self
+pub const bitcoin_units::locktime::relative::Height::MAX: Self
+pub const bitcoin_units::locktime::relative::Height::MIN: Self
+pub const bitcoin_units::locktime::relative::Height::ZERO: Self
+pub const bitcoin_units::locktime::relative::Time::MAX: Self
+pub const bitcoin_units::locktime::relative::Time::MIN: Self
+pub const bitcoin_units::locktime::relative::Time::ZERO: Self
+pub const bitcoin_units::weight::WITNESS_SCALE_FACTOR: usize
+pub const bitcoin_units::weight::Weight::MAX: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MAX_BLOCK: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MIN: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::MIN_TRANSACTION: bitcoin_units::weight::Weight
+pub const bitcoin_units::weight::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin_units::weight::Weight::ZERO: bitcoin_units::weight::Weight
+pub const fn bitcoin_units::Amount::checked_add(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::checked_sub(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::Amount::from_int_btc_const(btc: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::to_sat(self) -> u64
+pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
+pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeight::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockInterval::to_u32(&self) -> u32
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_sub(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kvb(sat_kvb: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_vb_unchecked(sat_vb: u64) -> Self
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_kwu(self) -> u64
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin_units::fee_rate::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin_units::locktime::absolute::Height::from_consensus(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Height, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Height::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::Time::from_consensus(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Time, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Time::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
+pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
+pub const fn bitcoin_units::locktime::relative::Height::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Height::value(self) -> u16
+pub const fn bitcoin_units::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::Time::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Time::value(self) -> u16
+pub const fn bitcoin_units::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::weight::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::weight::Weight
+pub const fn bitcoin_units::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::from_wu_usize(wu: usize) -> Self
+pub const fn bitcoin_units::weight::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin_units::weight::Weight::to_wu(self) -> u64
+pub fn &bitcoin_units::fee_rate::FeeRate::add(self, other: &'a bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::add(self, other: bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::sub(self, other: &'a bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn &bitcoin_units::fee_rate::FeeRate::sub(self, other: bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add_assign(&mut self, other: bitcoin_units::Amount)
+pub fn bitcoin_units::Amount::clone(&self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::cmp(&self, other: &bitcoin_units::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::Amount::default() -> Self
+pub fn bitcoin_units::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
+pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Amount::from_int_btc(btc: u64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Amount::partial_cmp(&self, other: &bitcoin_units::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Amount::rem(self, modulus: u64) -> Self
+pub fn bitcoin_units::Amount::rem_assign(&mut self, modulus: u64)
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub_assign(&mut self, other: bitcoin_units::Amount)
+pub fn bitcoin_units::Amount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::Amount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Amount>
+pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::Amount::unchecked_add(self, rhs: bitcoin_units::Amount) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::unchecked_sub(self, rhs: bitcoin_units::Amount) -> bitcoin_units::Amount
+pub fn bitcoin_units::SignedAmount::abs(self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add_assign(&mut self, other: bitcoin_units::SignedAmount)
+pub fn bitcoin_units::SignedAmount::clone(&self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::cmp(&self, other: &bitcoin_units::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::SignedAmount::default() -> Self
+pub fn bitcoin_units::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
+pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::SignedAmount::from_int_btc(btc: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::SignedAmount::neg(self) -> Self::Output
+pub fn bitcoin_units::SignedAmount::partial_cmp(&self, other: &bitcoin_units::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::SignedAmount::positive_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn bitcoin_units::SignedAmount::rem(self, modulus: i64) -> Self
+pub fn bitcoin_units::SignedAmount::rem_assign(&mut self, modulus: i64)
+pub fn bitcoin_units::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub_assign(&mut self, other: bitcoin_units::SignedAmount)
+pub fn bitcoin_units::SignedAmount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::SignedAmount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::SignedAmount>
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::try_from(value: bitcoin_units::Amount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::SignedAmount::unchecked_add(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
+pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::error::InputTooLargeError::clone(&self) -> bitcoin_units::amount::error::InputTooLargeError
+pub fn bitcoin_units::amount::error::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::error::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::error::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::error::InvalidCharacterError
+pub fn bitcoin_units::amount::error::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::error::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::error::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::MissingDenominationError::clone(&self) -> bitcoin_units::amount::error::MissingDenominationError
+pub fn bitcoin_units::amount::error::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::error::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::error::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::MissingDigitsError::clone(&self) -> bitcoin_units::amount::error::MissingDigitsError
+pub fn bitcoin_units::amount::error::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::error::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::error::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::OutOfRangeError::clone(&self) -> bitcoin_units::amount::error::OutOfRangeError
+pub fn bitcoin_units::amount::error::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::error::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::OutOfRangeError::is_above_max(&self) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::is_below_min(&self) -> bool
+pub fn bitcoin_units::amount::error::OutOfRangeError::valid_range(&self) -> (i64, u64)
+pub fn bitcoin_units::amount::error::ParseAmountError::clone(&self) -> bitcoin_units::amount::error::ParseAmountError
+pub fn bitcoin_units::amount::error::ParseAmountError::eq(&self, other: &bitcoin_units::amount::error::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::error::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::error::ParseDenominationError::clone(&self) -> bitcoin_units::amount::error::ParseDenominationError
+pub fn bitcoin_units::amount::error::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::error::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::error::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::ParseError::clone(&self) -> bitcoin_units::amount::error::ParseError
+pub fn bitcoin_units::amount::error::ParseError::eq(&self, other: &bitcoin_units::amount::error::ParseError) -> bool
+pub fn bitcoin_units::amount::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::error::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::error::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::error::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::TooPreciseError::clone(&self) -> bitcoin_units::amount::error::TooPreciseError
+pub fn bitcoin_units::amount::error::TooPreciseError::eq(&self, other: &bitcoin_units::amount::error::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::error::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::error::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::error::UnknownDenominationError
+pub fn bitcoin_units::amount::error::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::error::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::error::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
+pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeight::eq(&self, other: &bitcoin_units::block::BlockHeight) -> bool
+pub fn bitcoin_units::block::BlockHeight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_units::block::BlockHeight::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeight::partial_cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockInterval::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::clone(&self) -> bitcoin_units::block::BlockInterval
+pub fn bitcoin_units::block::BlockInterval::cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockInterval::eq(&self, other: &bitcoin_units::block::BlockInterval) -> bool
+pub fn bitcoin_units::block::BlockInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockInterval::from(h: bitcoin_units::locktime::relative::Height) -> Self
+pub fn bitcoin_units::block::BlockInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockInterval::sub(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockInterval)
+pub fn bitcoin_units::block::BlockInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockInterval>
+pub fn bitcoin_units::block::BlockInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::clone(&self) -> bitcoin_units::block::TooBigForRelativeBlockHeightError
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::eq(&self, other: &bitcoin_units::block::TooBigForRelativeBlockHeightError) -> bool
+pub fn bitcoin_units::block::TooBigForRelativeBlockHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::fee_rate::FeeRate::add(self, other: &bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn bitcoin_units::fee_rate::FeeRate::add(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::add_assign(&mut self, rhs: &bitcoin_units::fee_rate::FeeRate)
+pub fn bitcoin_units::fee_rate::FeeRate::add_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::fee_rate::FeeRate::clone(&self) -> bitcoin_units::fee_rate::FeeRate
+pub fn bitcoin_units::fee_rate::FeeRate::cmp(&self, other: &bitcoin_units::fee_rate::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin_units::fee_rate::FeeRate::eq(&self, other: &bitcoin_units::fee_rate::FeeRate) -> bool
+pub fn bitcoin_units::fee_rate::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::fee_rate::FeeRate::fee_wu(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::fee_rate::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::fee_rate::FeeRate::from_sat_per_vb(sat_vb: u64) -> core::option::Option<Self>
+pub fn bitcoin_units::fee_rate::FeeRate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::fee_rate::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::fee_rate::FeeRate::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::partial_cmp(&self, other: &bitcoin_units::fee_rate::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::fee_rate::FeeRate::sub(self, other: &bitcoin_units::fee_rate::FeeRate) -> <bitcoin_units::fee_rate::FeeRate as core::ops::arith::Add>::Output
+pub fn bitcoin_units::fee_rate::FeeRate::sub(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::fee_rate::FeeRate::sub_assign(&mut self, rhs: &bitcoin_units::fee_rate::FeeRate)
+pub fn bitcoin_units::fee_rate::FeeRate::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::fee_rate::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::fee_rate::FeeRate>
+pub fn bitcoin_units::fee_rate::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::fee_rate::FeeRate::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ConversionError::clone(&self) -> bitcoin_units::locktime::absolute::ConversionError
+pub fn bitcoin_units::locktime::absolute::ConversionError::eq(&self, other: &bitcoin_units::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin_units::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::clone(&self) -> bitcoin_units::locktime::absolute::Height
+pub fn bitcoin_units::locktime::absolute::Height::cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Height::eq(&self, other: &bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseHeightError>
+pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(h: bitcoin_units::block::BlockHeight) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::ParseHeightError
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin_units::locktime::absolute::ParseTimeError
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Time::clone(&self) -> bitcoin_units::locktime::absolute::Time
+pub fn bitcoin_units::locktime::absolute::Time::cmp(&self, other: &bitcoin_units::locktime::absolute::Time) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Time::eq(&self, other: &bitcoin_units::locktime::absolute::Time) -> bool
+pub fn bitcoin_units::locktime::absolute::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Time::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseTimeError>
+pub fn bitcoin_units::locktime::absolute::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Time::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::clone(&self) -> bitcoin_units::locktime::relative::Height
+pub fn bitcoin_units::locktime::relative::Height::cmp(&self, other: &bitcoin_units::locktime::relative::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::Height::default() -> bitcoin_units::locktime::relative::Height
+pub fn bitcoin_units::locktime::relative::Height::eq(&self, other: &bitcoin_units::locktime::relative::Height) -> bool
+pub fn bitcoin_units::locktime::relative::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::Height::from(value: u16) -> Self
+pub fn bitcoin_units::locktime::relative::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::Height::partial_cmp(&self, other: &bitcoin_units::locktime::relative::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::Height::try_from(h: bitcoin_units::block::BlockInterval) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::Time::clone(&self) -> bitcoin_units::locktime::relative::Time
+pub fn bitcoin_units::locktime::relative::Time::cmp(&self, other: &bitcoin_units::locktime::relative::Time) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::Time::default() -> bitcoin_units::locktime::relative::Time
+pub fn bitcoin_units::locktime::relative::Time::eq(&self, other: &bitcoin_units::locktime::relative::Time) -> bool
+pub fn bitcoin_units::locktime::relative::Time::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::Time::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::Time::partial_cmp(&self, other: &bitcoin_units::locktime::relative::Time) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::Time::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::TimeOverflowError
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::TimeOverflowError) -> bool
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::new(seconds: u32) -> Self
+pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
+pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
+pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
+pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::int<T: bitcoin_units::parse::Integer, S: core::convert::AsRef<str> + core::convert::Into<bitcoin_internals::error::input_string::InputString>>(s: S) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::weight::Weight::add(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::add_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::weight::Weight::clone(&self) -> bitcoin_units::weight::Weight
+pub fn bitcoin_units::weight::Weight::cmp(&self, other: &bitcoin_units::weight::Weight) -> core::cmp::Ordering
+pub fn bitcoin_units::weight::Weight::div(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::weight::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::weight::Weight::eq(&self, other: &bitcoin_units::weight::Weight) -> bool
+pub fn bitcoin_units::weight::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::weight::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub fn bitcoin_units::weight::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::weight::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::weight::Weight::mul(self, rhs: bitcoin_units::fee_rate::FeeRate) -> Self::Output
+pub fn bitcoin_units::weight::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::weight::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::weight::Weight::partial_cmp(&self, other: &bitcoin_units::weight::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::weight::Weight::sub(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub fn bitcoin_units::weight::Weight::sub_assign(&mut self, rhs: Self)
+pub fn bitcoin_units::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::weight::Weight>
+pub fn bitcoin_units::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::weight::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockHeight) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockInterval) -> Self
+pub fn u64::from(value: bitcoin_units::fee_rate::FeeRate) -> Self
+pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
+pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
+pub macro bitcoin_units::impl_parse_str!
+pub macro bitcoin_units::impl_parse_str_from_int_infallible!
+pub macro bitcoin_units::impl_tryfrom_str!
+pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub mod bitcoin_units::amount::error
+pub mod bitcoin_units::block
+pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::locktime
+pub mod bitcoin_units::locktime::absolute
+pub mod bitcoin_units::locktime::relative
+pub mod bitcoin_units::parse
+pub mod bitcoin_units::weight
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::BlockHeight(pub u32)
+pub struct bitcoin_units::BlockInterval(pub u32)
+pub struct bitcoin_units::FeeRate(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::Weight(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::InputTooLargeError
+pub struct bitcoin_units::amount::InvalidCharacterError
+pub struct bitcoin_units::amount::MissingDigitsError
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::ParseAmountError(_)
+pub struct bitcoin_units::amount::ParseError(_)
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub struct bitcoin_units::amount::TooPreciseError
+pub struct bitcoin_units::amount::error::InputTooLargeError
+pub struct bitcoin_units::amount::error::InvalidCharacterError
+pub struct bitcoin_units::amount::error::MissingDigitsError
+pub struct bitcoin_units::amount::error::OutOfRangeError
+pub struct bitcoin_units::amount::error::ParseAmountError(_)
+pub struct bitcoin_units::amount::error::ParseError(_)
+pub struct bitcoin_units::amount::error::TooPreciseError
+pub struct bitcoin_units::block::BlockHeight(pub u32)
+pub struct bitcoin_units::block::BlockInterval(pub u32)
+pub struct bitcoin_units::block::TooBigForRelativeBlockHeightError(_)
+pub struct bitcoin_units::fee_rate::FeeRate(_)
+pub struct bitcoin_units::locktime::absolute::Height(_)
+pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin_units::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin_units::locktime::absolute::Time(_)
+pub struct bitcoin_units::locktime::relative::Height(_)
+pub struct bitcoin_units::locktime::relative::Time(_)
+pub struct bitcoin_units::locktime::relative::TimeOverflowError
+pub struct bitcoin_units::parse::PrefixedHexError(_)
+pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::weight::Weight(_)
+pub trait bitcoin_units::amount::CheckedSum<R>: private::SumSeal<R>
+pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized
+pub type &bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::error::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
+pub type bitcoin_units::Amount::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::error::ParseError
+pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockInterval
+pub type bitcoin_units::block::BlockInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockInterval::Output = bitcoin_units::block::BlockInterval
+pub type bitcoin_units::fee_rate::FeeRate::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::fee_rate::FeeRate::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::Amount
+pub type bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
+pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Time::Err = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::absolute::Time::Error = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::relative::Height::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::block::TooBigForRelativeBlockHeightError
+pub type bitcoin_units::locktime::relative::Height::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Time::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::Time::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::weight::Weight::Output = bitcoin_units::Amount
+pub type bitcoin_units::weight::Weight::Output = bitcoin_units::weight::Weight
+pub type bitcoin_units::weight::Weight::Output = u64
+pub type u64::Output = bitcoin_units::weight::Weight

--- a/contrib/api.sh
+++ b/contrib/api.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Script for querying the API.
+#
+# Shellcheck can't search dynamic paths
+# shellcheck source=/dev/null
+
+set -euo pipefail
+
+file=""                         # File name of the all-features API text file.
+crate_full_name=""              # Full crate name using underscores e.g., `bitcoin_primitives`.
+crate=""                        # Short name e.g., `primitives`.
+
+# Set to false to turn off verbose output.
+flag_verbose=false
+
+usage() {
+    cat <<EOF
+Usage:
+
+    ./api.sh CRATE COMMAND
+
+CRATE
+  - hashes          bitcoin_hashes
+  - io              bitcoin-io
+  - primitives      bitcoin-primitives
+  - units           bitcoin-units
+
+CMD
+  - types             Show all public types (structs and enums)
+  - types_no_err      Show all public types (structs and enums) excluding error types.
+EOF
+}
+
+main() {
+    if [ "$#" -lt 1 ]; then
+        usage
+        exit 1
+    fi
+
+    local _crate="${1:---help}"
+    if [[ "$_crate" == "-h" || "$_crate" == "--help" ]]; then
+        usage
+        exit 1
+    fi
+
+    if [ "$#" -lt 2 ]; then
+        say_err "Missing COMMAND"
+        usage
+        exit 1
+    fi
+
+    local _cmd="$2"
+
+    check_required_commands
+
+    case $_crate in
+        hashes)
+            crate_full_name="bitcoin_hashes"
+            ;;
+        io)
+            crate_full_name="bitcoin_io"
+            ;;
+        primitives)
+            crate_full_name="bitcoin_primitives"
+            ;;
+        units)
+            crate_full_name="bitcoin_units"
+            ;;
+        *)
+            say_err "unsupported crate: $_crate"
+            usage
+            exit 1
+    esac
+
+    crate=$_crate
+    file="./api/$crate/all-features.txt"
+
+    verbose_say "Running command '$_cmd' on crate '$crate'"
+
+    case $_cmd in
+	types)
+            structs_and_enums
+            ;;
+
+	types_no_err)
+            structs_and_enums_no_err
+            ;;
+
+        traits)
+            traits
+            ;;
+
+        *)
+            err "Error: unknown cmd $_cmd"
+            ;;
+    esac
+}
+
+# Print all public structs and enums.
+structs_and_enums() {
+    grep -oP 'pub (struct|enum) \K[\w:]+(?=\(|;| )' "$file" | sed "s/^${crate_full_name}:://"
+}
+
+# Print all public structs and enums excluding error types.
+structs_and_enums_no_err() {
+    grep -oP 'pub (struct|enum) \K[\w:]+(?=\(|;| )' "$file" | sed "s/^${crate_full_name}:://" | grep -v Error
+}
+
+# Print all public traits.
+traits() {
+    grep -oP '^pub trait \K[\w:]+' "$file" | sed "s/^${crate_full_name}:://" | sed 's/:$//'
+}
+
+# Check all the commands we use are present in the current environment.
+check_required_commands() {
+    need_cmd grep
+}
+
+say() {
+    echo "api: $1"
+}
+
+say_err() {
+    say "$1" >&2
+}
+
+verbose_say() {
+    if [ "$flag_verbose" = true ]; then
+	say "$1"
+    fi
+}
+
+err() {
+    echo "$1" >&2
+    exit 1
+}
+
+need_cmd() {
+    if ! command -v "$1" > /dev/null 2>&1
+    then err "need '$1' (command not found)"
+    fi
+}
+
+#
+# Main script
+#
+main "$@"
+exit 0

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Checks the public API of crates, exits with non-zero if there are currently
+# changes to the public API not already committed to in the various api/*.txt
+# files.
+
+set -euo pipefail
+
+REPO_DIR=$(git rev-parse --show-toplevel)
+API_DIR="$REPO_DIR/api"
+
+NIGHTLY=$(cat nightly-version)
+# Our docs have broken intra doc links if all features are not enabled.
+RUSTDOCFLAGS="-A rustdoc::broken_intra_doc_links"
+
+# `sort -n -u` doesn't work for some reason.
+SORT="sort --numeric-sort"
+
+# Sort order is effected by locale. See `man sort`.
+# > Set LC_ALL=C to get the traditional sort order that uses native byte values.
+export LC_ALL=C
+
+main() {
+    need_nightly
+
+    generate_api_files "hashes"
+    generate_api_files "io"
+    generate_api_files "primitives"
+    generate_api_files "units"
+
+    check_for_changes
+}
+
+# Uses `CARGO` to generate API files in the specified crate.
+#
+# Files:
+#
+# - no-features.txt
+# - alloc-only.txt
+# - all-features.txt
+generate_api_files() {
+    local crate=$1
+    pushd "$REPO_DIR/$crate" > /dev/null
+
+    run_cargo --no-default-features | $SORT | uniq > "$API_DIR/$crate/no-features.txt"
+    run_cargo --no-default-features --features=alloc | $SORT | uniq > "$API_DIR/$crate/alloc-only.txt"
+    run_cargo_all_features | $SORT | uniq > "$API_DIR/$crate/all-features.txt"
+
+    popd > /dev/null
+}
+
+# Check if there are changes (dirty git index) to the `api/` directory.
+check_for_changes() {
+    pushd "$REPO_DIR" > /dev/null
+
+    if [[ $(git status --porcelain api) ]]; then
+        git diff --color=always
+        echo
+        err "You have introduced changes to the public API, commit the changes to api/ currently in your working directory"
+    else
+        echo "No changes to the current public API"
+    fi
+
+    popd > /dev/null
+}
+
+# Run cargo when --all-features is not used.
+run_cargo() {
+    RUSTDOCFLAGS="$RUSTDOCFLAGS" cargo +"$NIGHTLY" public-api --simplified "$@"
+}
+
+# Run cargo with all features enabled.
+run_cargo_all_features() {
+    cargo +"$NIGHTLY" public-api --simplified --all-features
+}
+
+need_nightly() {
+    cargo_ver=$(cargo +"$NIGHTLY" --version)
+    if echo "$cargo_ver" | grep -q -v nightly; then
+        err "Need a nightly compiler; have $cargo_ver"
+    fi
+}
+
+err() {
+    echo "$1" >&2
+    exit 1
+}
+
+#
+# Main script
+#
+main "$@"
+exit 0

--- a/justfile
+++ b/justfile
@@ -36,6 +36,10 @@ sane: lint
   # Make an attempt to catch feature gate problems in doctests
   cargo test --manifest-path bitcoin/Cargo.toml --doc --no-default-features > /dev/null || exit 1
 
+# Check for API changes.
+check-api:
+ contrib/check-for-api-changes.sh
+
 # Update the recent and minimal lock files.
 update-lock-files:
   contrib/update-lock-files.sh

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set positional-arguments
+
 default:
   @just --list
 
@@ -39,6 +41,10 @@ sane: lint
 # Check for API changes.
 check-api:
  contrib/check-for-api-changes.sh
+
+# Query the current API.
+@query-api crate command:
+ contrib/api.sh $1 $2
 
 # Update the recent and minimal lock files.
 update-lock-files:


### PR DESCRIPTION
Last time we did this there was push back by Kixunil because he did not like updating the API files. This time we only add API files for those crates we are focused on stabalizing.

As we try to do the checklists for making sure the crates conform to the Rust API guidelines one has to repeatedly audit the code. Being able to quickly get lists of things out of the code is super useful.

And the after we release 1.0 these API text files become valuable for review. 

--

Add a script to generate API files using `cargo check-api` for the crates that we are trying to stabalise.

- hashes
- io
- primitives
- units

Add a script to query the API files. E.g., `contrib/api.sh units types`

Current commands are

`types`: Show all public structs and enums
`types_no_err`: Show all public structs and enums excluding errors
`traits`:  Show all public traits