### PR TITLE
Release tracking PR: `hashes 0.16.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -25,7 +25,7 @@ name = "base58ck"
 version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.15.0",
+ "bitcoin_hashes 0.16.0",
  "hex-conservative 0.3.0",
 ]
 
@@ -64,7 +64,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-primitives",
  "bitcoin-units",
- "bitcoin_hashes 0.15.0",
+ "bitcoin_hashes 0.16.0",
  "bitcoinconsensus",
  "hex-conservative 0.3.0",
  "hex_lit",
@@ -116,7 +116,7 @@ dependencies = [
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.15.0",
+ "bitcoin_hashes 0.16.0",
  "hex-conservative 0.3.0",
  "mutagen",
  "ordered",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.3.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -25,7 +25,7 @@ name = "base58ck"
 version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.15.0",
+ "bitcoin_hashes 0.16.0",
  "hex-conservative 0.3.0",
 ]
 
@@ -63,7 +63,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-primitives",
  "bitcoin-units",
- "bitcoin_hashes 0.15.0",
+ "bitcoin_hashes 0.16.0",
  "bitcoinconsensus",
  "hex-conservative 0.3.0",
  "hex_lit",
@@ -115,7 +115,7 @@ dependencies = [
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.15.0",
+ "bitcoin_hashes 0.16.0",
  "hex-conservative 0.3.0",
  "mutagen",
  "ordered",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.3.0",

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -18,7 +18,7 @@ std = ["alloc", "hashes/std", "internals/std"]
 alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = false }
+hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 
 [dev-dependencies]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -27,7 +27,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 [dependencies]
 base58 = { package = "base58ck", version = "0.2.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = false, features = ["alloc", "bitcoin-io", "hex"] }
+hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["alloc", "bitcoin-io", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.16.0 - 2024-12-12
+
+* Make `hex-conservative` an optional dependency [#3611](https://github.com/rust-bitcoin/rust-bitcoin/pull/3611)
+* Bump `hex-conservative` to `v0.3.0` [#3543](https://github.com/rust-bitcoin/rust-bitcoin/pull/3543)
+* Hide error internals [#3579](https://github.com/rust-bitcoin/rust-bitcoin/pull/3579)
+
 # 0.15.0 - 2024-10-16
 
 This release is massive. The biggest visable changes are to the `Hash` trait, which has mostly been replaced

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.15.0", default-features = false, features = ["bitcoin-io", "hex"] }
+hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["bitcoin-io", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false }


### PR DESCRIPTION
We need to do a quick release because our current `bitcoin` manifest does not work with hashes `v0.15.0` and we'd like to release an alpha version with the current state of `master`. https://github.com/rust-bitcoin/rust-bitcoin/pull/3718

```
the package `bitcoin` depends on `bitcoin_hashes`, with features: `hex`
but `bitcoin_hashes` does not have these features. It has a required
dependency with that name, but only optional dependencies can be used as
features.
```

Add a changelog, bump the version, depend on the new version repo wide, and update the lock files - like its our job.