### PR TITLE
Change `Amount::MAX` from `u64::MAX` to `Amount::MAX_MONEY`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1710,12 +1710,6 @@ mod tests {
     }
 
     #[test]
-    fn effective_value_value_does_not_overflow() {
-        let eff_value = effective_value(FeeRate::ZERO, Weight::ZERO, Amount::MAX);
-        assert!(eff_value.is_none());
-    }
-
-    #[test]
     fn txin_txout_weight() {
         // [(is_segwit, tx_hex, expected_weight)]
         let txs = [

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -2159,7 +2159,7 @@ mod tests {
         let output_1_val = Amount::from_sat(100_000_000);
         let prev_output_val = Amount::from_sat(200_000_000);
 
-        let mut t = Psbt {
+        let t = Psbt {
             unsigned_tx: Transaction {
                 version: transaction::Version::TWO,
                 lock_time: absolute::LockTime::from_consensus(1257139),
@@ -2251,13 +2251,6 @@ mod tests {
         t3.unsigned_tx.output[0].value = prev_output_val;
         match t3.fee().unwrap_err() {
             Error::NegativeFee => {}
-            e => panic!("unexpected error: {:?}", e),
-        }
-        // overflow
-        t.unsigned_tx.output[0].value = Amount::MAX;
-        t.unsigned_tx.output[1].value = Amount::MAX;
-        match t.fee().unwrap_err() {
-            Error::FeeOverflow => {}
             e => panic!("unexpected error: {:?}", e),
         }
     }


### PR DESCRIPTION
As discussed in #3688 and #3691 using `u64::MAX` causes errors when converting to `f64` so `MAX_MONEY` is should be used as the maximum `Amount`.  

 - `Amount::MAX` changed to equal `MAX_MONEY`
 - Add a check to add, multiply and from_str functions
 - Change tests to account for new lower maximum

Different approach to the existing PR #3692.  I have only done Amount and not SignedAmount until there is feedback on which approach to use.