### PR TITLE
Update regex lookahead to match when there are no characters

### DIFF
--- a/contrib/api.sh
+++ b/contrib/api.sh
@@ -99,12 +99,12 @@ main() {
 
 # Print all public structs and enums.
 structs_and_enums() {
-    grep -oP 'pub (struct|enum) \K[\w:]+(?=\(|;| )' "$file" | sed "s/^${crate_full_name}:://"
+    grep -oP 'pub (struct|enum) \K[\w:]+(?=\(|;| |$)' "$file" | sed "s/^${crate_full_name}:://"
 }
 
 # Print all public structs and enums excluding error types.
 structs_and_enums_no_err() {
-    grep -oP 'pub (struct|enum) \K[\w:]+(?=\(|;| )' "$file" | sed "s/^${crate_full_name}:://" | grep -v Error
+    grep -oP 'pub (struct|enum) \K[\w:]+(?=\(|;| |$)' "$file" | sed "s/^${crate_full_name}:://" | grep -v Error
 }
 
 # Print all public traits.


### PR DESCRIPTION
Was working on #3777 and noticed that `amount::Denomination` didn't show up when running `contrib/api.sh units types`. There are some structs/enums in `api/<crate>/all-features.txt` that dont have a `\(`, `;`, or ` ` after the struct/enum name, and the line just ends, so matching the end of line `$` should also be added.

This allows the script to find the additional type from `units`:
`#[non_exhaustive] pub enum bitcoin_units::amount::Denomination`

Also tested this in `primitives`, and it returned:
```
script::Script
BlockChecked
BlockUnchecked
absolute::LockTime
block::Checked
block::Unchecked
locktime::absolute::LockTime
locktime::relative::LockTime
opcodes::Class
opcodes::ClassifyContext
relative::LockTime
BlockHash
BlockHeader
CompactTarget
Sequence
TapBranchTag
TapLeafHash
TapLeafTag
TapNodeHash
TapTweakHash
TapTweakTag
Transaction
TxIn
TxMerkleNode
TxOut
Txid
Witness
WitnessCommitment
WitnessMerkleNode
Wtxid
block::BlockHash
block::Header
block::Version
block::WitnessCommitment
merkle_tree::TxMerkleNode
merkle_tree::WitnessMerkleNode
opcodes::Opcode
pow::CompactTarget
script::ScriptBuf
script::ScriptHash
script::WScriptHash
sequence::Sequence
taproot::TapBranchTag
taproot::TapLeafHash
taproot::TapLeafTag
taproot::TapNodeHash
taproot::TapTweakHash
taproot::TapTweakTag
transaction::OutPoint
transaction::Transaction
transaction::TxIn
transaction::TxOut
transaction::Txid
transaction::Version
transaction::Wtxid
witness::Witness
```

vs without this update (on `master`):
```
script::Script
BlockHash
CompactTarget
Sequence
TapLeafHash
TapNodeHash
TapTweakHash
TxMerkleNode
Txid
WitnessCommitment
WitnessMerkleNode
Wtxid
block::BlockHash
block::Version
block::WitnessCommitment
merkle_tree::TxMerkleNode
merkle_tree::WitnessMerkleNode
pow::CompactTarget
script::ScriptBuf
script::ScriptHash
script::WScriptHash
sequence::Sequence
taproot::TapLeafHash
taproot::TapNodeHash
taproot::TapTweakHash
transaction::Txid
transaction::Version
transaction::Wtxid
```