### PR TITLE
Add from sat checked

### DIFF
--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -108,7 +108,9 @@ impl SerdeAmount for SignedAmount {
         i64::serialize(&self.to_sat(), s)
     }
     fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
-        Ok(SignedAmount::from_sat(i64::deserialize(d)?))
+        use serde::de::Error;
+        let des = i64::deserialize(d)?;
+        SignedAmount::from_sat_checked(des).ok_or(<D as Deserializer>::Error::custom("exceeds MAX"))
     }
     #[cfg(feature = "alloc")]
     fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -63,7 +63,18 @@ impl SignedAmount {
     pub const MAX: SignedAmount = SignedAmount(i64::MAX);
 
     /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
-    pub const fn from_sat(satoshi: i64) -> SignedAmount { SignedAmount(satoshi) }
+    ///
+    /// # Panics
+    ///
+    /// On values exceeding [`SignedAmount::MAX`].
+    #[allow(clippy::absurd_extreme_comparisons)]
+    pub const fn from_sat(satoshi: i64) -> SignedAmount {
+        if satoshi <= Self::MAX.0 {
+            SignedAmount(satoshi)
+        } else {
+            panic!("Exceeds SignedAmount::MAX")
+        }
+    }
 
     /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
     #[allow(clippy::absurd_extreme_comparisons)]

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -65,6 +65,16 @@ impl SignedAmount {
     /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
     pub const fn from_sat(satoshi: i64) -> SignedAmount { SignedAmount(satoshi) }
 
+    /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
+    #[allow(clippy::absurd_extreme_comparisons)]
+    pub const fn from_sat_checked(satoshi: i64) -> Option<SignedAmount> {
+        if satoshi <= Self::MAX.0 {
+            Some(SignedAmount(satoshi))
+        } else {
+            None
+        }
+    }
+
     /// Gets the number of satoshis in this [`SignedAmount`].
     pub const fn to_sat(self) -> i64 { self.0 }
 


### PR DESCRIPTION
Replaces https://github.com/rust-bitcoin/rust-bitcoin/pull/3698

- Adds a checked variant of from_sats
- Explicitly panic in function from_sats

With these two changes, we can add another commit to change `MAX` to `MAX_MONEY` next.  Once that is done, remove `#[allow(clippy::absurd_extreme_comparisons)]`.