### PR TITLE
Range check against SignedAmount::MAX instead of i64::MAX

### DIFF
--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -108,7 +108,7 @@ impl SignedAmount {
     pub fn from_str_in(s: &str, denom: Denomination) -> Result<SignedAmount, ParseAmountError> {
         match parse_signed_to_satoshi(s, denom).map_err(|error| error.convert(true))? {
             // (negative, amount)
-            (false, sat) if sat > i64::MAX as u64 => Err(ParseAmountError(
+            (false, sat) if sat > SignedAmount::MAX.to_sat() as u64 => Err(ParseAmountError(
                 ParseAmountErrorInner::OutOfRange(OutOfRangeError::too_big(true)),
             )),
             (false, sat) => Ok(SignedAmount(sat as i64)),


### PR DESCRIPTION
Future proof this check by using SignedAmount::MAX in the case where the MAX SignedAmount changes to something other then i64::MAX.