### PR TITLE
units: Use Self in consts

### DIFF
--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -50,17 +50,17 @@ pub struct SignedAmount(i64);
 
 impl SignedAmount {
     /// The zero amount.
-    pub const ZERO: SignedAmount = SignedAmount(0);
+    pub const ZERO: Self = SignedAmount(0);
     /// Exactly one satoshi.
-    pub const ONE_SAT: SignedAmount = SignedAmount(1);
+    pub const ONE_SAT: Self = SignedAmount(1);
     /// Exactly one bitcoin.
-    pub const ONE_BTC: SignedAmount = SignedAmount(100_000_000);
+    pub const ONE_BTC: Self = SignedAmount(100_000_000);
     /// The maximum value allowed as an amount. Useful for sanity checking.
-    pub const MAX_MONEY: SignedAmount = SignedAmount(21_000_000 * 100_000_000);
+    pub const MAX_MONEY: Self = SignedAmount(21_000_000 * 100_000_000);
     /// The minimum value of an amount.
-    pub const MIN: SignedAmount = SignedAmount(i64::MIN);
+    pub const MIN: Self = SignedAmount(i64::MIN);
     /// The maximum value of an amount.
-    pub const MAX: SignedAmount = SignedAmount(i64::MAX);
+    pub const MAX: Self = SignedAmount(i64::MAX);
 
     /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
     pub const fn from_sat(satoshi: i64) -> SignedAmount { SignedAmount(satoshi) }

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -55,17 +55,17 @@ pub struct Amount(u64);
 
 impl Amount {
     /// The zero amount.
-    pub const ZERO: Amount = Amount(0);
+    pub const ZERO: Self = Amount(0);
     /// Exactly one satoshi.
-    pub const ONE_SAT: Amount = Amount(1);
+    pub const ONE_SAT: Self = Amount(1);
     /// Exactly one bitcoin.
-    pub const ONE_BTC: Amount = Self::from_int_btc_const(1);
+    pub const ONE_BTC: Self = Self::from_int_btc_const(1);
     /// The maximum value allowed as an amount. Useful for sanity checking.
-    pub const MAX_MONEY: Amount = Self::from_int_btc_const(21_000_000);
+    pub const MAX_MONEY: Self = Self::from_int_btc_const(21_000_000);
     /// The minimum value of an amount.
-    pub const MIN: Amount = Amount::ZERO;
+    pub const MIN: Self = Amount::ZERO;
     /// The maximum value of an amount.
-    pub const MAX: Amount = Amount::MAX_MONEY;
+    pub const MAX: Self = Amount::MAX_MONEY;
     /// The number of bytes that an amount contributes to the size of a transaction.
     pub const SIZE: usize = 8; // Serialized length of a u64.
 


### PR DESCRIPTION
Use `Self` in the public consts in `Amount` and `SignedAmount`. This is more terse with no loss of clarity.

Internal change only.