### PR TITLE
hashes: Add `must_use`

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -58,6 +58,8 @@
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]
 #![doc(test(attr(warn(unused))))]
+// Pedantic lints that we enforce.
+#![warn(clippy::return_self_not_must_use)]
 // Instead of littering the codebase for non-fuzzing and bench code just globally allow.
 #![cfg_attr(hashes_fuzz, allow(dead_code, unused_imports))]
 #![cfg_attr(bench, allow(dead_code, unused_imports))]

--- a/hashes/src/sha256.rs
+++ b/hashes/src/sha256.rs
@@ -135,6 +135,7 @@ impl crate::HashEngine for HashEngine {
 
 impl Hash {
     /// Iterate the sha256 algorithm to turn a sha256 hash into a sha256d hash
+    #[must_use]
     pub fn hash_again(&self) -> sha256d::Hash {
         crate::Hash::from_byte_array(<Self as crate::GeneralHash>::hash(&self.0).0)
     }
@@ -202,6 +203,7 @@ impl Midstate {
     ///
     /// Computes non-finalized hash of `sha256(tag) || sha256(tag)` for use in [`sha256t`]. It's
     /// provided for use with [`sha256t`].
+    #[must_use]
     pub const fn hash_tag(tag: &[u8]) -> Self {
         let hash = Hash::hash_unoptimized(tag);
         let mut buf = [0u8; 64];


### PR DESCRIPTION
Enable `return_self_must_use` and also run the linter locally with `must_use_candidate`.

Add `must_use` attribute as required excluding obvious functions (conversion, getters, etc).

Done as part of #3185 