### PR TITLE
units: Improve default

### DIFF
--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -93,7 +93,7 @@ impl TryFrom<BlockHeight> for absolute::Height {
 ///
 /// This type is not meant for constructing relative height based timelocks, this is a general
 /// purpose block interval abstraction. For locktimes please see [`locktime::relative::Height`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 // Public to try and make it really clear that there are no invariants.
 pub struct BlockInterval(pub u32);

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -98,12 +98,13 @@ struct CommonTraits {
 }
 
 /// A struct that includes all types that implement `Default`.
-#[derive(Default)] // C-COMMON-TRAITS: `Default`
+#[derive(Debug, Default, PartialEq, Eq)] // C-COMMON-TRAITS: `Default`
 struct Default {
     a: Amount,
     b: SignedAmount,
-    c: relative::Height,
-    d: relative::Time,
+    c: BlockInterval,
+    d: relative::Height,
+    e: relative::Time,
 }
 
 /// A struct that includes all public error types.
@@ -248,4 +249,17 @@ fn test_sync() {
     fn assert_sync<T: Sync>() {}
     assert_sync::<Types>();
     assert_sync::<Errors>();
+}
+
+#[test]
+fn regression_default() {
+    let got: Default = Default::default();
+    let want = Default {
+        a: Amount::ZERO,
+        b: SignedAmount::ZERO,
+        c: BlockInterval::ZERO,
+        d: relative::Height::ZERO,
+        e: relative::Time::ZERO,
+    };
+    assert_eq!(got, want);
 }


### PR DESCRIPTION
Done while looking into [C-TOR](https://rust-lang.github.io/api-guidelines/predictability.html#c-ctor)

- Derive `Default` for `BlockInterval`
- Add regression test for all types that implement `Default`