### PR TITLE
Change paramater type used for whole bitcoin

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -687,7 +687,7 @@ pub const fn bitcoin_units::Amount::checked_div_by_weight_floor(self, rhs: bitco
 pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_sub(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
-pub const fn bitcoin_units::Amount::from_int_btc_const(btc: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::from_int_btc_const(whole_bitcoin: u32) -> bitcoin_units::Amount
 pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> bitcoin_units::Amount
 pub const fn bitcoin_units::Amount::to_sat(self) -> u64
 pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::SignedAmount>
@@ -696,7 +696,7 @@ pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
-pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
@@ -766,7 +766,7 @@ pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_int_btc(btc: u64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
@@ -813,7 +813,7 @@ pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmoun
 pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_int_btc(btc: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -645,7 +645,7 @@ pub const fn bitcoin_units::Amount::checked_div_by_weight_floor(self, rhs: bitco
 pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_sub(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
-pub const fn bitcoin_units::Amount::from_int_btc_const(btc: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::from_int_btc_const(whole_bitcoin: u32) -> bitcoin_units::Amount
 pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> bitcoin_units::Amount
 pub const fn bitcoin_units::Amount::to_sat(self) -> u64
 pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::SignedAmount>
@@ -654,7 +654,7 @@ pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
-pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
@@ -720,7 +720,7 @@ pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_int_btc(btc: u64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
@@ -756,7 +756,7 @@ pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmoun
 pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_int_btc(btc: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -627,7 +627,7 @@ pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option:
 pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_sub(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
-pub const fn bitcoin_units::Amount::from_int_btc_const(btc: u64) -> bitcoin_units::Amount
+pub const fn bitcoin_units::Amount::from_int_btc_const(whole_bitcoin: u32) -> bitcoin_units::Amount
 pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> bitcoin_units::Amount
 pub const fn bitcoin_units::Amount::to_sat(self) -> u64
 pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<bitcoin_units::SignedAmount>
@@ -636,7 +636,7 @@ pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
-pub const fn bitcoin_units::SignedAmount::from_int_btc_const(btc: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
 pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
@@ -700,7 +700,7 @@ pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
 pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: u64)
 pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::Amount::from_int_btc(btc: u64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
@@ -730,7 +730,7 @@ pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
 pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: i64)
 pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
 pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::SignedAmount::from_int_btc(btc: i64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -80,8 +80,8 @@ impl SignedAmount {
     ///
     /// The function errors if the argument multiplied by the number of sats
     /// per bitcoin overflows an `i64` type.
-    pub fn from_int_btc(btc: i64) -> Result<SignedAmount, OutOfRangeError> {
-        match btc.checked_mul(100_000_000) {
+    pub fn from_int_btc<T: Into<i64>>(whole_bitcoin: T) -> Result<SignedAmount, OutOfRangeError> {
+        match whole_bitcoin.into().checked_mul(100_000_000) {
             Some(amount) => Ok(SignedAmount::from_sat(amount)),
             None => Err(OutOfRangeError { is_signed: true, is_greater_than_max: true }),
         }
@@ -94,8 +94,8 @@ impl SignedAmount {
     ///
     /// The function panics if the argument multiplied by the number of sats
     /// per bitcoin overflows an `i64` type.
-    pub const fn from_int_btc_const(btc: i64) -> SignedAmount {
-        match btc.checked_mul(100_000_000) {
+    pub const fn from_int_btc_const(whole_bitcoin: i64) -> SignedAmount {
+        match whole_bitcoin.checked_mul(100_000_000) {
             Some(amount) => SignedAmount::from_sat(amount),
             None => panic!("checked_mul overflowed"),
         }

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -71,10 +71,6 @@ fn from_int_btc() {
     assert_eq!(Amount::from_sat(200_000_000), amt);
 }
 
-#[should_panic]
-#[test]
-fn from_int_btc_panic() { Amount::from_int_btc_const(u64::MAX); }
-
 #[test]
 fn test_signed_amount_try_from_amount() {
     let ua_positive = Amount::from_sat(123);

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -101,8 +101,8 @@ impl Amount {
     ///
     /// The function errors if the argument multiplied by the number of sats
     /// per bitcoin overflows a `u64` type.
-    pub fn from_int_btc(btc: u64) -> Result<Amount, OutOfRangeError> {
-        match btc.checked_mul(100_000_000) {
+    pub fn from_int_btc<T: Into<u64>>(whole_bitcoin: T) -> Result<Amount, OutOfRangeError> {
+        match whole_bitcoin.into().checked_mul(100_000_000) {
             Some(amount) => Ok(Amount::from_sat(amount)),
             None => Err(OutOfRangeError { is_signed: false, is_greater_than_max: true }),
         }
@@ -115,7 +115,8 @@ impl Amount {
     ///
     /// The function panics if the argument multiplied by the number of sats
     /// per bitcoin overflows a `u64` type.
-    pub const fn from_int_btc_const(btc: u64) -> Amount {
+    pub const fn from_int_btc_const(whole_bitcoin: u32) -> Amount {
+        let btc = whole_bitcoin as u64; // Can't call u64::from in const context.
         match btc.checked_mul(100_000_000) {
             Some(amount) => Amount::from_sat(amount),
             None => panic!("checked_mul overflowed"),


### PR DESCRIPTION
We have multiple constructors for `Amount`, one of which accepts an integer representing whole bitcoin.

In an attempt to make the API crystal clear change the parameter type used for whole bitcoin to `u32` instead of a `u64` which may well be mapped to sats in the mind of developers (it is in mine anyway).