### PR TITLE
Move script hash types to `primitives`

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -10,6 +10,8 @@ impl bitcoin_hashes::Hash for bitcoin_primitives::block::BlockHash
 impl bitcoin_hashes::Hash for bitcoin_primitives::block::WitnessCommitment
 impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::script::ScriptHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::script::WScriptHash
 impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapLeafHash
 impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapNodeHash
 impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapTweakHash
@@ -35,6 +37,8 @@ impl bitcoin_primitives::opcodes::Opcode
 impl bitcoin_primitives::pow::CompactTarget
 impl bitcoin_primitives::script::Script
 impl bitcoin_primitives::script::ScriptBuf
+impl bitcoin_primitives::script::ScriptHash
+impl bitcoin_primitives::script::WScriptHash
 impl bitcoin_primitives::sequence::Sequence
 impl bitcoin_primitives::taproot::TapLeafHash
 impl bitcoin_primitives::taproot::TapNodeHash
@@ -47,10 +51,12 @@ impl bitcoin_primitives::transaction::Txid
 impl bitcoin_primitives::transaction::Version
 impl bitcoin_primitives::transaction::Wtxid
 impl bitcoin_primitives::witness::Witness
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_primitives::script::ScriptHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::BlockHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::script::WScriptHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
@@ -60,6 +66,8 @@ impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::BlockHash
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::WitnessCommitment
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::script::ScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::script::WScriptHash
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapLeafHash
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapNodeHash
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapTweakHash
@@ -84,7 +92,11 @@ impl core::clone::Clone for bitcoin_primitives::opcodes::Class
 impl core::clone::Clone for bitcoin_primitives::opcodes::ClassifyContext
 impl core::clone::Clone for bitcoin_primitives::opcodes::Opcode
 impl core::clone::Clone for bitcoin_primitives::pow::CompactTarget
+impl core::clone::Clone for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::clone::Clone for bitcoin_primitives::script::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::script::ScriptHash
+impl core::clone::Clone for bitcoin_primitives::script::WScriptHash
+impl core::clone::Clone for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::clone::Clone for bitcoin_primitives::sequence::Sequence
 impl core::clone::Clone for bitcoin_primitives::taproot::TapBranchTag
 impl core::clone::Clone for bitcoin_primitives::taproot::TapLeafHash
@@ -118,8 +130,12 @@ impl core::cmp::Eq for bitcoin_primitives::opcodes::Class
 impl core::cmp::Eq for bitcoin_primitives::opcodes::ClassifyContext
 impl core::cmp::Eq for bitcoin_primitives::opcodes::Opcode
 impl core::cmp::Eq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Eq for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::cmp::Eq for bitcoin_primitives::script::Script
 impl core::cmp::Eq for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::Eq for bitcoin_primitives::script::ScriptHash
+impl core::cmp::Eq for bitcoin_primitives::script::WScriptHash
+impl core::cmp::Eq for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::cmp::Eq for bitcoin_primitives::sequence::Sequence
 impl core::cmp::Eq for bitcoin_primitives::taproot::TapBranchTag
 impl core::cmp::Eq for bitcoin_primitives::taproot::TapLeafHash
@@ -148,6 +164,8 @@ impl core::cmp::Ord for bitcoin_primitives::opcodes::ClassifyContext
 impl core::cmp::Ord for bitcoin_primitives::pow::CompactTarget
 impl core::cmp::Ord for bitcoin_primitives::script::Script
 impl core::cmp::Ord for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::Ord for bitcoin_primitives::script::ScriptHash
+impl core::cmp::Ord for bitcoin_primitives::script::WScriptHash
 impl core::cmp::Ord for bitcoin_primitives::sequence::Sequence
 impl core::cmp::Ord for bitcoin_primitives::taproot::TapBranchTag
 impl core::cmp::Ord for bitcoin_primitives::taproot::TapLeafHash
@@ -180,8 +198,12 @@ impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Class
 impl core::cmp::PartialEq for bitcoin_primitives::opcodes::ClassifyContext
 impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Opcode
 impl core::cmp::PartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::cmp::PartialEq for bitcoin_primitives::script::Script
 impl core::cmp::PartialEq for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialEq for bitcoin_primitives::script::ScriptHash
+impl core::cmp::PartialEq for bitcoin_primitives::script::WScriptHash
+impl core::cmp::PartialEq for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::cmp::PartialEq for bitcoin_primitives::sequence::Sequence
 impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapBranchTag
 impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapLeafHash
@@ -214,6 +236,8 @@ impl core::cmp::PartialOrd for bitcoin_primitives::opcodes::ClassifyContext
 impl core::cmp::PartialOrd for bitcoin_primitives::pow::CompactTarget
 impl core::cmp::PartialOrd for bitcoin_primitives::script::Script
 impl core::cmp::PartialOrd for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin_primitives::script::ScriptHash
+impl core::cmp::PartialOrd for bitcoin_primitives::script::WScriptHash
 impl core::cmp::PartialOrd for bitcoin_primitives::sequence::Sequence
 impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapBranchTag
 impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapLeafHash
@@ -235,10 +259,12 @@ impl core::convert::AsMut<[u8]> for bitcoin_primitives::script::Script
 impl core::convert::AsMut<[u8]> for bitcoin_primitives::script::ScriptBuf
 impl core::convert::AsMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::Script
 impl core::convert::AsMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsRef<[u8; 20]> for bitcoin_primitives::script::ScriptHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::BlockHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::script::WScriptHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
@@ -250,6 +276,8 @@ impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNod
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::Script
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::ScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::WScriptHash
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapLeafHash
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapNodeHash
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapTweakHash
@@ -266,6 +294,8 @@ impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitc
 impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin_primitives::witness::Witness
 impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin_primitives::witness::Witness
 impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin_primitives::script::ScriptHash
+impl core::convert::From<bitcoin_hashes::sha256::Hash> for bitcoin_primitives::script::WScriptHash
 impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::BlockHash
 impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::WitnessCommitment
 impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::merkle_tree::TxMerkleNode
@@ -285,6 +315,8 @@ impl core::convert::From<bitcoin_primitives::merkle_tree::WitnessMerkleNode> for
 impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin_primitives::script::Script>
 impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::boxed::Box<bitcoin_primitives::script::Script>
 impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin_primitives::script::ScriptHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin_primitives::script::WScriptHash> for bitcoin_hashes::sha256::Hash
 impl core::convert::From<bitcoin_primitives::sequence::Sequence> for u32
 impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>
 impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_primitives::taproot::TapNodeHash
@@ -298,14 +330,22 @@ impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_
 impl core::convert::From<bitcoin_units::locktime::absolute::Time> for bitcoin_primitives::locktime::absolute::LockTime
 impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_primitives::locktime::relative::LockTime
 impl core::convert::From<bitcoin_units::locktime::relative::Time> for bitcoin_primitives::locktime::relative::LockTime
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::ParseOutPointError
 impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
+impl core::convert::TryFrom<&bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::script::Script> for bitcoin_primitives::script::WScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::WScriptHash
 impl core::convert::TryFrom<&str> for bitcoin_primitives::locktime::absolute::LockTime
 impl core::convert::TryFrom<&str> for bitcoin_primitives::sequence::Sequence
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_primitives::locktime::absolute::LockTime
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_primitives::sequence::Sequence
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_primitives::locktime::absolute::LockTime
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_primitives::sequence::Sequence
+impl core::convert::TryFrom<bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::WScriptHash
 impl core::convert::TryFrom<bitcoin_primitives::sequence::Sequence> for bitcoin_primitives::locktime::relative::LockTime
 impl core::default::Default for bitcoin_primitives::block::Version
 impl core::default::Default for bitcoin_primitives::pow::CompactTarget
@@ -318,6 +358,8 @@ impl core::default::Default for bitcoin_primitives::witness::Witness
 impl core::error::Error for bitcoin_primitives::locktime::relative::DisabledLockTimeError
 impl core::error::Error for bitcoin_primitives::locktime::relative::IncompatibleHeightError
 impl core::error::Error for bitcoin_primitives::locktime::relative::IncompatibleTimeError
+impl core::error::Error for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::error::Error for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::error::Error for bitcoin_primitives::transaction::ParseOutPointError
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHash
 impl core::fmt::Debug for bitcoin_primitives::block::Checked
@@ -336,8 +378,12 @@ impl core::fmt::Debug for bitcoin_primitives::opcodes::Class
 impl core::fmt::Debug for bitcoin_primitives::opcodes::ClassifyContext
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
 impl core::fmt::Debug for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::fmt::Debug for bitcoin_primitives::script::Script
 impl core::fmt::Debug for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::Debug for bitcoin_primitives::script::ScriptHash
