### PR TITLE
Remove double spacing in rustdocs

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -773,11 +773,11 @@ impl Decodable for Transaction {
 
 /// Computes the value of an output accounting for the cost of spending it.
 ///
-/// The effective value is the value of an output value minus the amount to spend it.  That is, the
+/// The effective value is the value of an output value minus the amount to spend it. That is, the
 /// effective_value can be calculated as: value - (fee_rate * weight).
 ///
 /// Note: the effective value of a [`Transaction`] may increase less than the effective value of
-/// a [`TxOut`] when adding another [`TxOut`] to the transaction.  This happens when the new
+/// a [`TxOut`] when adding another [`TxOut`] to the transaction. This happens when the new
 /// [`TxOut`] added causes the output length `VarInt` to increase its encoding length.
 ///
 /// # Parameters

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -68,12 +68,12 @@ impl ServiceFlags {
     /// clients.
     pub const NETWORK: ServiceFlags = ServiceFlags(1 << 0);
 
-    /// GETUTXO means the node is capable of responding to the getutxo protocol request.  Bitcoin
+    /// GETUTXO means the node is capable of responding to the getutxo protocol request. Bitcoin
     /// Core does not support this but a patch set called Bitcoin XT does.
     /// See BIP 64 for details on how this is implemented.
     pub const GETUTXO: ServiceFlags = ServiceFlags(1 << 1);
 
-    /// BLOOM means the node is capable and willing to handle bloom-filtered connections.  Bitcoin
+    /// BLOOM means the node is capable and willing to handle bloom-filtered connections. Bitcoin
     /// Core nodes used to support this by default, without advertising this bit, but no longer do
     /// as of protocol version 70011 (= NO_BLOOM_VERSION)
     pub const BLOOM: ServiceFlags = ServiceFlags(1 << 2);

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -44,7 +44,7 @@ pub use self::{
 ///
 /// # Note
 ///
-/// Due to ambiguity between mega and milli we prohibit usage of leading capital 'M'.  It is
+/// Due to ambiguity between mega and milli we prohibit usage of leading capital 'M'. It is
 /// more important to protect users from incorrectly using a capital M to mean milli than to
 /// allow Megabitcoin which is not a realistic denomination, and Megasatoshi which is
 /// equivalent to cBTC which is allowed.
@@ -124,7 +124,7 @@ impl Denomination {
     }
 }
 
-/// These form are ambigous and could have many meanings.  For example, M could denote Mega or Milli.
+/// These form are ambigous and could have many meanings. For example, M could denote Mega or Milli.
 /// If any of these forms are used, an error type PossiblyConfusingDenomination is returned.
 const CONFUSING_FORMS: [&str; 6] = ["CBTC", "Cbtc", "MBTC", "Mbtc", "UBTC", "Ubtc"];
 

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -27,7 +27,7 @@ use super::{
 /// This type implements several arithmetic operations from [`core::ops`].
 /// To prevent errors due to overflow or underflow when using these operations,
 /// it is advised to instead use the checked arithmetic methods whose names
-/// start with `checked_`.  The operations from [`core::ops`] that [`Amount`]
+/// start with `checked_`. The operations from [`core::ops`] that [`Amount`]
 /// implements will panic when overflow or underflow occurs.
 ///
 /// # Examples
@@ -103,7 +103,7 @@ impl SignedAmount {
 
     /// Parses a decimal string as a value in the given denomination.
     ///
-    /// Note: This only parses the value string.  If you want to parse a value
+    /// Note: This only parses the value string. If you want to parse a value
     /// with denomination, use [`FromStr`].
     pub fn from_str_in(s: &str, denom: Denomination) -> Result<SignedAmount, ParseAmountError> {
         match parse_signed_to_satoshi(s, denom).map_err(|error| error.convert(true))? {

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -29,8 +29,8 @@ use crate::{FeeRate, Weight};
 /// This type implements several arithmetic operations from [`core::ops`].
 /// To prevent errors due to overflow or underflow when using these operations,
 /// it is advised to instead use the checked arithmetic methods whose names
-/// start with `checked_`.  The operations from [`core::ops`] that [`Amount`]
-/// implements will panic when overflow or underflow occurs.  Also note that
+/// start with `checked_`. The operations from [`core::ops`] that [`Amount`]
+/// implements will panic when overflow or underflow occurs. Also note that
 /// since the internal representation of amounts is unsigned, subtracting below
 /// zero is considered an underflow and will cause a panic if you're not using
 /// the checked arithmetic methods.
@@ -125,7 +125,7 @@ impl Amount {
 
     /// Parses a decimal string as a value in the given [`Denomination`].
     ///
-    /// Note: This only parses the value string.  If you want to parse a string
+    /// Note: This only parses the value string. If you want to parse a string
     /// containing the value with denomination, use [`FromStr`].
     ///
     /// # Errors
@@ -325,8 +325,8 @@ impl Amount {
     /// Checked weight ceiling division.
     ///
     /// Be aware that integer division loses the remainder if no exact division
-    /// can be made.  This method rounds up ensuring the transaction fee-rate is
-    /// sufficient.  See also [`Amount::checked_div_by_weight_floor`].
+    /// can be made. This method rounds up ensuring the transaction fee-rate is
+    /// sufficient. See also [`Amount::checked_div_by_weight_floor`].
     ///
     /// Returns [`None`] if overflow occurred.
     ///
@@ -359,7 +359,7 @@ impl Amount {
     /// Checked weight floor division.
     ///
     /// Be aware that integer division loses the remainder if no exact division
-    /// can be made.  See also [`Amount::checked_div_by_weight_ceil`].
+    /// can be made. See also [`Amount::checked_div_by_weight_ceil`].
     ///
     /// Returns [`None`] if overflow occurred.
     #[cfg(feature = "alloc")]
@@ -422,7 +422,7 @@ impl Amount {
         }
     }
 
-    /// Checks if the amount is below the maximum value.  Returns `None` if it is above.
+    /// Checks if the amount is below the maximum value. Returns `None` if it is above.
     const fn check_max(self) -> Option<Amount> {
         if self.0 > Self::MAX.0 {
             None


### PR DESCRIPTION
Fixes #3761