### PR TITLE
units: test for C-SEND-SYNC

### DIFF
--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -235,3 +235,17 @@ fn api_all_non_error_types_have_non_empty_debug() {
     let debug = format!("{:?}", t.b.k);
     assert!(!debug.is_empty());
 }
+
+#[test]
+fn test_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<Types>();
+    assert_send::<Errors>();
+}
+
+#[test]
+fn test_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<Types>();
+    assert_sync::<Errors>();
+}


### PR DESCRIPTION
Done as part of the Rust API guidelines checklist.

Add a unit test for `Send` and one for `Sync`.