### PR TITLE
Improve fee API

### DIFF
--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -43,7 +43,7 @@ pub mod fee_rate {
 
             let rate = FeeRate::from_sat_per_vb(1).expect("1 sat/byte is valid");
 
-            assert_eq!(rate.fee_vb(tx.vsize().to_u64()), rate.fee_wu(tx.weight()));
+            assert_eq!(rate.fee_vb(tx.vsize().to_u64()), rate.fee(tx.weight()));
         }
     }
 }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -799,7 +799,7 @@ pub fn effective_value(
     value: Amount,
 ) -> Option<SignedAmount> {
     let weight = satisfaction_weight.checked_add(TX_IN_BASE_WEIGHT)?;
-    let signed_input_fee = fee_rate.checked_mul_by_weight(weight)?.to_signed().ok()?;
+    let signed_input_fee = fee_rate.fee(weight)?.to_signed().ok()?;
     value.to_signed().ok()?.checked_sub(signed_input_fee)
 }
 

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -140,17 +140,17 @@ fn checked_arithmetic() {
 #[test]
 fn amount_checked_div_by_weight_ceil() {
     let weight = Weight::from_kwu(1).unwrap();
-    let fee_rate = Amount::from_sat(1).checked_div_by_weight_ceil(weight).unwrap();
+    let fee_rate = Amount::from_sat(1).fee_rate_ceil(weight).unwrap();
     // 1 sats / 1,000 wu = 1 sats/kwu
     assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1));
 
     let weight = Weight::from_wu(381);
-    let fee_rate = Amount::from_sat(329).checked_div_by_weight_ceil(weight).unwrap();
+    let fee_rate = Amount::from_sat(329).fee_rate_ceil(weight).unwrap();
     // 329 sats / 381 wu = 863.5 sats/kwu
     // round up to 864
     assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(864));
 
-    let fee_rate = Amount::ONE_SAT.checked_div_by_weight_ceil(Weight::ZERO);
+    let fee_rate = Amount::ONE_SAT.fee_rate_ceil(Weight::ZERO);
     assert!(fee_rate.is_none());
 }
 
@@ -158,17 +158,17 @@ fn amount_checked_div_by_weight_ceil() {
 #[test]
 fn amount_checked_div_by_weight_floor() {
     let weight = Weight::from_kwu(1).unwrap();
-    let fee_rate = Amount::from_sat(1).checked_div_by_weight_floor(weight).unwrap();
+    let fee_rate = Amount::from_sat(1).fee_rate_floor(weight).unwrap();
     // 1 sats / 1,000 wu = 1 sats/kwu
     assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1));
 
     let weight = Weight::from_wu(381);
-    let fee_rate = Amount::from_sat(329).checked_div_by_weight_floor(weight).unwrap();
+    let fee_rate = Amount::from_sat(329).fee_rate_floor(weight).unwrap();
     // 329 sats / 381 wu = 863.5 sats/kwu
     // round down to 863
     assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(863));
 
-    let fee_rate = Amount::ONE_SAT.checked_div_by_weight_floor(Weight::ZERO);
+    let fee_rate = Amount::ONE_SAT.fee_rate_floor(Weight::ZERO);
     assert!(fee_rate.is_none());
 }
 

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -10,6 +10,8 @@ use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::{Amount, FeeRate};
+
 /// The factor that non-witness serialization data is multiplied by during weight calculation.
 pub const WITNESS_SCALE_FACTOR: usize = 4;
 
@@ -150,6 +152,18 @@ impl Weight {
             None => None,
         }
     }
+
+    /// Calculates the fee by multiplying this weight by a fee rate.
+    ///
+    /// Computes the absolute fee amount for a given [`FeeRate`] for this weight. When the resulting
+    /// fee is a non-integer amount, the amount is rounded up, ensuring that the transaction fee is
+    /// enough instead of falling short if rounded down.
+    ///
+    /// # Returns
+    ///
+    /// The fee or `None` if an overflow occurred.
+    #[must_use]
+    pub const fn fee(self, rate: FeeRate) -> Option<Amount> { rate.fee(self) }
 }
 
 /// Alternative will display the unit.


### PR DESCRIPTION
The API around converting a weight/fee_rate to a fee (`Amount`) could do with some improvements.

Currently we have a seemingly low level function in the public API of `units` - `FeeRate::checked_mul_by_weight`. This function is used by `FeeRate::fee_wu` and differs only in that its const.

Similarly we have `Amount::checked_div_by_weight_` functions that are also seemingly low level because they could just be called `fee_rate_`.

Next, there is no obvious reason why one can call a fee function on `FeeRate` but not on `Weight` - since the fee is the result of multiplying these two together it seems reasonable that users may expect to be able to do `weight.fee(fee_rate)`.

Finally, the `FeeRate`'s provides two fee functions `fee_wu` and `fee_vb`. However the parameter to `fee_wu` is a `Weight` type so the `_wu` adds nothing other than to differentiate from `fee_vb`. We can drop the `_wu` with no loss of clarity.

Improve the fee API by doing the following:

- Rename `Amount::checked_dive_by_weight_floor` to `fee_rate_floor`
- Rename `Amount::checked_dive_by_weight_ceil` to `fee_rate_ceil`
- Remove `FeeRate::checked_mul_by_weight` (inline into `fee_wu`)
- Rename `FeeRate::fee_wu` to `FeeRate::fee` and make it const
- Add `Weight::fee` that calls through to `FeeRate::fee`

No deprecation done because this stuff is all in `units` and we do not want to release deprecated code in `v1.0`.