### PR TITLE
Bounds Check from_sat() constructor for SignedAmount

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -722,6 +722,7 @@ pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
 pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -721,7 +721,7 @@ pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
-pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
 pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -679,7 +679,7 @@ pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
-pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
 pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -680,6 +680,7 @@ pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
 pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -661,7 +661,7 @@ pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
-pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
 pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -662,6 +662,7 @@ pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
 pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32

--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -135,7 +135,9 @@ impl SerdeAmount for SignedAmount {
         i64::serialize(&self.to_sat(), s)
     }
     fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
-        Ok(SignedAmount::from_sat(i64::deserialize(d)?))
+        use serde::de::Error;
+        SignedAmount::from_sat(i64::deserialize(d)?)
+            .map_err(D::Error::custom)
     }
     #[cfg(feature = "alloc")]
     fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -65,6 +65,16 @@ impl SignedAmount {
     /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
     pub const fn from_sat(satoshi: i64) -> SignedAmount { SignedAmount(satoshi) }
 
+    /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
+    ///
+    /// Warning, it's possible to violate the [`SignedAmount`] range invariant.  If the value
+    /// passed is lower than [`SignedAmount::MIN`] or greater than [`SignedAmount::MAX`], your code
+    /// will misbehave in unspecified ways.  If you wish to represent values outside this range,
+    /// you should use a different type.
+    pub const fn from_sat_unchecked(satoshi: i64) -> SignedAmount {
+        SignedAmount(satoshi)
+    }
+
     /// Gets the number of satoshis in this [`SignedAmount`].
     pub const fn to_sat(self) -> i64 { self.0 }
 
@@ -93,7 +103,7 @@ impl SignedAmount {
     /// # Panics
     ///
     /// The function panics if the argument multiplied by the number of sats
-    /// per bitcoin overflows an `i64` type.
+    /// per bitcoin overflows an `i64` type or if the value is out of range.
     pub const fn from_int_btc_const(whole_bitcoin: i64) -> SignedAmount {
         match whole_bitcoin.checked_mul(100_000_000) {
             Some(amount) => SignedAmount::from_sat(amount),
@@ -144,7 +154,7 @@ impl SignedAmount {
     ///
     /// ```
     /// # use bitcoin_units::amount::{SignedAmount, Denomination};
-    /// let amount = SignedAmount::from_sat(100_000);
+    /// let amount = SignedAmount::from_sat_unchecked(100_000);
     /// assert_eq!(amount.to_btc(), amount.to_float_in(Denomination::Bitcoin))
     /// ```
     #[cfg(feature = "alloc")]
@@ -476,7 +486,7 @@ impl TryFrom<Amount> for SignedAmount {
 impl core::iter::Sum for SignedAmount {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         let sats: i64 = iter.map(|amt| amt.0).sum();
-        SignedAmount::from_sat(sats)
+        SignedAmount::from_sat_unchecked(sats)
     }
 }
 
@@ -486,7 +496,7 @@ impl<'a> core::iter::Sum<&'a SignedAmount> for SignedAmount {
         I: Iterator<Item = &'a SignedAmount>,
     {
         let sats: i64 = iter.map(|amt| amt.0).sum();
-        SignedAmount::from_sat(sats)
+        SignedAmount::from_sat_unchecked(sats)
     }
 }
 

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -419,7 +419,7 @@ impl Amount {
         if self.to_sat() > SignedAmount::MAX.to_sat() as u64 { // Cast ok, signed max is positive and fits in u64.
             Err(OutOfRangeError::too_big(true))
         } else {
-            Ok(SignedAmount::from_sat(self.to_sat() as i64)) // Cast ok, checked not too big above.
+            Ok(SignedAmount::from_sat_unchecked(self.to_sat() as i64)) // Cast ok, checked not too big above.
         }
     }
 

--- a/units/src/amount/verification.rs
+++ b/units/src/amount/verification.rs
@@ -52,24 +52,24 @@ fn s_amount_homomorphic() {
     // Assume we don't overflow in the actual tests.
     kani::assume(n1.checked_add(n2).is_some()); // Adding i64s doesn't overflow.
     kani::assume(n1.checked_sub(n2).is_some()); // Subbing i64s doesn't overflow.
-    let a1 = SignedAmount::from_sat(n1); // TODO: If from_sat enforces invariant assume this `is_ok()`.
-    let a2 = SignedAmount::from_sat(n2);
+    let a1 = SignedAmount::from_sat_unchecked(n1); // TODO: If from_sat enforces invariant assume this `is_ok()`.
+    let a2 = SignedAmount::from_sat_unchecked(n2);
     kani::assume(a1.checked_add(a2).is_some()); // Adding amounts doesn't overflow.
     kani::assume(a1.checked_sub(a2).is_some()); // Subbing amounts doesn't overflow.
 
     assert_eq!(
-        SignedAmount::from_sat(n1) + SignedAmount::from_sat(n2),
-        SignedAmount::from_sat(n1 + n2)
+        SignedAmount::from_sat_unchecked(n1) + SignedAmount::from_sat_unchecked(n2),
+        SignedAmount::from_sat_unchecked(n1 + n2)
     );
     assert_eq!(
-        SignedAmount::from_sat(n1) - SignedAmount::from_sat(n2),
-        SignedAmount::from_sat(n1 - n2)
+        SignedAmount::from_sat_unchecked(n1) - SignedAmount::from_sat_unchecked(n2),
+        SignedAmount::from_sat_unchecked(n1 - n2)
     );
 
-    let mut amt = SignedAmount::from_sat(n1);
-    amt += SignedAmount::from_sat(n2);
-    assert_eq!(amt, SignedAmount::from_sat(n1 + n2));
-    let mut amt = SignedAmount::from_sat(n1);
-    amt -= SignedAmount::from_sat(n2);
-    assert_eq!(amt, SignedAmount::from_sat(n1 - n2));
+    let mut amt = SignedAmount::from_sat_unchecked(n1);
+    amt += SignedAmount::from_sat_unchecked(n2);
+    assert_eq!(amt, SignedAmount::from_sat_unchecked(n1 + n2));
+    let mut amt = SignedAmount::from_sat_unchecked(n1);
+    amt -= SignedAmount::from_sat_unchecked(n2);
+    assert_eq!(amt, SignedAmount::from_sat_unchecked(n1 - n2));
 }


### PR DESCRIPTION
Replaces https://github.com/rust-bitcoin/rust-bitcoin/pull/3703

- Change SignedAmount::from_sat() to return a Result type
- Adds SignedAmount::from_sat_unchecked()

Once MAX/MIN is changed, then `#[allow(clippy::absurd_extreme_comparisons)].` can be removed.