### PR TITLE
Enforce MAX_MONEY invariant in amount types

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -261,7 +261,7 @@ crate::internal_macros::define_extension_trait! {
         /// Returns the minimum value an output with this script should have in order to be
         /// broadcastable on today’s Bitcoin network.
         #[deprecated(since = "0.32.0", note = "use `minimal_non_dust` etc. instead")]
-        fn dust_value(&self) -> Amount { self.minimal_non_dust() }
+        fn dust_value(&self) -> Option<Amount> { self.minimal_non_dust() }
 
         /// Returns the minimum value an output with this script should have in order to be
         /// broadcastable on today's Bitcoin network.
@@ -272,7 +272,7 @@ crate::internal_macros::define_extension_trait! {
         /// To use a custom value, use [`minimal_non_dust_custom`].
         ///
         /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
-        fn minimal_non_dust(&self) -> Amount {
+        fn minimal_non_dust(&self) -> Option<Amount> {
             self.minimal_non_dust_internal(DUST_RELAY_TX_FEE.into())
         }
 
@@ -287,7 +287,7 @@ crate::internal_macros::define_extension_trait! {
         /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
         ///
         /// [`minimal_non_dust`]: Script::minimal_non_dust
-        fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> Amount {
+        fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> Option<Amount> {
             self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu() * 4)
         }
 
@@ -394,7 +394,7 @@ mod sealed {
 
 crate::internal_macros::define_extension_trait! {
     pub(crate) trait ScriptExtPriv impl for Script {
-        fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> Amount {
+        fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> Option<Amount> {
             // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
             // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
             let sats = dust_relay_fee
@@ -408,13 +408,12 @@ crate::internal_macros::define_extension_trait! {
                     32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
                     8 + // The serialized size of the TxOut's amount field
                     self.consensus_encode(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
-                })
-                .expect("dust_relay_fee or script length should not be absurdly large")
+                })?
                 / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE
                         // Note: We ensure the division happens at the end, since Core performs the division at the end.
                         //       This will make sure none of the implicit floor operations mess with the value.
 
-            Amount::from_sat(sats)
+            Some(Amount::from_sat(sats))
         }
 
         fn count_sigops_internal(&self, accurate: bool) -> usize {

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -413,7 +413,7 @@ crate::internal_macros::define_extension_trait! {
                         // Note: We ensure the division happens at the end, since Core performs the division at the end.
                         //       This will make sure none of the implicit floor operations mess with the value.
 
-            Some(Amount::from_sat(sats))
+            Amount::from_sat(sats).ok()
         }
 
         fn count_sigops_internal(&self, accurate: bool) -> usize {

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -685,10 +685,10 @@ fn default_dust_value() {
     // well-known scriptPubKey types.
     let script_p2wpkh = Builder::new().push_int_unchecked(0).push_slice([42; 20]).into_script();
     assert!(script_p2wpkh.is_p2wpkh());
-    assert_eq!(script_p2wpkh.minimal_non_dust(), Amount::from_sat_unchecked(294));
+    assert_eq!(script_p2wpkh.minimal_non_dust(), Some(Amount::from_sat_unchecked(294)));
     assert_eq!(
         script_p2wpkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
-        Amount::from_sat_unchecked(588)
+        Some(Amount::from_sat_unchecked(588))
     );
 
     let script_p2pkh = Builder::new()
@@ -699,10 +699,10 @@ fn default_dust_value() {
         .push_opcode(OP_CHECKSIG)
         .into_script();
     assert!(script_p2pkh.is_p2pkh());
-    assert_eq!(script_p2pkh.minimal_non_dust(), Amount::from_sat_unchecked(546));
+    assert_eq!(script_p2pkh.minimal_non_dust(), Some(Amount::from_sat_unchecked(546)));
     assert_eq!(
         script_p2pkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
-        Amount::from_sat_unchecked(1092)
+        Some(Amount::from_sat_unchecked(1092))
     );
 }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -183,8 +183,8 @@ crate::internal_macros::define_extension_trait! {
         /// To use a custom value, use [`minimal_non_dust_custom`].
         ///
         /// [`minimal_non_dust_custom`]: TxOut::minimal_non_dust_custom
-        fn minimal_non_dust(script_pubkey: ScriptBuf) -> Self {
-            TxOut { value: script_pubkey.minimal_non_dust(), script_pubkey }
+        fn minimal_non_dust(script_pubkey: ScriptBuf) -> Option<TxOut> {
+            Some(TxOut { value: script_pubkey.minimal_non_dust()?, script_pubkey })
         }
 
         /// Constructs a new `TxOut` with given script and the smallest possible `value` that is **not** dust
@@ -198,8 +198,8 @@ crate::internal_macros::define_extension_trait! {
         /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
         ///
         /// [`minimal_non_dust`]: TxOut::minimal_non_dust
-        fn minimal_non_dust_custom(script_pubkey: ScriptBuf, dust_relay_fee: FeeRate) -> Self {
-            TxOut { value: script_pubkey.minimal_non_dust_custom(dust_relay_fee), script_pubkey }
+        fn minimal_non_dust_custom(script_pubkey: ScriptBuf, dust_relay_fee: FeeRate) -> Option<TxOut> {
+            Some(TxOut { value: script_pubkey.minimal_non_dust_custom(dust_relay_fee)?, script_pubkey })
         }
     }
 }

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -13,7 +13,10 @@ use crate::crypto::ecdsa;
 use crate::prelude::Vec;
 #[cfg(doc)]
 use crate::script::ScriptExt as _;
-use crate::taproot::{self, LeafScript, LeafVersion, TAPROOT_ANNEX_PREFIX, TAPROOT_CONTROL_BASE_SIZE, TAPROOT_LEAF_MASK};
+use crate::taproot::{
+    self, LeafScript, LeafVersion, TAPROOT_ANNEX_PREFIX, TAPROOT_CONTROL_BASE_SIZE,
+    TAPROOT_LEAF_MASK,
+};
 use crate::Script;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -249,14 +252,16 @@ impl<'a> P2TrSpend<'a> {
         // for the fact that annex is still there.
         match witness.len() {
             0 => None,
-            1 => Some(P2TrSpend::Key { /* signature: witness.last().expect("len > 0") ,*/ annex: None }),
+            1 => Some(P2TrSpend::Key {
+                /* signature: witness.last().expect("len > 0") ,*/ annex: None,
+            }),
             2 if witness.last().expect("len > 0").starts_with(&[TAPROOT_ANNEX_PREFIX]) => {
                 let spend = P2TrSpend::Key {
                     // signature: witness.second_to_last().expect("len > 1"),
                     annex: witness.last(),
                 };
                 Some(spend)
-            },
+            }
             // 2 => this is script spend without annex - same as when there are 3+ elements and the
             //   last one does NOT start with TAPROOT_ANNEX_PREFIX. This is handled in the catchall
             //   arm.
@@ -267,7 +272,7 @@ impl<'a> P2TrSpend<'a> {
                     annex: witness.last(),
                 };
                 Some(spend)
-            },
+            }
             _ => {
                 let spend = P2TrSpend::Script {
                     leaf_script: Script::from_bytes(witness.second_to_last().expect("len > 1")),
@@ -275,7 +280,7 @@ impl<'a> P2TrSpend<'a> {
                     annex: None,
                 };
                 Some(spend)
-            },
+            }
         }
     }
 
@@ -390,7 +395,8 @@ mod test {
     #[test]
     fn get_taproot_leaf_script() {
         let tapscript = hex!("deadbeef");
-        let control_block = hex!("c0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        let control_block =
+            hex!("c0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
@@ -403,10 +409,8 @@ mod test {
         let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
         let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
 
-        let expected_leaf_script = LeafScript {
-            version: LeafVersion::TapScript,
-            script: Script::from_bytes(&tapscript),
-        };
+        let expected_leaf_script =
+            LeafScript { version: LeafVersion::TapScript, script: Script::from_bytes(&tapscript) };
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.taproot_leaf_script().unwrap(), expected_leaf_script);
@@ -451,7 +455,8 @@ mod test {
 
         let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
         let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
-        let witness_key_spend_annex = deserialize::<Witness>(&witness_serialized_key_spend_annex[..]).unwrap();
+        let witness_key_spend_annex =
+            deserialize::<Witness>(&witness_serialized_key_spend_annex[..]).unwrap();
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.taproot_control_block(), Some(&control_block[..]));

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -435,9 +435,7 @@ impl EcdsaSighashType {
     /// type (after masking with 0x1f), regardless of the ANYONECANPAY flag.
     ///
     /// See: <https://github.com/bitcoin/bitcoin/blob/e486597/src/script/interpreter.cpp#L1618-L1619>
-    pub fn is_single(&self) -> bool {
-        matches!(self, Self::Single | Self::SinglePlusAnyoneCanPay)
-    }
+    pub fn is_single(&self) -> bool { matches!(self, Self::Single | Self::SinglePlusAnyoneCanPay) }
 
     /// Constructs a new [`EcdsaSighashType`] from a raw `u32`.
     ///

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -199,7 +199,7 @@ pub mod amount {
     //! This module mainly introduces the [`Amount`] and [`SignedAmount`] types.
     //! We refer to the documentation on the types for more information.
 
-    use crate::consensus::{encode, Decodable, Encodable};
+    use crate::consensus::{self, encode, Decodable, Encodable};
     use crate::io::{BufRead, Write};
 
     #[rustfmt::skip]            // Keep public re-exports separate.
@@ -216,7 +216,9 @@ pub mod amount {
     impl Decodable for Amount {
         #[inline]
         fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-            Ok(Amount::from_sat(Decodable::consensus_decode(r)?))
+            Amount::from_sat(Decodable::consensus_decode(r)?).map_err(|_| {
+                consensus::parse_failed_error("amount is greater than Amount::MAX_MONEY")
+            })
         }
     }
 

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -2279,7 +2279,7 @@ mod tests {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
             input: vec![TxIn::EMPTY_COINBASE, TxIn::EMPTY_COINBASE],
-            output: vec![TxOut { value: Amount::from_sat(0), script_pubkey: ScriptBuf::new() }],
+            output: vec![TxOut { value: Amount::ZERO, script_pubkey: ScriptBuf::new() }],
         };
         let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
 

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1264,7 +1264,7 @@ mod tests {
                     witness: Witness::default(),
                 }],
                 output: vec![TxOut {
-                    value: Amount::from_sat(output),
+                    value: Amount::from_sat(output).unwrap(),
                     script_pubkey: ScriptBuf::from_hex(
                         "a9143545e6e33b832c47050f24d3eeb93c9c03948bc787",
                     )
@@ -1278,7 +1278,7 @@ mod tests {
 
             inputs: vec![Input {
                 witness_utxo: Some(TxOut {
-                    value: Amount::from_sat(input),
+                    value: Amount::from_sat(input).unwrap(),
                     script_pubkey: ScriptBuf::from_hex(
                         "a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587",
                     )

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -61,7 +61,9 @@ impl ScriptBuf {
 
     /// Constructs a new empty script with pre-allocated capacity.
     #[inline]
-    pub fn with_capacity(capacity: usize) -> Self { ScriptBuf::from_bytes(Vec::with_capacity(capacity)) }
+    pub fn with_capacity(capacity: usize) -> Self {
+        ScriptBuf::from_bytes(Vec::with_capacity(capacity))
+    }
 
     /// Pre-allocates at least `additional_len` bytes if needed.
     ///
@@ -96,9 +98,7 @@ impl ScriptBuf {
     ///
     /// It is guaranteed that `script.capacity() >= script.len()` always holds.
     #[inline]
-    pub fn capacity(&self) -> usize {
-        self.0.capacity()
-    }
+    pub fn capacity(&self) -> usize { self.0.capacity() }
 }
 
 impl Deref for ScriptBuf {

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -547,7 +547,9 @@ impl Version {
     /// As of Bitcoin Core 28.0 ([release notes](https://bitcoincore.org/en/releases/28.0/)),
     /// versions 1, 2, and 3 are considered standard.
     #[inline]
-    pub fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO || *self == Version::THREE }
+    pub fn is_standard(&self) -> bool {
+        *self == Version::ONE || *self == Version::TWO || *self == Version::THREE
+    }
 }
 
 impl fmt::Display for Version {

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -641,7 +641,8 @@ mod tests {
             witness: Witness::new(),
         };
 
-        let txout = TxOut { value: Amount::from_sat(123456789), script_pubkey: ScriptBuf::new() };
+        let txout =
+            TxOut { value: Amount::from_sat(123456789).unwrap(), script_pubkey: ScriptBuf::new() };
 
         let tx_orig = Transaction {
             version: Version::ONE,
@@ -653,7 +654,7 @@ mod tests {
         // Test changing the transaction
         let mut tx = tx_orig.clone();
         tx.inputs_mut()[0].previous_output.txid = Txid::from_byte_array([0xFF; 32]);
-        tx.outputs_mut()[0].value = Amount::from_sat(987654321);
+        tx.outputs_mut()[0].value = Amount::from_sat(987654321).unwrap();
         assert_eq!(tx.inputs()[0].previous_output.txid.to_byte_array(), [0xFF; 32]);
         assert_eq!(tx.outputs()[0].value.to_sat(), 987654321);
 

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -39,6 +39,7 @@ pub use self::{
     signed::SignedAmount,
     unsigned::Amount,
 };
+pub(crate) use self::result::OptionExt;
 
 /// A set of denominations in which amounts can be expressed.
 ///

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -59,7 +59,7 @@ pub(crate) use self::result::OptionExt;
 /// # Examples
 ///
 /// ```
-/// # use bitcoin_units::Amount;
+/// # use bitcoin_units::{amount, Amount};
 ///
 /// let equal = [
 ///     ("1 BTC", 100_000_000),
@@ -72,9 +72,10 @@ pub(crate) use self::result::OptionExt;
 /// for (string, sats) in equal {
 ///     assert_eq!(
 ///         string.parse::<Amount>().expect("valid bitcoin amount string"),
-///         Amount::from_sat(sats),
+///         Amount::from_sat(sats)?,
 ///     )
 /// }
+/// # Ok::<_, amount::OutOfRangeError>(())
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[non_exhaustive]

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -299,7 +299,9 @@ crate::internal_macros::impl_op_for_references! {
 impl ops::Neg for SignedAmount {
     type Output = Self;
 
-    fn neg(self) -> Self::Output { Self::from_sat(self.to_sat().neg()) }
+    fn neg(self) -> Self::Output {
+        Self::from_sat(self.to_sat().neg()).expect("all +ve and -ve values are valid")
+    }
 }
 
 impl core::iter::Sum<NumOpResult<Amount>> for NumOpResult<Amount> {

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -348,7 +348,7 @@ impl<'a> core::iter::Sum<&'a NumOpResult<SignedAmount>> for NumOpResult<SignedAm
     }
 }
 
-pub(in crate::amount) trait OptionExt<T> {
+pub(crate) trait OptionExt<T> {
     fn valid_or_error(self) -> NumOpResult<T>;
 }
 

--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -92,7 +92,8 @@ impl SerdeAmount for Amount {
         u64::serialize(&self.to_sat(), s)
     }
     fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
-        Ok(Amount::from_sat(u64::deserialize(d)?))
+        use serde::de::Error;
+        Amount::from_sat(u64::deserialize(d)?).map_err(D::Error::custom)
     }
     #[cfg(feature = "alloc")]
     fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {
@@ -137,7 +138,8 @@ impl SerdeAmount for SignedAmount {
         i64::serialize(&self.to_sat(), s)
     }
     fn des_sat<'d, D: Deserializer<'d>>(d: D, _: private::Token) -> Result<Self, D::Error> {
-        Ok(SignedAmount::from_sat(i64::deserialize(d)?))
+        use serde::de::Error;
+        SignedAmount::from_sat(i64::deserialize(d)?).map_err(D::Error::custom)
     }
     #[cfg(feature = "alloc")]
     fn ser_btc<S: Serializer>(self, s: S, _: private::Token) -> Result<S::Ok, S::Error> {

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -402,32 +402,6 @@ impl SignedAmount {
         }
     }
 
-    /// Unchecked addition.
-    ///
-    /// Computes `self + rhs`.
-    ///
-    /// # Panics
-    ///
-    /// On overflow, panics in debug mode, wraps in release mode.
-    #[must_use]
-    #[deprecated(since = "TBD", note = "consider converting to u64 using `to_sat`")]
-    pub fn unchecked_add(self, rhs: SignedAmount) -> SignedAmount {
-        Self::from_sat(self.to_sat() + rhs.to_sat())
-    }
-
-    /// Unchecked subtraction.
-    ///
-    /// Computes `self - rhs`.
-    ///
-    /// # Panics
-    ///
-    /// On overflow, panics in debug mode, wraps in release mode.
-    #[must_use]
-    #[deprecated(since = "TBD", note = "consider converting to u64 using `to_sat`")]
-    pub fn unchecked_sub(self, rhs: SignedAmount) -> SignedAmount {
-        Self::from_sat(self.to_sat() - rhs.to_sat())
-    }
-
     /// Subtraction that doesn't allow negative [`SignedAmount`]s.
     ///
     /// Returns [`None`] if either `self`, `rhs` or the result is strictly negative.

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -50,17 +50,17 @@ pub struct SignedAmount(i64);
 
 impl SignedAmount {
     /// The zero amount.
-    pub const ZERO: Self = SignedAmount(0);
+    pub const ZERO: Self = SignedAmount::from_sat_unchecked(0);
     /// Exactly one satoshi.
-    pub const ONE_SAT: Self = SignedAmount(1);
+    pub const ONE_SAT: Self = SignedAmount::from_sat_unchecked(1);
     /// Exactly one bitcoin.
-    pub const ONE_BTC: Self = SignedAmount(100_000_000);
+    pub const ONE_BTC: Self = SignedAmount::from_sat_unchecked(100_000_000);
     /// Exactly fifty bitcoin.
-    pub const FIFTY_BTC: Self = Self::from_sat_unchecked(50 * 100_000_000);
+    pub const FIFTY_BTC: Self = SignedAmount::from_sat_unchecked(50 * 100_000_000);
     /// The maximum value allowed as an amount. Useful for sanity checking.
-    pub const MAX_MONEY: Self = SignedAmount(21_000_000 * 100_000_000);
+    pub const MAX_MONEY: Self = SignedAmount::from_sat_unchecked(21_000_000 * 100_000_000);
     /// The minimum value of an amount.
-    pub const MIN: Self = SignedAmount(-21_000_000 * 100_000_000);
+    pub const MIN: Self = SignedAmount::from_sat_unchecked(-21_000_000 * 100_000_000);
     /// The maximum value of an amount.
     pub const MAX: Self = SignedAmount::MAX_MONEY;
 

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -121,29 +121,19 @@ impl SignedAmount {
     }
 
     /// Converts from a value expressing a whole number of bitcoin to a [`SignedAmount`].
-    ///
-    /// # Errors
-    ///
-    /// The function errors if the argument multiplied by the number of sats
-    /// per bitcoin overflows an `i64` type.
-    pub fn from_int_btc<T: Into<i64>>(whole_bitcoin: T) -> Result<SignedAmount, OutOfRangeError> {
-        match whole_bitcoin.into().checked_mul(100_000_000) {
-            Some(amount) => Ok(Self::from_sat(amount)),
-            None => Err(OutOfRangeError { is_signed: true, is_greater_than_max: true }),
-        }
+    #[allow(clippy::missing_panics_doc)]
+    pub fn from_int_btc<T: Into<i32>>(whole_bitcoin: T) -> SignedAmount {
+        SignedAmount::from_int_btc_const(whole_bitcoin.into())
     }
 
     /// Converts from a value expressing a whole number of bitcoin to a [`SignedAmount`]
     /// in const context.
-    ///
-    /// # Panics
-    ///
-    /// The function panics if the argument multiplied by the number of sats
-    /// per bitcoin overflows an `i64` type.
-    pub const fn from_int_btc_const(whole_bitcoin: i64) -> SignedAmount {
-        match whole_bitcoin.checked_mul(100_000_000) {
+    #[allow(clippy::missing_panics_doc)]
+    pub const fn from_int_btc_const(whole_bitcoin: i32) -> SignedAmount {
+        let btc = whole_bitcoin as i64; // Can't call `into` in const context.
+        match btc.checked_mul(100_000_000) {
             Some(amount) => SignedAmount::from_sat(amount),
-            None => panic!("checked_mul overflowed"),
+            None => panic!("cannot overflow in i64"),
         }
     }
 

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -158,7 +158,7 @@ impl SignedAmount {
     pub fn from_str_in(s: &str, denom: Denomination) -> Result<SignedAmount, ParseAmountError> {
         match parse_signed_to_satoshi(s, denom).map_err(|error| error.convert(true))? {
             // (negative, amount)
-            (false, sat) if sat > SignedAmount::MAX.to_sat() as u64 => Err(ParseAmountError(
+            (false, sat) if sat > SignedAmount::MAX_MONEY.to_sat() as u64 => Err(ParseAmountError(
                 ParseAmountErrorInner::OutOfRange(OutOfRangeError::too_big(true)),
             )),
             (false, sat) => Ok(SignedAmount::from_sat(sat as i64)), // Cast ok, value in this arm does not wrap.
@@ -350,7 +350,7 @@ impl SignedAmount {
 
     /// Checked addition.
     ///
-    /// Returns [`None`] if the sum is above [`SignedAmount::MAX`] or below [`SignedAmount::MIN`].
+    /// Returns [`None`] if the sum is above [`SignedAmount::MAX_MONEY`] or below [`SignedAmount::MIN`].
     #[must_use]
     pub const fn checked_add(self, rhs: SignedAmount) -> Option<SignedAmount> {
         // No `map()` in const context.
@@ -362,7 +362,7 @@ impl SignedAmount {
 
     /// Checked subtraction.
     ///
-    /// Returns [`None`] if the difference is above [`SignedAmount::MAX`] or below
+    /// Returns [`None`] if the difference is above [`SignedAmount::MAX_MONEY`] or below
     /// [`SignedAmount::MIN`].
     #[must_use]
     pub const fn checked_sub(self, rhs: SignedAmount) -> Option<SignedAmount> {
@@ -375,7 +375,7 @@ impl SignedAmount {
 
     /// Checked multiplication.
     ///
-    /// Returns [`None`] if the product is above [`SignedAmount::MAX`] or below
+    /// Returns [`None`] if the product is above [`SignedAmount::MAX_MONEY`] or below
     /// [`SignedAmount::MIN`].
     #[must_use]
     pub const fn checked_mul(self, rhs: i64) -> Option<SignedAmount> {

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -16,37 +16,60 @@ use super::{
     DisplayStyle, OutOfRangeError, ParseAmountError, ParseError,
 };
 
-/// A signed amount.
-///
-/// The [`SignedAmount`] type can be used to express Bitcoin amounts that support arithmetic and
-/// conversion to various denominations. The [`SignedAmount`] type does not implement [`serde`]
-/// traits but we do provide modules for serializing as satoshis or bitcoin.
-///
-/// Warning!
-///
-/// This type implements several arithmetic operations from [`core::ops`].
-/// To prevent errors due to overflow or underflow when using these operations,
-/// it is advised to instead use the checked arithmetic methods whose names
-/// start with `checked_`. The operations from [`core::ops`] that [`SignedAmount`]
-/// implements will panic when overflow or underflow occurs.
-///
-/// # Examples
-///
-/// ```
-/// # #[cfg(feature = "serde")] {
-/// use serde::{Serialize, Deserialize};
-/// use bitcoin_units::SignedAmount;
-///
-/// #[derive(Serialize, Deserialize)]
-/// struct Foo {
-///     // If you are using `rust-bitcoin` then `bitcoin::amount::serde::as_sat` also works.
-///     #[serde(with = "bitcoin_units::amount::serde::as_sat")]  // Also `serde::as_btc`.
-///     amount: SignedAmount,
-/// }
-/// # }
-/// ```
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SignedAmount(i64);
+mod encapsulate {
+    /// A signed amount.
+    ///
+    /// The [`SignedAmount`] type can be used to express Bitcoin amounts that support arithmetic and
+    /// conversion to various denominations. The [`SignedAmount`] type does not implement [`serde`]
+    /// traits but we do provide modules for serializing as satoshis or bitcoin.
+    ///
+    /// Warning!
+    ///
+    /// This type implements several arithmetic operations from [`core::ops`].
+    /// To prevent errors due to overflow or underflow when using these operations,
+    /// it is advised to instead use the checked arithmetic methods whose names
+    /// start with `checked_`. The operations from [`core::ops`] that [`SignedAmount`]
+    /// implements will panic when overflow or underflow occurs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "serde")] {
+    /// use serde::{Serialize, Deserialize};
+    /// use bitcoin_units::SignedAmount;
+    ///
+    /// #[derive(Serialize, Deserialize)]
+    /// struct Foo {
+    ///     // If you are using `rust-bitcoin` then `bitcoin::amount::serde::as_sat` also works.
+    ///     #[serde(with = "bitcoin_units::amount::serde::as_sat")]  // Also `serde::as_btc`.
+    ///     amount: SignedAmount,
+    /// }
+    /// # }
+    /// ```
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct SignedAmount(i64);
+
+    impl SignedAmount {
+        /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
+        ///
+        /// Caller to guarantee that `satoshi` is within valid range.
+        ///
+        /// See [`Self::MIN`] and [`Self::MAX_MONEY`].
+        pub const fn from_sat_unchecked(satoshi: i64) -> SignedAmount { SignedAmount(satoshi) }
+
+        /// Gets the number of satoshis in this [`SignedAmount`].
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// # use bitcoin_units::SignedAmount;
+        /// assert_eq!(SignedAmount::ONE_BTC.to_sat(), 100_000_000);
+        /// ```
+        pub const fn to_sat(self) -> i64 { self.0 }
+    }
+}
+#[doc(inline)]
+pub use encapsulate::SignedAmount;
 
 impl SignedAmount {
     /// The zero amount.
@@ -73,24 +96,9 @@ impl SignedAmount {
     /// let amount = SignedAmount::from_sat(-100_000);
     /// assert_eq!(amount.to_sat(), -100_000);
     /// ```
-    pub const fn from_sat(satoshi: i64) -> SignedAmount { SignedAmount(satoshi) }
-
-    /// Gets the number of satoshis in this [`SignedAmount`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bitcoin_units::SignedAmount;
-    /// assert_eq!(SignedAmount::ONE_BTC.to_sat(), 100_000_000);
-    /// ```
-    pub const fn to_sat(self) -> i64 { self.0 }
-
-    /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
-    ///
-    /// Caller to guarantee that `satoshi` is within valid range.
-    ///
-    /// See [`Self::MIN`] and [`Self::MAX_MONEY`].
-    pub const fn from_sat_unchecked(satoshi: i64) -> SignedAmount { SignedAmount(satoshi) }
+    pub const fn from_sat(satoshi: i64) -> SignedAmount {
+        SignedAmount::from_sat_unchecked(satoshi)
+    }
 
     /// Converts from a value expressing a decimal number of bitcoin to a [`SignedAmount`].
     ///
@@ -153,11 +161,11 @@ impl SignedAmount {
             (false, sat) if sat > SignedAmount::MAX.to_sat() as u64 => Err(ParseAmountError(
                 ParseAmountErrorInner::OutOfRange(OutOfRangeError::too_big(true)),
             )),
-            (false, sat) => Ok(SignedAmount(sat as i64)), // Cast ok, value in this arm does not wrap.
+            (false, sat) => Ok(SignedAmount::from_sat(sat as i64)), // Cast ok, value in this arm does not wrap.
             (true, sat) if sat > SignedAmount::MIN.to_sat().unsigned_abs() => Err(
                 ParseAmountError(ParseAmountErrorInner::OutOfRange(OutOfRangeError::too_small())),
             ),
-            (true, sat) => Ok(SignedAmount(-(sat as i64))), // Cast ok, value in this arm does not wrap.
+            (true, sat) => Ok(SignedAmount::from_sat(-(sat as i64))), // Cast ok, value in this arm does not wrap.
         }
     }
 
@@ -300,11 +308,11 @@ impl SignedAmount {
 
     /// Gets the absolute value of this [`SignedAmount`].
     #[must_use]
-    pub fn abs(self) -> SignedAmount { SignedAmount(self.0.abs()) }
+    pub fn abs(self) -> SignedAmount { SignedAmount::from_sat(self.to_sat().abs()) }
 
     /// Gets the absolute value of this [`SignedAmount`] returning [`Amount`].
     #[must_use]
-    pub fn unsigned_abs(self) -> Amount { Amount::from_sat(self.0.unsigned_abs()) }
+    pub fn unsigned_abs(self) -> Amount { Amount::from_sat(self.to_sat().unsigned_abs()) }
 
     /// Returns a number representing sign of this [`SignedAmount`].
     ///
@@ -312,19 +320,19 @@ impl SignedAmount {
     /// - `1` if the amount is positive
     /// - `-1` if the amount is negative
     #[must_use]
-    pub fn signum(self) -> i64 { self.0.signum() }
+    pub fn signum(self) -> i64 { self.to_sat().signum() }
 
     /// Checks if this [`SignedAmount`] is positive.
     ///
     /// Returns `true` if this [`SignedAmount`] is positive and `false` if
     /// this [`SignedAmount`] is zero or negative.
-    pub fn is_positive(self) -> bool { self.0.is_positive() }
+    pub fn is_positive(self) -> bool { self.to_sat().is_positive() }
 
     /// Checks if this [`SignedAmount`] is negative.
     ///
     /// Returns `true` if this [`SignedAmount`] is negative and `false` if
     /// this [`SignedAmount`] is zero or positive.
-    pub fn is_negative(self) -> bool { self.0.is_negative() }
+    pub fn is_negative(self) -> bool { self.to_sat().is_negative() }
 
     /// Returns the absolute value of this [`SignedAmount`].
     ///
@@ -334,8 +342,8 @@ impl SignedAmount {
     #[must_use]
     pub const fn checked_abs(self) -> Option<SignedAmount> {
         // No `map()` in const context.
-        match self.0.checked_abs() {
-            Some(res) => Some(SignedAmount(res)),
+        match self.to_sat().checked_abs() {
+            Some(res) => Some(SignedAmount::from_sat(res)),
             None => None,
         }
     }
@@ -346,8 +354,8 @@ impl SignedAmount {
     #[must_use]
     pub const fn checked_add(self, rhs: SignedAmount) -> Option<SignedAmount> {
         // No `map()` in const context.
-        match self.0.checked_add(rhs.0) {
-            Some(res) => SignedAmount(res).check_min_max(),
+        match self.to_sat().checked_add(rhs.to_sat()) {
+            Some(res) => SignedAmount::from_sat(res).check_min_max(),
             None => None,
         }
     }
@@ -359,8 +367,8 @@ impl SignedAmount {
     #[must_use]
     pub const fn checked_sub(self, rhs: SignedAmount) -> Option<SignedAmount> {
         // No `map()` in const context.
-        match self.0.checked_sub(rhs.0) {
-            Some(res) => SignedAmount(res).check_min_max(),
+        match self.to_sat().checked_sub(rhs.to_sat()) {
+            Some(res) => SignedAmount::from_sat(res).check_min_max(),
             None => None,
         }
     }
@@ -372,8 +380,8 @@ impl SignedAmount {
     #[must_use]
     pub const fn checked_mul(self, rhs: i64) -> Option<SignedAmount> {
         // No `map()` in const context.
-        match self.0.checked_mul(rhs) {
-            Some(res) => SignedAmount(res).check_min_max(),
+        match self.to_sat().checked_mul(rhs) {
+            Some(res) => SignedAmount::from_sat(res).check_min_max(),
             None => None,
         }
     }
@@ -386,8 +394,8 @@ impl SignedAmount {
     #[must_use]
     pub const fn checked_div(self, rhs: i64) -> Option<SignedAmount> {
         // No `map()` in const context.
-        match self.0.checked_div(rhs) {
-            Some(res) => Some(SignedAmount(res)),
+        match self.to_sat().checked_div(rhs) {
+            Some(res) => Some(SignedAmount::from_sat(res)),
             None => None,
         }
     }
@@ -398,8 +406,8 @@ impl SignedAmount {
     #[must_use]
     pub const fn checked_rem(self, rhs: i64) -> Option<SignedAmount> {
         // No `map()` in const context.
-        match self.0.checked_rem(rhs) {
-            Some(res) => Some(SignedAmount(res)),
+        match self.to_sat().checked_rem(rhs) {
+            Some(res) => Some(SignedAmount::from_sat(res)),
             None => None,
         }
     }
@@ -413,7 +421,9 @@ impl SignedAmount {
     /// On overflow, panics in debug mode, wraps in release mode.
     #[must_use]
     #[deprecated(since = "TBD", note = "consider converting to u64 using `to_sat`")]
-    pub fn unchecked_add(self, rhs: SignedAmount) -> SignedAmount { Self(self.0 + rhs.0) }
+    pub fn unchecked_add(self, rhs: SignedAmount) -> SignedAmount {
+        Self::from_sat(self.to_sat() + rhs.to_sat())
+    }
 
     /// Unchecked subtraction.
     ///
@@ -424,7 +434,9 @@ impl SignedAmount {
     /// On overflow, panics in debug mode, wraps in release mode.
     #[must_use]
     #[deprecated(since = "TBD", note = "consider converting to u64 using `to_sat`")]
-    pub fn unchecked_sub(self, rhs: SignedAmount) -> SignedAmount { Self(self.0 - rhs.0) }
+    pub fn unchecked_sub(self, rhs: SignedAmount) -> SignedAmount {
+        Self::from_sat(self.to_sat() - rhs.to_sat())
+    }
 
     /// Subtraction that doesn't allow negative [`SignedAmount`]s.
     ///
@@ -453,7 +465,7 @@ impl SignedAmount {
 
     /// Checks the amount is within the allowed range.
     const fn check_min_max(self) -> Option<SignedAmount> {
-        if self.0 < Self::MIN.0 || self.0 > Self::MAX.0 {
+        if self.to_sat() < Self::MIN.to_sat() || self.to_sat() > Self::MAX.to_sat() {
             None
         } else {
             Some(self)
@@ -514,6 +526,6 @@ impl From<Amount> for SignedAmount {
 impl<'a> Arbitrary<'a> for SignedAmount {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let s = i64::arbitrary(u)?;
-        Ok(Self(s))
+        Ok(Self::from_sat(s))
     }
 }

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -334,53 +334,62 @@ fn floating_point() {
 #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
 fn parsing() {
     use super::ParseAmountError as E;
-    let btc = Denomination::Bitcoin;
-    let sat = Denomination::Satoshi;
+    let den_btc = Denomination::Bitcoin;
+    let den_sat = Denomination::Satoshi;
     let p = Amount::from_str_in;
     let sp = SignedAmount::from_str_in;
 
-    assert_eq!(p("x", btc), Err(E::from(InvalidCharacterError { invalid_char: 'x', position: 0 })));
     assert_eq!(
-        p("-", btc),
+        p("x", den_btc),
+        Err(E::from(InvalidCharacterError { invalid_char: 'x', position: 0 }))
+    );
+    assert_eq!(
+        p("-", den_btc),
         Err(E::from(MissingDigitsError { kind: MissingDigitsKind::OnlyMinusSign }))
     );
     assert_eq!(
-        sp("-", btc),
+        sp("-", den_btc),
         Err(E::from(MissingDigitsError { kind: MissingDigitsKind::OnlyMinusSign }))
     );
     assert_eq!(
-        p("-1.0x", btc),
+        p("-1.0x", den_btc),
         Err(E::from(InvalidCharacterError { invalid_char: 'x', position: 4 }))
     );
     assert_eq!(
-        p("0.0 ", btc),
+        p("0.0 ", den_btc),
         Err(E::from(InvalidCharacterError { invalid_char: ' ', position: 3 }))
     );
     assert_eq!(
-        p("0.000.000", btc),
+        p("0.000.000", den_btc),
         Err(E::from(InvalidCharacterError { invalid_char: '.', position: 5 }))
     );
     #[cfg(feature = "alloc")]
     let more_than_max = format!("{}", Amount::MAX.to_sat() + 1);
     #[cfg(feature = "alloc")]
-    assert_eq!(p(&more_than_max, btc), Err(OutOfRangeError::too_big(false).into()));
-    assert_eq!(p("0.000000042", btc), Err(TooPreciseError { position: 10 }.into()));
-    assert_eq!(p("1.0000000", sat), Ok(Amount::from_sat_unchecked(1)));
-    assert_eq!(p("1.1", sat), Err(TooPreciseError { position: 2 }.into()));
-    assert_eq!(p("1000.1", sat), Err(TooPreciseError { position: 5 }.into()));
-    assert_eq!(p("1001.0000000", sat), Ok(Amount::from_sat_unchecked(1001)));
-    assert_eq!(p("1000.0000001", sat), Err(TooPreciseError { position: 11 }.into()));
+    assert_eq!(p(&more_than_max, den_btc), Err(OutOfRangeError::too_big(false).into()));
+    assert_eq!(p("0.000000042", den_btc), Err(TooPreciseError { position: 10 }.into()));
+    assert_eq!(p("1.0000000", den_sat), Ok(Amount::from_sat_unchecked(1)));
+    assert_eq!(p("1.1", den_sat), Err(TooPreciseError { position: 2 }.into()));
+    assert_eq!(p("1000.1", den_sat), Err(TooPreciseError { position: 5 }.into()));
+    assert_eq!(p("1001.0000000", den_sat), Ok(Amount::from_sat_unchecked(1001)));
+    assert_eq!(p("1000.0000001", den_sat), Err(TooPreciseError { position: 11 }.into()));
 
-    assert_eq!(p("1", btc), Ok(Amount::from_sat_unchecked(1_000_000_00)));
-    assert_eq!(sp("-.5", btc), Ok(SignedAmount::from_sat_unchecked(-500_000_00)));
+    assert_eq!(p("1", den_btc), Ok(Amount::from_sat_unchecked(1_000_000_00)));
+    assert_eq!(sp("-.5", den_btc), Ok(SignedAmount::from_sat_unchecked(-500_000_00)));
     #[cfg(feature = "alloc")]
-    assert_eq!(sp(&SignedAmount::MIN.to_sat().to_string(), sat), Ok(SignedAmount::MIN));
-    assert_eq!(p("1.1", btc), Ok(Amount::from_sat_unchecked(1_100_000_00)));
-    assert_eq!(p("100", sat), Ok(Amount::from_sat_unchecked(100)));
-    assert_eq!(p("55", sat), Ok(Amount::from_sat_unchecked(55)));
-    assert_eq!(p("2100000000000000", sat), Ok(Amount::from_sat_unchecked(21_000_000__000_000_00)));
-    assert_eq!(p("2100000000000000.", sat), Ok(Amount::from_sat_unchecked(21_000_000__000_000_00)));
-    assert_eq!(p("21000000", btc), Ok(Amount::from_sat_unchecked(21_000_000__000_000_00)));
+    assert_eq!(sp(&SignedAmount::MIN.to_sat().to_string(), den_sat), Ok(SignedAmount::MIN));
+    assert_eq!(p("1.1", den_btc), Ok(Amount::from_sat_unchecked(1_100_000_00)));
+    assert_eq!(p("100", den_sat), Ok(Amount::from_sat_unchecked(100)));
+    assert_eq!(p("55", den_sat), Ok(Amount::from_sat_unchecked(55)));
+    assert_eq!(
+        p("2100000000000000", den_sat),
+        Ok(Amount::from_sat_unchecked(21_000_000__000_000_00))
+    );
+    assert_eq!(
+        p("2100000000000000.", den_sat),
+        Ok(Amount::from_sat_unchecked(21_000_000__000_000_00))
+    );
+    assert_eq!(p("21000000", den_btc), Ok(Amount::from_sat_unchecked(21_000_000__000_000_00)));
 
     // exactly 50 chars.
     assert_eq!(

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -18,16 +18,14 @@ use crate::{FeeRate, Weight};
 
 #[test]
 fn sanity_check() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert_eq!(ssat(-100).abs(), ssat(100));
-    assert_eq!(ssat(i64::MIN + 1).checked_abs().unwrap(), ssat(i64::MAX));
     assert_eq!(ssat(-100).signum(), -1);
     assert_eq!(ssat(0).signum(), 0);
     assert_eq!(ssat(100).signum(), 1);
     assert_eq!(SignedAmount::from(sat(100)), ssat(100));
-    assert!(ssat(i64::MIN).checked_abs().is_none());
     assert!(!ssat(-100).is_positive());
     assert!(ssat(100).is_positive());
 
@@ -96,16 +94,16 @@ fn from_str_zero_without_denomination() {
 
 #[test]
 fn from_int_btc() {
-    let sat = Amount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
 
-    let amt = Amount::from_int_btc_const(2);
+    let amt = Amount::from_int_btc_const(2).unwrap();
     assert_eq!(sat(200_000_000), amt);
 }
 
 #[test]
 fn amount_try_from_signed_amount() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     let sa_positive = ssat(123);
     let ua_positive = Amount::try_from(sa_positive).unwrap();
@@ -118,11 +116,11 @@ fn amount_try_from_signed_amount() {
 
 #[test]
 fn mul_div() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
-    let op_result_sat = |sat| NumOpResult::Valid(Amount::from_sat(sat));
-    let op_result_ssat = |sat| NumOpResult::Valid(SignedAmount::from_sat(sat));
+    let op_result_sat = |sat| NumOpResult::Valid(Amount::from_sat(sat).unwrap());
+    let op_result_ssat = |sat| NumOpResult::Valid(SignedAmount::from_sat(sat).unwrap());
 
     assert_eq!(sat(14) * 3, op_result_sat(42));
     assert_eq!(sat(14) / 2, op_result_sat(7));
@@ -138,21 +136,10 @@ fn neg() {
     assert_eq!(amount.to_sat(), -2);
 }
 
-#[cfg(feature = "std")]
-#[test]
-fn overflows() {
-    let sat = Amount::from_sat;
-
-    let result = Amount::MAX_MONEY + sat(1);
-    assert!(result.is_error());
-    let result = sat(8_446_744_073_709_551_615) * 3;
-    assert!(result.is_error());
-}
-
 #[test]
 fn add() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert!(sat(0) + sat(0) == sat(0).into());
     assert!(sat(127) + sat(179) == sat(306).into());
@@ -166,8 +153,8 @@ fn add() {
 
 #[test]
 fn sub() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert!(sat(0) - sat(0) == sat(0).into());
     assert!(sat(179) - sat(127) == sat(52).into());
@@ -182,8 +169,8 @@ fn sub() {
 
 #[test]
 fn checked_arithmetic() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert_eq!(SignedAmount::MAX_MONEY.checked_add(ssat(1)), None);
     assert_eq!(SignedAmount::MIN.checked_sub(ssat(1)), None);
@@ -196,7 +183,7 @@ fn checked_arithmetic() {
 
 #[test]
 fn positive_sub() {
-    let ssat = SignedAmount::from_sat;
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert_eq!(ssat(10).positive_sub(ssat(7)).unwrap(), ssat(3));
     assert!(ssat(-10).positive_sub(ssat(7)).is_none());
@@ -207,7 +194,7 @@ fn positive_sub() {
 #[cfg(feature = "alloc")]
 #[test]
 fn amount_checked_div_by_weight_ceil() {
-    let sat = Amount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
 
     let weight = Weight::from_kwu(1).unwrap();
     let fee_rate = sat(1).checked_div_by_weight_ceil(weight).unwrap();
@@ -227,7 +214,7 @@ fn amount_checked_div_by_weight_ceil() {
 #[cfg(feature = "alloc")]
 #[test]
 fn amount_checked_div_by_weight_floor() {
-    let sat = Amount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
 
     let weight = Weight::from_kwu(1).unwrap();
     let fee_rate = sat(1).checked_div_by_weight_floor(weight).unwrap();
@@ -247,7 +234,7 @@ fn amount_checked_div_by_weight_floor() {
 #[cfg(feature = "alloc")]
 #[test]
 fn amount_checked_div_by_fee_rate() {
-    let sat = Amount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
 
     let amount = sat(1000);
     let fee_rate = FeeRate::from_sat_per_kwu(2);
@@ -280,12 +267,6 @@ fn amount_checked_div_by_fee_rate() {
     let weight = max_amount.checked_div_by_fee_rate_floor(small_fee_rate).unwrap();
     // 21_000_000_0000_0000 sats / (1 sat/kwu) = 2_100_000_000_000_000_000 wu
     assert_eq!(weight, Weight::from_wu(2_100_000_000_000_000_000));
-
-    // Test overflow case
-    let tiny_fee_rate = FeeRate::from_sat_per_kwu(1);
-    let large_amount = Amount::from_sat(u64::MAX);
-    assert!(large_amount.checked_div_by_fee_rate_floor(tiny_fee_rate).is_none());
-    assert!(large_amount.checked_div_by_fee_rate_ceil(tiny_fee_rate).is_none());
 }
 
 #[cfg(feature = "alloc")]
@@ -294,8 +275,8 @@ fn floating_point() {
     use super::Denomination as D;
     let f = Amount::from_float_in;
     let sf = SignedAmount::from_float_in;
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert_eq!(f(11.22, D::Bitcoin), Ok(sat(1_122_000_000)));
     assert_eq!(sf(-11.22, D::MilliBitcoin), Ok(ssat(-1_122_000)));
@@ -336,7 +317,7 @@ fn floating_point() {
 fn parsing() {
     use super::ParseAmountError as E;
 
-    let ssat = SignedAmount::from_sat;
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     let den_btc = Denomination::Bitcoin;
     let den_sat = Denomination::Satoshi;
@@ -412,7 +393,7 @@ fn parsing() {
 fn to_string() {
     use super::Denomination as D;
 
-    let ssat = SignedAmount::from_sat;
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert_eq!(Amount::ONE_BTC.to_string_in(D::Bitcoin), "1");
     assert_eq!(format!("{:.8}", Amount::ONE_BTC.display_in(D::Bitcoin)), "1.00000000");
@@ -445,8 +426,8 @@ macro_rules! check_format_non_negative {
             #[test]
             #[cfg(feature = "alloc")]
             fn $test_name() {
-                assert_eq!(format!($format_string, Amount::from_sat($val).display_in(Denomination::$denom)), $expected);
-                assert_eq!(format!($format_string, SignedAmount::from_sat($val as i64).display_in(Denomination::$denom)), $expected);
+                assert_eq!(format!($format_string, Amount::from_sat($val).unwrap().display_in(Denomination::$denom)), $expected);
+                assert_eq!(format!($format_string, SignedAmount::from_sat($val as i64).unwrap().display_in(Denomination::$denom)), $expected);
             }
         )*
     }
@@ -458,8 +439,8 @@ macro_rules! check_format_non_negative_show_denom {
             #[test]
             #[cfg(feature = "alloc")]
             fn $test_name() {
-                assert_eq!(format!($format_string, Amount::from_sat($val).display_in(Denomination::$denom).show_denomination()), concat!($expected, $denom_suffix));
-                assert_eq!(format!($format_string, SignedAmount::from_sat($val as i64).display_in(Denomination::$denom).show_denomination()), concat!($expected, $denom_suffix));
+                assert_eq!(format!($format_string, Amount::from_sat($val).unwrap().display_in(Denomination::$denom).show_denomination()), concat!($expected, $denom_suffix));
+                assert_eq!(format!($format_string, SignedAmount::from_sat($val as i64).unwrap().display_in(Denomination::$denom).show_denomination()), concat!($expected, $denom_suffix));
             }
         )*
     }
@@ -600,8 +581,8 @@ check_format_non_negative_show_denom! {
 
 #[test]
 fn unsigned_signed_conversion() {
-    let ssat = SignedAmount::from_sat;
-    let sat = Amount::from_sat;
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
+    let sat = |sat| Amount::from_sat(sat).unwrap();
     let max_sats: u64 = Amount::MAX_MONEY.to_sat();
 
     assert_eq!(sat(max_sats).to_signed(), ssat(max_sats as i64));
@@ -613,8 +594,8 @@ fn unsigned_signed_conversion() {
 #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
 #[allow(clippy::items_after_statements)] // Define functions where we use them.
 fn from_str() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     use ParseDenominationError::*;
 
@@ -790,7 +771,7 @@ fn to_string_with_denomination_from_str_roundtrip() {
 
     use super::Denomination as D;
 
-    let sat = Amount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
 
     let amt = sat(42);
     let denom = Amount::to_string_with_denomination;
@@ -822,8 +803,8 @@ fn serde_as_sat() {
         pub samt: SignedAmount,
     }
 
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     serde_test::assert_tokens(
         &T { amt: sat(123_456_789), samt: ssat(-123_456_789) },
@@ -853,8 +834,8 @@ fn serde_as_btc() {
         pub samt: SignedAmount,
     }
 
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     let orig = T { amt: sat(20_000_000__000_000_01), samt: ssat(-20_000_000__000_000_01) };
 
@@ -889,8 +870,8 @@ fn serde_as_str() {
         pub samt: SignedAmount,
     }
 
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     serde_test::assert_tokens(
         &T { amt: sat(123_456_789), samt: ssat(-123_456_789) },
@@ -920,8 +901,8 @@ fn serde_as_btc_opt() {
         pub samt: Option<SignedAmount>,
     }
 
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     let with = T { amt: Some(sat(2_500_000_00)), samt: Some(ssat(-2_500_000_00)) };
     let without = T { amt: None, samt: None };
@@ -962,8 +943,8 @@ fn serde_as_sat_opt() {
         pub samt: Option<SignedAmount>,
     }
 
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     let with = T { amt: Some(sat(2_500_000_00)), samt: Some(ssat(-2_500_000_00)) };
     let without = T { amt: None, samt: None };
@@ -1004,8 +985,8 @@ fn serde_as_str_opt() {
         pub samt: Option<SignedAmount>,
     }
 
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     let with = T { amt: Some(sat(123_456_789)), samt: Some(ssat(-123_456_789)) };
     let without = T { amt: None, samt: None };
@@ -1034,8 +1015,8 @@ fn serde_as_str_opt() {
 
 #[test]
 fn sum_amounts() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert_eq!([].iter().sum::<NumOpResult<Amount>>(), Amount::ZERO.into());
     assert_eq!([].iter().sum::<NumOpResult<SignedAmount>>(), SignedAmount::ZERO.into());
@@ -1063,8 +1044,8 @@ fn sum_amounts() {
 
 #[test]
 fn checked_sum_amounts() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     assert_eq!([].into_iter().checked_sum(), Some(Amount::ZERO));
     assert_eq!([].into_iter().checked_sum(), Some(SignedAmount::ZERO));
@@ -1073,7 +1054,7 @@ fn checked_sum_amounts() {
     let sum = amounts.into_iter().checked_sum();
     assert_eq!(sum, Some(sat(1400)));
 
-    let amounts = [sat(u64::MAX), sat(1337), sat(21)];
+    let amounts = [Amount::MAX_MONEY, sat(1337), sat(21)];
     let sum = amounts.into_iter().checked_sum();
     assert_eq!(sum, None);
 
@@ -1131,7 +1112,7 @@ fn disallow_unknown_denomination() {
 #[test]
 #[cfg(feature = "alloc")]
 fn trailing_zeros_for_amount() {
-    let sat = Amount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
 
     assert_eq!(format!("{}", sat(1_000_000)), "0.01 BTC");
     assert_eq!(format!("{}", Amount::ONE_SAT), "0.00000001 BTC");
@@ -1159,7 +1140,7 @@ fn trailing_zeros_for_amount() {
 #[test]
 #[allow(clippy::op_ref)]
 fn unsigned_addition() {
-    let sat = Amount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
 
     let one = sat(1);
     let two = sat(2);
@@ -1175,7 +1156,7 @@ fn unsigned_addition() {
 #[test]
 #[allow(clippy::op_ref)]
 fn unsigned_subtract() {
-    let sat = Amount::from_sat;
+    let sat = |sat| Amount::from_sat(sat).unwrap();
 
     let one = sat(1);
     let two = sat(2);
@@ -1190,7 +1171,7 @@ fn unsigned_subtract() {
 #[test]
 #[allow(clippy::op_ref)]
 fn signed_addition() {
-    let ssat = SignedAmount::from_sat;
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     let one = ssat(1);
     let two = ssat(2);
@@ -1205,7 +1186,7 @@ fn signed_addition() {
 #[test]
 #[allow(clippy::op_ref)]
 fn signed_subtract() {
-    let ssat = SignedAmount::from_sat;
+    let ssat = |ssat| SignedAmount::from_sat(ssat).unwrap();
 
     let one = ssat(1);
     let two = ssat(2);
@@ -1250,8 +1231,8 @@ fn sanity_all_ops() {
 #[test]
 #[allow(clippy::op_ref)] // We are explicitly testing the references work with ops.
 fn num_op_result_ops() {
-    let sat = Amount::from_sat(1);
-    let ssat = SignedAmount::from_sat(1);
+    let sat = Amount::from_sat(1).unwrap();
+    let ssat = SignedAmount::from_sat(1).unwrap();
 
     // Explicit type as sanity check.
     let res: NumOpResult<Amount> = sat + sat;
@@ -1301,8 +1282,8 @@ fn num_op_result_ops() {
 #[test]
 #[allow(clippy::op_ref)] // We are explicitly testing the references work with ops.
 fn num_op_result_ops_integer() {
-    let sat = Amount::from_sat(1);
-    let ssat = SignedAmount::from_sat(1);
+    let sat = Amount::from_sat(1).unwrap();
+    let ssat = SignedAmount::from_sat(1).unwrap();
 
     // Explicit type as sanity check.
     let res: NumOpResult<Amount> = sat + sat;
@@ -1335,8 +1316,8 @@ fn num_op_result_ops_integer() {
 fn amount_op_result_neg() {
     // TODO: Implement Neg all round.
 
-    // let sat = Amount::from_sat(1);
-    let ssat = SignedAmount::from_sat(1);
+    // let sat = Amount::from_sat(1).unwrap();
+    let ssat = SignedAmount::from_sat(1).unwrap();
 
     // let _ = -sat;
     let _ = -ssat;
@@ -1347,7 +1328,7 @@ fn amount_op_result_neg() {
 // Verify we have implemented all `Sum` for the `NumOpResult` type.
 #[test]
 fn amount_op_result_sum() {
-    let res = Amount::from_sat(1) + Amount::from_sat(1);
+    let res = Amount::from_sat(1).unwrap() + Amount::from_sat(1).unwrap();
     let amounts = [res, res];
     let amount_refs = [&res, &res];
 

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -143,7 +143,7 @@ fn neg() {
 fn overflows() {
     let sat = Amount::from_sat;
 
-    let result = Amount::MAX + sat(1);
+    let result = Amount::MAX_MONEY + sat(1);
     assert!(result.is_error());
     let result = sat(8_446_744_073_709_551_615) * 3;
     assert!(result.is_error());
@@ -185,9 +185,9 @@ fn checked_arithmetic() {
     let sat = Amount::from_sat;
     let ssat = SignedAmount::from_sat;
 
-    assert_eq!(SignedAmount::MAX.checked_add(ssat(1)), None);
+    assert_eq!(SignedAmount::MAX_MONEY.checked_add(ssat(1)), None);
     assert_eq!(SignedAmount::MIN.checked_sub(ssat(1)), None);
-    assert_eq!(Amount::MAX.checked_add(sat(1)), None);
+    assert_eq!(Amount::MAX_MONEY.checked_add(sat(1)), None);
     assert_eq!(Amount::MIN.checked_sub(sat(1)), None);
 
     assert_eq!(sat(5).checked_div(2), Some(sat(2))); // integer division
@@ -287,7 +287,7 @@ fn amount_checked_div_by_fee_rate() {
     assert!(amount.checked_div_by_fee_rate_ceil(zero_fee_rate).is_none());
 
     // Test with maximum amount
-    let max_amount = Amount::MAX;
+    let max_amount = Amount::MAX_MONEY;
     let small_fee_rate = FeeRate::from_sat_per_kwu(1);
     let weight = max_amount.checked_div_by_fee_rate_floor(small_fee_rate).unwrap();
     // 21_000_000_0000_0000 sats / (1 sat/kwu) = 2_100_000_000_000_000_000 wu
@@ -324,12 +324,12 @@ fn floating_point() {
     );
 
     assert_eq!(
-        f(Amount::MAX.to_float_in(D::Satoshi) + 1.0, D::Satoshi),
+        f(Amount::MAX_MONEY.to_float_in(D::Satoshi) + 1.0, D::Satoshi),
         Err(OutOfRangeError::too_big(false).into())
     );
 
     assert_eq!(
-        sf(SignedAmount::MAX.to_float_in(D::Satoshi) + 1.0, D::Satoshi),
+        sf(SignedAmount::MAX_MONEY.to_float_in(D::Satoshi) + 1.0, D::Satoshi),
         Err(OutOfRangeError::too_big(true).into())
     );
 
@@ -380,7 +380,7 @@ fn parsing() {
         Err(E::from(InvalidCharacterError { invalid_char: '.', position: 5 }))
     );
     #[cfg(feature = "alloc")]
-    let more_than_max = format!("{}", Amount::MAX.to_sat() + 1);
+    let more_than_max = format!("{}", Amount::MAX_MONEY.to_sat() + 1);
     #[cfg(feature = "alloc")]
     assert_eq!(p(&more_than_max, den_btc), Err(OutOfRangeError::too_big(false).into()));
     assert_eq!(p("0.000000042", den_btc), Err(TooPreciseError { position: 10 }.into()));
@@ -614,7 +614,7 @@ check_format_non_negative_show_denom! {
 fn unsigned_signed_conversion() {
     let ssat = SignedAmount::from_sat;
     let sat = Amount::from_sat;
-    let max_sats: u64 = Amount::MAX.to_sat();
+    let max_sats: u64 = Amount::MAX_MONEY.to_sat();
 
     assert_eq!(sat(max_sats).to_signed(), ssat(max_sats as i64));
     assert_eq!(ssat(max_sats as i64).to_unsigned(), Ok(sat(max_sats)));
@@ -700,8 +700,8 @@ fn from_str() {
     ok_scase("-5 satoshi", ssat(-5));
     ok_case("0.10000000 BTC", sat(100_000_00));
     ok_scase("-100 bits", ssat(-10_000));
-    ok_case("21000000 BTC", Amount::MAX);
-    ok_scase("21000000 BTC", SignedAmount::MAX);
+    ok_case("21000000 BTC", Amount::MAX_MONEY);
+    ok_scase("21000000 BTC", SignedAmount::MAX_MONEY);
     ok_scase("-21000000 BTC", SignedAmount::MIN);
 }
 
@@ -761,18 +761,31 @@ fn to_from_string_in() {
     assert_eq!(ua_str(&ua_sat(21_000_000).to_string_in(D::Bit), D::Bit), Ok(ua_sat(21_000_000)));
     assert_eq!(ua_str(&ua_sat(0).to_string_in(D::Satoshi), D::Satoshi), Ok(ua_sat(0)));
 
-    assert!(ua_str(&ua_sat(Amount::MAX.to_sat()).to_string_in(D::Bitcoin), D::Bitcoin).is_ok());
-    assert!(ua_str(&ua_sat(Amount::MAX.to_sat()).to_string_in(D::CentiBitcoin), D::CentiBitcoin)
-        .is_ok());
-    assert!(ua_str(&ua_sat(Amount::MAX.to_sat()).to_string_in(D::MilliBitcoin), D::MilliBitcoin)
-        .is_ok());
-    assert!(ua_str(&ua_sat(Amount::MAX.to_sat()).to_string_in(D::MicroBitcoin), D::MicroBitcoin)
-        .is_ok());
-    assert!(ua_str(&ua_sat(Amount::MAX.to_sat()).to_string_in(D::Bit), D::Bit).is_ok());
-    assert!(ua_str(&ua_sat(Amount::MAX.to_sat()).to_string_in(D::Satoshi), D::Satoshi).is_ok());
+    assert!(
+        ua_str(&ua_sat(Amount::MAX_MONEY.to_sat()).to_string_in(D::Bitcoin), D::Bitcoin).is_ok()
+    );
+    assert!(ua_str(
+        &ua_sat(Amount::MAX_MONEY.to_sat()).to_string_in(D::CentiBitcoin),
+        D::CentiBitcoin
+    )
+    .is_ok());
+    assert!(ua_str(
+        &ua_sat(Amount::MAX_MONEY.to_sat()).to_string_in(D::MilliBitcoin),
+        D::MilliBitcoin
+    )
+    .is_ok());
+    assert!(ua_str(
+        &ua_sat(Amount::MAX_MONEY.to_sat()).to_string_in(D::MicroBitcoin),
+        D::MicroBitcoin
+    )
+    .is_ok());
+    assert!(ua_str(&ua_sat(Amount::MAX_MONEY.to_sat()).to_string_in(D::Bit), D::Bit).is_ok());
+    assert!(
+        ua_str(&ua_sat(Amount::MAX_MONEY.to_sat()).to_string_in(D::Satoshi), D::Satoshi).is_ok()
+    );
 
     assert_eq!(
-        sa_str(&SignedAmount::MAX.to_string_in(D::Satoshi), D::MicroBitcoin),
+        sa_str(&SignedAmount::MAX_MONEY.to_string_in(D::Satoshi), D::MicroBitcoin),
         Err(OutOfRangeError::too_big(true).into())
     );
     // Test an overflow bug in `abs()`
@@ -1080,7 +1093,7 @@ fn checked_sum_amounts() {
     let sum = amounts.into_iter().checked_sum();
     assert_eq!(sum, None);
 
-    let amounts = [SignedAmount::MAX, ssat(1), ssat(21)];
+    let amounts = [SignedAmount::MAX_MONEY, ssat(1), ssat(21)];
     let sum = amounts.into_iter().checked_sum();
     assert_eq!(sum, None);
 

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -195,18 +195,6 @@ fn checked_arithmetic() {
 }
 
 #[test]
-#[allow(deprecated_in_future)]
-fn unchecked_arithmetic() {
-    let sat = Amount::from_sat;
-    let ssat = SignedAmount::from_sat;
-
-    assert_eq!(ssat(10).unchecked_add(ssat(20)), ssat(30));
-    assert_eq!(ssat(50).unchecked_sub(ssat(10)), ssat(40));
-    assert_eq!(sat(5).unchecked_add(sat(7)), sat(12));
-    assert_eq!(sat(10).unchecked_sub(sat(7)), sat(3));
-}
-
-#[test]
 fn positive_sub() {
     let ssat = SignedAmount::from_sat;
 

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -53,15 +53,15 @@ pub struct Amount(u64);
 
 impl Amount {
     /// The zero amount.
-    pub const ZERO: Self = Amount(0);
+    pub const ZERO: Self = Amount::from_sat_unchecked(0);
     /// Exactly one satoshi.
-    pub const ONE_SAT: Self = Amount(1);
+    pub const ONE_SAT: Self = Amount::from_sat_unchecked(1);
     /// Exactly one bitcoin.
-    pub const ONE_BTC: Self = Self::from_int_btc_const(1);
+    pub const ONE_BTC: Self = Amount::from_sat_unchecked(100_000_000);
     /// Exactly fifty bitcoin.
-    pub const FIFTY_BTC: Self = Self::from_sat_unchecked(50 * 100_000_000);
+    pub const FIFTY_BTC: Self = Amount::from_sat_unchecked(50 * 100_000_000);
     /// The maximum value allowed as an amount. Useful for sanity checking.
-    pub const MAX_MONEY: Self = Self::from_int_btc_const(21_000_000);
+    pub const MAX_MONEY: Self = Amount::from_sat_unchecked(21_000_000 * 100_000_000);
     /// The minimum value of an amount.
     pub const MIN: Self = Amount::ZERO;
     /// The maximum value of an amount.

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -361,32 +361,6 @@ impl Amount {
         }
     }
 
-    /// Unchecked addition.
-    ///
-    /// Computes `self + rhs`.
-    ///
-    /// # Panics
-    ///
-    /// On overflow, panics in debug mode, wraps in release mode.
-    #[must_use]
-    #[deprecated(since = "TBD", note = "consider converting to u64 using `to_sat`")]
-    pub fn unchecked_add(self, rhs: Amount) -> Amount {
-        Self::from_sat(self.to_sat() + rhs.to_sat())
-    }
-
-    /// Unchecked subtraction.
-    ///
-    /// Computes `self - rhs`.
-    ///
-    /// # Panics
-    ///
-    /// On overflow, panics in debug mode, wraps in release mode.
-    #[must_use]
-    #[deprecated(since = "TBD", note = "consider converting to u64 using `to_sat`")]
-    pub fn unchecked_sub(self, rhs: Amount) -> Amount {
-        Self::from_sat(self.to_sat() - rhs.to_sat())
-    }
-
     /// Converts to a signed amount.
     #[rustfmt::skip] // Moves code comments to the wrong line.
     pub fn to_signed(self) -> SignedAmount {

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -16,40 +16,61 @@ use super::{
     OutOfRangeError, ParseAmountError, ParseError, SignedAmount,
 };
 
-/// An amount.
-///
-/// The [`Amount`] type can be used to express Bitcoin amounts that support arithmetic and
-/// conversion to various denominations. The [`Amount`] type does not implement [`serde`] traits
-/// but we do provide modules for serializing as satoshis or bitcoin.
-///
-/// Warning!
-///
-/// This type implements several arithmetic operations from [`core::ops`].
-/// To prevent errors due to overflow or underflow when using these operations,
-/// it is advised to instead use the checked arithmetic methods whose names
-/// start with `checked_`. The operations from [`core::ops`] that [`Amount`]
-/// implements will panic when overflow or underflow occurs. Also note that
-/// since the internal representation of amounts is unsigned, subtracting below
-/// zero is considered an underflow and will cause a panic if you're not using
-/// the checked arithmetic methods.
-///
-/// # Examples
-///
-/// ```
-/// # #[cfg(feature = "serde")] {
-/// use serde::{Serialize, Deserialize};
-/// use bitcoin_units::Amount;
-///
-/// #[derive(Serialize, Deserialize)]
-/// struct Foo {
-///     // If you are using `rust-bitcoin` then `bitcoin::amount::serde::as_sat` also works.
-///     #[serde(with = "bitcoin_units::amount::serde::as_sat")]  // Also `serde::as_btc`.
-///     amount: Amount,
-/// }
-/// # }
-/// ```
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Amount(u64);
+mod encapsulate {
+    /// An amount.
+    ///
+    /// The [`Amount`] type can be used to express Bitcoin amounts that support arithmetic and
+    /// conversion to various denominations. The [`Amount`] type does not implement [`serde`] traits
+    /// but we do provide modules for serializing as satoshis or bitcoin.
+    ///
+    /// Warning!
+    ///
+    /// This type implements several arithmetic operations from [`core::ops`].
+    /// To prevent errors due to overflow or underflow when using these operations,
+    /// it is advised to instead use the checked arithmetic methods whose names
+    /// start with `checked_`. The operations from [`core::ops`] that [`Amount`]
+    /// implements will panic when overflow or underflow occurs. Also note that
+    /// since the internal representation of amounts is unsigned, subtracting below
+    /// zero is considered an underflow and will cause a panic if you're not using
+    /// the checked arithmetic methods.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "serde")] {
+    /// use serde::{Serialize, Deserialize};
+    /// use bitcoin_units::Amount;
+    ///
+    /// #[derive(Serialize, Deserialize)]
+    /// struct Foo {
+    ///     // If you are using `rust-bitcoin` then `bitcoin::amount::serde::as_sat` also works.
+    ///     #[serde(with = "bitcoin_units::amount::serde::as_sat")]  // Also `serde::as_btc`.
+    ///     amount: Amount,
+    /// }
+    /// # }
+    /// ```
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Amount(u64);
+
+    impl Amount {
+        /// Constructs a new [`Amount`] with satoshi precision and the given number of satoshis.
+        ///
+        /// Caller to guarantee that `satoshi` is within valid range. See [`Self::MAX_MONEY`].
+        pub const fn from_sat_unchecked(satoshi: u64) -> Amount { Self(satoshi) }
+
+        /// Gets the number of satoshis in this [`Amount`].
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// # use bitcoin_units::Amount;
+        /// assert_eq!(Amount::ONE_BTC.to_sat(), 100_000_000);
+        /// ```
+        pub const fn to_sat(self) -> u64 { self.0 }
+    }
+}
+#[doc(inline)]
+pub use encapsulate::Amount;
 
 impl Amount {
     /// The zero amount.
@@ -78,22 +99,7 @@ impl Amount {
     /// let amount = Amount::from_sat(100_000);
     /// assert_eq!(amount.to_sat(), 100_000);
     /// ```
-    pub const fn from_sat(satoshi: u64) -> Amount { Amount(satoshi) }
-
-    /// Gets the number of satoshis in this [`Amount`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bitcoin_units::Amount;
-    /// assert_eq!(Amount::ONE_BTC.to_sat(), 100_000_000);
-    /// ```
-    pub const fn to_sat(self) -> u64 { self.0 }
-
-    /// Constructs a new [`Amount`] with satoshi precision and the given number of satoshis.
-    ///
-    /// Caller to guarantee that `satoshi` is within valid range. See [`Self::MAX_MONEY`].
-    pub const fn from_sat_unchecked(satoshi: u64) -> Amount { Self(satoshi) }
+    pub const fn from_sat(satoshi: u64) -> Amount { Amount::from_sat_unchecked(satoshi) }
 
     /// Converts from a value expressing a decimal number of bitcoin to an [`Amount`].
     ///
@@ -159,7 +165,7 @@ impl Amount {
                 OutOfRangeError::negative(),
             )));
         }
-        if sats > Self::MAX.0 {
+        if sats > Self::MAX.to_sat() {
             return Err(ParseAmountError(ParseAmountErrorInner::OutOfRange(
                 OutOfRangeError::too_big(false),
             )));
@@ -310,8 +316,8 @@ impl Amount {
     #[must_use]
     pub const fn checked_add(self, rhs: Amount) -> Option<Amount> {
         // No `map()` in const context.
-        match self.0.checked_add(rhs.0) {
-            Some(res) => Amount(res).check_max(),
+        match self.to_sat().checked_add(rhs.to_sat()) {
+            Some(res) => Amount::from_sat(res).check_max(),
             None => None,
         }
     }
@@ -322,8 +328,8 @@ impl Amount {
     #[must_use]
     pub const fn checked_sub(self, rhs: Amount) -> Option<Amount> {
         // No `map()` in const context.
-        match self.0.checked_sub(rhs.0) {
-            Some(res) => Some(Amount(res)),
+        match self.to_sat().checked_sub(rhs.to_sat()) {
+            Some(res) => Some(Amount::from_sat(res)),
             None => None,
         }
     }
@@ -334,8 +340,8 @@ impl Amount {
     #[must_use]
     pub const fn checked_mul(self, rhs: u64) -> Option<Amount> {
         // No `map()` in const context.
-        match self.0.checked_mul(rhs) {
-            Some(res) => Amount(res).check_max(),
+        match self.to_sat().checked_mul(rhs) {
+            Some(res) => Amount::from_sat(res).check_max(),
             None => None,
         }
     }
@@ -348,8 +354,8 @@ impl Amount {
     #[must_use]
     pub const fn checked_div(self, rhs: u64) -> Option<Amount> {
         // No `map()` in const context.
-        match self.0.checked_div(rhs) {
-            Some(res) => Some(Amount(res)),
+        match self.to_sat().checked_div(rhs) {
+            Some(res) => Some(Amount::from_sat(res)),
             None => None,
         }
     }
@@ -360,8 +366,8 @@ impl Amount {
     #[must_use]
     pub const fn checked_rem(self, rhs: u64) -> Option<Amount> {
         // No `map()` in const context.
-        match self.0.checked_rem(rhs) {
-            Some(res) => Some(Amount(res)),
+        match self.to_sat().checked_rem(rhs) {
+            Some(res) => Some(Amount::from_sat(res)),
             None => None,
         }
     }
@@ -375,7 +381,9 @@ impl Amount {
     /// On overflow, panics in debug mode, wraps in release mode.
     #[must_use]
     #[deprecated(since = "TBD", note = "consider converting to u64 using `to_sat`")]
-    pub fn unchecked_add(self, rhs: Amount) -> Amount { Self(self.0 + rhs.0) }
+    pub fn unchecked_add(self, rhs: Amount) -> Amount {
+        Self::from_sat(self.to_sat() + rhs.to_sat())
+    }
 
     /// Unchecked subtraction.
     ///
@@ -386,7 +394,9 @@ impl Amount {
     /// On overflow, panics in debug mode, wraps in release mode.
     #[must_use]
     #[deprecated(since = "TBD", note = "consider converting to u64 using `to_sat`")]
-    pub fn unchecked_sub(self, rhs: Amount) -> Amount { Self(self.0 - rhs.0) }
+    pub fn unchecked_sub(self, rhs: Amount) -> Amount {
+        Self::from_sat(self.to_sat() - rhs.to_sat())
+    }
 
     /// Converts to a signed amount.
     #[rustfmt::skip] // Moves code comments to the wrong line.
@@ -396,7 +406,7 @@ impl Amount {
 
     /// Checks if the amount is below the maximum value. Returns `None` if it is above.
     const fn check_max(self) -> Option<Amount> {
-        if self.0 > Self::MAX.0 {
+        if self.to_sat() > Self::MAX.to_sat() {
             None
         } else {
             Some(self)
@@ -456,6 +466,6 @@ impl TryFrom<SignedAmount> for Amount {
 impl<'a> Arbitrary<'a> for Amount {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let a = u64::arbitrary(u)?;
-        Ok(Self(a))
+        Ok(Self::from_sat(a))
     }
 }

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -122,30 +122,19 @@ impl Amount {
     }
 
     /// Converts from a value expressing a whole number of bitcoin to an [`Amount`].
-    ///
-    /// # Errors
-    ///
-    /// The function errors if the argument multiplied by the number of sats
-    /// per bitcoin overflows a `u64` type.
-    pub fn from_int_btc<T: Into<u64>>(whole_bitcoin: T) -> Result<Amount, OutOfRangeError> {
-        match whole_bitcoin.into().checked_mul(100_000_000) {
-            Some(amount) => Ok(Self::from_sat(amount)),
-            None => Err(OutOfRangeError { is_signed: false, is_greater_than_max: true }),
-        }
+    #[allow(clippy::missing_panics_doc)]
+    pub fn from_int_btc<T: Into<u32>>(whole_bitcoin: T) -> Amount {
+        Amount::from_int_btc_const(whole_bitcoin.into())
     }
 
     /// Converts from a value expressing a whole number of bitcoin to an [`Amount`]
     /// in const context.
-    ///
-    /// # Panics
-    ///
-    /// The function panics if the argument multiplied by the number of sats
-    /// per bitcoin overflows a `u64` type.
+    #[allow(clippy::missing_panics_doc)]
     pub const fn from_int_btc_const(whole_bitcoin: u32) -> Amount {
-        let btc = whole_bitcoin as u64; // Can't call u64::from in const context.
+        let btc = whole_bitcoin as u64; // Can't call `into` in const context.
         match btc.checked_mul(100_000_000) {
             Some(amount) => Amount::from_sat(amount),
-            None => panic!("checked_mul overflowed"),
+            None => panic!("cannot overflow a u64"),
         }
     }
 

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -312,7 +312,7 @@ impl Amount {
 
     /// Checked addition.
     ///
-    /// Returns [`None`] if the sum is larger than [`Amount::MAX`].
+    /// Returns [`None`] if the sum is larger than [`Amount::MAX_MONEY`].
     #[must_use]
     pub const fn checked_add(self, rhs: Amount) -> Option<Amount> {
         // No `map()` in const context.
@@ -336,7 +336,7 @@ impl Amount {
 
     /// Checked multiplication.
     ///
-    /// Returns [`None`] if the product is larger than [`Amount::MAX`].
+    /// Returns [`None`] if the product is larger than [`Amount::MAX_MONEY`].
     #[must_use]
     pub const fn checked_mul(self, rhs: u64) -> Option<Amount> {
         // No `map()` in const context.

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -47,9 +47,9 @@ struct Structs {
 impl Structs {
     fn max() -> Self {
         Self {
-            a: Amount::MAX,
-            b: Amount::MAX.display_in(amount::Denomination::Bitcoin),
-            c: SignedAmount::MAX,
+            a: Amount::MAX_MONEY,
+            b: Amount::MAX_MONEY.display_in(amount::Denomination::Bitcoin),
+            c: SignedAmount::MAX_MONEY,
             d: BlockHeight::MAX,
             e: BlockInterval::MAX,
             f: FeeRate::MAX,
@@ -273,7 +273,7 @@ impl<'a> Arbitrary<'a> for Structs {
         let a = Structs {
             a: Amount::arbitrary(u)?,
             // Skip the `Display` type.
-            b: Amount::MAX.display_in(amount::Denomination::Bitcoin),
+            b: Amount::MAX_MONEY.display_in(amount::Denomination::Bitcoin),
             c: SignedAmount::arbitrary(u)?,
             d: BlockHeight::arbitrary(u)?,
             e: BlockInterval::arbitrary(u)?,

--- a/units/tests/serde.rs
+++ b/units/tests/serde.rs
@@ -57,17 +57,17 @@ impl Serde {
     /// Constructs an arbitrary instance.
     fn new() -> Self {
         Self {
-            unsigned_as_sat: Amount::MAX,
-            unsigned_as_btc: Amount::MAX,
+            unsigned_as_sat: Amount::MAX_MONEY,
+            unsigned_as_btc: Amount::MAX_MONEY,
 
-            unsigned_opt_as_sat: Some(Amount::MAX),
-            unsigned_opt_as_btc: Some(Amount::MAX),
+            unsigned_opt_as_sat: Some(Amount::MAX_MONEY),
+            unsigned_opt_as_btc: Some(Amount::MAX_MONEY),
 
-            signed_as_sat: SignedAmount::MAX,
-            signed_as_btc: SignedAmount::MAX,
+            signed_as_sat: SignedAmount::MAX_MONEY,
+            signed_as_btc: SignedAmount::MAX_MONEY,
 
-            signed_opt_as_sat: Some(SignedAmount::MAX),
-            signed_opt_as_btc: Some(SignedAmount::MAX),
+            signed_opt_as_sat: Some(SignedAmount::MAX_MONEY),
+            signed_opt_as_btc: Some(SignedAmount::MAX_MONEY),
 
             vb_floor: FeeRate::BROADCAST_MIN,
             vb_ceil: FeeRate::BROADCAST_MIN,


### PR DESCRIPTION
Enforcing the MAX_MONEY invariant is quite involved because it means multiple things:

Enforcing the `MAX_MONEY` invariant is quite involved because it means multiple things:
    
- Constructing amounts is now fallible
- Converting from unsigned to signed is now infallible
- Taking the absolute value is now infallible
- Integer overflow is illuminated in various places
    
Details:
- Update `from_sat` to check the invariant
- Fix all docs including examples
- Use the unchecked constructor in test code
- Comment any other use of the unchecked constructor
- Deprecate `unchecked_abs`
- Fail serde (using the horrible string error variant)
- Try not to use the unchecked constructor in rustdocs, no need to encourage unsuspecting users to use it.
- Use `?` in rustdoc examples (required by Rust API guidlines)
- Remove `TryFrom<Amount> for SignedAmount` because the conversion is now infallible. Add a `From` impl.
- Fix the arbitrary impls
- Maintain correct formatting
- Remove private `check_max` function as its no longer needed

Close #620