### PR TITLE
BitVM Changes

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -797,6 +797,7 @@ impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
 impl core::str::traits::FromStr for bitcoin_primitives::locktime::absolute::LockTime
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::opcodes::Opcode
 impl core::str::traits::FromStr for bitcoin_primitives::script::ScriptHash
 impl core::str::traits::FromStr for bitcoin_primitives::script::WScriptHash
 impl core::str::traits::FromStr for bitcoin_primitives::sequence::Sequence
@@ -942,6 +943,7 @@ pub bitcoin_primitives::opcodes::Class::ReturnOp
 pub bitcoin_primitives::opcodes::Class::SuccessOp
 pub bitcoin_primitives::opcodes::ClassifyContext::Legacy
 pub bitcoin_primitives::opcodes::ClassifyContext::TapScript
+pub bitcoin_primitives::opcodes::Opcode::code: u8
 pub bitcoin_primitives::relative::IncompatibleHeightError::height: bitcoin_units::locktime::relative::Height
 pub bitcoin_primitives::relative::IncompatibleHeightError::time: bitcoin_units::locktime::relative::Time
 pub bitcoin_primitives::relative::IncompatibleTimeError::height: bitcoin_units::locktime::relative::Height
@@ -1536,6 +1538,7 @@ pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
 pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_primitives::opcodes::Opcode::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
 pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
@@ -1990,6 +1993,7 @@ pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes:
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Err = hex_conservative::error::HexToArrayError
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::opcodes::Opcode::Err = ()
 pub type bitcoin_primitives::script::Script::Output = bitcoin_primitives::script::Script
 pub type bitcoin_primitives::script::Script::Owned = bitcoin_primitives::script::ScriptBuf
 pub type bitcoin_primitives::script::ScriptBuf::Target = bitcoin_primitives::script::Script

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -791,6 +791,7 @@ impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
 impl core::str::traits::FromStr for bitcoin_primitives::locktime::absolute::LockTime
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::opcodes::Opcode
 impl core::str::traits::FromStr for bitcoin_primitives::script::ScriptHash
 impl core::str::traits::FromStr for bitcoin_primitives::script::WScriptHash
 impl core::str::traits::FromStr for bitcoin_primitives::sequence::Sequence
@@ -868,6 +869,7 @@ pub bitcoin_primitives::opcodes::Class::ReturnOp
 pub bitcoin_primitives::opcodes::Class::SuccessOp
 pub bitcoin_primitives::opcodes::ClassifyContext::Legacy
 pub bitcoin_primitives::opcodes::ClassifyContext::TapScript
+pub bitcoin_primitives::opcodes::Opcode::code: u8
 pub bitcoin_primitives::relative::IncompatibleHeightError::height: bitcoin_units::locktime::relative::Height
 pub bitcoin_primitives::relative::IncompatibleHeightError::time: bitcoin_units::locktime::relative::Time
 pub bitcoin_primitives::relative::IncompatibleTimeError::height: bitcoin_units::locktime::relative::Height
@@ -1437,6 +1439,7 @@ pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
 pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
 pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
 pub fn bitcoin_primitives::pow::CompactTarget::default() -> bitcoin_primitives::pow::CompactTarget
@@ -1847,6 +1850,7 @@ pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes:
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Err = hex_conservative::error::HexToArrayError
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::opcodes::Opcode::Err = ()
 pub type bitcoin_primitives::script::Script::Output = bitcoin_primitives::script::Script
 pub type bitcoin_primitives::script::Script::Owned = bitcoin_primitives::script::ScriptBuf
 pub type bitcoin_primitives::script::ScriptBuf::Target = bitcoin_primitives::script::Script

--- a/api/primitives/no-features.txt
+++ b/api/primitives/no-features.txt
@@ -517,6 +517,7 @@ impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
 impl core::str::traits::FromStr for bitcoin_primitives::locktime::absolute::LockTime
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::opcodes::Opcode
 impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapLeafHash
 impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapNodeHash
 impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapTweakHash
@@ -553,6 +554,7 @@ pub bitcoin_primitives::opcodes::Class::ReturnOp
 pub bitcoin_primitives::opcodes::Class::SuccessOp
 pub bitcoin_primitives::opcodes::ClassifyContext::Legacy
 pub bitcoin_primitives::opcodes::ClassifyContext::TapScript