+impl core::fmt::Debug for bitcoin_primitives::script::WScriptHash
+impl core::fmt::Debug for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::fmt::Debug for bitcoin_primitives::sequence::Sequence
 impl core::fmt::Debug for bitcoin_primitives::taproot::TapLeafHash
 impl core::fmt::Debug for bitcoin_primitives::taproot::TapNodeHash
@@ -361,8 +407,12 @@ impl core::fmt::Display for bitcoin_primitives::locktime::relative::LockTime
 impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::fmt::Display for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::fmt::Display for bitcoin_primitives::opcodes::Opcode
+impl core::fmt::Display for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::fmt::Display for bitcoin_primitives::script::Script
 impl core::fmt::Display for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::Display for bitcoin_primitives::script::ScriptHash
+impl core::fmt::Display for bitcoin_primitives::script::WScriptHash
+impl core::fmt::Display for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::fmt::Display for bitcoin_primitives::sequence::Sequence
 impl core::fmt::Display for bitcoin_primitives::taproot::TapLeafHash
 impl core::fmt::Display for bitcoin_primitives::taproot::TapNodeHash
@@ -379,6 +429,8 @@ impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::fmt::LowerHex for bitcoin_primitives::pow::CompactTarget
 impl core::fmt::LowerHex for bitcoin_primitives::script::Script
 impl core::fmt::LowerHex for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::LowerHex for bitcoin_primitives::script::ScriptHash
+impl core::fmt::LowerHex for bitcoin_primitives::script::WScriptHash
 impl core::fmt::LowerHex for bitcoin_primitives::sequence::Sequence
 impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapLeafHash
 impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapNodeHash
@@ -392,6 +444,8 @@ impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::fmt::UpperHex for bitcoin_primitives::pow::CompactTarget
 impl core::fmt::UpperHex for bitcoin_primitives::script::Script
 impl core::fmt::UpperHex for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::UpperHex for bitcoin_primitives::script::ScriptHash
+impl core::fmt::UpperHex for bitcoin_primitives::script::WScriptHash
 impl core::fmt::UpperHex for bitcoin_primitives::sequence::Sequence
 impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapLeafHash
 impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapNodeHash
@@ -412,6 +466,8 @@ impl core::hash::Hash for bitcoin_primitives::opcodes::ClassifyContext
 impl core::hash::Hash for bitcoin_primitives::pow::CompactTarget
 impl core::hash::Hash for bitcoin_primitives::script::Script
 impl core::hash::Hash for bitcoin_primitives::script::ScriptBuf
+impl core::hash::Hash for bitcoin_primitives::script::ScriptHash
+impl core::hash::Hash for bitcoin_primitives::script::WScriptHash
 impl core::hash::Hash for bitcoin_primitives::sequence::Sequence
 impl core::hash::Hash for bitcoin_primitives::taproot::TapBranchTag
 impl core::hash::Hash for bitcoin_primitives::taproot::TapLeafHash
@@ -440,6 +496,8 @@ impl core::marker::Copy for bitcoin_primitives::opcodes::Class
 impl core::marker::Copy for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Copy for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Copy for bitcoin_primitives::script::ScriptHash
+impl core::marker::Copy for bitcoin_primitives::script::WScriptHash
 impl core::marker::Copy for bitcoin_primitives::sequence::Sequence
 impl core::marker::Copy for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Copy for bitcoin_primitives::taproot::TapLeafHash
@@ -468,8 +526,12 @@ impl core::marker::Freeze for bitcoin_primitives::opcodes::Class
 impl core::marker::Freeze for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Freeze for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Freeze for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::Freeze for bitcoin_primitives::script::Script
 impl core::marker::Freeze for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Freeze for bitcoin_primitives::script::ScriptHash
+impl core::marker::Freeze for bitcoin_primitives::script::WScriptHash
+impl core::marker::Freeze for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::Freeze for bitcoin_primitives::sequence::Sequence
 impl core::marker::Freeze for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Freeze for bitcoin_primitives::taproot::TapLeafHash
@@ -503,8 +565,12 @@ impl core::marker::Send for bitcoin_primitives::opcodes::Class
 impl core::marker::Send for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Send for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Send for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Send for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::Send for bitcoin_primitives::script::Script
 impl core::marker::Send for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Send for bitcoin_primitives::script::ScriptHash
+impl core::marker::Send for bitcoin_primitives::script::WScriptHash
+impl core::marker::Send for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::Send for bitcoin_primitives::sequence::Sequence
 impl core::marker::Send for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Send for bitcoin_primitives::taproot::TapLeafHash
@@ -538,8 +604,12 @@ impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Class
 impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
 impl core::marker::StructuralPartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::StructuralPartialEq for bitcoin_primitives::script::Script
 impl core::marker::StructuralPartialEq for bitcoin_primitives::script::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::ScriptHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::WScriptHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::StructuralPartialEq for bitcoin_primitives::sequence::Sequence
 impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapLeafHash
@@ -573,8 +643,12 @@ impl core::marker::Sync for bitcoin_primitives::opcodes::Class
 impl core::marker::Sync for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Sync for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Sync for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Sync for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::Sync for bitcoin_primitives::script::Script
 impl core::marker::Sync for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Sync for bitcoin_primitives::script::ScriptHash
+impl core::marker::Sync for bitcoin_primitives::script::WScriptHash
+impl core::marker::Sync for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::Sync for bitcoin_primitives::sequence::Sequence
 impl core::marker::Sync for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Sync for bitcoin_primitives::taproot::TapLeafHash
@@ -608,8 +682,12 @@ impl core::marker::Unpin for bitcoin_primitives::opcodes::Class
 impl core::marker::Unpin for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Unpin for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Unpin for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Unpin for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::Unpin for bitcoin_primitives::script::Script
 impl core::marker::Unpin for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Unpin for bitcoin_primitives::script::ScriptHash
+impl core::marker::Unpin for bitcoin_primitives::script::WScriptHash
+impl core::marker::Unpin for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::Unpin for bitcoin_primitives::sequence::Sequence
 impl core::marker::Unpin for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Unpin for bitcoin_primitives::taproot::TapLeafHash
@@ -653,8 +731,12 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Cl
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Opcode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::Script
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::ScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::WScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::sequence::Sequence
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapBranchTag
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapLeafHash
@@ -688,8 +770,12 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Class
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Opcode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::Script
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::ScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::WScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::sequence::Sequence
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapBranchTag
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapLeafHash
@@ -711,6 +797,8 @@ impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
 impl core::str::traits::FromStr for bitcoin_primitives::locktime::absolute::LockTime
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::script::ScriptHash
+impl core::str::traits::FromStr for bitcoin_primitives::script::WScriptHash
 impl core::str::traits::FromStr for bitcoin_primitives::sequence::Sequence
 impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapLeafHash
 impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapNodeHash
@@ -732,6 +820,8 @@ impl serde::ser::Serialize for bitcoin_primitives::opcodes::Opcode
 impl serde::ser::Serialize for bitcoin_primitives::pow::CompactTarget
 impl serde::ser::Serialize for bitcoin_primitives::script::Script
 impl serde::ser::Serialize for bitcoin_primitives::script::ScriptBuf
+impl serde::ser::Serialize for bitcoin_primitives::script::ScriptHash
+impl serde::ser::Serialize for bitcoin_primitives::script::WScriptHash
 impl serde::ser::Serialize for bitcoin_primitives::sequence::Sequence
 impl serde::ser::Serialize for bitcoin_primitives::taproot::TapLeafHash
 impl serde::ser::Serialize for bitcoin_primitives::taproot::TapNodeHash
@@ -784,6 +874,8 @@ impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::merkle_tree::TxMer
 impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::pow::CompactTarget
 impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::script::ScriptBuf
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::script::ScriptHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::script::WScriptHash
 impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::sequence::Sequence
 impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::taproot::TapLeafHash
 impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::taproot::TapNodeHash
@@ -856,6 +948,8 @@ pub bitcoin_primitives::relative::IncompatibleTimeError::height: bitcoin_units::
 pub bitcoin_primitives::relative::IncompatibleTimeError::time: bitcoin_units::locktime::relative::Time
 pub bitcoin_primitives::relative::LockTime::Blocks(bitcoin_units::locktime::relative::Height)
 pub bitcoin_primitives::relative::LockTime::Time(bitcoin_units::locktime::relative::Time)
+pub bitcoin_primitives::script::RedeemScriptSizeError::size: usize
+pub bitcoin_primitives::script::WitnessScriptSizeError::size: usize
 pub bitcoin_primitives::transaction::OutPoint::txid: bitcoin_primitives::transaction::Txid
 pub bitcoin_primitives::transaction::OutPoint::vout: u32
 pub bitcoin_primitives::transaction::ParseOutPointError::Format
@@ -1146,6 +1240,10 @@ pub const bitcoin_primitives::opcodes::all::OP_VERIFY: bitcoin_primitives::opcod
 pub const bitcoin_primitives::opcodes::all::OP_VERNOTIF: bitcoin_primitives::opcodes::Opcode
 pub const bitcoin_primitives::opcodes::all::OP_WITHIN: bitcoin_primitives::opcodes::Opcode
 pub const bitcoin_primitives::opcodes::all::OP_XOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::script::MAX_REDEEM_SCRIPT_SIZE: usize
