### PR TITLE
Remove Weight::from_wu_usize function

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -10,7 +10,7 @@
 use core::fmt;
 
 use hashes::{sha256d, HashEngine};
-use internals::compact_size;
+use internals::{compact_size, ToU64};
 use io::{BufRead, Write};
 
 use super::Weight;
@@ -263,7 +263,7 @@ impl BlockCheckedExt for Block<Checked> {
     fn weight(&self) -> Weight {
         // This is the exact definition of a weight unit, as defined by BIP-141 (quote above).
         let wu = block_base_size(self.transactions()) * 3 + self.total_size();
-        Weight::from_wu_usize(wu)
+        Weight::from_wu(wu.to_u64())
     }
 
     fn total_size(&self) -> usize {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -352,7 +352,7 @@ impl TransactionExt for Transaction {
     fn weight(&self) -> Weight {
         // This is the exact definition of a weight unit, as defined by BIP-141 (quote above).
         let wu = self.base_size() * 3 + self.total_size();
-        Weight::from_wu_usize(wu)
+        Weight::from_wu(wu.to_u64())
     }
 
     fn base_size(&self) -> usize {
@@ -1151,7 +1151,9 @@ impl InputWeightPrediction {
     ///
     /// See also [`InputWeightPrediction::total_weight`]
     pub const fn witness_weight(&self) -> Weight {
-        Weight::from_wu_usize(self.script_size * 4 + self.witness_size)
+        let wu = self.script_size * 4 + self.witness_size;
+        let wu = wu as u64; // Can't use `ToU64` in const context.
+        Weight::from_wu(wu)
     }
 }
 

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -48,9 +48,6 @@ impl Weight {
     /// Constructs a new [`Weight`] from weight units.
     pub const fn from_wu(wu: u64) -> Self { Weight(wu) }
 
-    /// Constructs a new [`Weight`] from usize weight units.
-    pub const fn from_wu_usize(wu: usize) -> Self { Weight(wu as u64) }
-
     /// Constructs a new [`Weight`] from kilo weight units returning [`None`] if an overflow occurred.
     pub fn from_kwu(wu: u64) -> Option<Self> { wu.checked_mul(1000).map(Weight) }
 
@@ -254,7 +251,6 @@ mod tests {
     #[test]
     fn weight_constructor() {
         assert_eq!(Weight::ZERO, Weight::from_wu(0));
-        assert_eq!(Weight::ZERO, Weight::from_wu_usize(0_usize));
     }
 
     #[test]


### PR DESCRIPTION
This constructor is an anomaly in this repo. Also it is ugly to have the type parameter hard coded in the function name.

The problem the constructor is trying to solve is that we don't like casts that don't obviously loose data. We have a solution for that already in `internals::ToU64`. This trait cannot be used in const contexts though so we do introduce a single cast in this patch.