### PR TITLE
io: Add lint `return_self_not_must_use`

### DIFF
--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -14,6 +14,8 @@
 // Coding conventions.
 #![warn(missing_docs)]
 #![doc(test(attr(warn(unused))))]
+// Pedantic lints that we enforce.
+#![warn(clippy::return_self_not_must_use)]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.


### PR DESCRIPTION
Enable lint `clippy::return_self_not_must_use`. Does not generate any new warnings.

Also run the linter with `clippy::must_use_candidate` enabled. Also does not generate any new warnings.

Done as part of #3185