### PR TITLE
primitives: Add `must_use`

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -77,6 +77,7 @@ impl Block<Unchecked> {
     /// Ignores block validation logic and just assumes you know what you are doing.
     ///
     /// You should only use this function if you trust the block i.e., it comes from a trusted node.
+    #[must_use]
     pub fn assume_checked(self, witness_root: Option<WitnessMerkleNode>) -> Block<Checked> {
         Block {
             header: self.header,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -16,6 +16,9 @@
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]
 #![doc(test(attr(warn(unused))))]
+// Pedantic lints that we enforce.
+// #![warn(clippy::must_use_candidate)]
+#![warn(clippy::return_self_not_must_use)]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -351,6 +351,7 @@ pub enum ClassifyContext {
 impl Opcode {
     /// Classifies an Opcode into a broad class.
     #[inline]
+    #[must_use]
     pub fn classify(self, ctx: ClassifyContext) -> Class {
         match (self, ctx) {
             // 3 opcodes illegal in all contexts
@@ -424,6 +425,7 @@ impl Opcode {
     ///
     /// Returns `None` if `self` is not a PUSHNUM.
     #[inline]
+    #[must_use]
     pub const fn decode_pushnum(self) -> Option<u8> {
         const START: u8 = OP_PUSHNUM_1.code;
         const END: u8 = OP_PUSHNUM_16.code;

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -115,7 +115,7 @@ impl Script {
     pub fn is_empty(&self) -> bool { self.0.is_empty() }
 
     /// Converts a [`Box<Script>`](Box) into a [`ScriptBuf`] without copying or allocating.
-    #[must_use = "`self` will be dropped if the result is not used"]
+    #[must_use]
     pub fn into_script_buf(self: Box<Self>) -> ScriptBuf {
         let rw = Box::into_raw(self) as *mut [u8];
         // SAFETY: copied from `std`

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -48,7 +48,7 @@ impl ScriptBuf {
     /// when they are equal. If you know beforehand that you need to create a script of exact size
     /// use [`reserve_exact`](Self::reserve_exact) before adding data to the script so that the
     /// reallocation can be avoided.
-    #[must_use = "`self` will be dropped if the result is not used"]
+    #[must_use]
     #[inline]
     pub fn into_boxed_script(self) -> Box<Script> {
         // Copied from PathBuf::into_boxed_path

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -103,6 +103,7 @@ impl Witness {
     pub fn is_empty(&self) -> bool { self.witness_elements == 0 }
 
     /// Returns a struct implementing [`Iterator`].
+    #[must_use = "returned iterator should be used"]
     pub fn iter(&self) -> Iter {
         Iter { inner: self.content.as_slice(), indices_start: self.indices_start, current_index: 0 }
     }


### PR DESCRIPTION
Enable lint `clippy::return_self_not_must_use` and add attribute `must_use` as required.

Also run the linter with `clippy::must_use_candidate` enabled and manually check every warning site.

Done as part of #3185