### PR TITLE
Create no-std-error crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "fuzz", "hashes", "internals", "io", "primitives", "units"]
+members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "error", "fuzz", "hashes", "internals", "io", "primitives", "units"]
 resolver = "2"
 
 [patch.crates-io.bitcoin-addresses]
@@ -10,6 +10,9 @@ path = "base58"
 
 [patch.crates-io.bitcoin]
 path = "bitcoin"
+
+[patch.crates-io.no-std-error]
+path = "error"
 
 [patch.crates-io.bitcoin_hashes]
 path = "hashes"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -96,3 +96,4 @@ name = "sighash"
 
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(mutate)'] }
+

--- a/error/CHANGELOG.md
+++ b/error/CHANGELOG.md
@@ -1,0 +1,6 @@
+# 0.1.0 - 2024-12-12
+
+Initial release. Code copied directly from
+[`bitcoin-internals v0.4.0`](https://docs.rs/bitcoin-internals/0.4.0/bitcoin_internals/).
+
+Specifically `rust-bitcoin/internals/src/error/mod.rs` and `error/input_string.rs`.

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "no-std-error"
+version = "0.1.0"
+authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/no-std-error"
+documentation = "https://docs.rs/no-std-error"
+description = "Error handling tools for code that is expected to work in both `std` and `no_std` environments."
+categories = ["no-std", "rust-patterns"]
+keywords = ["error handling", "no_std"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.63.0"
+exclude = ["tests", "contrib"]
+
+[features]
+default = []
+std = ["alloc"]
+alloc = []
+
+[dependencies]
+
+[dev-dependencies]

--- a/error/README.md
+++ b/error/README.md
@@ -1,0 +1,31 @@
+<div align="center">
+  <h1>no-std-error</h1>
+
+  <p>Error handling tools for code that is expected to work in both `std` and `no_std` environments.
+  </p>
+
+  <p>
+    <a href="https://crates.io/crates/no-std-error"><img alt="Crate Info" src="https://img.shields.io/crates/v/no-std-error.svg"/></a>
+    <a href="https://github.com/rust-bitcoin/rust-bitcoin/blob/master/LICENSE"><img alt="CC0 1.0 Universal Licensed" src="https://img.shields.io/badge/license-CC0--1.0-blue.svg"/></a>
+    <a href="https://github.com/rust-bitcoin/rust-bitcoin/actions?query=workflow%3AContinuous%20integration"><img alt="CI Status" src="https://github.com/rust-bitcoin/rust-bitcoin/workflows/Continuous%20integration/badge.svg"></a>
+    <a href="https://docs.rs/no-std-error"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-no-std-error-green"/></a>
+    <a href="https://blog.rust-lang.org/2021/11/01/Rust-1.63.0.html"><img alt="Rustc Version 1.63.0+" src="https://img.shields.io/badge/rustc-1.63.0%2B-lightgrey.svg"/></a>
+  </p>
+</div>
+
+Provides:
+
+- A `write_err!` macro that gracefully handles the error `source` in both `std` and `no_std`.
+- An `InputString` type that can be used as part of an error type when parsing strings and still
+  work in environments without an allocator.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should compile with any combination of features on **Rust 1.63.0**.
+
+Use `Cargo-minimal.lock` to build the MSRV by copying to `Cargo.lock` and building.
+
+## Licensing
+
+The code in this project is licensed under the [Creative Commons CC0 1.0 Universal license](LICENSE).
+We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX IDs](https://spdx.dev/ids/).

--- a/error/contrib/test_vars.sh
+++ b/error/contrib/test_vars.sh
@@ -1,0 +1,14 @@
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
+
+# Test all these features with "std" enabled.
+FEATURES_WITH_STD=""
+
+# Test all these features without "std" enabled.
+FEATURES_WITHOUT_STD="alloc"
+
+# Run these examples.
+EXAMPLES=""

--- a/error/src/input_string.rs
+++ b/error/src/input_string.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Implements the [`InputString`] type storing the parsed input.
+
+use core::fmt;
+
+use self::storage::Storage;
+
+/// Conditionally stores the input string in parse errors.
+///
+/// This type stores the input string of a parse function depending on whether `alloc` feature is
+/// enabled. When it is enabled, the string is stored inside as `String`. When disabled this is a
+/// zero-sized type and attempt to store a string does nothing.
+///
+/// This provides two methods to format the error strings depending on the context.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct InputString(Storage);
+
+impl InputString {
+    /// Displays a message saying `failed to parse <self> as <what>`.
+    ///
+    /// This is normally used with the `write_err!` macro.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::fmt;
+    /// use no_std_error::{write_err, InputString};
+    ///
+    /// /// An example parsing error including the parse error from core.
+    /// #[derive(Debug, Clone, PartialEq, Eq)]
+    /// pub struct ParseError {
+    ///     input: InputString,
+    ///     error: core::num::ParseIntError,
+    /// }
+    ///
+    /// impl fmt::Display for ParseError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         // Outputs "failed to parse '<input string>' as foo"
+    ///         write_err!(f, "{}", self.input.display_cannot_parse("foo"); self.error)
+    ///     }
+    /// }
+    /// ```
+    pub fn display_cannot_parse<'a, T>(&'a self, what: &'a T) -> CannotParse<'a, T>
+    where
+        T: fmt::Display + ?Sized,
+    {
+        CannotParse { input: self, what }
+    }
+
+    /// Formats a message saying `<self> is not a known <what>`.
+    ///
+    /// This is normally used in leaf parse errors (with no source) when parsing an enum.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::fmt;
+    /// use no_std_error::InputString;
+    ///
+    /// /// An example parsing error.
+    /// #[derive(Debug, Clone, PartialEq, Eq)]
+    /// pub struct ParseError(InputString);
+    ///
+    /// impl fmt::Display for ParseError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         // Outputs "'<input string>' is not a known foo"
+    ///         self.0.unknown_variant("foo", f)
+    ///     }
+    /// }
+    /// ```
+    pub fn unknown_variant<T>(&self, what: &T, f: &mut fmt::Formatter) -> fmt::Result
+    where
+        T: fmt::Display + ?Sized,
+    {
+        storage::unknown_variant(&self.0, what, f)
+    }
+}
+
+macro_rules! impl_from {
+    ($($type:ty),+ $(,)?) => {
+        $(
+            impl From<$type> for InputString {
+                fn from(input: $type) -> Self {
+                    #[allow(clippy::useless_conversion)]
+                    InputString(input.into())
+                }
+            }
+        )+
+    }
+}
+
+impl_from!(&str);
+
+/// Displays message saying `failed to parse <input> as <what>`.
+///
+/// This is created by the `display_cannot_parse` method and should be used as
+/// `write_err!("{}", self.input.display_cannot_parse("what is parsed"); self.source)` in parse
+/// error [`Display`](fmt::Display) imlementation if the error has source. If the error doesn't
+/// have a source just use regular `write!` with the same formatting arguments.
+pub struct CannotParse<'a, T: fmt::Display + ?Sized> {
+    input: &'a InputString,
+    what: &'a T,
+}
+
+impl<T: fmt::Display + ?Sized> fmt::Display for CannotParse<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        storage::cannot_parse(&self.input.0, &self.what, f)
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+mod storage {
+    use core::fmt;
+
+    #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+    pub(super) struct Storage;
+
+    impl fmt::Debug for Storage {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("<unknown input string - compiled without the `alloc` feature>")
+        }
+    }
+
+    impl From<&str> for Storage {
+        fn from(_value: &str) -> Self { Storage }
+    }
+
+    pub(super) fn cannot_parse<W>(_: &Storage, what: &W, f: &mut fmt::Formatter) -> fmt::Result
+    where
+        W: fmt::Display + ?Sized,
+    {
+        write!(f, "failed to parse {}", what)
+    }
+
+    pub(super) fn unknown_variant<W>(_: &Storage, what: &W, f: &mut fmt::Formatter) -> fmt::Result
+    where
+        W: fmt::Display + ?Sized,
+    {
+        write!(f, "unknown {}", what)
+    }
+}
+
+#[cfg(feature = "alloc")]
+mod storage {
+    use core::fmt;
+
+    use super::InputString;
+
+    pub(super) type Storage = alloc::string::String;
+
+    pub(super) fn cannot_parse<W>(input: &Storage, what: &W, f: &mut fmt::Formatter) -> fmt::Result
+    where
+        W: fmt::Display + ?Sized,
+    {
+        write!(f, "failed to parse '{}' as {}", input, what)
+    }
+
+    pub(super) fn unknown_variant<W>(inp: &Storage, what: &W, f: &mut fmt::Formatter) -> fmt::Result
+    where
+        W: fmt::Display + ?Sized,
+    {
+        write!(f, "'{}' is not a known {}", inp, what)
+    }
+
+    impl_from!(alloc::string::String, alloc::boxed::Box<str>, alloc::borrow::Cow<'_, str>);
+}

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! # Error
+//!
+//! Error handling tools for code that is expected to work in both `std` and `no_std` environments.
+
+#![no_std]
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// Coding conventions.
+#![warn(missing_docs)]
+#![warn(deprecated_in_future)]
+#![doc(test(attr(warn(unused))))]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+pub mod input_string;
+
+pub use input_string::InputString;
+
+/// Formats error.
+///
+/// If `std` feature is OFF appends error source (delimited by `: `). We do this because
+/// `e.source()` is only available in std builds, without this macro the error source is lost for
+/// no-std builds.
+#[macro_export]
+macro_rules! write_err {
+    ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
+        {
+            #[cfg(feature = "std")]
+            {
+                let _ = &$source;   // Prevents clippy warnings.
+                write!($writer, $string $(, $args)*)
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Chasing concept ACK please @apoelstra. Also we need to bike shed the crate name and create the repo.

Split out the `write_err` and `InputString` from `internals` into their own crate currently called `no-std-error`.

As a demo the crate is part of this repo still but it should be moved up to a standalone repo because it is not Bitcoin specific.

Please note the authors list has Kix up front because he wrote all this code originally. He is not around right now to give his consent but I believe this is still the correct thing to do to give him credit for work done. Andrew is up next because he is BDFL round here. I'm last because I just did the cut'n paste and raised the PR.

Next step, if this gets concept ACK'd is to create a new repo.

Close: #3322