### PR TITLE
Rename private module to sealed

### DIFF
--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -562,7 +562,7 @@ enum DisplayStyle {
 }
 
 /// Calculates the sum over the iterator using checked arithmetic.
-pub trait CheckedSum<R>: private::SumSeal<R> {
+pub trait CheckedSum<R>: sealed::Sealed<R> {
     /// Calculates the sum over the iterator using checked arithmetic. If an over or underflow would
     /// happen it returns [`None`].
     fn checked_sum(self) -> Option<R>;
@@ -590,12 +590,12 @@ where
     }
 }
 
-mod private {
+mod sealed {
     use super::{Amount, SignedAmount};
 
     /// Used to seal the `CheckedSum` trait
-    pub trait SumSeal<A> {}
+    pub trait Sealed<A> {}
 
-    impl<T> SumSeal<Amount> for T where T: Iterator<Item = Amount> {}
-    impl<T> SumSeal<SignedAmount> for T where T: Iterator<Item = SignedAmount> {}
+    impl<T> Sealed<Amount> for T where T: Iterator<Item = Amount> {}
+    impl<T> Sealed<SignedAmount> for T where T: Iterator<Item = SignedAmount> {}
 }


### PR DESCRIPTION
There are two `private` modules in `amount` but they do slightly different things. One provides a private `Token` and one is for trait sealing. We have various other trait sealing modules in the codebase and they are all called `sealed` not `private`. Also the seal trait is called `Sealed`.

Rename the `private` module and the trait to be uniform with the rest of the codebase.