+pub bitcoin_primitives::opcodes::Opcode::code: u8
 pub bitcoin_primitives::relative::IncompatibleHeightError::height: bitcoin_units::locktime::relative::Height
 pub bitcoin_primitives::relative::IncompatibleHeightError::time: bitcoin_units::locktime::relative::Time
 pub bitcoin_primitives::relative::IncompatibleTimeError::height: bitcoin_units::locktime::relative::Height
@@ -1045,6 +1047,7 @@ pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
 pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
 pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
 pub fn bitcoin_primitives::pow::CompactTarget::default() -> bitcoin_primitives::pow::CompactTarget
@@ -1258,6 +1261,7 @@ pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes:
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Err = hex_conservative::error::HexToArrayError
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::opcodes::Opcode::Err = ()
 pub type bitcoin_primitives::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub type bitcoin_primitives::taproot::TapLeafHash::Err = hex_conservative::error::HexToArrayError
 pub type bitcoin_primitives::taproot::TapNodeHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapBranchTag> as bitcoin_hashes::Hash>::Bytes

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -29,7 +29,8 @@ use crate::prelude::ToString;
 /// </details>
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Opcode {
-    code: u8,
+    /// The opcode value.
+    pub code: u8,
 }
 
 use self::all::*;

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -7,7 +7,7 @@
 
 #![allow(non_camel_case_types)]
 
-use core::fmt;
+use core::{fmt, str};
 
 use internals::debug_from_display;
 
@@ -69,6 +69,40 @@ macro_rules! all_opcodes {
                    $(
                         $op => core::fmt::Display::fmt(stringify!($op), f),
                     )+
+                }
+            }
+        }
+
+        impl str::FromStr for Opcode {
+            type Err = ();
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    "OP_0" => Ok(OP_0),
+                    "OP_TRUE" | "TRUE" => Ok(OP_TRUE),
+                    "OP_FALSE" | "FALSE" => Ok(OP_FALSE),
+                    "OP_NOP2" | "NOP2" => Ok(OP_NOP2),
+                    "OP_NOP3" | "NOP3" => Ok(OP_NOP3),
+                    "OP_1" => Ok(OP_PUSHNUM_1),
+                    "OP_2" => Ok(OP_PUSHNUM_2),
+                    "OP_3" => Ok(OP_PUSHNUM_3),
+                    "OP_4" => Ok(OP_PUSHNUM_4),
+                    "OP_5" => Ok(OP_PUSHNUM_5),
+                    "OP_6" => Ok(OP_PUSHNUM_6),
+                    "OP_7" => Ok(OP_PUSHNUM_7),
+                    "OP_8" => Ok(OP_PUSHNUM_8),
+                    "OP_9" => Ok(OP_PUSHNUM_9),
+                    "OP_10" => Ok(OP_PUSHNUM_10),
+                    "OP_11" => Ok(OP_PUSHNUM_11),
+                    "OP_12" => Ok(OP_PUSHNUM_12),
+                    "OP_13" => Ok(OP_PUSHNUM_13),
+                    "OP_14" => Ok(OP_PUSHNUM_14),
+                    "OP_15" => Ok(OP_PUSHNUM_15),
+                    "OP_16" => Ok(OP_PUSHNUM_16),
+                    $(
+                        // NB all opcodes begin with OP_
+                        s if s == stringify!($op) || s == &stringify!($op)[3..] => Ok($op),
+                    )+
+                    _ => Err(()),
                 }
             }
         }
@@ -552,7 +586,13 @@ mod tests {
             assert_eq!($op, Opcode::from($op.to_u8()));
 
             let s1 = format!("{}", $op);
+            let parsed = s1.parse::<Opcode>().expect("failed to parse opcode (Display)");
+            assert_eq!(parsed, $op);
+
             let s2 = format!("{:?}", $op);
+            let parsed = s2.parse::<Opcode>().expect("failed to parse opcode (Debug)");
+            assert_eq!(parsed, $op);
+
             assert_eq!(s1, s2);
             assert_eq!(s1, stringify!($op));
             assert!($unique.insert(s1));


### PR DESCRIPTION
Supersedes #2613.

- Exposes the internal `u8` from `Opcode`
- Defines a `FromStr` implementation for `Opcode`.