### PR TITLE
contrib: check if the user has cargo-public-api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,9 @@ running `just check-api`.
 - `primitives`
 - `units`
 
+Check the [API text files](api/README.md) for more information
+on how to install the dependencies and create the text files.
+
 ### Repository maintainers
 
 Pull request merge requirements:

--- a/api/README.md
+++ b/api/README.md
@@ -6,7 +6,7 @@ enabled. To create these files run `../contrib/check-for-api-changes.sh`:
 Requires `cargo-public-api`, install with:
 
 ```
-cargo +stable install cargo-public-api --locked
+cargo +nightly install cargo-public-api --locked
 ```
 
 ref: https://github.com/enselic/cargo-public-api

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -22,6 +22,7 @@ export LC_ALL=C
 
 main() {
     need_nightly
+    need_cargo_public_api
 
     generate_api_files "hashes"
     generate_api_files "io"
@@ -79,6 +80,13 @@ need_nightly() {
     if echo "$cargo_ver" | grep -q -v nightly; then
         err "Need a nightly compiler; have $cargo_ver"
     fi
+}
+
+need_cargo_public_api() {
+    if command -v cargo-public-api > /dev/null; then
+        return
+    fi
+    err "cargo-public-api is not installed; please run 'cargo +nightly install cargo-public-api --locked'"
 }
 
 err() {


### PR DESCRIPTION
Closes #3764.

yancyribbens can you test it locally? It works in my end both with and without `cargo-public-api`. Of course without gives the error message that I was supposed to see.

EDIT: You can run it with `just check-api`.