### PR TITLE
Add from sat unchecked and checked to signed

### DIFF
--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -108,7 +108,8 @@ impl SerdeAmount for SignedAmount {
         i64::serialize(&self.to_sat(), s)
     }
     fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
-        Ok(SignedAmount::from_sat(i64::deserialize(d)?))
+        // TODO: replace with checked version
+        Ok(SignedAmount::from_sat_unchecked(i64::deserialize(d)?))
     }
     #[cfg(feature = "alloc")]
     fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {

--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -108,8 +108,9 @@ impl SerdeAmount for SignedAmount {
         i64::serialize(&self.to_sat(), s)
     }
     fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
-        // TODO: replace with checked version
-        Ok(SignedAmount::from_sat_unchecked(i64::deserialize(d)?))
+        use serde::de::Error;
+        let des = i64::deserialize(d)?;
+        SignedAmount::from_sat(des).ok_or(<D as Deserializer>::Error::custom("exceeds MAX"))
     }
     #[cfg(feature = "alloc")]
     fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -63,14 +63,20 @@ impl SignedAmount {
     pub const MAX: SignedAmount = SignedAmount(i64::MAX);
 
     /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
-    #[deprecated(since = "TBD", note = "use `SignedAmount::from_sat_unchecked` instead")]
-    pub const fn from_sat(satoshi: i64) -> SignedAmount { SignedAmount(satoshi) }
+    #[allow(clippy::absurd_extreme_comparisons)]
+    pub const fn from_sat(satoshi: i64) -> Option<SignedAmount> {
+        if satoshi <= Self::MAX.0 {
+            Some(SignedAmount(satoshi))
+        } else {
+            None
+        }
+    }
 
     /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
     ///
     /// # Panics
     ///
-    /// On values exceeding [`Amount::MAX`].
+    /// On values exceeding [`SignedAmount::MAX`].
     #[allow(clippy::absurd_extreme_comparisons)]
     pub const fn from_sat_unchecked(satoshi: i64) -> SignedAmount {
         if satoshi <= Self::MAX.0 {

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -329,7 +329,8 @@ impl Amount {
         if self.to_sat() > SignedAmount::MAX.to_sat() as u64 {
             Err(OutOfRangeError::too_big(true))
         } else {
-            Ok(SignedAmount::from_sat(self.to_sat() as i64))
+            // TODO replace with checked version and return error if NONE
+            Ok(SignedAmount::from_sat_unchecked(self.to_sat() as i64))
         }
     }
 }

--- a/units/src/amount/verification.rs
+++ b/units/src/amount/verification.rs
@@ -41,7 +41,7 @@ fn u_amount_homomorphic() {
     assert_eq!(
         Amount::from_sat(n1).to_signed(),
         if n1 <= i64::MAX as u64 {
-            Ok(SignedAmount::from_sat(n1.try_into().unwrap()))
+            Ok(SignedAmount::from_sat_unchecked(n1.try_into().unwrap()))
         } else {
             Err(OutOfRangeError::too_big(true))
         },
@@ -71,23 +71,23 @@ fn s_amount_homomorphic() {
     kani::assume(n1.checked_add(n2).is_some()); // assume we don't overflow in the actual test
     kani::assume(n1.checked_sub(n2).is_some()); // assume we don't overflow in the actual test
     assert_eq!(
-        SignedAmount::from_sat(n1) + SignedAmount::from_sat(n2),
-        SignedAmount::from_sat(n1 + n2)
+        SignedAmount::from_sat_unchecked(n1) + SignedAmount::from_sat_unchecked(n2),
+        SignedAmount::from_sat_unchecked(n1 + n2)
     );
     assert_eq!(
-        SignedAmount::from_sat(n1) - SignedAmount::from_sat(n2),
-        SignedAmount::from_sat(n1 - n2)
+        SignedAmount::from_sat_unchecked(n1) - SignedAmount::from_sat_unchecked(n2),
+        SignedAmount::from_sat_unchecked(n1 - n2)
     );
 
-    let mut amt = SignedAmount::from_sat(n1);
-    amt += SignedAmount::from_sat(n2);
-    assert_eq!(amt, SignedAmount::from_sat(n1 + n2));
-    let mut amt = SignedAmount::from_sat(n1);
-    amt -= SignedAmount::from_sat(n2);
-    assert_eq!(amt, SignedAmount::from_sat(n1 - n2));
+    let mut amt = SignedAmount::from_sat_unchecked(n1);
+    amt += SignedAmount::from_sat_unchecked(n2);
+    assert_eq!(amt, SignedAmount::from_sat_unchecked(n1 + n2));
+    let mut amt = SignedAmount::from_sat_unchecked(n1);
+    amt -= SignedAmount::from_sat_unchecked(n2);
+    assert_eq!(amt, SignedAmount::from_sat_unchecked(n1 - n2));
 
     assert_eq!(
-        SignedAmount::from_sat(n1).to_unsigned(),
+        SignedAmount::from_sat_unchecked(n1).to_unsigned(),
         if n1 >= 0 {
             Ok(Amount::from_sat(n1.try_into().unwrap()))
         } else {
@@ -102,16 +102,16 @@ fn s_amount_homomorphic_checked() {
     let n1 = kani::any::<i64>();
     let n2 = kani::any::<i64>();
     assert_eq!(
-        SignedAmount::from_sat(n1).checked_add(SignedAmount::from_sat(n2)),
-        n1.checked_add(n2).map(SignedAmount::from_sat),
+        SignedAmount::from_sat_unchecked(n1).checked_add(SignedAmount::from_sat_unchecked(n2)),
+        n1.checked_add(n2).map(SignedAmount::from_sat_unchecked),
     );
     assert_eq!(
-        SignedAmount::from_sat(n1).checked_sub(SignedAmount::from_sat(n2)),
-        n1.checked_sub(n2).map(SignedAmount::from_sat),
+        SignedAmount::from_sat_unchecked(n1).checked_sub(SignedAmount::from_sat_unchecked(n2)),
+        n1.checked_sub(n2).map(SignedAmount::from_sat_unchecked),
     );
 
     assert_eq!(
-        SignedAmount::from_sat(n1).positive_sub(SignedAmount::from_sat(n2)),
-        if n1 >= 0 && n2 >= 0 && n1 >= n2 { Some(SignedAmount::from_sat(n1 - n2)) } else { None },
+        SignedAmount::from_sat_unchecked(n1).positive_sub(SignedAmount::from_sat_unchecked(n2)),
+        if n1 >= 0 && n2 >= 0 && n1 >= n2 { Some(SignedAmount::from_sat_unchecked(n1 - n2)) } else { None },
     );
 }


### PR DESCRIPTION
This PR adds `from_sat_unchecked` to `SignedAmount` and changes the type signature of `from_sat` to return an `Option`.  This segways into https://github.com/rust-bitcoin/rust-bitcoin/issues/3691 where the next commit would change MAX to MAX_MONEY.  Since `SignedAmount` is used less, it's also a simple way to prototype this change before applying the larger change to `Amount`.