### PR TITLE
Add `Weight::to_kwu_ceil`

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -738,6 +738,7 @@ pub const fn bitcoin_units::weight::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::weight::Weight
 pub const fn bitcoin_units::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
 pub const fn bitcoin_units::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_kwu_floor(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_vbytes_floor(self) -> u64

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -696,6 +696,7 @@ pub const fn bitcoin_units::weight::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::weight::Weight
 pub const fn bitcoin_units::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
 pub const fn bitcoin_units::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_kwu_floor(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_vbytes_floor(self) -> u64

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -678,6 +678,7 @@ pub const fn bitcoin_units::weight::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::weight::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::weight::Weight
 pub const fn bitcoin_units::weight::Weight::from_witness_data_size(witness_size: u64) -> Self
 pub const fn bitcoin_units::weight::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::weight::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_kwu_floor(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::weight::Weight::to_vbytes_floor(self) -> u64

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -92,6 +92,9 @@ impl Weight {
     /// Converts to kilo weight units rounding down.
     pub const fn to_kwu_floor(self) -> u64 { self.0 / 1000 }
 
+    /// Converts to kilo weight units rounding up.
+    pub const fn to_kwu_ceil(self) -> u64 { (self.0 + 999) / 1000 }
+
     /// Converts to vB rounding down.
     pub const fn to_vbytes_floor(self) -> u64 { self.0 / Self::WITNESS_SCALE_FACTOR }
 
@@ -298,6 +301,13 @@ mod tests {
     #[test]
     fn to_kwu_floor() {
         assert_eq!(1, Weight(1_000).to_kwu_floor());
+        assert_eq!(1, Weight(1_999).to_kwu_floor());
+    }
+
+    #[test]
+    fn to_kwu_ceil() {
+        assert_eq!(1, Weight(1_000).to_kwu_ceil());
+        assert_eq!(2, Weight(1_001).to_kwu_ceil());
     }
 
     #[test]


### PR DESCRIPTION
It is not immediately obvious why we have floor and ceil versions of `to_vbytes` but not for `to_kwu`.

Add a conversion function to get weight by kilo weight units rounding up.

And then clean up the `weight` unit tests.