+pub const bitcoin_primitives::script::MAX_WITNESS_SCRIPT_SIZE: usize
+pub const bitcoin_primitives::script::ScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::script::WScriptHash::DISPLAY_BACKWARD: bool
 pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
 pub const bitcoin_primitives::sequence::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
@@ -1194,6 +1292,12 @@ pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(s
 pub const fn bitcoin_primitives::opcodes::Opcode::decode_pushnum(self) -> core::option::Option<u8>
 pub const fn bitcoin_primitives::opcodes::Opcode::to_u8(self) -> u8
 pub const fn bitcoin_primitives::script::ScriptBuf::new() -> Self
+pub const fn bitcoin_primitives::script::ScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::ScriptHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::script::ScriptHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::WScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::WScriptHash::from_byte_array(bytes: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::script::WScriptHash::to_byte_array(self) -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
 pub const fn bitcoin_primitives::taproot::TapLeafHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub const fn bitcoin_primitives::taproot::TapLeafHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub const fn bitcoin_primitives::taproot::TapLeafHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
@@ -1230,6 +1334,8 @@ pub fn alloc::boxed::Box<bitcoin_primitives::script::Script>::from(value: alloc:
 pub fn alloc::rc::Rc<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
 pub fn alloc::sync::Arc<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
 pub fn alloc::vec::Vec<u8>::from(v: bitcoin_primitives::script::ScriptBuf) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin_primitives::script::ScriptHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::sha256::Hash::from(hashtype: bitcoin_primitives::script::WScriptHash) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::BlockHash) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::WitnessCommitment) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::merkle_tree::TxMerkleNode) -> bitcoin_hashes::sha256d::Hash
