### PR TITLE
Update to arbitrary v1.4

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -10,9 +10,9 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "arbitrary"
-version = "1.0.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -10,9 +10,9 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "arrayvec"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -35,7 +35,7 @@ primitives = { package = "bitcoin-primitives", version = "0.101.0", default-feat
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false, features = ["alloc"] }
 
-arbitrary = { version = "1.0.1", optional = true }
+arbitrary = { version = "1.4", optional = true }
 base64 = { version = "0.22.0", optional = true }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -28,7 +28,7 @@ internals = { package = "bitcoin-internals", version = "0.4.0" }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
-arbitrary = { version = "1", optional = true }
+arbitrary = { version = "1.4", optional = true }
 ordered = { version = "0.2.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
 

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["internals/alloc","serde?/alloc"]
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
-arbitrary = { version = "1", optional =true }
+arbitrary = { version = "1.4", optional = true }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", version = "0.4.0", features = ["test-serde"] }


### PR DESCRIPTION
Out with the old in with the new, update to the latest minor version of arbitrary.

No real reason to do this except that I wanted to add the minor version instead of using just `1` so that we don't accidentally pull a new minor version in during a patch release (after we 1.0).

(I'm unsure if this is necessary and did not test it against MSRV.)