### PR TITLE
Release tracking PR: bitcoin `0.33.0-alpha.0` - again

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -22,7 +22,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes 0.15.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes 0.15.0",

--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.2.0 - 2024-12-10
+
+- Bump MSRV to `1.63` [#3100](https://github.com/rust-bitcoin/rust-bitcoin/pull/3100)
+- Optimize `base58` on small inputs [#3002](https://github.com/rust-bitcoin/rust-bitcoin/pull/3002)
+- Add `alloc` feature [#2996](https://github.com/rust-bitcoin/rust-bitcoin/pull/2996)
+- Remove zeroed vector by pushing front [#3227](https://github.com/rust-bitcoin/rust-bitcoin/pull/3227)
+- Close all errors [#3533](https://github.com/rust-bitcoin/rust-bitcoin/pull/3533)
+- Bump `hex-conservative` to `0.3.0` [#3543](https://github.com/rust-bitcoin/rust-bitcoin/pull/3543)
+
 # 0.1.0 - 2024-03-14
 
 Initial release of the `base58ck` crate. This crate was cut out of

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base58ck"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -22,7 +22,7 @@ For changes to our dependencies included in this release see:
 - `bitcoin_hashes 0.15`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/hashes/CHANGELOG.md)
 - `hex-conservative 0.3`: [changelog](https://github.com/rust-bitcoin/hex-conservative/blob/master/CHANGELOG.md)
 - `bitcoin-io 0.2`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/io/CHANGELOG.md)
-- `bitcoin-primitives: 0.101`: [changelog]((https://github.com/rust-bitcoin/rust-bitcoin/blob/master/primitives/CHANGELOG.md))
+- `bitcoin-primitives: 0.101`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/primitives/CHANGELOG.md)
 - `bitcoin-units 0.2`: [changelog]((https://github.com/rust-bitcoin/rust-bitcoin/blob/master/units/CHANGELOG.md))
 - `bitcoinconsensus: 0.106.0+26`: [changelog](https://github.com/rust-bitcoin/rust-bitcoinconsensus/blob/master/CHANGELOG.md)
 

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.33.0-alpha.0 - 2024-11-18
+# 0.33.0-alpha.0 - 2024-12-10
 
 This series of alpha releases is meant for two things:
 
@@ -25,9 +25,13 @@ For changes to our dependencies included in this release see:
 - `bitcoin-primitives: 0.101`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/primitives/CHANGELOG.md)
 - `bitcoin-units 0.2`: [changelog]((https://github.com/rust-bitcoin/rust-bitcoin/blob/master/units/CHANGELOG.md))
 - `bitcoinconsensus: 0.106.0+26`: [changelog](https://github.com/rust-bitcoin/rust-bitcoinconsensus/blob/master/CHANGELOG.md)
+- `base58ck: 0.2.0`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/base58/CHANGELOG.md)
 
 ## Changes
 
+- base58ck: Bump version to `0.2.0` [#3717](https://github.com/rust-bitcoin/rust-bitcoin/pull/3717)
+- Explicitly define `Ord` for `NodeInfo` [#3699](https://github.com/rust-bitcoin/rust-bitcoin/pull/3699)
+- Change `Amount::MAX` from `u64::MAX` to `Amount::MAX_MONEY` [#3693](https://github.com/rust-bitcoin/rust-bitcoin/pull/3693)
 - Fix psbt fuzz crash [#3667](https://github.com/rust-bitcoin/rust-bitcoin/pull/3667)
 - Update `from_next_work_required` to take an `i64` for timespan [#3660](https://github.com/rust-bitcoin/rust-bitcoin/pull/3660)
 - Account for data pushing opcodes in `is_standard_op_return` [#3643](https://github.com/rust-bitcoin/rust-bitcoin/pull/3643)

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -25,7 +25,7 @@ secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 
 [dependencies]
-base58 = { package = "base58ck", version = "0.1.0", default-features = false, features = ["alloc"] }
+base58 = { package = "base58ck", version = "0.2.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = false, features = ["alloc", "bitcoin-io", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Before doing #3630 we forgot to release `base58ck`. Lesson learned was that `cargo publish` should be run as part of release tracking PRs (e.g.,  `cargo publish -p bitcoin --dry-run`).

## TODO

- Merge https://github.com/rust-bitcoin/rust-bitcoin/pull/3717 and release `base58ck`
- Rebase this and run the `cargo publish` command
- Publish (and meekly back away quietly)