### PR TITLE
units: Document public macros

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1195,7 +1195,6 @@ pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
-pub macro bitcoin_units::impl_tryfrom_str!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::amount::serde

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1196,7 +1196,6 @@ pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
 pub macro bitcoin_units::impl_tryfrom_str!
-pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::amount::serde

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1066,7 +1066,6 @@ pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
-pub macro bitcoin_units::impl_tryfrom_str!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::block

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1067,7 +1067,6 @@ pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
 pub macro bitcoin_units::impl_tryfrom_str!
-pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::block

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1021,7 +1021,6 @@ pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
 pub macro bitcoin_units::impl_tryfrom_str!
-pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::block

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1020,7 +1020,6 @@ pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
-pub macro bitcoin_units::impl_tryfrom_str!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::block

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -91,23 +91,6 @@ pub fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, Par
     })
 }
 
-/// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using infallible
-/// conversion function `fn`.
-#[macro_export]
-macro_rules! impl_tryfrom_str_from_int_infallible {
-    ($($from:ty, $to:ident, $inner:ident, $fn:ident);*) => {
-        $(
-        impl $crate::_export::_core::convert::TryFrom<$from> for $to {
-            type Error = $crate::parse::ParseIntError;
-
-            fn try_from(s: $from) -> $crate::_export::_core::result::Result<Self, Self::Error> {
-                $crate::parse::int::<$inner, $from>(s).map($to::$fn)
-            }
-        }
-        )*
-    }
-}
-
 /// Implements `FromStr` and `TryFrom<{&str, String, Box<str>}> for $to` using `parse::int`, mapping
 /// the output using infallible conversion function `fn`.
 ///
@@ -127,6 +110,23 @@ macro_rules! impl_parse_str_from_int_infallible {
             }
         }
 
+    }
+}
+
+/// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using infallible
+/// conversion function `fn`.
+#[macro_export]
+macro_rules! impl_tryfrom_str_from_int_infallible {
+    ($($from:ty, $to:ident, $inner:ident, $fn:ident);*) => {
+        $(
+        impl $crate::_export::_core::convert::TryFrom<$from> for $to {
+            type Error = $crate::parse::ParseIntError;
+
+            fn try_from(s: $from) -> $crate::_export::_core::result::Result<Self, Self::Error> {
+                $crate::parse::int::<$inner, $from>(s).map($to::$fn)
+            }
+        }
+        )*
     }
 }
 

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -116,6 +116,7 @@ macro_rules! impl_parse_str_from_int_infallible {
 /// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using infallible
 /// conversion function `fn`.
 #[macro_export]
+#[doc(hidden)]                  // Helper macro called by `impl_parse_str_from_int_infallible`.
 macro_rules! impl_tryfrom_str_from_int_infallible {
     ($($from:ty, $to:ident, $inner:ident, $fn:ident);*) => {
         $(

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -131,22 +131,6 @@ macro_rules! impl_tryfrom_str_from_int_infallible {
     }
 }
 
-/// Implements `TryFrom<$from> for $to`.
-#[macro_export]
-macro_rules! impl_tryfrom_str {
-    ($($from:ty, $to:ty, $err:ty, $inner_fn:expr);*) => {
-        $(
-            impl $crate::_export::_core::convert::TryFrom<$from> for $to {
-                type Error = $err;
-
-                fn try_from(s: $from) -> $crate::_export::_core::result::Result<Self, Self::Error> {
-                    $inner_fn(s)
-                }
-            }
-        )*
-    }
-}
-
 /// Implements standard parsing traits for `$type` by calling into `$inner_fn`.
 #[macro_export]
 macro_rules! impl_parse_str {
@@ -162,6 +146,22 @@ macro_rules! impl_parse_str {
                 $inner_fn(s)
             }
         }
+    }
+}
+
+/// Implements `TryFrom<$from> for $to`.
+#[macro_export]
+macro_rules! impl_tryfrom_str {
+    ($($from:ty, $to:ty, $err:ty, $inner_fn:expr);*) => {
+        $(
+            impl $crate::_export::_core::convert::TryFrom<$from> for $to {
+                type Error = $err;
+
+                fn try_from(s: $from) -> $crate::_export::_core::result::Result<Self, Self::Error> {
+                    $inner_fn(s)
+                }
+            }
+        )*
     }
 }
 

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -151,6 +151,7 @@ macro_rules! impl_parse_str {
 
 /// Implements `TryFrom<$from> for $to`.
 #[macro_export]
+#[doc(hidden)]                  // Helper macro called by `impl_parse_str`.
 macro_rules! impl_tryfrom_str {
     ($($from:ty, $to:ty, $err:ty, $inner_fn:expr);*) => {
         $(

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -91,10 +91,30 @@ pub fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, Par
     })
 }
 
-/// Implements `FromStr` and `TryFrom<{&str, String, Box<str>}> for $to` using `parse::int`, mapping
-/// the output using infallible conversion function `fn`.
+/// Implements standard parsing traits for `$type` by calling `parse::int`.
 ///
-/// The `Error` type is `ParseIntError`
+/// Once the string is converted to an integer the infallible conversion function `fn` is used to
+/// create the type `to`.
+///
+/// Implements:
+///
+/// * `FromStr`
+/// * `TryFrom<&str>`
+///
+/// And if `alloc` feature is enabled in calling crate:
+///
+/// * `TryFrom<Box<str>>`
+/// * `TryFrom<String>`
+///
+/// # Arguments
+///
+/// * `to` - the type converted to e.g., `impl From<&str> for $to`.
+/// * `err` - the error type returned by `$inner_fn` (implies returned by `FromStr` and `TryFrom`).
+/// * `fn`: The infallible conversion function to call to convert from an integer.
+///
+/// # Errors
+///
+/// If parsing the string fails then a `units::parse::ParseIntError` is returned.
 #[macro_export]
 macro_rules! impl_parse_str_from_int_infallible {
     ($to:ident, $inner:ident, $fn:ident) => {
@@ -131,7 +151,27 @@ macro_rules! impl_tryfrom_str_from_int_infallible {
     }
 }
 
-/// Implements standard parsing traits for `$type` by calling into `$inner_fn`.
+/// Implements standard parsing traits for `$type` by calling through to `$inner_fn`.
+///
+/// Implements:
+///
+/// * `FromStr`
+/// * `TryFrom<&str>`
+///
+/// And if `alloc` feature is enabled in calling crate:
+///
+/// * `TryFrom<Box<str>>`
+/// * `TryFrom<String>`
+///
+/// # Arguments
+///
+/// * `to` - the type converted to e.g., `impl From<&str> for $to`.
+/// * `err` - the error type returned by `$inner_fn` (implies returned by `FromStr` and `TryFrom`).
+/// * `inner_fn`: The fallible conversion function to call to convert from a string reference.
+///
+/// # Errors
+///
+/// All functions use the error returned by `$inner_fn`.
 #[macro_export]
 macro_rules! impl_parse_str {
     ($to:ty, $err:ty, $inner_fn:expr) => {


### PR DESCRIPTION
Document the public macros in `units::parse`. Done as part of #3632

First 2 patches are trivial preparatory refactor.