@@ -1376,8 +1482,8 @@ pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_height(
 pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_time(&self, time: bitcoin_units::locktime::relative::Time) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleTimeError>
 pub fn bitcoin_primitives::locktime::relative::LockTime::partial_cmp(&self, other: &bitcoin_primitives::locktime::relative::LockTime) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::locktime::relative::LockTime::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-pub fn bitcoin_primitives::locktime::relative::LockTime::to_consensus_u32(&self) -> u32
-pub fn bitcoin_primitives::locktime::relative::LockTime::to_sequence(&self) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_consensus_u32(self) -> u32
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_sequence(self) -> bitcoin_primitives::sequence::Sequence
 pub fn bitcoin_primitives::locktime::relative::LockTime::try_from(seq: bitcoin_primitives::sequence::Sequence) -> core::result::Result<bitcoin_primitives::locktime::relative::LockTime, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -1443,6 +1549,10 @@ pub fn bitcoin_primitives::pow::CompactTarget::partial_cmp(&self, other: &bitcoi
 pub fn bitcoin_primitives::pow::CompactTarget::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin_primitives::pow::CompactTarget::to_consensus(self) -> u32
 pub fn bitcoin_primitives::pow::CompactTarget::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::clone(&self) -> bitcoin_primitives::script::RedeemScriptSizeError
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::eq(&self, other: &bitcoin_primitives::script::RedeemScriptSizeError) -> bool
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::script::Script::as_bytes(&self) -> &[u8]
 pub fn bitcoin_primitives::script::Script::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin_primitives::script::Script::as_mut(&mut self) -> &mut bitcoin_primitives::script::Script
@@ -1506,6 +1616,56 @@ pub fn bitcoin_primitives::script::ScriptBuf::reserve_exact(&mut self, additiona
 pub fn bitcoin_primitives::script::ScriptBuf::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
 pub fn bitcoin_primitives::script::ScriptBuf::to_hex(&self) -> alloc::string::String
 pub fn bitcoin_primitives::script::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::script::ScriptHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_primitives::script::ScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptHash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_primitives::script::ScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptHash::clone(&self) -> bitcoin_primitives::script::ScriptHash
+pub fn bitcoin_primitives::script::ScriptHash::cmp(&self, other: &bitcoin_primitives::script::ScriptHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::ScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::script::ScriptHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::script::ScriptHash::eq(&self, other: &bitcoin_primitives::script::ScriptHash) -> bool
+pub fn bitcoin_primitives::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::ScriptHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin_primitives::script::ScriptHash
+pub fn bitcoin_primitives::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::from_script(redeem_script: &bitcoin_primitives::script::Script) -> core::result::Result<Self, bitcoin_primitives::script::RedeemScriptSizeError>
+pub fn bitcoin_primitives::script::ScriptHash::from_script_unchecked(script: &bitcoin_primitives::script::Script) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::script::ScriptHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::script::ScriptHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::ScriptHash::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::ScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::script::ScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: &bitcoin_primitives::script::Script) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: &bitcoin_primitives::script::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: bitcoin_primitives::script::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::script::WScriptHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::script::WScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::WScriptHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::script::WScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::script::WScriptHash::clone(&self) -> bitcoin_primitives::script::WScriptHash
+pub fn bitcoin_primitives::script::WScriptHash::cmp(&self, other: &bitcoin_primitives::script::WScriptHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::WScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::script::WScriptHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::script::WScriptHash::eq(&self, other: &bitcoin_primitives::script::WScriptHash) -> bool
+pub fn bitcoin_primitives::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::WScriptHash::from(inner: bitcoin_hashes::sha256::Hash) -> bitcoin_primitives::script::WScriptHash
+pub fn bitcoin_primitives::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::script::WScriptHash::from_script(witness_script: &bitcoin_primitives::script::Script) -> core::result::Result<Self, bitcoin_primitives::script::WitnessScriptSizeError>
+pub fn bitcoin_primitives::script::WScriptHash::from_script_unchecked(script: &bitcoin_primitives::script::Script) -> Self
+pub fn bitcoin_primitives::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::script::WScriptHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::script::WScriptHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::WScriptHash::partial_cmp(&self, other: &bitcoin_primitives::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::WScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::script::WScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: &bitcoin_primitives::script::Script) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: &bitcoin_primitives::script::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: bitcoin_primitives::script::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::clone(&self) -> bitcoin_primitives::script::WitnessScriptSizeError
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::eq(&self, other: &bitcoin_primitives::script::WitnessScriptSizeError) -> bool
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::sequence::Sequence::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_primitives::sequence::Sequence::clone(&self) -> bitcoin_primitives::sequence::Sequence
 pub fn bitcoin_primitives::sequence::Sequence::cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::cmp::Ordering
@@ -1533,7 +1693,7 @@ pub fn bitcoin_primitives::sequence::Sequence::partial_cmp(&self, other: &bitcoi
 pub fn bitcoin_primitives::sequence::Sequence::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin_primitives::sequence::Sequence::to_consensus_u32(self) -> u32
 pub fn bitcoin_primitives::sequence::Sequence::to_hex(&self) -> alloc::string::String
-pub fn bitcoin_primitives::sequence::Sequence::to_relative_lock_time(&self) -> core::option::Option<bitcoin_primitives::locktime::relative::LockTime>
+pub fn bitcoin_primitives::sequence::Sequence::to_relative_lock_time(self) -> core::option::Option<bitcoin_primitives::locktime::relative::LockTime>
 pub fn bitcoin_primitives::sequence::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_primitives::sequence::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_primitives::sequence::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
@@ -1794,7 +1954,11 @@ pub struct bitcoin_primitives::merkle_tree::WitnessMerkleNode(_)
 pub struct bitcoin_primitives::opcodes::Opcode
 pub struct bitcoin_primitives::pow::CompactTarget(_)
 pub struct bitcoin_primitives::relative::DisabledLockTimeError(_)
+pub struct bitcoin_primitives::script::RedeemScriptSizeError
 pub struct bitcoin_primitives::script::ScriptBuf(_)
+pub struct bitcoin_primitives::script::ScriptHash(_)
+pub struct bitcoin_primitives::script::WScriptHash(_)
+pub struct bitcoin_primitives::script::WitnessScriptSizeError
 pub struct bitcoin_primitives::sequence::Sequence(pub u32)
 pub struct bitcoin_primitives::taproot::TapBranchTag
 pub struct bitcoin_primitives::taproot::TapLeafHash(_)
@@ -1829,6 +1993,12 @@ pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservat
 pub type bitcoin_primitives::script::Script::Output = bitcoin_primitives::script::Script
 pub type bitcoin_primitives::script::Script::Owned = bitcoin_primitives::script::ScriptBuf
 pub type bitcoin_primitives::script::ScriptBuf::Target = bitcoin_primitives::script::Script
+pub type bitcoin_primitives::script::ScriptHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::ScriptHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::ScriptHash::Error = bitcoin_primitives::script::RedeemScriptSizeError
+pub type bitcoin_primitives::script::WScriptHash::Bytes = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::WScriptHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::WScriptHash::Error = bitcoin_primitives::script::WitnessScriptSizeError
 pub type bitcoin_primitives::sequence::Sequence::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_primitives::sequence::Sequence::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_primitives::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -10,6 +10,8 @@ impl bitcoin_hashes::Hash for bitcoin_primitives::block::BlockHash
 impl bitcoin_hashes::Hash for bitcoin_primitives::block::WitnessCommitment
 impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::script::ScriptHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::script::WScriptHash
 impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapLeafHash
 impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapNodeHash
 impl bitcoin_hashes::Hash for bitcoin_primitives::taproot::TapTweakHash
@@ -35,6 +37,8 @@ impl bitcoin_primitives::opcodes::Opcode
 impl bitcoin_primitives::pow::CompactTarget
 impl bitcoin_primitives::script::Script
 impl bitcoin_primitives::script::ScriptBuf
+impl bitcoin_primitives::script::ScriptHash
+impl bitcoin_primitives::script::WScriptHash
 impl bitcoin_primitives::sequence::Sequence
 impl bitcoin_primitives::taproot::TapLeafHash
 impl bitcoin_primitives::taproot::TapNodeHash
@@ -47,10 +51,12 @@ impl bitcoin_primitives::transaction::Txid
 impl bitcoin_primitives::transaction::Version
 impl bitcoin_primitives::transaction::Wtxid
 impl bitcoin_primitives::witness::Witness
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_primitives::script::ScriptHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::BlockHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::script::WScriptHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
@@ -60,6 +66,8 @@ impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::BlockHash
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::WitnessCommitment
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::script::ScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::script::WScriptHash
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapLeafHash
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapNodeHash
 impl core::borrow::Borrow<[u8]> for bitcoin_primitives::taproot::TapTweakHash
@@ -84,7 +92,11 @@ impl core::clone::Clone for bitcoin_primitives::opcodes::Class
 impl core::clone::Clone for bitcoin_primitives::opcodes::ClassifyContext
 impl core::clone::Clone for bitcoin_primitives::opcodes::Opcode
 impl core::clone::Clone for bitcoin_primitives::pow::CompactTarget
+impl core::clone::Clone for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::clone::Clone for bitcoin_primitives::script::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::script::ScriptHash
+impl core::clone::Clone for bitcoin_primitives::script::WScriptHash
+impl core::clone::Clone for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::clone::Clone for bitcoin_primitives::sequence::Sequence
 impl core::clone::Clone for bitcoin_primitives::taproot::TapBranchTag
 impl core::clone::Clone for bitcoin_primitives::taproot::TapLeafHash
@@ -118,8 +130,12 @@ impl core::cmp::Eq for bitcoin_primitives::opcodes::Class
 impl core::cmp::Eq for bitcoin_primitives::opcodes::ClassifyContext
 impl core::cmp::Eq for bitcoin_primitives::opcodes::Opcode
 impl core::cmp::Eq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Eq for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::cmp::Eq for bitcoin_primitives::script::Script
 impl core::cmp::Eq for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::Eq for bitcoin_primitives::script::ScriptHash
+impl core::cmp::Eq for bitcoin_primitives::script::WScriptHash
+impl core::cmp::Eq for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::cmp::Eq for bitcoin_primitives::sequence::Sequence
 impl core::cmp::Eq for bitcoin_primitives::taproot::TapBranchTag
 impl core::cmp::Eq for bitcoin_primitives::taproot::TapLeafHash
@@ -148,6 +164,8 @@ impl core::cmp::Ord for bitcoin_primitives::opcodes::ClassifyContext
 impl core::cmp::Ord for bitcoin_primitives::pow::CompactTarget
 impl core::cmp::Ord for bitcoin_primitives::script::Script
 impl core::cmp::Ord for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::Ord for bitcoin_primitives::script::ScriptHash
+impl core::cmp::Ord for bitcoin_primitives::script::WScriptHash
 impl core::cmp::Ord for bitcoin_primitives::sequence::Sequence
 impl core::cmp::Ord for bitcoin_primitives::taproot::TapBranchTag
 impl core::cmp::Ord for bitcoin_primitives::taproot::TapLeafHash
@@ -180,8 +198,12 @@ impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Class
 impl core::cmp::PartialEq for bitcoin_primitives::opcodes::ClassifyContext
 impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Opcode
 impl core::cmp::PartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::cmp::PartialEq for bitcoin_primitives::script::Script
 impl core::cmp::PartialEq for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialEq for bitcoin_primitives::script::ScriptHash
+impl core::cmp::PartialEq for bitcoin_primitives::script::WScriptHash
+impl core::cmp::PartialEq for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::cmp::PartialEq for bitcoin_primitives::sequence::Sequence
 impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapBranchTag
 impl core::cmp::PartialEq for bitcoin_primitives::taproot::TapLeafHash
@@ -214,6 +236,8 @@ impl core::cmp::PartialOrd for bitcoin_primitives::opcodes::ClassifyContext
 impl core::cmp::PartialOrd for bitcoin_primitives::pow::CompactTarget
 impl core::cmp::PartialOrd for bitcoin_primitives::script::Script
 impl core::cmp::PartialOrd for bitcoin_primitives::script::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin_primitives::script::ScriptHash
+impl core::cmp::PartialOrd for bitcoin_primitives::script::WScriptHash
 impl core::cmp::PartialOrd for bitcoin_primitives::sequence::Sequence
 impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapBranchTag
 impl core::cmp::PartialOrd for bitcoin_primitives::taproot::TapLeafHash
@@ -235,10 +259,12 @@ impl core::convert::AsMut<[u8]> for bitcoin_primitives::script::Script
 impl core::convert::AsMut<[u8]> for bitcoin_primitives::script::ScriptBuf
 impl core::convert::AsMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::Script
 impl core::convert::AsMut<bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsRef<[u8; 20]> for bitcoin_primitives::script::ScriptHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::BlockHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::script::WScriptHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapLeafHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapNodeHash
 impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::taproot::TapTweakHash
@@ -250,6 +276,8 @@ impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNod
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::Script
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::ScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::WScriptHash
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapLeafHash
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapNodeHash
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::taproot::TapTweakHash
@@ -266,6 +294,8 @@ impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitc
 impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin_primitives::witness::Witness
 impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin_primitives::witness::Witness
 impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin_primitives::script::ScriptBuf
+impl core::convert::From<bitcoin_hashes::hash160::Hash> for bitcoin_primitives::script::ScriptHash
+impl core::convert::From<bitcoin_hashes::sha256::Hash> for bitcoin_primitives::script::WScriptHash
 impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::BlockHash
 impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::block::WitnessCommitment
 impl core::convert::From<bitcoin_hashes::sha256d::Hash> for bitcoin_primitives::merkle_tree::TxMerkleNode
@@ -285,6 +315,8 @@ impl core::convert::From<bitcoin_primitives::merkle_tree::WitnessMerkleNode> for
 impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin_primitives::script::Script>
 impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::boxed::Box<bitcoin_primitives::script::Script>
 impl core::convert::From<bitcoin_primitives::script::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin_primitives::script::ScriptHash> for bitcoin_hashes::hash160::Hash
+impl core::convert::From<bitcoin_primitives::script::WScriptHash> for bitcoin_hashes::sha256::Hash
 impl core::convert::From<bitcoin_primitives::sequence::Sequence> for u32
 impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag>
 impl core::convert::From<bitcoin_primitives::taproot::TapLeafHash> for bitcoin_primitives::taproot::TapNodeHash
@@ -298,14 +330,22 @@ impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_
 impl core::convert::From<bitcoin_units::locktime::absolute::Time> for bitcoin_primitives::locktime::absolute::LockTime
 impl core::convert::From<bitcoin_units::locktime::relative::Height> for bitcoin_primitives::locktime::relative::LockTime
 impl core::convert::From<bitcoin_units::locktime::relative::Time> for bitcoin_primitives::locktime::relative::LockTime
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::ParseOutPointError
 impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
+impl core::convert::TryFrom<&bitcoin_primitives::script::Script> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::script::Script> for bitcoin_primitives::script::WScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::WScriptHash
 impl core::convert::TryFrom<&str> for bitcoin_primitives::locktime::absolute::LockTime
 impl core::convert::TryFrom<&str> for bitcoin_primitives::sequence::Sequence
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_primitives::locktime::absolute::LockTime
 impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_primitives::sequence::Sequence
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_primitives::locktime::absolute::LockTime
 impl core::convert::TryFrom<alloc::string::String> for bitcoin_primitives::sequence::Sequence
+impl core::convert::TryFrom<bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<bitcoin_primitives::script::ScriptBuf> for bitcoin_primitives::script::WScriptHash
 impl core::convert::TryFrom<bitcoin_primitives::sequence::Sequence> for bitcoin_primitives::locktime::relative::LockTime
 impl core::default::Default for bitcoin_primitives::block::Version
 impl core::default::Default for bitcoin_primitives::pow::CompactTarget
@@ -332,8 +372,12 @@ impl core::fmt::Debug for bitcoin_primitives::opcodes::Class
 impl core::fmt::Debug for bitcoin_primitives::opcodes::ClassifyContext
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
 impl core::fmt::Debug for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::fmt::Debug for bitcoin_primitives::script::Script
 impl core::fmt::Debug for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::Debug for bitcoin_primitives::script::ScriptHash
+impl core::fmt::Debug for bitcoin_primitives::script::WScriptHash
+impl core::fmt::Debug for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::fmt::Debug for bitcoin_primitives::sequence::Sequence
 impl core::fmt::Debug for bitcoin_primitives::taproot::TapLeafHash
 impl core::fmt::Debug for bitcoin_primitives::taproot::TapNodeHash
@@ -357,8 +401,12 @@ impl core::fmt::Display for bitcoin_primitives::locktime::relative::LockTime
 impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::fmt::Display for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::fmt::Display for bitcoin_primitives::opcodes::Opcode
+impl core::fmt::Display for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::fmt::Display for bitcoin_primitives::script::Script
 impl core::fmt::Display for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::Display for bitcoin_primitives::script::ScriptHash
+impl core::fmt::Display for bitcoin_primitives::script::WScriptHash
+impl core::fmt::Display for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::fmt::Display for bitcoin_primitives::sequence::Sequence
 impl core::fmt::Display for bitcoin_primitives::taproot::TapLeafHash
 impl core::fmt::Display for bitcoin_primitives::taproot::TapNodeHash
@@ -375,6 +423,8 @@ impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::fmt::LowerHex for bitcoin_primitives::pow::CompactTarget
 impl core::fmt::LowerHex for bitcoin_primitives::script::Script
 impl core::fmt::LowerHex for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::LowerHex for bitcoin_primitives::script::ScriptHash
+impl core::fmt::LowerHex for bitcoin_primitives::script::WScriptHash
 impl core::fmt::LowerHex for bitcoin_primitives::sequence::Sequence
 impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapLeafHash
 impl core::fmt::LowerHex for bitcoin_primitives::taproot::TapNodeHash
@@ -388,6 +438,8 @@ impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::fmt::UpperHex for bitcoin_primitives::pow::CompactTarget
 impl core::fmt::UpperHex for bitcoin_primitives::script::Script
 impl core::fmt::UpperHex for bitcoin_primitives::script::ScriptBuf
+impl core::fmt::UpperHex for bitcoin_primitives::script::ScriptHash
+impl core::fmt::UpperHex for bitcoin_primitives::script::WScriptHash
 impl core::fmt::UpperHex for bitcoin_primitives::sequence::Sequence
 impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapLeafHash
 impl core::fmt::UpperHex for bitcoin_primitives::taproot::TapNodeHash
@@ -408,6 +460,8 @@ impl core::hash::Hash for bitcoin_primitives::opcodes::ClassifyContext
 impl core::hash::Hash for bitcoin_primitives::pow::CompactTarget
 impl core::hash::Hash for bitcoin_primitives::script::Script
 impl core::hash::Hash for bitcoin_primitives::script::ScriptBuf
+impl core::hash::Hash for bitcoin_primitives::script::ScriptHash
+impl core::hash::Hash for bitcoin_primitives::script::WScriptHash
 impl core::hash::Hash for bitcoin_primitives::sequence::Sequence
 impl core::hash::Hash for bitcoin_primitives::taproot::TapBranchTag
 impl core::hash::Hash for bitcoin_primitives::taproot::TapLeafHash
@@ -436,6 +490,8 @@ impl core::marker::Copy for bitcoin_primitives::opcodes::Class
 impl core::marker::Copy for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Copy for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Copy for bitcoin_primitives::script::ScriptHash
+impl core::marker::Copy for bitcoin_primitives::script::WScriptHash
 impl core::marker::Copy for bitcoin_primitives::sequence::Sequence
 impl core::marker::Copy for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Copy for bitcoin_primitives::taproot::TapLeafHash
@@ -464,8 +520,12 @@ impl core::marker::Freeze for bitcoin_primitives::opcodes::Class
 impl core::marker::Freeze for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Freeze for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Freeze for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::Freeze for bitcoin_primitives::script::Script
 impl core::marker::Freeze for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Freeze for bitcoin_primitives::script::ScriptHash
+impl core::marker::Freeze for bitcoin_primitives::script::WScriptHash
+impl core::marker::Freeze for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::Freeze for bitcoin_primitives::sequence::Sequence
 impl core::marker::Freeze for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Freeze for bitcoin_primitives::taproot::TapLeafHash
@@ -499,8 +559,12 @@ impl core::marker::Send for bitcoin_primitives::opcodes::Class
 impl core::marker::Send for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Send for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Send for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Send for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::Send for bitcoin_primitives::script::Script
 impl core::marker::Send for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Send for bitcoin_primitives::script::ScriptHash
+impl core::marker::Send for bitcoin_primitives::script::WScriptHash
+impl core::marker::Send for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::Send for bitcoin_primitives::sequence::Sequence
 impl core::marker::Send for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Send for bitcoin_primitives::taproot::TapLeafHash
@@ -534,8 +598,12 @@ impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Class
 impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
 impl core::marker::StructuralPartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::StructuralPartialEq for bitcoin_primitives::script::Script
 impl core::marker::StructuralPartialEq for bitcoin_primitives::script::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::ScriptHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::WScriptHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::StructuralPartialEq for bitcoin_primitives::sequence::Sequence
 impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::StructuralPartialEq for bitcoin_primitives::taproot::TapLeafHash
@@ -569,8 +637,12 @@ impl core::marker::Sync for bitcoin_primitives::opcodes::Class
 impl core::marker::Sync for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Sync for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Sync for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Sync for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::Sync for bitcoin_primitives::script::Script
 impl core::marker::Sync for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Sync for bitcoin_primitives::script::ScriptHash
+impl core::marker::Sync for bitcoin_primitives::script::WScriptHash
+impl core::marker::Sync for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::Sync for bitcoin_primitives::sequence::Sequence
 impl core::marker::Sync for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Sync for bitcoin_primitives::taproot::TapLeafHash
@@ -604,8 +676,12 @@ impl core::marker::Unpin for bitcoin_primitives::opcodes::Class
 impl core::marker::Unpin for bitcoin_primitives::opcodes::ClassifyContext
 impl core::marker::Unpin for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Unpin for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Unpin for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::marker::Unpin for bitcoin_primitives::script::Script
 impl core::marker::Unpin for bitcoin_primitives::script::ScriptBuf
+impl core::marker::Unpin for bitcoin_primitives::script::ScriptHash
+impl core::marker::Unpin for bitcoin_primitives::script::WScriptHash
+impl core::marker::Unpin for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::marker::Unpin for bitcoin_primitives::sequence::Sequence
 impl core::marker::Unpin for bitcoin_primitives::taproot::TapBranchTag
 impl core::marker::Unpin for bitcoin_primitives::taproot::TapLeafHash
@@ -649,8 +725,12 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Cl
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::opcodes::Opcode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::Script
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::ScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::WScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::sequence::Sequence
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapBranchTag
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::taproot::TapLeafHash
@@ -684,8 +764,12 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Class
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::ClassifyContext
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::opcodes::Opcode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::RedeemScriptSizeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::Script
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::ScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::WScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::WitnessScriptSizeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::sequence::Sequence
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapBranchTag
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::taproot::TapLeafHash
@@ -707,6 +791,8 @@ impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
 impl core::str::traits::FromStr for bitcoin_primitives::locktime::absolute::LockTime
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::script::ScriptHash
+impl core::str::traits::FromStr for bitcoin_primitives::script::WScriptHash
 impl core::str::traits::FromStr for bitcoin_primitives::sequence::Sequence
 impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapLeafHash
 impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapNodeHash
@@ -788,6 +874,8 @@ pub bitcoin_primitives::relative::IncompatibleTimeError::height: bitcoin_units::
 pub bitcoin_primitives::relative::IncompatibleTimeError::time: bitcoin_units::locktime::relative::Time
 pub bitcoin_primitives::relative::LockTime::Blocks(bitcoin_units::locktime::relative::Height)
 pub bitcoin_primitives::relative::LockTime::Time(bitcoin_units::locktime::relative::Time)
+pub bitcoin_primitives::script::RedeemScriptSizeError::size: usize
+pub bitcoin_primitives::script::WitnessScriptSizeError::size: usize
 pub bitcoin_primitives::transaction::OutPoint::txid: bitcoin_primitives::transaction::Txid
 pub bitcoin_primitives::transaction::OutPoint::vout: u32
 pub bitcoin_primitives::transaction::ParseOutPointError::Format
@@ -1078,6 +1166,10 @@ pub const bitcoin_primitives::opcodes::all::OP_VERIFY: bitcoin_primitives::opcod
 pub const bitcoin_primitives::opcodes::all::OP_VERNOTIF: bitcoin_primitives::opcodes::Opcode
 pub const bitcoin_primitives::opcodes::all::OP_WITHIN: bitcoin_primitives::opcodes::Opcode
 pub const bitcoin_primitives::opcodes::all::OP_XOR: bitcoin_primitives::opcodes::Opcode
+pub const bitcoin_primitives::script::MAX_REDEEM_SCRIPT_SIZE: usize
+pub const bitcoin_primitives::script::MAX_WITNESS_SCRIPT_SIZE: usize
+pub const bitcoin_primitives::script::ScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::script::WScriptHash::DISPLAY_BACKWARD: bool
 pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_primitives::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
 pub const bitcoin_primitives::sequence::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
@@ -1126,6 +1218,12 @@ pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(s
 pub const fn bitcoin_primitives::opcodes::Opcode::decode_pushnum(self) -> core::option::Option<u8>
 pub const fn bitcoin_primitives::opcodes::Opcode::to_u8(self) -> u8
 pub const fn bitcoin_primitives::script::ScriptBuf::new() -> Self
+pub const fn bitcoin_primitives::script::ScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::ScriptHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::script::ScriptHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::WScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::WScriptHash::from_byte_array(bytes: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::script::WScriptHash::to_byte_array(self) -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
 pub const fn bitcoin_primitives::taproot::TapLeafHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
 pub const fn bitcoin_primitives::taproot::TapLeafHash::from_byte_array(bytes: <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes) -> Self
 pub const fn bitcoin_primitives::taproot::TapLeafHash::to_byte_array(self) -> <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes
@@ -1161,6 +1259,8 @@ pub fn alloc::boxed::Box<bitcoin_primitives::script::Script>::from(value: alloc:
 pub fn alloc::rc::Rc<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
 pub fn alloc::sync::Arc<bitcoin_primitives::script::Script>::from(value: &'a bitcoin_primitives::script::Script) -> Self
 pub fn alloc::vec::Vec<u8>::from(v: bitcoin_primitives::script::ScriptBuf) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from(hashtype: bitcoin_primitives::script::ScriptHash) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::sha256::Hash::from(hashtype: bitcoin_primitives::script::WScriptHash) -> bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::BlockHash) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::block::WitnessCommitment) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from(hashtype: bitcoin_primitives::merkle_tree::TxMerkleNode) -> bitcoin_hashes::sha256d::Hash
@@ -1287,8 +1387,8 @@ pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by(&self, 
 pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_height(&self, height: bitcoin_units::locktime::relative::Height) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleHeightError>
 pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_time(&self, time: bitcoin_units::locktime::relative::Time) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleTimeError>
 pub fn bitcoin_primitives::locktime::relative::LockTime::partial_cmp(&self, other: &bitcoin_primitives::locktime::relative::LockTime) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin_primitives::locktime::relative::LockTime::to_consensus_u32(&self) -> u32
-pub fn bitcoin_primitives::locktime::relative::LockTime::to_sequence(&self) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_consensus_u32(self) -> u32
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_sequence(self) -> bitcoin_primitives::sequence::Sequence
 pub fn bitcoin_primitives::locktime::relative::LockTime::try_from(seq: bitcoin_primitives::sequence::Sequence) -> core::result::Result<bitcoin_primitives::locktime::relative::LockTime, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -1347,6 +1447,10 @@ pub fn bitcoin_primitives::pow::CompactTarget::hash<__H: core::hash::Hasher>(&se
 pub fn bitcoin_primitives::pow::CompactTarget::partial_cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::pow::CompactTarget::to_consensus(self) -> u32
 pub fn bitcoin_primitives::pow::CompactTarget::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::clone(&self) -> bitcoin_primitives::script::RedeemScriptSizeError
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::eq(&self, other: &bitcoin_primitives::script::RedeemScriptSizeError) -> bool
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::script::Script::as_bytes(&self) -> &[u8]
 pub fn bitcoin_primitives::script::Script::as_mut(&mut self) -> &mut [u8]
 pub fn bitcoin_primitives::script::Script::as_mut(&mut self) -> &mut bitcoin_primitives::script::Script
@@ -1406,6 +1510,52 @@ pub fn bitcoin_primitives::script::ScriptBuf::reserve(&mut self, additional_len:
 pub fn bitcoin_primitives::script::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
 pub fn bitcoin_primitives::script::ScriptBuf::to_hex(&self) -> alloc::string::String
 pub fn bitcoin_primitives::script::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::script::ScriptHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_primitives::script::ScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptHash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_primitives::script::ScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptHash::clone(&self) -> bitcoin_primitives::script::ScriptHash
+pub fn bitcoin_primitives::script::ScriptHash::cmp(&self, other: &bitcoin_primitives::script::ScriptHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::ScriptHash::eq(&self, other: &bitcoin_primitives::script::ScriptHash) -> bool
+pub fn bitcoin_primitives::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::ScriptHash::from(inner: bitcoin_hashes::hash160::Hash) -> bitcoin_primitives::script::ScriptHash
+pub fn bitcoin_primitives::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::from_script(redeem_script: &bitcoin_primitives::script::Script) -> core::result::Result<Self, bitcoin_primitives::script::RedeemScriptSizeError>
+pub fn bitcoin_primitives::script::ScriptHash::from_script_unchecked(script: &bitcoin_primitives::script::Script) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::script::ScriptHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::script::ScriptHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::ScriptHash::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::ScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: &bitcoin_primitives::script::Script) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: &bitcoin_primitives::script::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: bitcoin_primitives::script::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::script::WScriptHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::script::WScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::WScriptHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::script::WScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::script::WScriptHash::clone(&self) -> bitcoin_primitives::script::WScriptHash
+pub fn bitcoin_primitives::script::WScriptHash::cmp(&self, other: &bitcoin_primitives::script::WScriptHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::WScriptHash::eq(&self, other: &bitcoin_primitives::script::WScriptHash) -> bool
+pub fn bitcoin_primitives::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::WScriptHash::from(inner: bitcoin_hashes::sha256::Hash) -> bitcoin_primitives::script::WScriptHash
+pub fn bitcoin_primitives::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::script::WScriptHash::from_script(witness_script: &bitcoin_primitives::script::Script) -> core::result::Result<Self, bitcoin_primitives::script::WitnessScriptSizeError>
+pub fn bitcoin_primitives::script::WScriptHash::from_script_unchecked(script: &bitcoin_primitives::script::Script) -> Self
+pub fn bitcoin_primitives::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::script::WScriptHash, bitcoin_hashes::error::FromSliceError>
+pub fn bitcoin_primitives::script::WScriptHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::WScriptHash::partial_cmp(&self, other: &bitcoin_primitives::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::WScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: &bitcoin_primitives::script::Script) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: &bitcoin_primitives::script::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: bitcoin_primitives::script::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::clone(&self) -> bitcoin_primitives::script::WitnessScriptSizeError
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::eq(&self, other: &bitcoin_primitives::script::WitnessScriptSizeError) -> bool
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::sequence::Sequence::clone(&self) -> bitcoin_primitives::sequence::Sequence
 pub fn bitcoin_primitives::sequence::Sequence::cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::cmp::Ordering
 pub fn bitcoin_primitives::sequence::Sequence::default() -> Self
@@ -1430,7 +1580,7 @@ pub fn bitcoin_primitives::sequence::Sequence::is_time_locked(&self) -> bool
 pub fn bitcoin_primitives::sequence::Sequence::partial_cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::sequence::Sequence::to_consensus_u32(self) -> u32
 pub fn bitcoin_primitives::sequence::Sequence::to_hex(&self) -> alloc::string::String
-pub fn bitcoin_primitives::sequence::Sequence::to_relative_lock_time(&self) -> core::option::Option<bitcoin_primitives::locktime::relative::LockTime>
+pub fn bitcoin_primitives::sequence::Sequence::to_relative_lock_time(self) -> core::option::Option<bitcoin_primitives::locktime::relative::LockTime>
 pub fn bitcoin_primitives::sequence::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_primitives::sequence::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_primitives::sequence::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
@@ -1661,7 +1811,11 @@ pub struct bitcoin_primitives::merkle_tree::WitnessMerkleNode(_)
 pub struct bitcoin_primitives::opcodes::Opcode
 pub struct bitcoin_primitives::pow::CompactTarget(_)
 pub struct bitcoin_primitives::relative::DisabledLockTimeError(_)
+pub struct bitcoin_primitives::script::RedeemScriptSizeError
 pub struct bitcoin_primitives::script::ScriptBuf(_)
+pub struct bitcoin_primitives::script::ScriptHash(_)
+pub struct bitcoin_primitives::script::WScriptHash(_)
+pub struct bitcoin_primitives::script::WitnessScriptSizeError
 pub struct bitcoin_primitives::sequence::Sequence(pub u32)
 pub struct bitcoin_primitives::taproot::TapBranchTag
 pub struct bitcoin_primitives::taproot::TapLeafHash(_)
@@ -1696,6 +1850,12 @@ pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservat
 pub type bitcoin_primitives::script::Script::Output = bitcoin_primitives::script::Script
 pub type bitcoin_primitives::script::Script::Owned = bitcoin_primitives::script::ScriptBuf
 pub type bitcoin_primitives::script::ScriptBuf::Target = bitcoin_primitives::script::Script
+pub type bitcoin_primitives::script::ScriptHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::ScriptHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::ScriptHash::Error = bitcoin_primitives::script::RedeemScriptSizeError
+pub type bitcoin_primitives::script::WScriptHash::Bytes = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::WScriptHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::WScriptHash::Error = bitcoin_primitives::script::WitnessScriptSizeError
 pub type bitcoin_primitives::sequence::Sequence::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_primitives::sequence::Sequence::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_primitives::taproot::TapLeafHash::Bytes = <bitcoin_hashes::sha256t::Hash<bitcoin_primitives::taproot::TapLeafTag> as bitcoin_hashes::Hash>::Bytes

--- a/api/primitives/no-features.txt
+++ b/api/primitives/no-features.txt
@@ -995,8 +995,8 @@ pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by(&self, 
 pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_height(&self, height: bitcoin_units::locktime::relative::Height) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleHeightError>
 pub fn bitcoin_primitives::locktime::relative::LockTime::is_satisfied_by_time(&self, time: bitcoin_units::locktime::relative::Time) -> core::result::Result<bool, bitcoin_primitives::locktime::relative::IncompatibleTimeError>
 pub fn bitcoin_primitives::locktime::relative::LockTime::partial_cmp(&self, other: &bitcoin_primitives::locktime::relative::LockTime) -> core::option::Option<core::cmp::Ordering>
-pub fn bitcoin_primitives::locktime::relative::LockTime::to_consensus_u32(&self) -> u32
-pub fn bitcoin_primitives::locktime::relative::LockTime::to_sequence(&self) -> bitcoin_primitives::sequence::Sequence
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_consensus_u32(self) -> u32
+pub fn bitcoin_primitives::locktime::relative::LockTime::to_sequence(self) -> bitcoin_primitives::sequence::Sequence
 pub fn bitcoin_primitives::locktime::relative::LockTime::try_from(seq: bitcoin_primitives::sequence::Sequence) -> core::result::Result<bitcoin_primitives::locktime::relative::LockTime, bitcoin_primitives::locktime::relative::DisabledLockTimeError>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
@@ -1076,7 +1076,7 @@ pub fn bitcoin_primitives::sequence::Sequence::is_relative_lock_time(&self) -> b
 pub fn bitcoin_primitives::sequence::Sequence::is_time_locked(&self) -> bool
 pub fn bitcoin_primitives::sequence::Sequence::partial_cmp(&self, other: &bitcoin_primitives::sequence::Sequence) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::sequence::Sequence::to_consensus_u32(self) -> u32
-pub fn bitcoin_primitives::sequence::Sequence::to_relative_lock_time(&self) -> core::option::Option<bitcoin_primitives::locktime::relative::LockTime>
+pub fn bitcoin_primitives::sequence::Sequence::to_relative_lock_time(self) -> core::option::Option<bitcoin_primitives::locktime::relative::LockTime>
 pub fn bitcoin_primitives::taproot::TapBranchTag::clone(&self) -> bitcoin_primitives::taproot::TapBranchTag
 pub fn bitcoin_primitives::taproot::TapBranchTag::cmp(&self, other: &bitcoin_primitives::taproot::TapBranchTag) -> core::cmp::Ordering
 pub fn bitcoin_primitives::taproot::TapBranchTag::default() -> bitcoin_primitives::taproot::TapBranchTag

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -699,9 +699,9 @@ pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoi
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
-pub const fn bitcoin_units::block::BlockHeight::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32
 pub const fn bitcoin_units::block::BlockInterval::from_u32(inner: u32) -> Self
-pub const fn bitcoin_units::block::BlockInterval::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockInterval::to_u32(self) -> u32
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
@@ -720,12 +720,12 @@ pub const fn bitcoin_units::locktime::absolute::Time::to_consensus_u32(self) -> 
 pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
 pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
 pub const fn bitcoin_units::locktime::relative::Height::from_height(blocks: u16) -> Self
-pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::Height::value(self) -> u16
 pub const fn bitcoin_units::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::Time::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
-pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::Time::value(self) -> u16
 pub const fn bitcoin_units::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
 pub const fn bitcoin_units::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
@@ -756,6 +756,7 @@ pub fn bitcoin_units::Amount::cmp(&self, other: &bitcoin_units::Amount) -> core:
 pub fn bitcoin_units::Amount::default() -> Self
 pub fn bitcoin_units::Amount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::Amount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::Amount::des_str<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
@@ -779,6 +780,8 @@ pub fn bitcoin_units::Amount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: 
 pub fn bitcoin_units::Amount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::Amount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::Amount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_str<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_str_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
 pub fn bitcoin_units::Amount::sub_assign(&mut self, other: bitcoin_units::Amount)
 pub fn bitcoin_units::Amount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
@@ -801,6 +804,7 @@ pub fn bitcoin_units::SignedAmount::cmp(&self, other: &bitcoin_units::SignedAmou
 pub fn bitcoin_units::SignedAmount::default() -> Self
 pub fn bitcoin_units::SignedAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::SignedAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::SignedAmount::des_str<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
@@ -827,6 +831,8 @@ pub fn bitcoin_units::SignedAmount::ser_btc<S: serde::ser::Serializer>(self, s: 
 pub fn bitcoin_units::SignedAmount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::SignedAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::SignedAmount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_str<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_str_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::SignedAmount::signum(self) -> i64
 pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
 pub fn bitcoin_units::SignedAmount::sub_assign(&mut self, other: bitcoin_units::SignedAmount)
@@ -909,10 +915,13 @@ pub fn bitcoin_units::amount::error::UnknownDenominationError::fmt(&self, f: &mu
 pub fn bitcoin_units::amount::error::UnknownDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_units::amount::serde::SerdeAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_str<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_str<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_str_opt<S: serde::ser::Serializer>(self, s: S, _: private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::type_prefix(_: private::Token) -> &'static str
 pub fn bitcoin_units::amount::serde::as_btc::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::amount::serde::as_btc::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
@@ -922,6 +931,10 @@ pub fn bitcoin_units::amount::serde::as_sat::deserialize<'d, A: bitcoin_units::a
 pub fn bitcoin_units::amount::serde::as_sat::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::amount::serde::as_sat::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::serde::as_sat::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_str::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_str::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_str::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_str::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
 pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
 pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
@@ -1132,6 +1145,8 @@ pub mod bitcoin_units::amount::serde::as_btc
 pub mod bitcoin_units::amount::serde::as_btc::opt
 pub mod bitcoin_units::amount::serde::as_sat
 pub mod bitcoin_units::amount::serde::as_sat::opt
+pub mod bitcoin_units::amount::serde::as_str
+pub mod bitcoin_units::amount::serde::as_str::opt
 pub mod bitcoin_units::block
 pub mod bitcoin_units::fee_rate
 pub mod bitcoin_units::locktime

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -657,9 +657,9 @@ pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoi
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
-pub const fn bitcoin_units::block::BlockHeight::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32
 pub const fn bitcoin_units::block::BlockInterval::from_u32(inner: u32) -> Self
-pub const fn bitcoin_units::block::BlockInterval::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockInterval::to_u32(self) -> u32
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
@@ -678,12 +678,12 @@ pub const fn bitcoin_units::locktime::absolute::Time::to_consensus_u32(self) -> 
 pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
 pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
 pub const fn bitcoin_units::locktime::relative::Height::from_height(blocks: u16) -> Self
-pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::Height::value(self) -> u16
 pub const fn bitcoin_units::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::Time::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
-pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::Time::value(self) -> u16
 pub const fn bitcoin_units::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
 pub const fn bitcoin_units::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -639,9 +639,9 @@ pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoi
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
-pub const fn bitcoin_units::block::BlockHeight::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32
 pub const fn bitcoin_units::block::BlockInterval::from_u32(inner: u32) -> Self
-pub const fn bitcoin_units::block::BlockInterval::to_u32(&self) -> u32
+pub const fn bitcoin_units::block::BlockInterval::to_u32(self) -> u32
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
@@ -660,12 +660,12 @@ pub const fn bitcoin_units::locktime::absolute::Time::to_consensus_u32(self) -> 
 pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
 pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
 pub const fn bitcoin_units::locktime::relative::Height::from_height(blocks: u16) -> Self
-pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Height::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::Height::value(self) -> u16
 pub const fn bitcoin_units::locktime::relative::Time::from_512_second_intervals(intervals: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::Time::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::Time::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
-pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(&self) -> u32
+pub const fn bitcoin_units::locktime::relative::Time::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::Time::value(self) -> u16
 pub const fn bitcoin_units::weight::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
 pub const fn bitcoin_units::weight::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -38,9 +38,9 @@ pub const PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111; // 0x6f
 /// Test (tesnet, signet, regtest) script address prefix.
 pub const SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196; // 0xc4
 /// The maximum allowed redeem script size for a P2SH output.
-pub const MAX_REDEEM_SCRIPT_SIZE: usize = 520;
+pub const MAX_REDEEM_SCRIPT_SIZE: usize = primitives::script::MAX_REDEEM_SCRIPT_SIZE; // 520
 /// The maximum allowed redeem script size of the witness script.
-pub const MAX_WITNESS_SCRIPT_SIZE: usize = 10_000;
+pub const MAX_WITNESS_SCRIPT_SIZE: usize = primitives::script::MAX_WITNESS_SCRIPT_SIZE; // 10_000
 /// The maximum allowed size of any single witness stack element.
 pub const MAX_STACK_ELEMENT_SIZE: usize = 520;
 /// How may blocks between halvings.

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -81,7 +81,7 @@ pub use self::{
     push_bytes::{PushBytes, PushBytesBuf, PushBytesError, PushBytesErrorReport},
 };
 #[doc(inline)]
-pub use primitives::script::*;
+pub use primitives::script::{Script, ScriptBuf};
 
 pub(crate) use self::borrowed::ScriptExtPriv;
 pub(crate) use self::owned::ScriptBufExtPriv;

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -59,13 +59,11 @@ pub mod witness_version;
 
 use core::fmt;
 
-use hashes::{hash160, sha256};
 use io::{BufRead, Write};
 use primitives::opcodes::all::*;
 use primitives::opcodes::Opcode;
 
 use crate::consensus::{encode, Decodable, Encodable};
-use crate::constants::{MAX_REDEEM_SCRIPT_SIZE, MAX_WITNESS_SCRIPT_SIZE};
 use crate::internal_macros::impl_asref_push_bytes;
 use crate::key::WPubkeyHash;
 use crate::prelude::Vec;
@@ -81,129 +79,14 @@ pub use self::{
     push_bytes::{PushBytes, PushBytesBuf, PushBytesError, PushBytesErrorReport},
 };
 #[doc(inline)]
-pub use primitives::script::{Script, ScriptBuf};
+pub use primitives::script::{
+    RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, WScriptHash, WitnessScriptSizeError,
+};
 
 pub(crate) use self::borrowed::ScriptExtPriv;
 pub(crate) use self::owned::ScriptBufExtPriv;
 
-hashes::hash_newtype! {
-    /// A hash of Bitcoin Script bytecode.
-    pub struct ScriptHash(hash160::Hash);
-    /// SegWit version of a Bitcoin Script bytecode hash.
-    pub struct WScriptHash(sha256::Hash);
-}
-
-hashes::impl_hex_for_newtype!(ScriptHash, WScriptHash);
-#[cfg(feature = "serde")]
-hashes::impl_serde_for_newtype!(ScriptHash, WScriptHash);
-
 impl_asref_push_bytes!(ScriptHash, WScriptHash);
-
-impl ScriptHash {
-    /// Constructs a new `ScriptHash` after first checking the script size.
-    ///
-    /// # 520-byte limitation on serialized script size
-    ///
-    /// > As a consequence of the requirement for backwards compatibility the serialized script is
-    /// > itself subject to the same rules as any other PUSHDATA operation, including the rule that
-    /// > no data greater than 520 bytes may be pushed to the stack. Thus it is not possible to
-    /// > spend a P2SH output if the redemption script it refers to is >520 bytes in length.
-    ///
-    /// ref: [BIP-16](https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#user-content-520byte_limitation_on_serialized_script_size)
-    pub fn from_script(redeem_script: &Script) -> Result<Self, RedeemScriptSizeError> {
-        if redeem_script.len() > MAX_REDEEM_SCRIPT_SIZE {
-            return Err(RedeemScriptSizeError { size: redeem_script.len() });
-        }
-
-        Ok(ScriptHash(hash160::Hash::hash(redeem_script.as_bytes())))
-    }
-
-    /// Constructs a new `ScriptHash` from any script irrespective of script size.
-    ///
-    /// If you hash a script that exceeds 520 bytes in size and use it to create a P2SH output
-    /// then the output will be unspendable (see [BIP-16]).
-    ///
-    /// [BIP-16]: <https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#user-content-520byte_limitation_on_serialized_script_size>
-    pub fn from_script_unchecked(script: &Script) -> Self {
-        ScriptHash(hash160::Hash::hash(script.as_bytes()))
-    }
-}
-
-impl WScriptHash {
-    /// Constructs a new `WScriptHash` after first checking the script size.
-    ///
-    /// # 10,000-byte limit on the witness script
-    ///
-    /// > The witnessScript (≤ 10,000 bytes) is popped off the initial witness stack. SHA256 of the
-    /// > witnessScript must match the 32-byte witness program.
-    ///
-    /// ref: [BIP-141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
-    pub fn from_script(witness_script: &Script) -> Result<Self, WitnessScriptSizeError> {
-        if witness_script.len() > MAX_WITNESS_SCRIPT_SIZE {
-            return Err(WitnessScriptSizeError { size: witness_script.len() });
-        }
-
-        Ok(WScriptHash(sha256::Hash::hash(witness_script.as_bytes())))
-    }
-
-    /// Constructs a new `WScriptHash` from any script irrespective of script size.
-    ///
-    /// If you hash a script that exceeds 10,000 bytes in size and use it to create a Segwit
-    /// output then the output will be unspendable (see [BIP-141]).
-    ///
-    /// ref: [BIP-141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
-    pub fn from_script_unchecked(script: &Script) -> Self {
-        WScriptHash(sha256::Hash::hash(script.as_bytes()))
-    }
-}
-
-impl TryFrom<ScriptBuf> for ScriptHash {
-    type Error = RedeemScriptSizeError;
-
-    fn try_from(redeem_script: ScriptBuf) -> Result<Self, Self::Error> {
-        Self::from_script(&redeem_script)
-    }
-}
-
-impl TryFrom<&ScriptBuf> for ScriptHash {
-    type Error = RedeemScriptSizeError;
-
-    fn try_from(redeem_script: &ScriptBuf) -> Result<Self, Self::Error> {
-        Self::from_script(redeem_script)
-    }
-}
-
-impl TryFrom<&Script> for ScriptHash {
-    type Error = RedeemScriptSizeError;
-
-    fn try_from(redeem_script: &Script) -> Result<Self, Self::Error> {
-        Self::from_script(redeem_script)
-    }
-}
-
-impl TryFrom<ScriptBuf> for WScriptHash {
-    type Error = WitnessScriptSizeError;
-
-    fn try_from(witness_script: ScriptBuf) -> Result<Self, Self::Error> {
-        Self::from_script(&witness_script)
-    }
-}
-
-impl TryFrom<&ScriptBuf> for WScriptHash {
-    type Error = WitnessScriptSizeError;
-
-    fn try_from(witness_script: &ScriptBuf) -> Result<Self, Self::Error> {
-        Self::from_script(witness_script)
-    }
-}
-
-impl TryFrom<&Script> for WScriptHash {
-    type Error = WitnessScriptSizeError;
-
-    fn try_from(witness_script: &Script) -> Result<Self, Self::Error> {
-        Self::from_script(witness_script)
-    }
-}
 
 /// Constructs a new [`ScriptBuf`] containing the script code used for spending a P2WPKH output.
 ///
@@ -383,39 +266,3 @@ impl std::error::Error for Error {
         }
     }
 }
-
-/// Error while hashing a redeem script.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RedeemScriptSizeError {
-    /// Invalid redeem script size (cannot exceed 520 bytes).
-    pub size: usize,
-}
-
-internals::impl_from_infallible!(RedeemScriptSizeError);
-
-impl fmt::Display for RedeemScriptSizeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "redeem script size exceeds {} bytes: {}", MAX_REDEEM_SCRIPT_SIZE, self.size)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for RedeemScriptSizeError {}
-
-/// Error while hashing a witness script.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WitnessScriptSizeError {
-    /// Invalid witness script size (cannot exceed 10,000 bytes).
-    pub size: usize,
-}
-
-internals::impl_from_infallible!(WitnessScriptSizeError);
-
-impl fmt::Display for WitnessScriptSizeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "witness script size exceeds {} bytes: {}", MAX_WITNESS_SCRIPT_SIZE, self.size)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for WitnessScriptSizeError {}


### PR DESCRIPTION
Woops, this should have been done before v0.101.0 was released.
    
Move the `ScriptHash` and `WScriptHash` types to `primitives`.
    
Requires moving constants and error types as well. We re-export the errors because they are in the `mod.rs` file so they should appear in both `primitives::script::FooError` and `bitcoin::script::FooError`.
